### PR TITLE
fix(inbox): unread email filter surfaces all unread threads

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -67,6 +67,7 @@ import {
   isWithNotification,
   type Notification,
   toNotificationEntity,
+  unreadFilterFn,
 } from '@entity';
 import { useNotificationsForEntity } from '@notifications';
 import { SYSTEM_PROPERTY_IDS } from '@property/constants';
@@ -767,12 +768,19 @@ export const SoupViewContextProvider: FlowComponent<
         documentSeen: seen,
         emailSeen: seen,
         channelSeen: seen,
-        // channelThreadSeen: seen,
+        channelThreadSeen: seen,
         chatSeen: seen,
         folderSeen: seen,
         foreignEntitySeen: seen,
       },
     };
+  };
+
+  const entityMatchesInboxReadFilter = (entity: EntityData): boolean => {
+    const filter = readFilter();
+    if (filter === 'all' || !isInboxView()) return true;
+    const isUnread = unreadFilterFn(entity);
+    return filter === 'unread' ? isUnread : !isUnread;
   };
 
   const applyViewFilters = (state: QueryState): QueryState => {
@@ -947,9 +955,10 @@ export const SoupViewContextProvider: FlowComponent<
     const membershipFilter = config().itemMembershipFilter;
     if (membershipFilter && !membershipFilter(item)) return false;
 
-    return soup.predicates.test(
-      mapApiSoupItemToEntity(item) as SoupEntity,
-      getFilterContext()
+    const entity = mapApiSoupItemToEntity(item) as SoupEntity;
+    return (
+      soup.predicates.test(entity, getFilterContext()) &&
+      entityMatchesInboxReadFilter(entity)
     );
   };
 
@@ -1051,6 +1060,9 @@ export const SoupViewContextProvider: FlowComponent<
     const next = [];
     for (const entity of transformed) {
       if (!soup.predicates.test(entity, ctx)) {
+        continue;
+      }
+      if (!entityMatchesInboxReadFilter(entity)) {
         continue;
       }
       if (!entityMatchesTagFilter(entity, tagOptionIds, tagFilterMode)) {

--- a/crates/email/src/outbound/email_pg_repo/dynamic/filters.rs
+++ b/crates/email/src/outbound/email_pg_repo/dynamic/filters.rs
@@ -875,12 +875,12 @@ pub(super) fn build_thread_email_filter(
             build_thread_property_predicate(lit)
         }
 
-        filter_ast::ExprFrame::Literal(EmailLiteral::NotificationSeen(seen)) => {
-            SqlFragment::raw(if *seen {
-                "t.is_read = TRUE"
-            } else {
-                "t.is_read = FALSE"
-            })
+        filter_ast::ExprFrame::Literal(EmailLiteral::NotificationSeen(true)) => {
+            SqlFragment::raw("t.is_read = TRUE")
+        }
+
+        filter_ast::ExprFrame::Literal(EmailLiteral::NotificationSeen(false)) => {
+            SqlFragment::raw("t.is_read = FALSE")
         }
 
         filter_ast::ExprFrame::Literal(

--- a/crates/email/src/outbound/email_pg_repo/dynamic/filters.rs
+++ b/crates/email/src/outbound/email_pg_repo/dynamic/filters.rs
@@ -875,13 +875,20 @@ pub(super) fn build_thread_email_filter(
             build_thread_property_predicate(lit)
         }
 
+        filter_ast::ExprFrame::Literal(EmailLiteral::NotificationSeen(seen)) => {
+            SqlFragment::raw(if *seen {
+                "t.is_read = TRUE"
+            } else {
+                "t.is_read = FALSE"
+            })
+        }
+
         filter_ast::ExprFrame::Literal(
             EmailLiteral::Sender(_)
             | EmailLiteral::Cc(_)
             | EmailLiteral::Bcc(_)
             | EmailLiteral::Recipient(_)
             | EmailLiteral::NotificationDone(_)
-            | EmailLiteral::NotificationSeen(_)
             | EmailLiteral::Shared(_),
         ) => SqlFragment::raw("TRUE"),
     });

--- a/crates/email/src/outbound/email_pg_repo/dynamic/filters.rs
+++ b/crates/email/src/outbound/email_pg_repo/dynamic/filters.rs
@@ -36,6 +36,8 @@ pub(super) fn has_thread_literals(ast: &Expr<EmailLiteral>) -> bool {
             | EmailLiteral::ProjectId(_)
             | EmailLiteral::CalendarOnly(_)
             | EmailLiteral::Importance(_)
+            | EmailLiteral::NotificationSeen(_)
+            | EmailLiteral::NotificationDone(_)
             | EmailLiteral::CreatedAt(_)
             | EmailLiteral::UpdatedAt(_)
             | EmailLiteral::Property(_),
@@ -56,6 +58,8 @@ pub(super) fn has_message_literals(ast: &Expr<EmailLiteral>) -> bool {
             | EmailLiteral::Shared(_)
             | EmailLiteral::CalendarOnly(_)
             | EmailLiteral::Importance(_)
+            | EmailLiteral::NotificationSeen(_)
+            | EmailLiteral::NotificationDone(_)
             | EmailLiteral::CreatedAt(_)
             | EmailLiteral::UpdatedAt(_)
             | EmailLiteral::Property(_),

--- a/crates/email/src/outbound/email_pg_repo/dynamic/tests.rs
+++ b/crates/email/src/outbound/email_pg_repo/dynamic/tests.rs
@@ -254,6 +254,36 @@ fn test_partial_and_domain_emit_different_predicates_for_same_string() {
 }
 
 #[test]
+fn test_notification_seen_compiles_to_thread_is_read() {
+    let unread = build_thread_email_filter(
+        &Expr::Literal(EmailLiteral::NotificationSeen(false)),
+        DEFAULT_SORT_TS,
+    )
+    .to_debug_sql();
+    assert!(unread.contains("t.is_read = FALSE"));
+
+    let read = build_thread_email_filter(
+        &Expr::Literal(EmailLiteral::NotificationSeen(true)),
+        DEFAULT_SORT_TS,
+    )
+    .to_debug_sql();
+    assert!(read.contains("t.is_read = TRUE"));
+}
+
+#[test]
+fn test_notification_seen_is_noop_in_message_filter() {
+    for seen in [true, false] {
+        let result = build_message_email_filter(
+            &Expr::Literal(EmailLiteral::NotificationSeen(seen)),
+            &ResolvedFilters::empty(),
+        );
+        let debug = result.to_debug_sql();
+        assert!(debug.contains("TRUE"));
+        assert!(!debug.contains("is_read"));
+    }
+}
+
+#[test]
 fn test_importance_compiles_to_thread_signal_flag() {
     let thread = build_thread_email_filter(
         &Expr::Literal(EmailLiteral::Importance(true)),

--- a/crates/email/src/outbound/email_pg_repo/dynamic/tests.rs
+++ b/crates/email/src/outbound/email_pg_repo/dynamic/tests.rs
@@ -254,6 +254,13 @@ fn test_partial_and_domain_emit_different_predicates_for_same_string() {
 }
 
 #[test]
+fn test_has_thread_literals_true_when_notification_seen_present() {
+    let expr = Expr::Literal(EmailLiteral::NotificationSeen(false));
+    assert!(has_thread_literals(&expr));
+    assert!(!has_message_literals(&expr));
+}
+
+#[test]
 fn test_notification_seen_compiles_to_thread_is_read() {
     let unread = build_thread_email_filter(
         &Expr::Literal(EmailLiteral::NotificationSeen(false)),
@@ -281,6 +288,28 @@ fn test_notification_seen_is_noop_in_message_filter() {
         assert!(debug.contains("TRUE"));
         assert!(!debug.contains("is_read"));
     }
+}
+
+#[test]
+fn test_full_query_notification_seen_filters_candidate_by_is_read() {
+    let view = PreviewView::StandardLabel(PreviewViewStandardLabel::Inbox);
+    let unread = super::query::debug_build_query_sql(
+        &view,
+        &Expr::Literal(EmailLiteral::NotificationSeen(false)),
+    );
+    assert!(
+        unread.contains("t.is_read = FALSE"),
+        "unread NotificationSeen must land in the candidate WHERE: {unread}"
+    );
+
+    let read = super::query::debug_build_query_sql(
+        &view,
+        &Expr::Literal(EmailLiteral::NotificationSeen(true)),
+    );
+    assert!(
+        read.contains("t.is_read = TRUE"),
+        "read NotificationSeen must land in the candidate WHERE: {read}"
+    );
 }
 
 #[test]

--- a/crates/email/src/outbound/email_pg_repo/test/dynamic_query.rs
+++ b/crates/email/src/outbound/email_pg_repo/test/dynamic_query.rs
@@ -58,16 +58,9 @@ async fn test_dynamic_query_notification_seen_filters_by_is_read(
     let view = PreviewView::StandardLabel(PreviewViewStandardLabel::Inbox);
     let unread_filter = Arc::new(Expr::Literal(EmailLiteral::NotificationSeen(false)));
     let unread_query = Query::new(None, SimpleSortMethod::UpdatedAt, unread_filter);
-    let unread_results = dynamic::dynamic_email_thread_cursor(
-        &pool,
-        &[link_id],
-        50,
-        &view,
-        unread_query,
-        "",
-        None,
-    )
-    .await?;
+    let unread_results =
+        dynamic::dynamic_email_thread_cursor(&pool, &[link_id], 50, &view, unread_query, "", None)
+            .await?;
 
     assert!(
         unread_results.iter().all(|r| !r.is_read),

--- a/crates/email/src/outbound/email_pg_repo/test/dynamic_query.rs
+++ b/crates/email/src/outbound/email_pg_repo/test/dynamic_query.rs
@@ -41,6 +41,72 @@ async fn test_dynamic_query_inbox_view(pool: Pool<Postgres>) -> anyhow::Result<(
     migrator = "MACRO_DB_MIGRATIONS",
     fixtures(path = "../../../../fixtures", scripts("email_dynamic_query"))
 )]
+async fn test_dynamic_query_notification_seen_filters_by_is_read(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    let link_id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")?;
+    let read_thread = Uuid::parse_str("20000001-0000-0000-0000-000000000001")?;
+    let unread_thread = Uuid::parse_str("20000004-0000-0000-0000-000000000004")?;
+
+    // Fixture inbox threads all start unread; mark one read so the filter
+    // has both sides of the partition to distinguish.
+    sqlx::query("UPDATE email_threads SET is_read = TRUE WHERE id = $1")
+        .bind(read_thread)
+        .execute(&pool)
+        .await?;
+
+    let view = PreviewView::StandardLabel(PreviewViewStandardLabel::Inbox);
+    let unread_filter = Arc::new(Expr::Literal(EmailLiteral::NotificationSeen(false)));
+    let unread_query = Query::new(None, SimpleSortMethod::UpdatedAt, unread_filter);
+    let unread_results = dynamic::dynamic_email_thread_cursor(
+        &pool,
+        &[link_id],
+        50,
+        &view,
+        unread_query,
+        "",
+        None,
+    )
+    .await?;
+
+    assert!(
+        unread_results.iter().all(|r| !r.is_read),
+        "unread filter must not return read threads: {:?}",
+        unread_results
+            .iter()
+            .map(|r| (r.id, r.is_read))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        unread_results.iter().any(|r| r.id == unread_thread),
+        "unread filter should still return unread inbox threads"
+    );
+    assert!(
+        !unread_results.iter().any(|r| r.id == read_thread),
+        "unread filter must exclude the thread marked read"
+    );
+
+    let read_filter = Arc::new(Expr::Literal(EmailLiteral::NotificationSeen(true)));
+    let read_query = Query::new(None, SimpleSortMethod::UpdatedAt, read_filter);
+    let read_results =
+        dynamic::dynamic_email_thread_cursor(&pool, &[link_id], 50, &view, read_query, "", None)
+            .await?;
+
+    assert_eq!(
+        read_results.len(),
+        1,
+        "read filter should return only the marked-read inbox thread"
+    );
+    assert_eq!(read_results[0].id, read_thread);
+    assert!(read_results[0].is_read);
+
+    Ok(())
+}
+
+#[sqlx::test(
+    migrator = "MACRO_DB_MIGRATIONS",
+    fixtures(path = "../../../../fixtures", scripts("email_dynamic_query"))
+)]
 async fn test_dynamic_query_sent_view(pool: Pool<Postgres>) -> anyhow::Result<()> {
     let link_id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")?;
     let view = PreviewView::StandardLabel(PreviewViewStandardLabel::Sent);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the unread email filter bug reported by sp6370 in [Macro Support x sp6370](https://macro.com/app/channel/01a00c06-f377-7b39-800f-9da80d232968).

## Problem

The inbox unread/read filter injected `emailSeen` → `EmailLiteral::NotificationSeen`, but emails were never filtered by read state. Two bugs compounded:

1. `build_thread_email_filter` treated `NotificationSeen` as SQL `TRUE` (noop)
2. Even after wiring it to `t.is_read`, `has_thread_literals` omitted `NotificationSeen`, so the candidate WHERE never received the clause

Symptoms matched the report: unread pages mixed in read emails, and scrolling revealed more unread threads only because pagination walked an unfiltered email set.

## Fix

- Compile `NotificationSeen` to `t.is_read = TRUE/FALSE`
- Classify `NotificationSeen` / `NotificationDone` as thread literals (not message literals) so the candidate query applies them
- Client-side inbox read/unread enforcement via `unreadFilterFn` as defense in depth
- Enable `channelThreadSeen` in the inbox read filter query

## Testing

- `cargo test -p email --features outbound notification_seen` — 5 passed (SQL compile + full-query + sqlx integration against mixed read/unread inbox threads)
- Manual inbox Status Unread/Read filter exercised in local stack (no Gmail connected locally; channel notification read/unread path verified in UI)

[Unread filter active empty inbox](https://cursor.com/agents/bc-01a03b53-ee24-7cdc-959c-1cb04e5abf1e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finbox-unread-filter-empty.webp)
[Unread filter selected in status menu](https://cursor.com/agents/bc-01a03b53-ee24-7cdc-959c-1cb04e5abf1e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finbox-unread-filter-selected.webp)
[Read filter shows read item](https://cursor.com/agents/bc-01a03b53-ee24-7cdc-959c-1cb04e5abf1e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finbox-read-filter-shows-read-email.webp)
[inbox-unread-email-filter-fix-demo.mp4](https://cursor.com/agents/bc-01a03b53-ee24-7cdc-959c-1cb04e5abf1e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finbox-unread-email-filter-fix-demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03b53-ee24-7cdc-959c-1cb04e5abf1e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03b53-ee24-7cdc-959c-1cb04e5abf1e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

