### PR TITLE
fix(channel): show the scroll-to-bottom button on mobile

### DIFF
--- a/apps/web/src/features/channel/Channel/ThreadList.tsx
+++ b/apps/web/src/features/channel/Channel/ThreadList.tsx
@@ -637,15 +637,18 @@ export function ThreadList(props: ThreadListProps) {
       const delta = handle.scrollOffset - previousScrollOffset;
       // Accumulate downward scroll distance only during user interaction
       // and only when the user is scrolling down. Used by the scroll-to-bottom overlay.
-      if (
+      if (delta < 0 || scrollIntent.lastDirection() === 'up') {
+        explicitScrollDownDistance = 0;
+      } else if (
         scrollIntent.isUserInteracting() &&
         delta > 0 &&
         scrollIntent.lastDirection() === 'down'
       ) {
         explicitScrollDownDistance += delta;
-      } else {
-        explicitScrollDownDistance = 0;
       }
+      // Downward scrolls the user did not drive (touch momentum outliving the
+      // interaction window, virtualizer reflows) leave the run as it stands:
+      // they neither extend it nor cancel it.
       nextIsScrollingDown =
         explicitScrollDownDistance >= EXPLICIT_SCROLL_DOWN_TRIGGER_DISTANCE;
     }

--- a/apps/web/src/features/channel/Channel/tests/thread-list-scroll.test.ts
+++ b/apps/web/src/features/channel/Channel/tests/thread-list-scroll.test.ts
@@ -1,5 +1,18 @@
 import { createScrollIntentTracker } from '@core/util/scroll-intent';
+import type { JSX } from 'solid-js';
 import { describe, expect, it } from 'vitest';
+
+type Handler<E> = (event: E) => void;
+
+/** Handler props are typed for JSX; call them directly in tests. */
+const fire = <E>(handler: JSX.EventHandlerUnion<HTMLElement, E>, event: E) => {
+  (handler as Handler<E>)(event);
+};
+
+const touchEvent = (...clientYs: number[]) =>
+  ({
+    touches: clientYs.map((clientY) => ({ clientY })),
+  }) as unknown as TouchEvent;
 
 describe('createScrollIntentTracker', () => {
   it('is not interacting by default', () => {
@@ -38,5 +51,50 @@ describe('createScrollIntentTracker', () => {
 
     const farFuture = Date.now() + 500;
     expect(tracker.lastDirection(farFuture)).toBe(undefined);
+  });
+
+  it('is interacting while a finger is down', () => {
+    const tracker = createScrollIntentTracker();
+    fire(tracker.handlers.onTouchStart, touchEvent(400));
+    // Well past the interaction timeout: the finger is still down.
+    expect(tracker.isUserInteracting(Date.now() + 5000)).toBe(true);
+  });
+
+  it('reads a down direction from a finger dragging up', () => {
+    const tracker = createScrollIntentTracker();
+    fire(tracker.handlers.onTouchStart, touchEvent(400));
+    fire(tracker.handlers.onTouchMove, touchEvent(300));
+    expect(tracker.lastDirection()).toBe('down');
+  });
+
+  it('reads an up direction from a finger dragging down', () => {
+    const tracker = createScrollIntentTracker();
+    fire(tracker.handlers.onTouchStart, touchEvent(300));
+    fire(tracker.handlers.onTouchMove, touchEvent(400));
+    expect(tracker.lastDirection()).toBe('up');
+  });
+
+  it('ignores finger jitter below the direction threshold', () => {
+    const tracker = createScrollIntentTracker();
+    fire(tracker.handlers.onTouchStart, touchEvent(400));
+    fire(tracker.handlers.onTouchMove, touchEvent(399));
+    expect(tracker.lastDirection()).toBe(undefined);
+  });
+
+  it('keeps interacting through the momentum fling after the finger lifts', () => {
+    const tracker = createScrollIntentTracker();
+    fire(tracker.handlers.onTouchStart, touchEvent(400));
+    fire(tracker.handlers.onTouchMove, touchEvent(300));
+    fire(tracker.handlers.onTouchEnd, touchEvent());
+
+    expect(tracker.lastDirection(Date.now() + 500)).toBe('down');
+    expect(tracker.isUserInteracting(Date.now() + 2000)).toBe(false);
+  });
+
+  it('stays in the gesture while another finger is still down', () => {
+    const tracker = createScrollIntentTracker();
+    fire(tracker.handlers.onTouchStart, touchEvent(400, 380));
+    fire(tracker.handlers.onTouchEnd, touchEvent(380));
+    expect(tracker.isUserInteracting(Date.now() + 5000)).toBe(true);
   });
 });

--- a/apps/web/src/lib/core/util/scroll-intent.ts
+++ b/apps/web/src/lib/core/util/scroll-intent.ts
@@ -5,6 +5,15 @@ import type { JSX } from 'solid-js';
  *  enough time to fire, even on slower devices or busy main threads. */
 const INTERACTION_TIMEOUT_MS = 300;
 
+/** How long after a finger lifts we still consider the user to be interacting.
+ *  Touch scrolling keeps emitting scroll events while the momentum fling
+ *  decays, and that coasting is still the user's scroll. */
+const TOUCH_MOMENTUM_TIMEOUT_MS = 1200;
+
+/** Finger travel needed before a touch drag counts as a direction change.
+ *  Filters out the jitter of a finger resting on the screen. */
+const TOUCH_DIRECTION_THRESHOLD_PX = 2;
+
 export type ScrollDirection = 'up' | 'down';
 
 type ScrollIntentTracker = {
@@ -20,7 +29,7 @@ type ScrollIntentTracker = {
   lastDirection: (now?: number) => ScrollDirection | undefined;
   /**
    * Event handler props to spread onto the scrollable container element.
-   * Covers pointer (scrollbar drag + touch), wheel, and keyboard scrolling.
+   * Covers pointer (scrollbar drag), touch, wheel, and keyboard scrolling.
    */
   handlers: ScrollIntentHandlers;
 };
@@ -29,6 +38,10 @@ type ScrollIntentHandlers = {
   onPointerDown: JSX.EventHandlerUnion<HTMLElement, PointerEvent>;
   onPointerUp: JSX.EventHandlerUnion<HTMLElement, PointerEvent>;
   onPointerCancel: JSX.EventHandlerUnion<HTMLElement, PointerEvent>;
+  onTouchStart: JSX.EventHandlerUnion<HTMLElement, TouchEvent>;
+  onTouchMove: JSX.EventHandlerUnion<HTMLElement, TouchEvent>;
+  onTouchEnd: JSX.EventHandlerUnion<HTMLElement, TouchEvent>;
+  onTouchCancel: JSX.EventHandlerUnion<HTMLElement, TouchEvent>;
   onWheel: JSX.EventHandlerUnion<HTMLElement, WheelEvent>;
   onKeyDown: JSX.EventHandlerUnion<HTMLElement, KeyboardEvent>;
 };
@@ -41,10 +54,18 @@ const SCROLL_DOWN_KEYS = new Set(['ArrowDown', 'PageDown', 'End', ' ']);
  * events from programmatic / virtualizer-driven ones.
  *
  * User interaction is detected via:
- * - `pointerdown` / `pointerup` — covers scrollbar drag and touch drag
+ * - `pointerdown` / `pointerup` — covers scrollbar drag
+ * - `touchstart` / `touchmove` / `touchend` — covers finger drag and the
+ *   momentum fling that follows it
  * - `wheel` — covers mouse wheel / trackpad
  * - `keydown` — covers native browser keyboard scrolling (Arrow, Page, Home/End, Space)
  * - `markUserIntent()` — for external callers (e.g. hotkey-driven `scrollToId`)
+ *
+ * Touch is tracked with touch events rather than pointer events on purpose:
+ * once the browser takes a finger drag over as a native scroll it fires
+ * `pointercancel` and stops sending pointer moves, while touch events keep
+ * flowing for the whole gesture. Touch moves are also the only signal that
+ * carries a direction on a touch device — there are no wheel events to read.
  *
  * Usage:
  * ```tsx
@@ -63,6 +84,8 @@ const SCROLL_DOWN_KEYS = new Set(['ArrowDown', 'PageDown', 'End', ' ']);
  */
 export function createScrollIntentTracker(): ScrollIntentTracker {
   let isPointerDown = false;
+  let isTouching = false;
+  let lastTouchY: number | undefined;
   let activeUntil = 0;
   let direction: ScrollDirection | undefined;
 
@@ -72,7 +95,7 @@ export function createScrollIntentTracker(): ScrollIntentTracker {
   };
 
   const isUserInteracting = (now = Date.now()) =>
-    isPointerDown || now < activeUntil;
+    isPointerDown || isTouching || now < activeUntil;
 
   const lastDirection = (now?: number) =>
     isUserInteracting(now) ? direction : undefined;
@@ -83,13 +106,17 @@ export function createScrollIntentTracker(): ScrollIntentTracker {
     activeUntil = Math.max(activeUntil, Date.now() + INTERACTION_TIMEOUT_MS);
   };
 
+  const endTouch = () => {
+    if (!isTouching) return;
+    isTouching = false;
+    lastTouchY = undefined;
+    activeUntil = Math.max(activeUntil, Date.now() + TOUCH_MOMENTUM_TIMEOUT_MS);
+  };
+
   const handlers: ScrollIntentHandlers = {
     onPointerDown: (event) => {
-      // Touch interactions always indicate scroll intent (finger drag)
-      if (event.pointerType === 'touch') {
-        isPointerDown = true;
-        return;
-      }
+      // Touch is handled by the touch handlers below.
+      if (event.pointerType === 'touch') return;
       // For mouse/pen, only track scrollbar drags. Scrollbar clicks
       // target the container element itself, while clicks on child
       // elements (messages, buttons, text selection) have a different
@@ -101,6 +128,34 @@ export function createScrollIntentTracker(): ScrollIntentTracker {
     },
     onPointerUp: endPointer,
     onPointerCancel: endPointer,
+    onTouchStart: (event) => {
+      isTouching = true;
+      lastTouchY = event.touches[0]?.clientY;
+    },
+    onTouchMove: (event) => {
+      isTouching = true;
+      const y = event.touches[0]?.clientY;
+      if (y === undefined) return;
+      if (lastTouchY === undefined) {
+        lastTouchY = y;
+        return;
+      }
+      // The content moves opposite the finger: dragging up scrolls down.
+      const delta = lastTouchY - y;
+      if (Math.abs(delta) < TOUCH_DIRECTION_THRESHOLD_PX) return;
+      direction = delta > 0 ? 'down' : 'up';
+      lastTouchY = y;
+    },
+    onTouchEnd: (event) => {
+      // Multi-touch: the gesture continues while any finger is still down.
+      const remaining = event.touches[0]?.clientY;
+      if (remaining !== undefined) {
+        lastTouchY = remaining;
+        return;
+      }
+      endTouch();
+    },
+    onTouchCancel: endTouch,
     onWheel: (event) => {
       if (event.deltaY === 0) return;
       markUserIntent(event.deltaY > 0 ? 'down' : 'up');


### PR DESCRIPTION
The channel's scroll-to-bottom overlay never appeared on mobile. Nothing hides it with CSS — the gate is `ThreadListScrollState.isScrollingDown`, which comes from `createScrollIntentTracker`. That tracker only learned a scroll direction from `wheel` and `keydown` events, neither of which exists on a touch device, so `lastDirection()` was always `undefined` on mobile and the downward-scroll run never accumulated.

Changes:

- `scroll-intent.ts`: track finger drags with touch events and derive the direction from finger movement (content moves opposite the finger). Touch events are used instead of pointer events because the browser fires `pointercancel` and stops sending pointer moves the moment it takes a drag over as a native scroll, while touch events keep flowing for the whole gesture. The interaction now also stays active while a finger is down and through the momentum fling after it lifts.
- `ThreadList.tsx`: downward scrolls the user did not drive (momentum outliving the interaction window, virtualizer reflows) no longer cancel an in-progress scroll-down run — only an upward scroll does. Without this the button blinks out mid-fling.

Tests cover the touch direction, jitter filtering, multi-touch, and the momentum window.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQ1pevDT3yWmdiv56QSqqn)_