### PR TITLE
fix(agent_session): select external identity in find_all_for_thread

### DIFF
--- a/.sqlx/query-f99b8550fdb6c82da89f3b8a66142290daab84ae3b10f784825276a9f2ff6317.json
+++ b/.sqlx/query-f99b8550fdb6c82da89f3b8a66142290daab84ae3b10f784825276a9f2ff6317.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                id, name, owner_id, thread_id, originating_message_id, bot_id,\n                model, harness, repo_url, workspace, sandbox_size, acp_session_id, status,\n                status_event_name, created_at, modified_at,\n                (SELECT channel_id FROM comms_messages WHERE id = agent_session.thread_id)\n                    AS \"thread_channel_id?\"\n            FROM agent_session\n            WHERE thread_id = $1\n            ORDER BY created_at DESC\n            ",
+  "query": "\n            SELECT\n                id, name, owner_id, thread_id, originating_message_id, bot_id,\n                model, harness, repo_url, workspace, sandbox_size, acp_session_id, status,\n                status_event_name, agent_session.created_at, modified_at,\n                (SELECT channel_id FROM comms_messages WHERE id = agent_session.thread_id)\n                    AS \"thread_channel_id?\",\n                ext.provider AS \"external_provider?\", ext.external_id AS \"external_id?\",\n                ext.external_name AS \"external_name?\", ext.external_url AS \"external_url?\"\n            FROM agent_session\n            LEFT JOIN external_agent_session AS ext ON ext.agent_session_id = agent_session.id\n            WHERE thread_id = $1\n            ORDER BY agent_session.created_at DESC\n            ",
   "describe": {
     "columns": [
       {
@@ -87,6 +87,26 @@
         "ordinal": 16,
         "name": "thread_channel_id?",
         "type_info": "Uuid"
+      },
+      {
+        "ordinal": 17,
+        "name": "external_provider?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 18,
+        "name": "external_id?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 19,
+        "name": "external_name?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "external_url?",
+        "type_info": "Text"
       }
     ],
     "parameters": {
@@ -111,8 +131,12 @@
       true,
       false,
       false,
-      null
+      null,
+      false,
+      false,
+      true,
+      true
     ]
   },
-  "hash": "1b9d5291cf17cb33b9ba0843863f59ff3cf2e1473c89880a5a21d32f881ebc54"
+  "hash": "f99b8550fdb6c82da89f3b8a66142290daab84ae3b10f784825276a9f2ff6317"
 }

--- a/crates/agent_harness/src/inbound/kafka/test.rs
+++ b/crates/agent_harness/src/inbound/kafka/test.rs
@@ -197,6 +197,7 @@ fn channel_message_from(bot: BotId, sender: ChannelSender<'static>) -> AgentTrig
     AgentTriggerTopicEvent::Existing(ExistingAgentSessionEvent::Channel(ChannelEventMetadata {
         bot_id: bot,
         session_id: AgentSessionId::TEST_A,
+        kind: ChannelKind::MentionThread,
         message: message(sender),
     }))
 }

--- a/crates/agent_harness/src/outbound/cursor/manager/test.rs
+++ b/crates/agent_harness/src/outbound/cursor/manager/test.rs
@@ -88,6 +88,13 @@ impl AgentSessionRepo for StubSessions {
         unimplemented!("the manager never routes channel events")
     }
 
+    async fn find_all_for_thread(
+        &self,
+        _thread_id: macro_uuid::Uuid,
+    ) -> SessionResult<Vec<AgentSession>> {
+        unimplemented!("the manager never lists thread sessions")
+    }
+
     async fn session_bot(&self, _id: BotId) -> SessionResult<SessionBot> {
         unimplemented!("the manager never renders bots")
     }

--- a/crates/agent_harness/src/outbound/routing/test.rs
+++ b/crates/agent_harness/src/outbound/routing/test.rs
@@ -119,6 +119,13 @@ impl AgentSessionRepo for FixedBotSessions {
         unimplemented!("the router never routes channel events")
     }
 
+    async fn find_all_for_thread(
+        &self,
+        _thread_id: macro_uuid::Uuid,
+    ) -> SessionResult<Vec<AgentSession>> {
+        unimplemented!("the router never lists thread sessions")
+    }
+
     async fn session_bot(&self, _id: BotId) -> SessionResult<SessionBot> {
         unimplemented!("the router never renders bots")
     }

