### PR TITLE
Allow videos inside table cells

### DIFF
--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/tables/tableCellContent.test.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/tables/tableCellContent.test.ts
@@ -7,6 +7,10 @@ import {
   $createImageNode,
   $isImageNode,
 } from '@macro-inc/lexical-core/nodes/ImageNode';
+import {
+  $createVideoNode,
+  $isVideoNode,
+} from '@macro-inc/lexical-core/nodes/VideoNode';
 import type { LexicalEditor } from 'lexical';
 import { describe, expect, it } from 'vitest';
 import {
@@ -46,6 +50,31 @@ describe('table cell allowed content', () => {
       expect(image).toBeDefined();
       expect(image?.getUrl()).toBe('https://example.com/cat.png');
       expect(image?.getAlt()).toBe('cat');
+    });
+  });
+
+  it('keeps a video appended to a table cell', async () => {
+    const editor = createTableEditor();
+    await buildTable(editor, textGrid([['hello']]));
+
+    await new Promise<void>((resolve) => {
+      editor.update(
+        () => {
+          $getCell(0, 0).append(
+            $createVideoNode({
+              srcType: 'url',
+              url: 'https://example.com/clip.mp4',
+            })
+          );
+        },
+        { onUpdate: () => resolve() }
+      );
+    });
+
+    editor.read(() => {
+      const video = $getCell(0, 0).getChildren().find($isVideoNode);
+      expect(video).toBeDefined();
+      expect(video?.getUrl()).toBe('https://example.com/clip.mp4');
     });
   });
 

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/tables/tablePlugin.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/tables/tablePlugin.ts
@@ -73,6 +73,7 @@ function _registerTablePlugin(editor: LexicalEditor, props: TablePluginProps) {
         'code',
         'custom-code',
         'image',
+        'video',
       ];
       return editor.registerNodeTransform(TableCellNode, (node) => {
         const children = node.getChildren();

--- a/apps/web/src/lib/core/component/LexicalMarkdown/styles.css
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/styles.css
@@ -386,8 +386,9 @@ in a cell — move the indent inside the box so markers stay visible.
   padding-left: 1.5em;
 }
 
-/* Keep images from stretching the cell wider than the column. */
-.md-table-cell img {
+/* Keep images and videos from stretching the cell wider than the column. */
+.md-table-cell img,
+.md-table-cell video {
   max-width: 100%;
 }
 

--- a/packages/lexical-core/tests/tables.test.ts
+++ b/packages/lexical-core/tests/tables.test.ts
@@ -25,6 +25,7 @@ import {
 import { describe, expect, it } from 'vitest';
 import { SupportedNodeTypes } from '../node-list';
 import { $createImageNode, $isImageNode } from '../nodes/ImageNode';
+import { $createVideoNode, $isVideoNode } from '../nodes/VideoNode';
 import { EXTERNAL_TRANSFORMERS, INTERNAL_TRANSFORMERS } from '../transformers';
 
 function createTestEditor() {
@@ -415,6 +416,94 @@ describe('images inside table cells', () => {
       const image = $getFirstCellImage();
       expect(image.getUrl()).toBe('https://example.com/cat.png');
       expect(image.getAlt()).toBe('cat');
+    });
+  });
+});
+
+describe('videos inside table cells', () => {
+  function $getFirstCellVideo() {
+    const table = $getFirstTable();
+    const [row] = table.getChildren().filter($isTableRowNode);
+    const [cell] = (row as TableRowNode).getChildren().filter($isTableCellNode);
+    const video = cell
+      .getChildren()
+      .flatMap((child) =>
+        $isVideoNode(child)
+          ? [child]
+          : $isElementNode(child)
+            ? child.getChildren().filter($isVideoNode)
+            : []
+      )[0];
+    expect(video).toBeDefined();
+    return video!;
+  }
+
+  it('round-trips a video in a cell through internal markdown', async () => {
+    const editor = createTestEditor();
+
+    await buildEditorState(editor, () => {
+      const table = $createTableNode();
+      const row = $createTableRowNode();
+      const cell = $createTableCellNode(TableCellHeaderStates.NO_STATUS);
+      cell.append(
+        $createVideoNode({
+          srcType: 'url',
+          url: 'https://example.com/clip.mp4',
+          width: 400,
+          height: 300,
+          constrainedWidth: 200,
+          constrainedHeight: 150,
+        })
+      );
+      row.append(cell);
+      table.append(row);
+      $getRoot().append(table);
+    });
+
+    const markdown = exportMarkdown(editor);
+    expect(markdown).toContain('<m-video>');
+    expect(markdown).toContain('https://example.com/clip.mp4');
+    expect(markdown).toContain('"constrainedWidth":200');
+
+    await importMarkdown(editor, markdown);
+    editor.getEditorState().read(() => {
+      const video = $getFirstCellVideo();
+      expect(video.getUrl()).toBe('https://example.com/clip.mp4');
+      expect(video.getConstrainedWidth()).toBe(200);
+      expect(video.getConstrainedHeight()).toBe(150);
+    });
+  });
+
+  it('round-trips a video in a cell through external pipe-table markdown', async () => {
+    const editor = createTestEditor();
+
+    await buildEditorState(editor, () => {
+      const table = $createTableNode();
+      const row = $createTableRowNode();
+      const videoCell = $createTableCellNode(TableCellHeaderStates.NO_STATUS);
+      videoCell.append(
+        $createVideoNode({
+          srcType: 'url',
+          url: 'https://example.com/clip.mp4',
+        })
+      );
+      row.append(videoCell, $createCell('plain'));
+      table.append(row);
+      $getRoot().append(table);
+    });
+
+    const markdown = exportMarkdown(editor, EXTERNAL_TRANSFORMERS);
+    expect(markdown).toContain('<m-video>');
+    expect(markdown).toContain('|');
+    expect(markdown).toContain('plain');
+
+    await buildEditorState(editor, () => {
+      $getRoot().clear();
+      $convertFromMarkdownString(markdown, EXTERNAL_TRANSFORMERS);
+    });
+    editor.getEditorState().read(() => {
+      const video = $getFirstCellVideo();
+      expect(video.getUrl()).toBe('https://example.com/clip.mp4');
     });
   });
 });

