### PR TITLE
Use ACP SessionId instead of a parallel AcpSessionId newtype

### DIFF
--- a/crates/agent_harness/src/outbound/cursor/manager.rs
+++ b/crates/agent_harness/src/outbound/cursor/manager.rs
@@ -22,12 +22,13 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use agent_client_protocol::schema::v1::SessionId;
 use agent_session::domain::model::{AgentSession, AgentSessionId, ExternalSession};
 use agent_session::domain::ports::{AgentSessionRepo, ExternalSessionRepo};
 use cursor_cloud_agents::api::{ApiKey, CursorClient, CursorConfig};
 use cursor_cloud_agents::domain::model::RepoUrl as CursorRepoUrl;
 use cursor_cloud_agents::domain::model::{
-    AcpSessionId, CursorAgentId, CursorModel, CursorRunId, McpServer, ModelChoice,
+    CursorAgentId, CursorModel, CursorRunId, McpServer, ModelChoice,
 };
 use cursor_cloud_agents::domain::ports::{CursorAgents, RepoResolver, RunStream};
 use cursor_cloud_agents::domain::service::CursorSessionService;
@@ -130,7 +131,7 @@ pub struct CursorContainerManager<Sessions, Keys> {
 /// it — so each is optional on its own; see [`CursorContainerManager::resume`].
 struct RestoredCursorSession {
     /// The ACP session id the harness will name in `session/load`.
-    acp_session: AcpSessionId,
+    acp_session: SessionId,
     /// The Cursor agent, when one was ever minted.
     agent: Option<CursorAgentId>,
     /// The model id the session last reported, from the projected column.

--- a/crates/agent_harness/src/outbound/cursor/manager.rs
+++ b/crates/agent_harness/src/outbound/cursor/manager.rs
@@ -294,7 +294,7 @@ where
                     .await?
                     .map(|external| CursorAgentId::new(external.external_id));
                 Some(RestoredCursorSession {
-                    acp_session: AcpSessionId::new(acp.0.as_ref()),
+                    acp_session: acp.clone(),
                     agent,
                     // The projected model column. It round-trips a picked
                     // model back into the wrapper — and for a session that

--- a/crates/cursor_cloud_agents/src/domain/error.rs
+++ b/crates/cursor_cloud_agents/src/domain/error.rs
@@ -1,6 +1,6 @@
 //! Errors the session service can produce.
 
-use crate::domain::model::AcpSessionId;
+use agent_client_protocol::schema::v1::SessionId;
 use thiserror::Error;
 
 /// Why a session operation failed.
@@ -8,12 +8,12 @@ use thiserror::Error;
 pub enum SessionError {
     /// The client referenced a session this agent never created.
     #[error("unknown session {0}")]
-    UnknownSession(AcpSessionId),
+    UnknownSession(SessionId),
     /// A prompt arrived while the session's previous turn was still running.
     /// ACP turns are strictly sequential; the client must wait for the
     /// previous `session/prompt` to respond.
     #[error("session {0} already has an active turn")]
-    TurnAlreadyActive(AcpSessionId),
+    TurnAlreadyActive(SessionId),
     /// The Cursor API or its stream failed.
     #[error("{0}")]
     Cursor(rootcause::Report),

--- a/crates/cursor_cloud_agents/src/domain/model.rs
+++ b/crates/cursor_cloud_agents/src/domain/model.rs
@@ -5,18 +5,6 @@ mod test;
 
 use serde::{Deserialize, Serialize};
 
-/// The identity of one ACP session as this agent knows it.
-///
-/// Minted by the agent on `session/new` and echoed by the client on every
-/// prompt. It is deliberately not the Cursor agent id: the ACP session exists
-/// before the first prompt, while Cursor only mints an agent once there is a
-/// prompt to run.
-///
-/// This is [`agent_client_protocol::schema::v1::SessionId`], not a parallel
-/// wrapper: the inbound adapter and the domain speak the same id, so there is
-/// nothing to convert.
-pub use agent_client_protocol::schema::v1::SessionId as AcpSessionId;
-
 /// The identity of a Cursor cloud agent (`bc-…`), which holds the
 /// conversation across runs.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/cursor_cloud_agents/src/domain/model.rs
+++ b/crates/cursor_cloud_agents/src/domain/model.rs
@@ -11,29 +11,11 @@ use serde::{Deserialize, Serialize};
 /// prompt. It is deliberately not the Cursor agent id: the ACP session exists
 /// before the first prompt, while Cursor only mints an agent once there is a
 /// prompt to run.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct AcpSessionId(String);
-
-impl AcpSessionId {
-    /// Wrap an existing session id string.
-    #[must_use]
-    pub fn new(id: impl Into<String>) -> Self {
-        Self(id.into())
-    }
-
-    /// The id as the string the wire uses.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::fmt::Display for AcpSessionId {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(formatter)
-    }
-}
+///
+/// This is [`agent_client_protocol::schema::v1::SessionId`], not a parallel
+/// wrapper: the inbound adapter and the domain speak the same id, so there is
+/// nothing to convert.
+pub use agent_client_protocol::schema::v1::SessionId as AcpSessionId;
 
 /// The identity of a Cursor cloud agent (`bc-…`), which holds the
 /// conversation across runs.

--- a/crates/cursor_cloud_agents/src/domain/ports.rs
+++ b/crates/cursor_cloud_agents/src/domain/ports.rs
@@ -9,10 +9,10 @@
 
 use crate::domain::event::CursorEvent;
 use crate::domain::model::{
-    AcpSessionId, CursorAgentId, CursorModel, CursorRunId, McpServer, ModelChoice, RepoUrl,
-    RunListing, RunOutcome,
+    CursorAgentId, CursorModel, CursorRunId, McpServer, ModelChoice, RepoUrl, RunListing,
+    RunOutcome,
 };
-use agent_client_protocol::schema::v1::SessionUpdate;
+use agent_client_protocol::schema::v1::{SessionId, SessionUpdate};
 use futures::Stream;
 use std::path::Path;
 
@@ -118,7 +118,7 @@ pub trait SessionNotifier {
     /// Send a `session/update` for the given session.
     fn notify(
         &self,
-        session: &AcpSessionId,
+        session: &SessionId,
         update: SessionUpdate,
     ) -> impl Future<Output = Result<(), rootcause::Report>> + Send;
 }

--- a/crates/cursor_cloud_agents/src/domain/service.rs
+++ b/crates/cursor_cloud_agents/src/domain/service.rs
@@ -26,13 +26,12 @@ mod test;
 use crate::domain::error::SessionError;
 use crate::domain::event::{CursorEvent, InteractionUpdate};
 use crate::domain::model::{
-    AcpSessionId, CursorAgentId, CursorModel, CursorRunId, McpServer, ModelChoice, RepoUrl,
-    RunStatus,
+    CursorAgentId, CursorModel, CursorRunId, McpServer, ModelChoice, RepoUrl, RunStatus,
 };
 use crate::domain::ports::{CursorAgents, RepoResolver, RunStream, SessionNotifier};
 use crate::domain::translate::TranslateMachine;
 use agent_client_protocol::schema::v1::{
-    ContentBlock, ContentChunk, SessionUpdate, StopReason, TextContent,
+    ContentBlock, ContentChunk, SessionId, SessionUpdate, StopReason, TextContent,
 };
 use futures::StreamExt as _;
 use futures::pin_mut;
@@ -150,7 +149,7 @@ pub struct CursorSessionService<Cursor, Notifier, Repos> {
     cursor: Cursor,
     notifier: Notifier,
     repos: Repos,
-    sessions: Mutex<HashMap<AcpSessionId, Arc<Session>>>,
+    sessions: Mutex<HashMap<SessionId, Arc<Session>>>,
     /// Monotonic counter for minting session ids without a clock or RNG.
     next_session: Mutex<u64>,
     /// A model id this deployment pins, applied to every new session. `None`
@@ -197,7 +196,7 @@ where
     /// The repository is resolved now rather than at first prompt so the
     /// warning about an unlisted (repo-less) session surfaces at `session/new`
     /// time, when the user can still do something about it.
-    pub fn new_session(&self, cwd: &Path, mcp_servers: Vec<McpServer>) -> AcpSessionId {
+    pub fn new_session(&self, cwd: &Path, mcp_servers: Vec<McpServer>) -> SessionId {
         let repo = self.repos.resolve(cwd);
         if repo.is_none() {
             tracing::warn!(
@@ -222,7 +221,7 @@ where
             let candidate = {
                 let mut next = self.next_session.lock().expect("session counter poisoned");
                 *next += 1;
-                AcpSessionId::new(format!("cursor-acp-{next}"))
+                SessionId::new(format!("cursor-acp-{next}"))
             };
             if !sessions.contains_key(&candidate) {
                 break candidate;
@@ -254,7 +253,7 @@ where
     /// the stream — so our own record is the only answer available.
     pub async fn session_model_id(
         &self,
-        session_id: &AcpSessionId,
+        session_id: &SessionId,
     ) -> Result<Option<String>, SessionError> {
         Ok(self
             .effective_model(session_id)
@@ -270,7 +269,7 @@ where
     /// at the next prompt.
     pub async fn set_model(
         &self,
-        session_id: &AcpSessionId,
+        session_id: &SessionId,
         model_id: &str,
     ) -> Result<(), SessionError> {
         let session = self.session(session_id)?;
@@ -300,7 +299,7 @@ where
     /// happens once per session.
     async fn effective_model(
         &self,
-        session_id: &AcpSessionId,
+        session_id: &SessionId,
     ) -> Result<Option<ModelChoice>, SessionError> {
         let session = self.session(session_id)?;
         if let Some(model) = session
@@ -371,7 +370,7 @@ where
     /// Driven by `session/load`: the list belongs to the client and the
     /// protocol restates it there, which is how a restored process — whose
     /// host never persisted it — learns it again.
-    pub fn set_mcp_servers(&self, session_id: &AcpSessionId, mcp_servers: Vec<McpServer>) {
+    pub fn set_mcp_servers(&self, session_id: &SessionId, mcp_servers: Vec<McpServer>) {
         if let Ok(session) = self.session(session_id) {
             session
                 .state
@@ -387,7 +386,7 @@ where
     #[tracing::instrument(skip(self, prompt), err)]
     pub async fn prompt(
         &self,
-        session_id: &AcpSessionId,
+        session_id: &SessionId,
         prompt: &str,
     ) -> Result<StopReason, SessionError> {
         let session = self.session(session_id)?;
@@ -495,7 +494,7 @@ where
     /// no active turn is a no-op rather than an error, because the turn may
     /// have ended while the cancel was in flight.
     #[tracing::instrument(skip(self), err)]
-    pub async fn cancel(&self, session_id: &AcpSessionId) -> Result<(), SessionError> {
+    pub async fn cancel(&self, session_id: &SessionId) -> Result<(), SessionError> {
         let session = self.session(session_id)?;
         let target = {
             let mut state = session.state.lock().expect("session state poisoned");
@@ -520,7 +519,7 @@ where
     ///
     /// The bool is what lets `session/close` answer a client that named a
     /// session this agent never had, rather than acknowledging a no-op.
-    pub fn close(&self, session_id: &AcpSessionId) -> bool {
+    pub fn close(&self, session_id: &SessionId) -> bool {
         self.sessions
             .lock()
             .expect("session map poisoned")
@@ -542,7 +541,7 @@ where
     /// with fresh ids because [`Self::new_session`] skips occupied ids.
     pub fn restore_session(
         &self,
-        id: AcpSessionId,
+        id: SessionId,
         agent: Option<CursorAgentId>,
         repo: Option<RepoUrl>,
         model_id: Option<String>,
@@ -569,7 +568,7 @@ where
     /// loading is a lookup, not a fetch, because restoring state into the
     /// process is [`Self::restore_session`]'s job and happens before serving.
     #[must_use]
-    pub fn has_session(&self, session_id: &AcpSessionId) -> bool {
+    pub fn has_session(&self, session_id: &SessionId) -> bool {
         self.sessions
             .lock()
             .expect("session map poisoned")
@@ -586,7 +585,7 @@ where
     /// answer.
     async fn stream_turn(
         &self,
-        session_id: &AcpSessionId,
+        session_id: &SessionId,
         session: &Session,
         agent: &CursorAgentId,
         run: &CursorRunId,
@@ -784,7 +783,7 @@ where
     /// Callers hold the session's turn gate.
     async fn backfill_foreign_runs(
         &self,
-        session_id: &AcpSessionId,
+        session_id: &SessionId,
         session: &Session,
         agent: &CursorAgentId,
         current_run: Option<&CursorRunId>,
@@ -834,7 +833,7 @@ where
     /// recorded final text when the stream cannot be had.
     async fn mirror_foreign_run(
         &self,
-        session_id: &AcpSessionId,
+        session_id: &SessionId,
         session: &Session,
         agent: &CursorAgentId,
         run: &CursorRunId,
@@ -946,7 +945,7 @@ where
     /// outcome, which is the part that must not be lost.
     async fn poll_turn(
         &self,
-        session_id: &AcpSessionId,
+        session_id: &SessionId,
         session: &Session,
         agent: &CursorAgentId,
         run: &CursorRunId,
@@ -1028,7 +1027,7 @@ where
     /// drove a run (no watermark to mirror from). Failures are logged per
     /// session and never stop the sweep.
     pub async fn sync_foreign_runs(&self) {
-        let sessions: Vec<(AcpSessionId, Arc<Session>)> = self
+        let sessions: Vec<(SessionId, Arc<Session>)> = self
             .sessions
             .lock()
             .expect("session map poisoned")
@@ -1057,7 +1056,7 @@ where
         }
     }
 
-    fn session(&self, id: &AcpSessionId) -> Result<Arc<Session>, SessionError> {
+    fn session(&self, id: &SessionId) -> Result<Arc<Session>, SessionError> {
         self.sessions
             .lock()
             .expect("session map poisoned")

--- a/crates/cursor_cloud_agents/src/domain/service/test.rs
+++ b/crates/cursor_cloud_agents/src/domain/service/test.rs
@@ -226,7 +226,7 @@ async fn concurrent_prompt_on_an_active_turn_is_rejected() {
 #[tokio::test]
 async fn unknown_session_is_an_error() {
     let (service, _cursor, _notifier) = service(None);
-    let missing = AcpSessionId::new("nope");
+    let missing = SessionId::new("nope");
     assert!(matches!(
         service.prompt(&missing, "hi").await,
         Err(SessionError::UnknownSession(_))
@@ -522,19 +522,19 @@ async fn a_session_without_mcp_servers_forwards_none() {
 async fn a_restored_session_prompts_its_existing_agent() {
     let (service, cursor, _notifier) = service(None);
     service.restore_session(
-        AcpSessionId::new("cursor-acp-7"),
+        SessionId::new("cursor-acp-7"),
         Some(CursorAgentId::new("bc-restored")),
         None,
         None,
     );
-    assert!(service.has_session(&AcpSessionId::new("cursor-acp-7")));
+    assert!(service.has_session(&SessionId::new("cursor-acp-7")));
 
     let events = cursor.script_stream();
     events.send(finished("run-fake-1")).expect("stream open");
     events.send(CursorEvent::Done).expect("stream open");
 
     service
-        .prompt(&AcpSessionId::new("cursor-acp-7"), "continue")
+        .prompt(&SessionId::new("cursor-acp-7"), "continue")
         .await
         .expect("prompt runs");
     assert_eq!(
@@ -552,15 +552,15 @@ async fn a_restored_session_prompts_its_existing_agent() {
 async fn new_sessions_never_collide_with_restored_ids() {
     let (service, _cursor, _notifier) = service(None);
     service.restore_session(
-        AcpSessionId::new("cursor-acp-1"),
+        SessionId::new("cursor-acp-1"),
         Some(CursorAgentId::new("bc-restored")),
         None,
         None,
     );
 
     let fresh = service.new_session(Path::new("/workspace"), Vec::new());
-    assert_ne!(fresh, AcpSessionId::new("cursor-acp-1"));
-    assert!(service.has_session(&AcpSessionId::new("cursor-acp-1")));
+    assert_ne!(fresh, SessionId::new("cursor-acp-1"));
+    assert!(service.has_session(&SessionId::new("cursor-acp-1")));
     assert!(service.has_session(&fresh));
 }
 
@@ -571,15 +571,15 @@ async fn new_sessions_never_collide_with_restored_ids() {
 #[tokio::test]
 async fn a_session_restored_without_an_agent_mints_one_on_the_next_prompt() {
     let (service, cursor, _notifier) = service(None);
-    service.restore_session(AcpSessionId::new("cursor-acp-9"), None, None, None);
-    assert!(service.has_session(&AcpSessionId::new("cursor-acp-9")));
+    service.restore_session(SessionId::new("cursor-acp-9"), None, None, None);
+    assert!(service.has_session(&SessionId::new("cursor-acp-9")));
 
     let events = cursor.script_stream();
     events.send(finished("run-fake-1")).expect("stream open");
     events.send(CursorEvent::Done).expect("stream open");
 
     service
-        .prompt(&AcpSessionId::new("cursor-acp-9"), "hello again")
+        .prompt(&SessionId::new("cursor-acp-9"), "hello again")
         .await
         .expect("prompt runs");
     assert!(matches!(

--- a/crates/cursor_cloud_agents/src/inbound/acp.rs
+++ b/crates/cursor_cloud_agents/src/inbound/acp.rs
@@ -28,7 +28,7 @@
 #[cfg(test)]
 mod test;
 
-use crate::domain::model::{AcpSessionId, McpHeader, McpServer, McpTransport};
+use crate::domain::model::{McpHeader, McpServer, McpTransport};
 use crate::domain::ports::{CursorAgents, RepoResolver, RunStream, SessionNotifier};
 use crate::domain::service::CursorSessionService;
 use agent_client_protocol::schema::ProtocolVersion;
@@ -39,8 +39,8 @@ use agent_client_protocol::schema::v1::{
     McpCapabilities, McpServer as AcpMcpServer, NewSessionRequest, NewSessionResponse,
     PromptCapabilities, PromptRequest, PromptResponse, SessionConfigId, SessionConfigKind,
     SessionConfigOption, SessionConfigSelect, SessionConfigSelectOption,
-    SessionConfigSelectOptions, SessionConfigValueId, SessionNotification, SessionUpdate,
-    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse,
+    SessionConfigSelectOptions, SessionConfigValueId, SessionId, SessionNotification,
+    SessionUpdate, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse,
 };
 use agent_client_protocol::{
     Agent, ByteStreams, Client, ConnectTo, ConnectionTo, on_receive_notification,
@@ -100,7 +100,7 @@ impl AcpNotifier {
 impl SessionNotifier for AcpNotifier {
     async fn notify(
         &self,
-        session: &AcpSessionId,
+        session: &SessionId,
         update: SessionUpdate,
     ) -> Result<(), rootcause::Report> {
         // Unreachable in practice: the binding runner starts with the
@@ -458,7 +458,7 @@ where
 /// the state it was in before any of this existed.
 async fn session_config_options<Cursor, Notifier, Repos>(
     service: &CursorSessionService<Cursor, Notifier, Repos>,
-    session: &AcpSessionId,
+    session: &SessionId,
 ) -> Vec<SessionConfigOption>
 where
     Cursor: CursorAgents + RunStream,

--- a/crates/cursor_cloud_agents/src/inbound/acp.rs
+++ b/crates/cursor_cloud_agents/src/inbound/acp.rs
@@ -39,8 +39,8 @@ use agent_client_protocol::schema::v1::{
     McpCapabilities, McpServer as AcpMcpServer, NewSessionRequest, NewSessionResponse,
     PromptCapabilities, PromptRequest, PromptResponse, SessionConfigId, SessionConfigKind,
     SessionConfigOption, SessionConfigSelect, SessionConfigSelectOption,
-    SessionConfigSelectOptions, SessionConfigValueId, SessionId, SessionNotification,
-    SessionUpdate, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse,
+    SessionConfigSelectOptions, SessionConfigValueId, SessionNotification, SessionUpdate,
+    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse,
 };
 use agent_client_protocol::{
     Agent, ByteStreams, Client, ConnectTo, ConnectionTo, on_receive_notification,
@@ -111,10 +111,7 @@ impl SessionNotifier for AcpNotifier {
             .get()
             .ok_or_else(|| rootcause::report!("session update before the acp connection was up"))?;
         connection
-            .send_notification(SessionNotification::new(
-                SessionId::new(session.as_str()),
-                update,
-            ))
+            .send_notification(SessionNotification::new(session.clone(), update))
             .map_err(|error| rootcause::report!("{error}"))
     }
 }
@@ -311,10 +308,7 @@ where
                     let mcp_servers = forwardable_mcp_servers(request.mcp_servers);
                     let session = service.new_session(&request.cwd, mcp_servers);
                     let options = session_config_options(&service, &session).await;
-                    responder.respond(
-                        NewSessionResponse::new(SessionId::new(session.as_str()))
-                            .config_options(options),
-                    )
+                    responder.respond(NewSessionResponse::new(session).config_options(options))
                 }
             },
             on_receive_request!(),
@@ -327,7 +321,7 @@ where
                     // cancels while the turn streams.
                     let service = Arc::clone(&service);
                     connection.spawn(async move {
-                        let session = AcpSessionId::new(request.session_id.0.as_ref());
+                        let session = request.session_id;
                         let text = prompt_text(&request.prompt);
                         // A failed respond means the client is gone; failing
                         // the spawned task would tear down the (already
@@ -360,7 +354,7 @@ where
                     // agent serves keep their own durable log of every frame,
                     // and Cursor accumulates the conversation server-side, so
                     // a replay would tell the client what it already knows.
-                    let session = AcpSessionId::new(request.session_id.0.as_ref());
+                    let session = request.session_id;
                     if service.has_session(&session) {
                         // The MCP list is the client's, and a load restates
                         // it — the one way a restored process, whose host
@@ -386,7 +380,7 @@ where
                     // session map does not grow for the process lifetime. A
                     // session this agent never had is the client's mistake,
                     // not a no-op worth acknowledging.
-                    if service.close(&AcpSessionId::new(request.session_id.0.as_ref())) {
+                    if service.close(&request.session_id) {
                         responder.respond(CloseSessionResponse::new())
                     } else {
                         responder.respond_with_error(AcpError::invalid_params())
@@ -399,7 +393,7 @@ where
             {
                 let service = Arc::clone(&service);
                 async move |request: SetSessionConfigOptionRequest, responder, _connection| {
-                    let session = AcpSessionId::new(request.session_id.0.as_ref());
+                    let session = request.session_id;
                     // Only the model is configurable, so anything else is the
                     // client naming an option this agent never advertised.
                     if request.config_id.to_string() != MODEL_CONFIG_ID {
@@ -432,7 +426,7 @@ where
                     // on it.
                     let service = Arc::clone(&service);
                     connection.spawn(async move {
-                        let session = AcpSessionId::new(notification.session_id.0.as_ref());
+                        let session = notification.session_id;
                         if let Err(error) = service.cancel(&session).await {
                             tracing::error!(error = %error, "cancel failed");
                         }

--- a/crates/cursor_cloud_agents/src/inbound/acp/test.rs
+++ b/crates/cursor_cloud_agents/src/inbound/acp/test.rs
@@ -225,7 +225,7 @@ async fn session_close_forgets_the_session() {
 
     // The service must no longer know it.
     let error = service
-        .prompt(&AcpSessionId::new(session), "hi")
+        .prompt(&SessionId::new(session), "hi")
         .await
         .expect_err("a closed session is gone");
     assert!(matches!(
@@ -486,7 +486,7 @@ async fn remote_mcp_servers_are_forwarded_to_the_agent() {
         .expect("stream open");
     events.send(CursorEvent::Done).expect("stream open");
     service
-        .prompt(&AcpSessionId::new(session), "go")
+        .prompt(&SessionId::new(session), "go")
         .await
         .expect("prompt runs");
 
@@ -566,7 +566,7 @@ async fn stdio_mcp_servers_are_declined_without_failing_the_session() {
         .expect("stream open");
     events.send(CursorEvent::Done).expect("stream open");
     service
-        .prompt(&AcpSessionId::new(session), "go")
+        .prompt(&SessionId::new(session), "go")
         .await
         .expect("prompt runs");
 
@@ -633,7 +633,7 @@ async fn the_initialize_response_is_pinned_whole() {
 async fn session_load_answers_for_restored_sessions_only() {
     let (_service, mut client) = serve_over_channel(FakeCursor::new(), |service| {
         service.restore_session(
-            AcpSessionId::new("cursor-acp-3"),
+            SessionId::new("cursor-acp-3"),
             Some(crate::domain::model::CursorAgentId::new("bc-restored")),
             None,
             None,
@@ -868,7 +868,7 @@ async fn a_restored_session_keeps_its_model() {
     cursor.script_models(offered_models());
     let (service, mut client) = serve_over_channel(cursor.clone(), |service| {
         service.restore_session(
-            AcpSessionId::new("cursor-acp-3"),
+            SessionId::new("cursor-acp-3"),
             Some(crate::domain::model::CursorAgentId::new("bc-restored")),
             None,
             Some("gpt-5.5".to_owned()),
@@ -898,7 +898,7 @@ async fn a_restored_session_keeps_its_model() {
         .expect("stream open");
     events.send(CursorEvent::Done).expect("stream open");
     service
-        .prompt(&AcpSessionId::new("cursor-acp-3"), "go")
+        .prompt(&SessionId::new("cursor-acp-3"), "go")
         .await
         .expect("prompt runs");
 
@@ -932,7 +932,7 @@ async fn a_restored_deployment_slug_falls_back_to_cursors_default() {
     cursor.script_models(offered_models());
     let (service, _client) = serve_over_channel(cursor.clone(), |service| {
         service.restore_session(
-            AcpSessionId::new("cursor-acp-3"),
+            SessionId::new("cursor-acp-3"),
             Some(crate::domain::model::CursorAgentId::new("bc-restored")),
             None,
             Some("claude".to_owned()),
@@ -950,7 +950,7 @@ async fn a_restored_deployment_slug_falls_back_to_cursors_default() {
         .expect("stream open");
     events.send(CursorEvent::Done).expect("stream open");
     service
-        .prompt(&AcpSessionId::new("cursor-acp-3"), "go")
+        .prompt(&SessionId::new("cursor-acp-3"), "go")
         .await
         .expect("a prompt with an unresolvable restored model still runs");
 
@@ -976,7 +976,7 @@ async fn session_load_restores_the_clients_mcp_servers() {
     let cursor = FakeCursor::new();
     let (service, mut client) = serve_over_channel(cursor.clone(), |service| {
         // Restored with *no* agent: the session opened, never prompted, died.
-        service.restore_session(AcpSessionId::new("cursor-acp-3"), None, None, None);
+        service.restore_session(SessionId::new("cursor-acp-3"), None, None, None);
     });
 
     let loaded = client
@@ -1010,7 +1010,7 @@ async fn session_load_restores_the_clients_mcp_servers() {
         .expect("stream open");
     events.send(CursorEvent::Done).expect("stream open");
     service
-        .prompt(&AcpSessionId::new("cursor-acp-3"), "go")
+        .prompt(&SessionId::new("cursor-acp-3"), "go")
         .await
         .expect("prompt runs");
 
@@ -1077,7 +1077,7 @@ async fn a_session_with_no_choice_rests_the_picker_on_auto() {
         .expect("stream open");
     events.send(CursorEvent::Done).expect("stream open");
     service
-        .prompt(&AcpSessionId::new(session), "go")
+        .prompt(&SessionId::new(session), "go")
         .await
         .expect("prompt runs");
     let asked = cursor

--- a/crates/cursor_cloud_agents/src/testing.rs
+++ b/crates/cursor_cloud_agents/src/testing.rs
@@ -2,11 +2,11 @@
 
 use crate::domain::event::CursorEvent;
 use crate::domain::model::{
-    AcpSessionId, CursorAgentId, CursorModel, CursorRunId, McpServer, ModelChoice, RepoUrl,
-    RunListing, RunOutcome,
+    CursorAgentId, CursorModel, CursorRunId, McpServer, ModelChoice, RepoUrl, RunListing,
+    RunOutcome,
 };
 use crate::domain::ports::{CursorAgents, RepoResolver, RunStream, SessionNotifier};
-use agent_client_protocol::schema::v1::SessionUpdate;
+use agent_client_protocol::schema::v1::{SessionId, SessionUpdate};
 use futures::Stream;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -278,7 +278,7 @@ impl RunStream for FakeCursor {
 /// Records every update it is asked to deliver.
 #[derive(Debug, Clone, Default)]
 pub struct RecordingNotifier {
-    updates: Arc<Mutex<Vec<(AcpSessionId, SessionUpdate)>>>,
+    updates: Arc<Mutex<Vec<(SessionId, SessionUpdate)>>>,
     delivered: Arc<tokio::sync::Notify>,
 }
 
@@ -291,7 +291,7 @@ impl RecordingNotifier {
 
     /// Everything delivered so far, in order.
     #[must_use]
-    pub fn updates(&self) -> Vec<(AcpSessionId, SessionUpdate)> {
+    pub fn updates(&self) -> Vec<(SessionId, SessionUpdate)> {
         self.updates.lock().expect("notifier poisoned").clone()
     }
 
@@ -317,7 +317,7 @@ impl RecordingNotifier {
 impl SessionNotifier for RecordingNotifier {
     async fn notify(
         &self,
-        session: &AcpSessionId,
+        session: &SessionId,
         update: SessionUpdate,
     ) -> Result<(), rootcause::Report> {
         self.updates


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`cursor_cloud_agents` minted its own `AcpSessionId` and converted it to/from `agent_client_protocol::schema::v1::SessionId` at every inbound ACP boundary.

This uses the protocol `SessionId` directly in the domain, ACP adapter, and Cursor harness resume path. The conversion shims go away. `CursorAgentId` is unchanged: that is a Cursor API identity, not an ACP type.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-191c745b-7de0-4bc9-8925-57787085746e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-191c745b-7de0-4bc9-8925-57787085746e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

