### PR TITLE
fix(auth): read Cursor KMS key from process env

### DIFF
--- a/services/authentication_service/src/config.rs
+++ b/services/authentication_service/src/config.rs
@@ -48,7 +48,9 @@ maybe_env_vars! {
     /// definition rather than Doppler, and the Doppler config validator
     /// deserializes this struct from Doppler alone — a required field it
     /// cannot see fails CI. The service still refuses to start without it;
-    /// see `cursor_api_key_kms_key_id`.
+    /// see [`Config::cursor_api_key_kms_key_id`], which also reads the
+    /// process environment because `MacroConfig` does not fall back to it
+    /// when `APP_SECRETS_JSON` is present.
     pub struct CursorApiKeyKmsKeyId;
     pub struct GaMeasurementId;
     pub struct GaApiSecret;
@@ -173,9 +175,16 @@ impl Config {
     /// feature of the settings surface, and a service that cannot encrypt one
     /// should fail at startup rather than at the first user who tries.
     pub(crate) fn cursor_api_key_kms_key_id(&self) -> anyhow::Result<String> {
-        nonblank_value(self.cursor_api_key_kms_key_id.value())
-            .map(str::to_owned)
-            .context("CURSOR_API_KEY_KMS_KEY_ID is required")
+        // `MacroConfig` will not see a Pulumi-injected process env var once
+        // Doppler's `APP_SECRETS_JSON` is present. Re-read through the env-var
+        // type, which does fall back to process env.
+        let from_process_env = CursorApiKeyKmsKeyId::new();
+        resolve_cursor_api_key_kms_key_id(
+            &self.cursor_api_key_kms_key_id,
+            from_process_env
+                .as_ref()
+                .and_then(CursorApiKeyKmsKeyId::value),
+        )
     }
 
     /// Resolves Microsoft credentials, enforcing that all values are configured together.
@@ -221,6 +230,21 @@ fn resolve_microsoft_credentials(
 
 fn nonblank_value(value: Option<&str>) -> Option<&str> {
     value.filter(|value| !value.trim().is_empty())
+}
+
+/// Pulumi injects `CURSOR_API_KEY_KMS_KEY_ID` as a container env var, not
+/// through Doppler. ECS always has `APP_SECRETS_JSON`, and `MacroConfig` will
+/// not look at process env once that blob is present, so the field on `Config`
+/// is unset in deployed environments. `CursorApiKeyKmsKeyId::new()` still
+/// falls back to process env, which is what `process_env` is.
+fn resolve_cursor_api_key_kms_key_id(
+    configured: &CursorApiKeyKmsKeyId,
+    process_env: Option<&str>,
+) -> anyhow::Result<String> {
+    nonblank_value(configured.value())
+        .or_else(|| nonblank_value(process_env))
+        .map(str::to_owned)
+        .context("CURSOR_API_KEY_KMS_KEY_ID is required")
 }
 
 #[cfg(test)]

--- a/services/authentication_service/src/config/test.rs
+++ b/services/authentication_service/src/config/test.rs
@@ -139,3 +139,46 @@ fn microsoft_token_kms_key_id(value: Option<&'static str>) -> MicrosoftTokenKmsK
         None => MicrosoftTokenKmsKeyId::new_unset(),
     }
 }
+
+#[test]
+fn cursor_kms_key_from_config_field() {
+    let configured = CursorApiKeyKmsKeyId::new_testing("arn:aws:kms:from-config");
+    assert_eq!(
+        resolve_cursor_api_key_kms_key_id(&configured, None).unwrap(),
+        "arn:aws:kms:from-config"
+    );
+}
+
+#[test]
+fn cursor_kms_key_from_process_env_when_config_unset() {
+    let configured = CursorApiKeyKmsKeyId::new_unset();
+    assert_eq!(
+        resolve_cursor_api_key_kms_key_id(&configured, Some("arn:aws:kms:from-env")).unwrap(),
+        "arn:aws:kms:from-env"
+    );
+}
+
+#[test]
+fn cursor_kms_key_prefers_config_over_process_env() {
+    let configured = CursorApiKeyKmsKeyId::new_testing("arn:aws:kms:from-config");
+    assert_eq!(
+        resolve_cursor_api_key_kms_key_id(&configured, Some("arn:aws:kms:from-env")).unwrap(),
+        "arn:aws:kms:from-config"
+    );
+}
+
+#[test]
+fn cursor_kms_key_blank_config_falls_back_to_process_env() {
+    let configured = CursorApiKeyKmsKeyId::new_testing("  ");
+    assert_eq!(
+        resolve_cursor_api_key_kms_key_id(&configured, Some("arn:aws:kms:from-env")).unwrap(),
+        "arn:aws:kms:from-env"
+    );
+}
+
+#[test]
+fn cursor_kms_key_required_when_both_absent() {
+    let configured = CursorApiKeyKmsKeyId::new_unset();
+    let error = resolve_cursor_api_key_kms_key_id(&configured, None).unwrap_err();
+    assert!(error.to_string().contains("CURSOR_API_KEY_KMS_KEY_ID"));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Setting a Cursor API key on https://dev.macro.com/app/settings/connections fails with:

```
Cross-Origin Request Blocked: … https://auth-service-dev.macro.com/cursor-api-key
Reason: CORS header ‘Access-Control-Allow-Origin’ missing. Status code: 404.
```

The CORS message is a red herring. `/cursor-api-key` is not on the running auth-service (live OpenAPI has no such path; `OPTIONS /permissions` gets CORS headers, `OPTIONS /cursor-api-key` is a bare 404). The route landed in #5849, but the new tasks crash at boot and ECS keeps the previous binary.

Pulumi injects `CURSOR_API_KEY_KMS_KEY_ID` as a container env var. Doppler injects `APP_SECRETS_JSON`. `MacroConfig` only reads that JSON blob when it is present, so the required KMS key looks unset and startup fails with `CURSOR_API_KEY_KMS_KEY_ID is required`.

## Fix

Re-read the key through `CursorApiKeyKmsKeyId::new()`, which falls back to process env the same way other env-var types do. Startup still fails if neither Doppler nor the container env has a non-blank value.

## Test plan

- [x] Unit tests for config vs process-env resolution
- [ ] `cargo test -p authentication_service` for the config tests
- After deploy, `OPTIONS https://auth-service-dev.macro.com/cursor-api-key` should return CORS headers (and 401 without a cookie, not 404)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-704c2be9-a24f-4e14-88fe-c251b6cc1934?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-704c2be9-a24f-4e14-88fe-c251b6cc1934&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

