### PR TITLE
feat(pipedream): report connect-flow outcomes via webhook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11969,6 +11969,7 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
+ "tower 0.5.3",
  "tracing",
  "utoipa",
  "workspace-hack",

--- a/crates/pipedream_mcp/Cargo.toml
+++ b/crates/pipedream_mcp/Cargo.toml
@@ -27,3 +27,4 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 tokio.workspace = true
+tower = { workspace = true }

--- a/crates/pipedream_mcp/src/inbound/axum_router.rs
+++ b/crates/pipedream_mcp/src/inbound/axum_router.rs
@@ -138,6 +138,86 @@ where
         .with_state(state)
 }
 
+/// The public Pipedream webhook route.
+///
+/// Pipedream posts connect-flow outcomes here, including the failures that
+/// happen inside its hosted Connect UI — those never reach an authenticated
+/// endpoint of ours, so without this the only evidence a flow died is a
+/// minted token with no matching completion. Unauthenticated by necessity
+/// (Pipedream is the caller), so the configured `webhook_uri` carries a
+/// shared secret that every request is checked against.
+///
+/// Mounted outside the authenticated router, alongside the MCP OAuth
+/// callback.
+pub fn pipedream_webhook_router<Global>(secret: String) -> Router<Global>
+where
+    Global: Send + Sync,
+{
+    Router::new()
+        .route("/pipedream/mcp/webhook", post(pipedream_webhook))
+        .with_state(PipedreamWebhookState {
+            secret: Arc::from(secret),
+        })
+}
+
+/// State for the public webhook route: the shared secret, nothing else.
+#[derive(Clone)]
+pub struct PipedreamWebhookState {
+    secret: Arc<str>,
+}
+
+/// Query parameters carried by the configured `webhook_uri`.
+#[derive(Debug, Deserialize)]
+pub struct PipedreamWebhookQuery {
+    /// Shared secret, compared against the configured one.
+    secret: Option<String>,
+}
+
+/// Record a connect-flow outcome reported by Pipedream.
+///
+/// The body is taken as raw JSON on purpose. The payload shape is
+/// Pipedream's to change, and an endpoint whose whole job is telling us why
+/// connections fail must not start dropping events with a 422 the day they
+/// add a field. Known keys are pulled out so they can be indexed; the rest
+/// is logged verbatim.
+#[tracing::instrument(skip_all)]
+async fn pipedream_webhook(
+    State(state): State<PipedreamWebhookState>,
+    Query(query): Query<PipedreamWebhookQuery>,
+    Json(payload): Json<serde_json::Value>,
+) -> StatusCode {
+    if query.secret.as_deref() != Some(state.secret.as_ref()) {
+        // Anyone can reach this route, so the payload stays out of the log.
+        tracing::warn!("rejected Pipedream webhook with a bad or missing secret");
+        return StatusCode::UNAUTHORIZED;
+    }
+
+    let event = payload.get("event").and_then(serde_json::Value::as_str);
+    let external_user_id = payload
+        .get("external_user_id")
+        .and_then(serde_json::Value::as_str);
+    let failed = payload.get("error").is_some()
+        || event.is_some_and(|e| e.to_ascii_uppercase().contains("ERROR"));
+
+    if failed {
+        tracing::warn!(
+            event = event,
+            external_user_id = external_user_id,
+            payload = %payload,
+            "Pipedream connect flow failed"
+        );
+    } else {
+        tracing::info!(
+            event = event,
+            external_user_id = external_user_id,
+            payload = %payload,
+            "Pipedream connect flow event"
+        );
+    }
+
+    StatusCode::NO_CONTENT
+}
+
 // -- request / response types ------------------------------------------------
 
 /// Request body for updating a connected app.

--- a/crates/pipedream_mcp/src/inbound/axum_router.rs
+++ b/crates/pipedream_mcp/src/inbound/axum_router.rs
@@ -21,6 +21,9 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
 
+#[cfg(test)]
+mod test;
+
 /// Hook invoked after a connect flow completes and the record is saved.
 /// Hosts use this to react to a connection the moment it exists (e.g. start
 /// import gather jobs); implementations must be quick or spawn.