--- a/crates/agent_session/src/outbound/postgres.rs
+++ b/crates/agent_session/src/outbound/postgres.rs
@@ -345,12 +345,15 @@ impl AgentSessionRepo for PgAgentSessionRepo {
             SELECT
                 id, name, owner_id, thread_id, originating_message_id, bot_id,
                 model, harness, repo_url, workspace, sandbox_size, acp_session_id, status,
-                status_event_name, created_at, modified_at,
+                status_event_name, agent_session.created_at, modified_at,
                 (SELECT channel_id FROM comms_messages WHERE id = agent_session.thread_id)
-                    AS "thread_channel_id?"
+                    AS "thread_channel_id?",
+                ext.provider AS "external_provider?", ext.external_id AS "external_id?",
+                ext.external_name AS "external_name?", ext.external_url AS "external_url?"
             FROM agent_session
+            LEFT JOIN external_agent_session AS ext ON ext.agent_session_id = agent_session.id
             WHERE thread_id = $1
-            ORDER BY created_at DESC
+            ORDER BY agent_session.created_at DESC
             "#,
             thread_id,
         )

--- a/crates/agent_session/src/outbound/postgres/test.rs
+++ b/crates/agent_session/src/outbound/postgres/test.rs
@@ -506,6 +506,60 @@ async fn find_for_channel_matches_the_originating_thread_and_bot(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn find_all_for_thread_returns_every_session_on_the_thread(pool: PgPool) {
+    let repo = PgAgentSessionRepo::new(pool.clone());
+    let bot_a = create_test_bot(&pool).await;
+    let bot_b = create_test_bot(&pool).await;
+    let (_channel, thread, originating_message) = insert_originating_thread_fixture(&pool).await;
+    let older = create_session(
+        &repo,
+        new_session(bot_a, Some(thread), Some(originating_message)),
+    )
+    .await;
+    let newer = create_session(
+        &repo,
+        new_session(bot_b, Some(thread), Some(originating_message)),
+    )
+    .await;
+    create_session(&repo, new_session(bot_a, None, None)).await;
+    ExternalSessionRepo::upsert(&repo, newer.id, cursor_external("bc-thread"))
+        .await
+        .expect("attach an external identity");
+
+    let found = repo
+        .find_all_for_thread(thread)
+        .await
+        .expect("list sessions on the thread");
+    assert_eq!(found.len(), 2);
+    assert!(found.iter().any(|session| session.id == newer.id));
+    assert!(found.iter().any(|session| session.id == older.id));
+    assert!(
+        found
+            .windows(2)
+            .all(|pair| pair[0].created_at >= pair[1].created_at)
+    );
+    let with_external = found
+        .iter()
+        .find(|session| session.id == newer.id)
+        .expect("the newer session is on the thread");
+    assert_eq!(with_external.external, Some(cursor_external("bc-thread")));
+    assert!(
+        found
+            .iter()
+            .find(|session| session.id == older.id)
+            .expect("the older session is on the thread")
+            .external
+            .is_none()
+    );
+
+    let empty = repo
+        .find_all_for_thread(macro_uuid::generate_uuid_v7())
+        .await
+        .expect("list an unrelated thread");
+    assert!(empty.is_empty());
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
 async fn find_for_channel_requires_thread_and_bot_for_originating_match(pool: PgPool) {
     let repo = PgAgentSessionRepo::new(pool.clone());
     let bot = create_test_bot(&pool).await;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

#5699 added `find_all_for_thread` against the pre-#5849 `AgentSessionRow` shape. `sqlx::query_as!` then omitted `external_*` and `agent_session` failed to compile on main. That is what turns Typecheck, SDK generate, deploy binary builds, and Cloud Storage tests red on otherwise unrelated PRs.

## Scope

- `find_all_for_thread` uses the same `LEFT JOIN external_agent_session` and `external_*` aliases as `get` and `find_for_channel`.
- `created_at` is qualified as `agent_session.created_at`.
- `StubSessions` and `FixedBotSessions` implement `find_all_for_thread`.
- `channel_message_from` sets `ChannelEventMetadata.kind`.
- Postgres test `find_all_for_thread_returns_every_session_on_the_thread` covers listing plus external identity.

## Tradeoffs

None. The other `AgentSessionRow` queries already selected these columns.

## Blast Radius

- Channel thread session listing (`find_all_for_thread`).
- Any CI job that compiles `agent_session` or `agent_harness` tests.
- Main stays red for those jobs until this lands.

## Verification

- Reproduced `error[E0063]` at `postgres.rs:343` with `SQLX_OFFLINE=true cargo check -p agent_session --lib`.
- Same command is green after the fix.
- `cargo test -p agent_session --lib`: 109 passed, including the new listing test.
- `cargo test -p agent_harness --lib --tests`: 105 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51d186d8-7c5e-4198-8b88-b37c030a9ed9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51d186d8-7c5e-4198-8b88-b37c030a9ed9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

