### PR TITLE
fix(agent-harness): enable in-memory agent in dev

### DIFF
--- a/infra/packages/shared/src/ai_tools.ts
+++ b/infra/packages/shared/src/ai_tools.ts
@@ -128,6 +128,16 @@ export function getAiToolsServiceRoleArns(): pulumi.Output<string>[] {
     'ai-tools-agent-schedule-service-stack',
     { name: `macro-inc/agent-schedule-service/${stack}` }
   );
+  const agentHarnessServiceRoleArns =
+    stack === 'dev'
+      ? [
+          new pulumi.StackReference('ai-tools-agent-harness-service-stack', {
+            name: `macro-inc/agent-harness-service/${stack}`,
+          })
+            .getOutput('agentHarnessServiceRoleArn')
+            .apply((v) => v as string),
+        ]
+      : [];
 
   return [
     mcpServerStack.getOutput('mcpServerRoleArn').apply((v) => v as string),
@@ -137,5 +147,6 @@ export function getAiToolsServiceRoleArns(): pulumi.Output<string>[] {
     agentScheduleServiceStack
       .getOutput('agentScheduleServiceRoleArn')
       .apply((v) => v as string),
+    ...agentHarnessServiceRoleArns,
   ];
 }

--- a/infra/stacks/agent-harness-service/agent_harness_service.ts
+++ b/infra/stacks/agent-harness-service/agent_harness_service.ts
@@ -40,7 +40,10 @@ type Args = {
   ecsClusterArn: pulumi.Output<string> | string;
   cloudStorageClusterName: pulumi.Output<string> | string;
   secretKeyArns: (pulumi.Output<string> | string)[];
-  sendQueueArns: pulumi.Output<string>[];
+  /** SQS queues the service is allowed to send messages to. */
+  queueArns: (pulumi.Output<string> | string)[];
+  /** S3 buckets the service needs access to. */
+  bucketArns: (pulumi.Output<string> | string)[];
 };
 
 /**
@@ -81,7 +84,8 @@ export class AgentHarnessService extends pulumi.ComponentResource {
       cloudStorageClusterName,
       containerEnvVars,
       secretKeyArns,
-      sendQueueArns,
+      queueArns,
+      bucketArns,
     } = args;
 
     this.domain = `https://${SERVICE_DOMAIN_NAME}`;
@@ -110,8 +114,8 @@ export class AgentHarnessService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // The harness fans channel side effects out over SQS (notification
-    // ingress and contacts) when it announces a session in a channel.
+    // The harness fans channel side effects and in-memory AI tool work out
+    // over the same queues as the other AI tool hosts.
     const queuePolicy = new aws.iam.Policy(
       `${BASE_NAME}-queue-policy`,
       {
@@ -125,7 +129,7 @@ export class AgentHarnessService extends pulumi.ComponentResource {
                 'sqs:GetQueueUrl',
                 'sqs:GetQueueAttributes',
               ],
-              Resource: sendQueueArns,
+              Resource: queueArns,
               Effect: 'Allow',
             },
           ],
@@ -134,6 +138,36 @@ export class AgentHarnessService extends pulumi.ComponentResource {
       },
       { parent: this }
     );
+
+    const s3Policy =
+      bucketArns.length > 0
+        ? new aws.iam.Policy(
+            `${BASE_NAME}-s3-policy`,
+            {
+              name: `${BASE_NAME}-s3-policy-${stack}`,
+              policy: pulumi.output({
+                Version: '2012-10-17',
+                Statement: [
+                  {
+                    Effect: 'Allow',
+                    Action: [
+                      's3:ListBucket',
+                      's3:GetObject',
+                      's3:PutObject',
+                      's3:DeleteObject',
+                    ],
+                    Resource: bucketArns.flatMap((arn) => [
+                      arn,
+                      pulumi.interpolate`${arn}/*`,
+                    ]),
+                  },
+                ],
+              }),
+              tags,
+            },
+            { parent: this }
+          )
+        : undefined;
 
     this.role = new aws.iam.Role(
       `${BASE_NAME}-role`,
@@ -151,7 +185,11 @@ export class AgentHarnessService extends pulumi.ComponentResource {
             },
           ],
         },
-        managedPolicyArns: [secretsManagerPolicy.arn, queuePolicy.arn],
+        managedPolicyArns: [
+          secretsManagerPolicy.arn,
+          queuePolicy.arn,
+          ...(s3Policy ? [s3Policy.arn] : []),
+        ],
         tags,
       },
       { parent: this }

--- a/infra/stacks/agent-harness-service/index.ts
+++ b/infra/stacks/agent-harness-service/index.ts
@@ -1,6 +1,10 @@
 import * as aws from '@pulumi/aws';
 import * as pulumi from '@pulumi/pulumi';
-import { getMacroApiToken, stack } from '../../packages/shared';
+import {
+  getAiToolsInfra,
+  getMacroApiToken,
+  stack,
+} from '../../packages/shared';
 import { get_coparse_api_vpc } from '../../packages/vpc';
 import { AgentHarnessService } from './agent_harness_service';
 
@@ -13,19 +17,24 @@ const tags = {
 };
 
 // ── Secrets ──────────────────────────────────────────────────────────────────
-// Config (DATABASE_URL, DAYTONA_API_KEY, KAFKA_BROKERS, ...) arrives through
-// the Doppler-synced APP_SECRETS_JSON. Doppler's JWT_SECRET_KEY and
-// MACRO_API_TOKEN_PUBLIC_KEY hold Secrets Manager secret *names* that
-// `JwtValidationArgs::new_with_secret_manager` resolves at runtime
-// (crates/remote_env_var), so the task role needs read access to those two
-// secrets - the same code path as agent-schedule-service and
-// connection-gateway.
+// Config (DATABASE_URL, DAYTONA_API_KEY, KAFKA_BROKERS, AI tool config, ...)
+// arrives through the Doppler-synced APP_SECRETS_JSON. Some values hold
+// Secrets Manager secret *names* that the service resolves at runtime, so the
+// task role needs access to both its auth secrets and the shared AI tool
+// secrets.
 
 const jwtSecretKeyArn = aws.secretsmanager
   .getSecretVersionOutput({ secretId: `fusionauth-jwt-secret-${stack}` })
   .apply((secret) => secret.arn);
 
 const MACRO_API_TOKENS = getMacroApiToken();
+
+// ── AI tools infra ───────────────────────────────────────────────────────────
+
+const aiTools =
+  stack === 'dev'
+    ? getAiToolsInfra()
+    : { secretArns: [], queueArns: [], bucketArns: [] };
 
 // ── Stack references ─────────────────────────────────────────────────────────
 
@@ -42,7 +51,8 @@ const cloudStorageClusterName = cloudStorageStack
   .apply((value) => value as string);
 
 // ── Queues ───────────────────────────────────────────────────────────────────
-// Channel side effects fan out over these; names match `macro_queues`.
+// Channel side effects use these in every environment. Dev's AI tool bundle
+// includes both plus the additional tool queues.
 
 const notificationIngressQueueArn = aws.sqs
   .getQueueOutput({ name: `notification-ingress-queue-${stack}` })
@@ -65,13 +75,30 @@ const service = new AgentHarnessService(`agent-harness-service-${stack}`, {
   isPrivate: false,
   ecsClusterArn: cloudStorageClusterArn,
   cloudStorageClusterName,
-  secretKeyArns: [jwtSecretKeyArn, MACRO_API_TOKENS.macroApiTokenPublicKeyArn],
-  sendQueueArns: [notificationIngressQueueArn, contactsQueueArn],
+  secretKeyArns: [
+    jwtSecretKeyArn,
+    MACRO_API_TOKENS.macroApiTokenPublicKeyArn,
+    ...aiTools.secretArns,
+  ],
+  queueArns:
+    stack === 'dev'
+      ? [...aiTools.queueArns]
+      : [notificationIngressQueueArn, contactsQueueArn],
+  bucketArns: [...aiTools.bucketArns],
   containerEnvVars: [
     {
       name: 'ENVIRONMENT',
       value: stack,
     },
+    ...(stack === 'dev'
+      ? [
+          {
+            // bot_id::MACRO_AI_BOT_ID: @macro runs on the in-process runtime.
+            name: 'INMEM_BOT_ID',
+            value: '00000000-0000-0000-0000-00000000a1a1',
+          },
+        ]
+      : []),
     // Datadog
     {
       name: 'DD_SERVICE',

--- a/services/agent_harness_service/src/config.rs
+++ b/services/agent_harness_service/src/config.rs
@@ -85,10 +85,10 @@ pub struct Config {
     /// Repository sessions run against, until it becomes per-request data.
     #[macro_config_default(String::from("https://github.com/macro-inc/macro"))]
     pub harness_repo_url: String,
-    /// The bot whose sessions run in-process (the in-memory agent) - the
-    /// Macro bot, `bot_id::MACRO_AI_BOT_ID`, in every real deployment. Unset
-    /// means this deployment serves only the sandboxed bot. It must be a real
-    /// `bots` row - `agent_session.bot_id` references it.
+    /// The bot whose sessions run in-process (the in-memory agent). Dev sets
+    /// this to `bot_id::MACRO_AI_BOT_ID`; unset deployments serve only the
+    /// sandboxed bot. It must be a real `bots` row because
+    /// `agent_session.bot_id` references it.
     pub inmem_bot_id: Option<Uuid>,
     /// Model id stamped onto sessions the in-memory bot opens. Unknown ids
     /// fall back to the agent loop's default model.


### PR DESCRIPTION
Enables the in-memory Macro agent in dev with the required AI-tool IAM, bucket policy, and prepared Doppler configuration.