--- a/crates/pipedream_mcp/src/inbound/axum_router/test.rs
+++ b/crates/pipedream_mcp/src/inbound/axum_router/test.rs
@@ -1,0 +1,52 @@
+use super::pipedream_webhook_router;
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use tower::ServiceExt;
+
+const SECRET: &str = "s3cret";
+const SUCCESS_BODY: &str = r#"{"event":"CONNECTION_SUCCESS"}"#;
+
+fn router() -> axum::Router {
+    pipedream_webhook_router(SECRET.to_owned())
+}
+
+async fn post_webhook(uri: &str, body: &'static str) -> StatusCode {
+    router()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+        .status()
+}
+
+#[tokio::test]
+async fn webhook_rejects_missing_secret() {
+    assert_eq!(
+        post_webhook("/pipedream/mcp/webhook", SUCCESS_BODY).await,
+        StatusCode::UNAUTHORIZED
+    );
+}
+
+#[tokio::test]
+async fn webhook_rejects_wrong_secret() {
+    assert_eq!(
+        post_webhook("/pipedream/mcp/webhook?secret=wrong", SUCCESS_BODY).await,
+        StatusCode::UNAUTHORIZED
+    );
+}
+
+#[tokio::test]
+async fn webhook_accepts_matching_secret() {
+    assert_eq!(
+        post_webhook("/pipedream/mcp/webhook?secret=s3cret", SUCCESS_BODY).await,
+        StatusCode::NO_CONTENT
+    );
+}

--- a/crates/pipedream_mcp/src/inbound/mod.rs
+++ b/crates/pipedream_mcp/src/inbound/mod.rs
@@ -1,4 +1,4 @@
 /// Axum HTTP adapter for Pipedream MCP connector management.
 pub mod axum_router;
 
-pub use axum_router::{PipedreamRouterState, pipedream_mcp_router};
+pub use axum_router::{PipedreamRouterState, pipedream_mcp_router, pipedream_webhook_router};