--- a/packages/lexical-core/transformers/tables.ts
+++ b/packages/lexical-core/transformers/tables.ts
@@ -32,6 +32,7 @@ import {
 	I_USER_MENTION,
 } from "./mentions";
 import { BR_TAG_TO_LINE_BREAK, HTML_ENTITY_TRANSFORMERS } from "./transformers";
+import { I_VIDEO } from "./video";
 
 // Internal Table Node
 
@@ -100,6 +101,7 @@ const internalTransformersWithinTables: Transformer[] = [
 	I_EQUATION_NODE,
 	I_IMAGE_CONSTRAINED,
 	IMAGE,
+	I_VIDEO,
 	...TRANSFORMERS,
 ];
 
@@ -247,6 +249,7 @@ const externalTransformersWithinTables: Transformer[] = [
 	E_CONTACT_MENTION,
 	E_BLOCK_EQUATION_NODE,
 	IMAGE,
+	I_VIDEO,
 	...HTML_ENTITY_TRANSFORMERS,
 	...TRANSFORMERS,
 ];

--- a/packages/lexical-core/transformers/video.ts
+++ b/packages/lexical-core/transformers/video.ts
@@ -10,7 +10,7 @@ import {
 export const I_VIDEO: ElementTransformer = {
   dependencies: [VideoNode, UnknownMentionNode],
   type: 'element',
-  regExp: /<m-video>(.*?)<\/m-video>/,
+  regExp: /^<m-video>(.*?)<\/m-video>\s*$/,
   export: (node: LexicalNode) => {
     if (!$isVideoNode(node)) return null;
     if (node.getSrcType() === 'local') return null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #5928. Table cells already keep images; this does the same for videos.

- Allow `video` in the table-cell node allowlist
- Include the video transformer when converting table cell markdown
- Anchor `<m-video>` so it cannot steal a nested tag from an `m-table` line
- CSS: `max-width: 100%` on videos inside cells

## Testing
- lexical-core: 33 passed (including new video-in-cell round-trips)
- table plugin: 48 passed (video kept; nested tables still stripped)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab71e08f-4181-4577-a17d-6bb9222750a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab71e08f-4181-4577-a17d-6bb9222750a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

