### PR TITLE
fix(agent_session): compile find_all_for_thread with external identity

### DIFF
--- a/.sqlx/query-f99b8550fdb6c82da89f3b8a66142290daab84ae3b10f784825276a9f2ff6317.json
+++ b/.sqlx/query-f99b8550fdb6c82da89f3b8a66142290daab84ae3b10f784825276a9f2ff6317.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                id, name, owner_id, thread_id, originating_message_id, bot_id,\n                model, harness, repo_url, workspace, sandbox_size, acp_session_id, status,\n                status_event_name, created_at, modified_at,\n                (SELECT channel_id FROM comms_messages WHERE id = agent_session.thread_id)\n                    AS \"thread_channel_id?\"\n            FROM agent_session\n            WHERE thread_id = $1\n            ORDER BY created_at DESC\n            ",
+  "query": "\n            SELECT\n                id, name, owner_id, thread_id, originating_message_id, bot_id,\n                model, harness, repo_url, workspace, sandbox_size, acp_session_id, status,\n                status_event_name, agent_session.created_at, modified_at,\n                (SELECT channel_id FROM comms_messages WHERE id = agent_session.thread_id)\n                    AS \"thread_channel_id?\",\n                ext.provider AS \"external_provider?\", ext.external_id AS \"external_id?\",\n                ext.external_name AS \"external_name?\", ext.external_url AS \"external_url?\"\n            FROM agent_session\n            LEFT JOIN external_agent_session AS ext ON ext.agent_session_id = agent_session.id\n            WHERE thread_id = $1\n            ORDER BY agent_session.created_at DESC\n            ",
   "describe": {
     "columns": [
       {
@@ -87,6 +87,26 @@
         "ordinal": 16,
         "name": "thread_channel_id?",
         "type_info": "Uuid"
+      },
+      {
+        "ordinal": 17,
+        "name": "external_provider?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 18,
+        "name": "external_id?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 19,
+        "name": "external_name?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "external_url?",
+        "type_info": "Text"
       }
     ],
     "parameters": {
@@ -111,8 +131,12 @@
       true,
       false,
       false,
-      null
+      null,
+      false,
+      false,
+      true,
+      true
     ]
   },
-  "hash": "1b9d5291cf17cb33b9ba0843863f59ff3cf2e1473c89880a5a21d32f881ebc54"
+  "hash": "f99b8550fdb6c82da89f3b8a66142290daab84ae3b10f784825276a9f2ff6317"
 }

--- a/crates/agent_session/src/outbound/postgres.rs
+++ b/crates/agent_session/src/outbound/postgres.rs
@@ -345,12 +345,15 @@ impl AgentSessionRepo for PgAgentSessionRepo {
             SELECT
                 id, name, owner_id, thread_id, originating_message_id, bot_id,
                 model, harness, repo_url, workspace, sandbox_size, acp_session_id, status,
-                status_event_name, created_at, modified_at,
+                status_event_name, agent_session.created_at, modified_at,
                 (SELECT channel_id FROM comms_messages WHERE id = agent_session.thread_id)
-                    AS "thread_channel_id?"
+                    AS "thread_channel_id?",
+                ext.provider AS "external_provider?", ext.external_id AS "external_id?",
+                ext.external_name AS "external_name?", ext.external_url AS "external_url?"
             FROM agent_session
+            LEFT JOIN external_agent_session AS ext ON ext.agent_session_id = agent_session.id
             WHERE thread_id = $1
-            ORDER BY created_at DESC
+            ORDER BY agent_session.created_at DESC
             "#,
             thread_id,
         )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`#5849` added `external_*` columns to `AgentSessionRow`. `find_all_for_thread` still selected the old shape, so `agent_session` fails to compile on `main`.

That break is what turns Typecheck, SDK Generated Code Check, and Web App Status Check red on otherwise unrelated PRs (including #5939). Cloud Storage clippy on merge-with-main hits the same error.

## Scope

- `find_all_for_thread` uses the same `LEFT JOIN external_agent_session` and `external_*` aliases as `get` / `find_for_channel`.
- Qualify `created_at` as `agent_session.created_at` so the join is unambiguous.

## Tradeoffs

None. The other `AgentSessionRow` queries already selected these columns.

## Blast Radius

- Channel thread session listing (`find_all_for_thread`).
- Any CI job that compiles `agent_session` (OpenAPI generate, workspace clippy).

## Verification

- `SQLX_OFFLINE` unset `cargo check -p agent_session --lib`
- `cargo test -p agent_session --lib` — 108 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4183335-6fc7-4bb0-9197-ca7d2de776aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4183335-6fc7-4bb0-9197-ca7d2de776aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

