### PR TITLE
fix(web): keep vitest tsconfig discovery inside the repository

### DIFF
--- a/apps/web/src/features/notifications/vitest.config.ts
+++ b/apps/web/src/features/notifications/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import solidPlugin from 'vite-plugin-solid';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
@@ -5,7 +6,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   plugins: [
     tsconfigPaths({
-      root: '../../../',
+      // Relative to the working directory, not to this file: from apps/web
+      // '../../../' escapes the repository and makes the plugin crawl the
+      // whole filesystem for tsconfigs, which fails outright where / holds
+      // unreadable directories such as Linux /proc.
+      root: fileURLToPath(new URL('../../../', import.meta.url)),
     }),
     solidPlugin(),
   ],

--- a/apps/web/src/lib/core/vitest.config.ts
+++ b/apps/web/src/lib/core/vitest.config.ts
@@ -8,7 +8,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   plugins: [
     tsconfigPaths({
-      root: '../../../',
+      // Relative to the working directory, not to this file: from apps/web
+      // '../../../' escapes the repository and makes the plugin crawl the
+      // whole filesystem for tsconfigs, which fails outright where / holds
+      // unreadable directories such as Linux /proc.
+      root: fileURLToPath(new URL('../../../', import.meta.url)),
     }),
     solidPlugin(),
     solidSvg({ defaultAsComponent: true }),

--- a/apps/web/src/lib/queries/vitest.config.ts
+++ b/apps/web/src/lib/queries/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import solidPlugin from 'vite-plugin-solid';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
@@ -5,7 +6,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   plugins: [
     tsconfigPaths({
-      root: '../../../',
+      // Relative to the working directory, not to this file: from apps/web
+      // '../../../' escapes the repository and makes the plugin crawl the
+      // whole filesystem for tsconfigs, which fails outright where / holds
+      // unreadable directories such as Linux /proc.
+      root: fileURLToPath(new URL('../../../', import.meta.url)),
     }),
     solidPlugin(),
   ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`bun run test` cannot start on Linux:

```
⎯⎯⎯⎯⎯⎯⎯ Startup Error ⎯⎯⎯⎯⎯⎯⎯⎯
AggregateError: Failed to initialize projects.
  [Error: EINVAL: invalid argument, scandir '//proc/2379/net']
```

Three per-area vitest configs pass `tsconfigPaths({ root: '../../../' })`. `vite-tsconfig-paths` resolves `root` against the working directory, not against the config file. Tests run from `apps/web`, so `'../../../'` resolves to `/` — the plugin then crawls the entire filesystem looking for tsconfigs. On Linux that crawl reaches `/proc/<pid>/net` and fails with `EINVAL`, taking every project that extends one of these configs down with it. On macOS there is no `/proc`, so the walk merely wastes time and the breakage goes unnoticed.

The intended root is `apps/web` (where `tsconfig.json` lives), which is also what the top-level `apps/web/vitest.config.ts` gets by passing no `root` at all.

## Fix

Resolve that root from each config's own URL, so it no longer depends on the working directory:

```ts
root: fileURLToPath(new URL('../../../', import.meta.url)),
```

All three files sit three levels below `apps/web`, so the resolved path is unchanged in intent and now correct in fact.

## Verification

Before, on Linux, the run aborts during project setup. After:

```
 Test Files  360 passed (360)
      Tests  3428 passed | 1 todo (3429)
   Duration  139.00s
```

[vitest_suite_runs_after_config_fix.log](https://cursor.com/agents/bc-d187338a-4e39-4a29-92f8-914a617507f4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvitest_suite_runs_after_config_fix.log)

Split out of [#5930](https://github.com/macro-inc/macro/pull/5930), where it was needed to run the suite at all. That PR keeps only the table change.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d187338a-4e39-4a29-92f8-914a617507f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d187338a-4e39-4a29-92f8-914a617507f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