--- a/crates/pipedream_mcp/src/outbound/api.rs
+++ b/crates/pipedream_mcp/src/outbound/api.rs
@@ -37,6 +37,10 @@ pub struct PipedreamConfig {
     /// framed by origins outside this list; localhost is only tolerated by
     /// default in the `development` project environment.
     pub allowed_origins: Vec<String>,
+    /// Absolute URL Pipedream posts connect-flow outcomes to, minted into
+    /// every Connect token. Without it a flow that dies inside the hosted
+    /// Connect UI leaves no trace on our side at all.
+    pub webhook_uri: String,
     /// Base URL of the Pipedream API. [`DEFAULT_API_URL`] unless overridden.
     pub api_url: String,
     /// URL of Pipedream's remote MCP server. [`DEFAULT_MCP_URL`] unless
@@ -143,6 +147,7 @@ impl PipedreamConnect for PipedreamClient {
         if !self.config.allowed_origins.is_empty() {
             body["allowed_origins"] = serde_json::json!(self.config.allowed_origins);
         }
+        body["webhook_uri"] = serde_json::json!(self.config.webhook_uri);
 
         let response = self
             .authed(self.http.post(self.connect_api("/tokens")))

--- a/crates/pipedream_mcp/src/outbound/api.rs
+++ b/crates/pipedream_mcp/src/outbound/api.rs
@@ -40,7 +40,7 @@ pub struct PipedreamConfig {
     /// Absolute URL Pipedream posts connect-flow outcomes to, minted into
     /// every Connect token. Without it a flow that dies inside the hosted
     /// Connect UI leaves no trace on our side at all.
-    pub webhook_uri: String,
+    pub webhook_uri: Option<String>,
     /// Base URL of the Pipedream API. [`DEFAULT_API_URL`] unless overridden.
     pub api_url: String,
     /// URL of Pipedream's remote MCP server. [`DEFAULT_MCP_URL`] unless
@@ -147,7 +147,9 @@ impl PipedreamConnect for PipedreamClient {
         if !self.config.allowed_origins.is_empty() {
             body["allowed_origins"] = serde_json::json!(self.config.allowed_origins);
         }
-        body["webhook_uri"] = serde_json::json!(self.config.webhook_uri);
+        if let Some(webhook_uri) = &self.config.webhook_uri {
+            body["webhook_uri"] = serde_json::json!(webhook_uri);
+        }
 
         let response = self
             .authed(self.http.post(self.connect_api("/tokens")))

--- a/crates/pipedream_mcp/src/outbound/api.rs
+++ b/crates/pipedream_mcp/src/outbound/api.rs
@@ -37,10 +37,6 @@ pub struct PipedreamConfig {
     /// framed by origins outside this list; localhost is only tolerated by
     /// default in the `development` project environment.
     pub allowed_origins: Vec<String>,
-    /// Absolute URL Pipedream posts connect-flow outcomes to, minted into
-    /// every Connect token. Without it a flow that dies inside the hosted
-    /// Connect UI leaves no trace on our side at all.
-    pub webhook_uri: Option<String>,
     /// Base URL of the Pipedream API. [`DEFAULT_API_URL`] unless overridden.
     pub api_url: String,
     /// URL of Pipedream's remote MCP server. [`DEFAULT_MCP_URL`] unless
@@ -58,6 +54,9 @@ pub struct PipedreamConfig {
 pub struct PipedreamClient {
     http: reqwest::Client,
     config: PipedreamConfig,
+    /// Absolute URL Pipedream posts connect-flow outcomes to, minted into
+    /// every Connect token. Unset when the host did not configure a webhook.
+    webhook_uri: Option<String>,
     access_token: Mutex<Option<CachedToken>>,
 }
 
@@ -78,8 +77,16 @@ impl PipedreamClient {
         Ok(Self {
             http,
             config,
+            webhook_uri: None,
             access_token: Mutex::new(None),
         })
+    }
+
+    /// Mint connect tokens with this webhook so Pipedream reports in-UI
+    /// connect-flow outcomes. Hosts that never mint tokens can skip this.
+    pub fn with_webhook_uri(mut self, webhook_uri: impl Into<String>) -> Self {
+        self.webhook_uri = Some(webhook_uri.into());
+        self
     }
 
     fn api(&self, path: &str) -> String {
@@ -147,7 +154,7 @@ impl PipedreamConnect for PipedreamClient {
         if !self.config.allowed_origins.is_empty() {
             body["allowed_origins"] = serde_json::json!(self.config.allowed_origins);
         }
-        if let Some(webhook_uri) = &self.config.webhook_uri {
+        if let Some(webhook_uri) = &self.webhook_uri {
             body["webhook_uri"] = serde_json::json!(webhook_uri);
         }
 

--- a/services/document_cognition_service/src/api.rs
+++ b/services/document_cognition_service/src/api.rs
@@ -128,8 +128,20 @@ fn api_router(api_context: ApiContext) -> Router {
         ))
         .with_state(api_context.clone());
 
+    // Pipedream calls this one itself, so it sits outside the authenticated
+    // router and is guarded by the secret baked into the configured
+    // `webhook_uri`.
+    let pipedream_webhook = pipedream_mcp::inbound::pipedream_webhook_router(
+        api_context
+            .config
+            .pipedream_webhook_secret
+            .as_ref()
+            .to_owned(),
+    );
+
     Router::new()
         .nest("/{version}", internal_router.clone())
         .merge(internal_router)
         .merge(mcp_client::inbound::mcp_oauth_callback_router(mcp_state))
+        .merge(pipedream_webhook)
 }

--- a/services/document_cognition_service/src/api.rs
+++ b/services/document_cognition_service/src/api.rs
@@ -130,18 +130,16 @@ fn api_router(api_context: ApiContext) -> Router {
 
     // Pipedream calls this one itself, so it sits outside the authenticated
     // router and is guarded by the secret baked into the configured
-    // `webhook_uri`.
-    let pipedream_webhook = pipedream_mcp::inbound::pipedream_webhook_router(
-        api_context
-            .config
-            .pipedream_webhook_secret
-            .as_ref()
-            .to_owned(),
-    );
-
-    Router::new()
+    // `webhook_uri`. If the secret is unset, the route is not mounted.
+    let app = Router::new()
         .nest("/{version}", internal_router.clone())
         .merge(internal_router)
-        .merge(mcp_client::inbound::mcp_oauth_callback_router(mcp_state))
-        .merge(pipedream_webhook)
+        .merge(mcp_client::inbound::mcp_oauth_callback_router(mcp_state));
+
+    match api_context.config.pipedream_webhook_secret.value() {
+        Some(secret) => app.merge(pipedream_mcp::inbound::pipedream_webhook_router(
+            secret.to_owned(),
+        )),
+        None => app,
+    }
 }

--- a/services/document_cognition_service/src/config.rs
+++ b/services/document_cognition_service/src/config.rs
@@ -23,6 +23,13 @@ env_vars!(
     pub struct DocumentPermissionJwt;
     /// Comma-separated Kafka bootstrap servers for the macro event broker.
     pub struct KafkaBrokers;
+    /// Absolute URL Pipedream posts connect-flow outcomes to, minted into
+    /// every Connect token. Must carry the shared secret as a `secret` query
+    /// parameter, matching `PIPEDREAM_WEBHOOK_SECRET`.
+    pub struct PipedreamWebhookUri;
+    /// Shared secret guarding the public Pipedream webhook route, which is
+    /// unauthenticated because Pipedream is the caller.
+    pub struct PipedreamWebhookSecret;
 );
 
 maybe_env_vars!(
@@ -102,6 +109,10 @@ pub struct Config {
     pub pipedream_mcp_url: PipedreamMcpUrl,
     /// Browser origins allowed to embed Pipedream's hosted Connect UI.
     pub pipedream_allowed_origins: PipedreamAllowedOrigins,
+    /// URL Pipedream posts connect-flow outcomes to.
+    pub pipedream_webhook_uri: PipedreamWebhookUri,
+    /// Shared secret guarding the public Pipedream webhook route.
+    pub pipedream_webhook_secret: PipedreamWebhookSecret,
     /// The internal api key
     pub internal_api_key: InternalApiKey,
     /// AI editing worker URL
@@ -163,6 +174,8 @@ impl Config {
             pipedream_api_url: PipedreamApiUrl::Unset,
             pipedream_mcp_url: PipedreamMcpUrl::Unset,
             pipedream_allowed_origins: PipedreamAllowedOrigins::Unset,
+            pipedream_webhook_uri: PipedreamWebhookUri::Comptime("PIPEDREAM_WEBHOOK_URI"),
+            pipedream_webhook_secret: PipedreamWebhookSecret::Comptime("PIPEDREAM_WEBHOOK_SECRET"),
             internal_api_key: InternalApiKey::Comptime(""),
             ai_editing_worker_url: AiEditingWorkerUrl::unwrap_new().to_string(),
             document_permission_jwt: DocumentPermissionJwt::Comptime("DOCUMENT_PERMISSION_JWT"),

--- a/services/document_cognition_service/src/config.rs
+++ b/services/document_cognition_service/src/config.rs
@@ -23,13 +23,6 @@ env_vars!(
     pub struct DocumentPermissionJwt;
     /// Comma-separated Kafka bootstrap servers for the macro event broker.
     pub struct KafkaBrokers;
-    /// Absolute URL Pipedream posts connect-flow outcomes to, minted into
-    /// every Connect token. Must carry the shared secret as a `secret` query
-    /// parameter, matching `PIPEDREAM_WEBHOOK_SECRET`.
-    pub struct PipedreamWebhookUri;
-    /// Shared secret guarding the public Pipedream webhook route, which is
-    /// unauthenticated because Pipedream is the caller.
-    pub struct PipedreamWebhookSecret;
 );
 
 maybe_env_vars!(
@@ -56,6 +49,15 @@ maybe_env_vars!(
     /// by deploy environment: the app origin (`https://macro.com` /
     /// `https://dev.macro.com`) plus localhost outside production.
     pub struct PipedreamAllowedOrigins;
+    /// Absolute URL Pipedream posts connect-flow outcomes to, minted into
+    /// every Connect token. Must carry the shared secret as a `secret` query
+    /// parameter, matching `PIPEDREAM_WEBHOOK_SECRET`. When unset (or when
+    /// the secret is unset), connect tokens are minted without a webhook.
+    pub struct PipedreamWebhookUri;
+    /// Shared secret guarding the public Pipedream webhook route, which is
+    /// unauthenticated because Pipedream is the caller. When unset, the
+    /// webhook route is not mounted.
+    pub struct PipedreamWebhookSecret;
 );
 
 /// The configuration parameters for the application.
@@ -174,8 +176,8 @@ impl Config {
             pipedream_api_url: PipedreamApiUrl::Unset,
             pipedream_mcp_url: PipedreamMcpUrl::Unset,
             pipedream_allowed_origins: PipedreamAllowedOrigins::Unset,
-            pipedream_webhook_uri: PipedreamWebhookUri::Comptime("PIPEDREAM_WEBHOOK_URI"),
-            pipedream_webhook_secret: PipedreamWebhookSecret::Comptime("PIPEDREAM_WEBHOOK_SECRET"),
+            pipedream_webhook_uri: PipedreamWebhookUri::Unset,
+            pipedream_webhook_secret: PipedreamWebhookSecret::Unset,
             internal_api_key: InternalApiKey::Comptime(""),
             ai_editing_worker_url: AiEditingWorkerUrl::unwrap_new().to_string(),
             document_permission_jwt: DocumentPermissionJwt::Comptime("DOCUMENT_PERMISSION_JWT"),

--- a/services/document_cognition_service/src/main.rs
+++ b/services/document_cognition_service/src/main.rs
@@ -504,6 +504,7 @@ async fn main() -> anyhow::Result<()> {
                             Environment::Local => vec!["http://localhost:3000".to_owned()],
                         },
                     },
+                    webhook_uri: config.pipedream_webhook_uri.as_ref().to_owned(),
                 },
             )
             .context("failed to build Pipedream client")?,

--- a/services/document_cognition_service/src/main.rs
+++ b/services/document_cognition_service/src/main.rs
@@ -481,50 +481,51 @@ async fn main() -> anyhow::Result<()> {
                     None
                 }
             };
-            Some(Arc::new(
-                pipedream_mcp::outbound::api::PipedreamClient::new(
-                    pipedream_mcp::outbound::api::PipedreamConfig {
-                        client_id: client_id.to_owned(),
-                        client_secret: client_secret.to_owned(),
-                        project_id: project_id.to_owned(),
-                        environment: config
-                            .pipedream_environment
-                            .value()
-                            .unwrap_or(match config.environment {
-                                Environment::Production => "production",
-                                _ => "development",
-                            })
-                            .to_owned(),
-                        api_url: config
-                            .pipedream_api_url
-                            .value()
-                            .unwrap_or(pipedream_mcp::outbound::api::DEFAULT_API_URL)
-                            .to_owned(),
-                        mcp_url: config
-                            .pipedream_mcp_url
-                            .value()
-                            .unwrap_or(pipedream_mcp::outbound::api::DEFAULT_MCP_URL)
-                            .to_owned(),
-                        allowed_origins: match config.pipedream_allowed_origins.value() {
-                            Some(origins) => origins
-                                .split(',')
-                                .map(|origin| origin.trim().to_owned())
-                                .filter(|origin| !origin.is_empty())
-                                .collect(),
-                            None => match config.environment {
-                                Environment::Production => vec!["https://macro.com".to_owned()],
-                                Environment::Develop => vec![
-                                    "https://dev.macro.com".to_owned(),
-                                    "http://localhost:3000".to_owned(),
-                                ],
-                                Environment::Local => vec!["http://localhost:3000".to_owned()],
-                            },
+            let client = pipedream_mcp::outbound::api::PipedreamClient::new(
+                pipedream_mcp::outbound::api::PipedreamConfig {
+                    client_id: client_id.to_owned(),
+                    client_secret: client_secret.to_owned(),
+                    project_id: project_id.to_owned(),
+                    environment: config
+                        .pipedream_environment
+                        .value()
+                        .unwrap_or(match config.environment {
+                            Environment::Production => "production",
+                            _ => "development",
+                        })
+                        .to_owned(),
+                    api_url: config
+                        .pipedream_api_url
+                        .value()
+                        .unwrap_or(pipedream_mcp::outbound::api::DEFAULT_API_URL)
+                        .to_owned(),
+                    mcp_url: config
+                        .pipedream_mcp_url
+                        .value()
+                        .unwrap_or(pipedream_mcp::outbound::api::DEFAULT_MCP_URL)
+                        .to_owned(),
+                    allowed_origins: match config.pipedream_allowed_origins.value() {
+                        Some(origins) => origins
+                            .split(',')
+                            .map(|origin| origin.trim().to_owned())
+                            .filter(|origin| !origin.is_empty())
+                            .collect(),
+                        None => match config.environment {
+                            Environment::Production => vec!["https://macro.com".to_owned()],
+                            Environment::Develop => vec![
+                                "https://dev.macro.com".to_owned(),
+                                "http://localhost:3000".to_owned(),
+                            ],
+                            Environment::Local => vec!["http://localhost:3000".to_owned()],
                         },
-                        webhook_uri,
                     },
-                )
-                .context("failed to build Pipedream client")?,
-            ))
+                },
+            )
+            .context("failed to build Pipedream client")?;
+            Some(Arc::new(match webhook_uri {
+                Some(uri) => client.with_webhook_uri(uri),
+                None => client,
+            }))
         }
         _ => {
             tracing::info!("Pipedream credentials not set; Pipedream MCP connectors disabled");

--- a/services/document_cognition_service/src/main.rs
+++ b/services/document_cognition_service/src/main.rs
@@ -459,56 +459,73 @@ async fn main() -> anyhow::Result<()> {
 
     // The Pipedream MCP stack, fully separate from the native one above
     // (own endpoints, own table, own toolset). Without credentials its
-    // endpoints answer 501 and its toolsets come up empty.
+    // endpoints answer 501 and its toolsets come up empty. Connect-flow
+    // webhooks need both URI and secret; a half-set pair is ignored so we
+    // never mint a callback we cannot serve.
     let pipedream_client: ai_tools::ToolPipedreamConnection = match (
         config.pipedream_client_id.value(),
         config.pipedream_client_secret.value(),
         config.pipedream_project_id.value(),
     ) {
-        (Some(client_id), Some(client_secret), Some(project_id)) => Some(Arc::new(
-            pipedream_mcp::outbound::api::PipedreamClient::new(
-                pipedream_mcp::outbound::api::PipedreamConfig {
-                    client_id: client_id.to_owned(),
-                    client_secret: client_secret.to_owned(),
-                    project_id: project_id.to_owned(),
-                    environment: config
-                        .pipedream_environment
-                        .value()
-                        .unwrap_or(match config.environment {
-                            Environment::Production => "production",
-                            _ => "development",
-                        })
-                        .to_owned(),
-                    api_url: config
-                        .pipedream_api_url
-                        .value()
-                        .unwrap_or(pipedream_mcp::outbound::api::DEFAULT_API_URL)
-                        .to_owned(),
-                    mcp_url: config
-                        .pipedream_mcp_url
-                        .value()
-                        .unwrap_or(pipedream_mcp::outbound::api::DEFAULT_MCP_URL)
-                        .to_owned(),
-                    allowed_origins: match config.pipedream_allowed_origins.value() {
-                        Some(origins) => origins
-                            .split(',')
-                            .map(|origin| origin.trim().to_owned())
-                            .filter(|origin| !origin.is_empty())
-                            .collect(),
-                        None => match config.environment {
-                            Environment::Production => vec!["https://macro.com".to_owned()],
-                            Environment::Develop => vec![
-                                "https://dev.macro.com".to_owned(),
-                                "http://localhost:3000".to_owned(),
-                            ],
-                            Environment::Local => vec!["http://localhost:3000".to_owned()],
+        (Some(client_id), Some(client_secret), Some(project_id)) => {
+            let webhook_uri = match (
+                config.pipedream_webhook_uri.value(),
+                config.pipedream_webhook_secret.value(),
+            ) {
+                (Some(uri), Some(_)) => Some(uri.to_owned()),
+                (None, None) => None,
+                _ => {
+                    tracing::warn!(
+                        "ignoring incomplete Pipedream webhook config; set both PIPEDREAM_WEBHOOK_URI and PIPEDREAM_WEBHOOK_SECRET"
+                    );
+                    None
+                }
+            };
+            Some(Arc::new(
+                pipedream_mcp::outbound::api::PipedreamClient::new(
+                    pipedream_mcp::outbound::api::PipedreamConfig {
+                        client_id: client_id.to_owned(),
+                        client_secret: client_secret.to_owned(),
+                        project_id: project_id.to_owned(),
+                        environment: config
+                            .pipedream_environment
+                            .value()
+                            .unwrap_or(match config.environment {
+                                Environment::Production => "production",
+                                _ => "development",
+                            })
+                            .to_owned(),
+                        api_url: config
+                            .pipedream_api_url
+                            .value()
+                            .unwrap_or(pipedream_mcp::outbound::api::DEFAULT_API_URL)
+                            .to_owned(),
+                        mcp_url: config
+                            .pipedream_mcp_url
+                            .value()
+                            .unwrap_or(pipedream_mcp::outbound::api::DEFAULT_MCP_URL)
+                            .to_owned(),
+                        allowed_origins: match config.pipedream_allowed_origins.value() {
+                            Some(origins) => origins
+                                .split(',')
+                                .map(|origin| origin.trim().to_owned())
+                                .filter(|origin| !origin.is_empty())
+                                .collect(),
+                            None => match config.environment {
+                                Environment::Production => vec!["https://macro.com".to_owned()],
+                                Environment::Develop => vec![
+                                    "https://dev.macro.com".to_owned(),
+                                    "http://localhost:3000".to_owned(),
+                                ],
+                                Environment::Local => vec!["http://localhost:3000".to_owned()],
+                            },
                         },
+                        webhook_uri,
                     },
-                    webhook_uri: config.pipedream_webhook_uri.as_ref().to_owned(),
-                },
-            )
-            .context("failed to build Pipedream client")?,
-        )),
+                )
+                .context("failed to build Pipedream client")?,
+            ))
+        }
         _ => {
             tracing::info!("Pipedream credentials not set; Pipedream MCP connectors disabled");
             None

--- a/tooling/xtask/crates/xtask_local/src/local/local_env.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/local_env.rs
@@ -451,6 +451,15 @@ impl BootStubEnv {
         );
         // search_processing_service; the local cluster has the security plugin
         // disabled so these are accepted but ignored (same as opensearch.rs).
+        // document_cognition_service requires both Pipedream webhook values
+        // at startup. Nothing local can receive Pipedream's callbacks, so
+        // these only need to be well-formed: the URI must carry the same
+        // secret the route checks against.
+        env.insert(
+            "PIPEDREAM_WEBHOOK_URI".into(),
+            "http://localhost:8080/pipedream/mcp/webhook?secret=local".into(),
+        );
+        env.insert("PIPEDREAM_WEBHOOK_SECRET".into(), "local".into());
         env.insert("OPENSEARCH_USERNAME".into(), "macrouser".into());
         env.insert("OPENSEARCH_PASSWORD".into(), "local".into());
         // document_storage_service's presigned-URL config. Locally the

--- a/tooling/xtask/crates/xtask_local/src/local/local_env.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/local_env.rs
@@ -451,8 +451,8 @@ impl BootStubEnv {
         );
         // search_processing_service; the local cluster has the security plugin
         // disabled so these are accepted but ignored (same as opensearch.rs).
-        // document_cognition_service requires both Pipedream webhook values
-        // at startup. Nothing local can receive Pipedream's callbacks, so
+        // document_cognition_service mounts the Pipedream webhook when both
+        // values are set. Nothing local can receive Pipedream's callbacks, so
         // these only need to be well-formed: the URI must carry the same
         // secret the route checks against.
         env.insert(


### PR DESCRIPTION
Pass a `webhook_uri` when minting Pipedream Connect tokens and add a secret-guarded public route that logs the connect-flow outcomes Pipedream posts back, so failures inside the hosted Connect UI stop being invisible to us.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an unauthenticated HTTP ingress protected only by a shared query secret; misconfiguration or secret leakage could allow arbitrary webhook posts and log noise, though it does not touch authenticated connector APIs.
> 
> **Overview**
> Adds visibility into **Pipedream Connect** flows that fail inside Pipedream’s hosted UI by registering a **`webhook_uri`** on minted connect tokens and exposing a **public, secret-guarded** `POST /pipedream/mcp/webhook` route (mounted outside the authenticated API, similar to the MCP OAuth callback).
> 
> The webhook accepts **raw JSON** (no strict schema) so Pipedream payload changes don’t 422; it checks a **`secret` query param**, logs success vs failure (including `error` / error-like `event` values), and returns **204**. **`PipedreamClient`** can be configured with **`with_webhook_uri`** so token creation includes `webhook_uri` when set.
> 
> **`document_cognition_service`** adds **`PIPEDREAM_WEBHOOK_URI`** and **`PIPEDREAM_WEBHOOK_SECRET`**: the route is only mounted when the secret is set, and the URI is only passed to the client when **both** values are present (partial config is warned and ignored). Local xtask env gets placeholder values; **`pipedream_mcp`** adds webhook router tests via **`tower`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f7a91ac2d4ea206475a56ccccfee3aac7a94808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->