### PR TITLE
Seanaye/fix/refetch on create

### DIFF
--- a/apps/web/src/features/block-md/util/taskComposerProperties.ts
+++ b/apps/web/src/features/block-md/util/taskComposerProperties.ts
@@ -15,7 +15,6 @@ import type {
 } from '@property/types';
 import { useListPropertiesQuery } from '@queries/properties/definitions';
 import { useTagsQuery } from '@queries/properties/tags';
-import { refetchSoupEntity } from '@queries/soup/cache';
 import type { PropertyDefinition } from '@service-properties/generated/schemas/propertyDefinition';
 import type { PropertyDefinitionDetailResponse } from '@service-properties/generated/schemas/propertyDefinitionDetailResponse';
 import { createStore, reconcile, type Store, unwrap } from 'solid-js/store';
@@ -91,10 +90,7 @@ export async function createTaskWithProperties(
     return null;
   }
 
-  // refetchSoupEntity is already called inside createTask — just upsert to history
-  refetchSoupEntity(createdTask.documentId, 'document');
-
-  // Upsert the new task to history
+  // createTaskWithInitialSnapshot already revalidates Soup; just update history.
   upsertToHistory({
     itemId: createdTask.documentId,
     itemType: 'document',

--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -966,6 +966,7 @@ export const SoupViewContextProvider: FlowComponent<
       return {
         enabled: enabled() && !search.isSearching(),
         showSupportedForeignEntities: showSupportedForeignEntitiesFF().enabled,
+        onBeforeGraphqlRefresh: () => groupQueries.resetToInitialPage(),
         meta: {
           itemFilter: (item) => soupItemMatchesActiveFilters(item, view),
         },

--- a/apps/web/src/lib/core/util/create.ts
+++ b/apps/web/src/lib/core/util/create.ts
@@ -66,7 +66,10 @@ export async function createMarkdownFile(
     name: args?.title ?? '',
     fileType: 'md',
   });
-  refetchSoupEntity(documentId, 'document', { ownTouch: true });
+  refetchSoupEntity(documentId, 'document', {
+    ownTouch: true,
+    refreshGraphql: true,
+  });
 
   analytics.track('create_entity', {
     entityType: 'md',
@@ -162,7 +165,10 @@ async function createTaskResponse(args?: CreateTaskArgs) {
     fileType: 'md',
     subType: { type: 'task', is_completed: false },
   });
-  refetchSoupEntity(documentId, 'document', { ownTouch: true });
+  refetchSoupEntity(documentId, 'document', {
+    ownTouch: true,
+    refreshGraphql: true,
+  });
 
   analytics.track('create_entity', {
     entityType: 'task',
@@ -221,7 +227,10 @@ export async function createSnippet(
     fileType: 'md',
     subType: { type: 'snippet' },
   });
-  refetchSoupEntity(documentId, 'document', { ownTouch: true });
+  refetchSoupEntity(documentId, 'document', {
+    ownTouch: true,
+    refreshGraphql: true,
+  });
 
   analytics.track('create_entity', {
     entityType: 'snippet',
@@ -269,7 +278,10 @@ export async function createSkill(
     fileType: 'md',
     subType: { type: 'skill' },
   });
-  refetchSoupEntity(documentId, 'document', { ownTouch: true });
+  refetchSoupEntity(documentId, 'document', {
+    ownTouch: true,
+    refreshGraphql: true,
+  });
 
   analytics.track('create_entity', {
     entityType: 'skill',
@@ -363,6 +375,7 @@ export async function createCodeFileFromText({
   });
   refetchSoupEntity(document.metadata.documentId, 'document', {
     ownTouch: true,
+    refreshGraphql: true,
   });
 
   analytics.track('create_entity', {
@@ -413,7 +426,10 @@ export async function createCanvasFileFromJsonString(args: {
     name: title ?? 'New Canvas',
     fileType: 'canvas',
   });
-  refetchSoupEntity(canvas.metadata.documentId, 'document', { ownTouch: true });
+  refetchSoupEntity(canvas.metadata.documentId, 'document', {
+    ownTouch: true,
+    refreshGraphql: true,
+  });
 
   analytics.track('create_entity', {
     entityType: 'canvas',
@@ -450,7 +466,10 @@ export async function createChat(
     itemType: 'chat',
     name: args?.name ?? DEFAULT_CHAT_NAME,
   });
-  refetchSoupEntity(chat.id, 'chat', { ownTouch: true });
+  refetchSoupEntity(chat.id, 'chat', {
+    ownTouch: true,
+    refreshGraphql: true,
+  });
 
   analytics.track('create_entity', {
     entityType: 'chat',

--- a/apps/web/src/lib/queries/soup/graphql/active-queries.test.ts
+++ b/apps/web/src/lib/queries/soup/graphql/active-queries.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  refreshActiveGraphqlSoupQueries,
+  registerActiveGraphqlSoupQuery,
+} from './active-queries';
+
+describe('active GraphQL Soup queries', () => {
+  it('refreshes only enabled registered queries', async () => {
+    const enabledRefresh = vi.fn(async () => undefined);
+    const disabledRefresh = vi.fn(async () => undefined);
+    const unregisterEnabled = registerActiveGraphqlSoupQuery({
+      isEnabled: () => true,
+      refresh: enabledRefresh,
+    });
+    const unregisterDisabled = registerActiveGraphqlSoupQuery({
+      isEnabled: () => false,
+      refresh: disabledRefresh,
+    });
+
+    await refreshActiveGraphqlSoupQueries();
+
+    expect(enabledRefresh).toHaveBeenCalledOnce();
+    expect(disabledRefresh).not.toHaveBeenCalled();
+
+    unregisterEnabled();
+    unregisterDisabled();
+  });
+
+  it('stops refreshing a query after it unregisters', async () => {
+    const refresh = vi.fn(async () => undefined);
+    const unregister = registerActiveGraphqlSoupQuery({
+      isEnabled: () => true,
+      refresh,
+    });
+    unregister();
+
+    await refreshActiveGraphqlSoupQueries();
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('isolates refresh failures so other active queries still refresh', async () => {
+    const error = new Error('refresh failed');
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const unregisterFailure = registerActiveGraphqlSoupQuery({
+      isEnabled: () => true,
+      refresh: vi.fn(async () => {
+        throw error;
+      }),
+    });
+    const successfulRefresh = vi.fn(async () => undefined);
+    const unregisterSuccess = registerActiveGraphqlSoupQuery({
+      isEnabled: () => true,
+      refresh: successfulRefresh,
+    });
+
+    await refreshActiveGraphqlSoupQueries();
+
+    expect(successfulRefresh).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      '[graphql-soup] failed to refresh active query',
+      error
+    );
+
+    unregisterFailure();
+    unregisterSuccess();
+    consoleError.mockRestore();
+  });
+});

--- a/apps/web/src/lib/queries/soup/graphql/active-queries.ts
+++ b/apps/web/src/lib/queries/soup/graphql/active-queries.ts
@@ -1,0 +1,28 @@
+type ActiveGraphqlSoupQuery = {
+  isEnabled: () => boolean;
+  refresh: () => Promise<void>;
+};
+
+const activeQueries = new Set<ActiveGraphqlSoupQuery>();
+
+/** Registers a mounted GraphQL Soup query for mutation-driven revalidation. */
+export function registerActiveGraphqlSoupQuery(
+  query: ActiveGraphqlSoupQuery
+): () => void {
+  activeQueries.add(query);
+  return () => activeQueries.delete(query);
+}
+
+/** Network-refreshes every mounted and enabled GraphQL Soup query. */
+export async function refreshActiveGraphqlSoupQueries(): Promise<void> {
+  await Promise.all(
+    [...activeQueries].map(async (query) => {
+      if (!query.isEnabled()) return;
+      try {
+        await query.refresh();
+      } catch (error) {
+        console.error('[graphql-soup] failed to refresh active query', error);
+      }
+    })
+  );
+}

--- a/apps/web/src/lib/queries/soup/items.transport-refetch.test.ts
+++ b/apps/web/src/lib/queries/soup/items.transport-refetch.test.ts
@@ -1,0 +1,144 @@
+import { createRoot } from 'solid-js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => ({ graphqlEnabled: false }));
+const restRefetch = vi.hoisted(() => vi.fn(async () => undefined));
+const flatQuery = vi.hoisted(() => makeGraphqlQuery(false));
+const groupedQuery = vi.hoisted(() => makeGraphqlQuery(true));
+
+function makeGraphqlQuery(enabled: boolean) {
+  return {
+    data: vi.fn(),
+    error: vi.fn(),
+    isSupported: vi.fn(() => true),
+    isEnabled: vi.fn(() => enabled),
+    isLoading: vi.fn(() => false),
+    isFetching: vi.fn(() => false),
+    isFetchingNextPage: vi.fn(() => false),
+    isPlaceholderData: vi.fn(() => false),
+    hasNextPage: vi.fn(() => false),
+    fetchNextPage: vi.fn(async () => undefined),
+    resetToInitialPage: vi.fn(),
+    refresh: vi.fn(async () => undefined),
+  };
+}
+
+vi.mock('@app/features/next-soup/filters/query-filters', () => ({
+  filterSoupItemByRequestBody: vi.fn(() => true),
+}));
+vi.mock('@app/lib/analytics/posthog', () => ({
+  useFeatureFlag: vi.fn(() => () => ({ enabled: testState.graphqlEnabled })),
+}));
+vi.mock('@core/constant/featureFlags', () => ({
+  ENABLE_GRAPHQL_SOUP_FLAG: 'enable-graphql-soup',
+  ENABLE_GRAPHQL_SOUP_OVERRIDE: undefined,
+}));
+vi.mock('@core/util/result', () => ({ throwOnErr: vi.fn() }));
+vi.mock('@queries/soup/grouped/api', () => ({
+  groupedSortMethod: vi.fn(),
+  makeGroupComparator: vi.fn(),
+  parseGroupMeta: vi.fn(),
+  serializeGroupByField: vi.fn(),
+}));
+vi.mock('@queries/soup/keys', () => ({
+  soupKeys: {
+    astItems: vi.fn(() => ({ queryKey: ['soup', 'ast'] })),
+  },
+}));
+vi.mock('@queries/soup/transform-utils', () => ({
+  isDisplayableSoupItem: vi.fn(() => true),
+  isInstructionsMdDoc: vi.fn(() => false),
+  mapApiSoupItemToEntity: vi.fn(),
+  mapSoupPageToEntityList: vi.fn(),
+}));
+vi.mock('@queries/storage/instructions-md', () => ({
+  useInstructionsMdIdQuery: vi.fn(() => ({})),
+}));
+vi.mock('@service-storage/client', () => ({
+  storageServiceClient: { getSoupItems: vi.fn() },
+}));
+vi.mock('@tanstack/solid-query', () => ({
+  useInfiniteQuery: vi.fn(() => ({
+    data: undefined,
+    error: null,
+    isLoading: false,
+    isFetching: false,
+    isPlaceholderData: false,
+    isFetchingNextPage: false,
+    isEnabled: true,
+    hasNextPage: false,
+    fetchNextPage: vi.fn(async () => undefined),
+    refetch: restRefetch,
+  })),
+}));
+vi.mock('../client', () => ({
+  queryClient: { setQueryData: vi.fn() },
+}));
+vi.mock('./graphql/items', () => ({
+  createGraphqlSoupAstItemsQuery: vi.fn(() => flatQuery),
+}));
+vi.mock('./graphql/grouped-items', () => ({
+  createGraphqlGroupedSoupAstItemsQuery: vi.fn(() => groupedQuery),
+}));
+
+import { refreshActiveGraphqlSoupQueries } from './graphql/active-queries';
+import { type SoupAstItemsQuery, useSoupAstItemsQuery } from './items';
+
+let disposeRoot: (() => void) | undefined;
+
+function mountAutoTransportQuery(): SoupAstItemsQuery {
+  let query: SoupAstItemsQuery | undefined;
+  createRoot((dispose) => {
+    disposeRoot = dispose;
+    query = useSoupAstItemsQuery(() => ({
+      params: {},
+      body: {},
+      groupBy: {
+        type: 'property',
+        propertyDefinitionId: 'priority',
+        entityType: 'TASK',
+      },
+    }));
+  });
+  return query!;
+}
+
+describe('Soup refetch transport selection', () => {
+  beforeEach(() => {
+    testState.graphqlEnabled = false;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    disposeRoot?.();
+    disposeRoot = undefined;
+  });
+
+  it('uses REST refetch and skips mutation-driven GraphQL refresh when the flag is off', async () => {
+    const query = mountAutoTransportQuery();
+
+    expect(query.transport).toBe('rest');
+    await query.refetch();
+    await refreshActiveGraphqlSoupQueries();
+
+    expect(restRefetch).toHaveBeenCalledOnce();
+    expect(groupedQuery.refresh).not.toHaveBeenCalled();
+  });
+
+  it('uses GraphQL refetch and mutation-driven refresh when the flag is on', async () => {
+    testState.graphqlEnabled = true;
+    const query = mountAutoTransportQuery();
+
+    expect(query.transport).toBe('graphql');
+    await query.refetch();
+    expect(groupedQuery.refresh).toHaveBeenCalledOnce();
+    expect(restRefetch).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    await refreshActiveGraphqlSoupQueries();
+
+    expect(groupedQuery.resetToInitialPage).toHaveBeenCalledOnce();
+    expect(groupedQuery.refresh).toHaveBeenCalledOnce();
+    expect(restRefetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/queries/soup/items.ts
+++ b/apps/web/src/lib/queries/soup/items.ts
@@ -33,8 +33,9 @@ import {
   type StaleTime,
   useInfiniteQuery,
 } from '@tanstack/solid-query';
-import type { Accessor } from 'solid-js';
+import { type Accessor, onCleanup } from 'solid-js';
 import { queryClient } from '../client';
+import { registerActiveGraphqlSoupQuery } from './graphql/active-queries';
 import { createGraphqlGroupedSoupAstItemsQuery } from './graphql/grouped-items';
 import { createGraphqlSoupAstItemsQuery } from './graphql/items';
 
@@ -71,6 +72,8 @@ interface SoupItemsQueryOptions {
     itemFilter?: (item: SoupApiItem) => boolean;
   };
   showSupportedForeignEntities?: boolean;
+  /** Resets view-owned GraphQL state before a mutation-driven network refresh. */
+  onBeforeGraphqlRefresh?: () => void;
 }
 
 /**
@@ -374,6 +377,17 @@ export function useSoupAstItemsQuery(
       enabled: queryEnabled() && !usesGraphql(),
     };
   });
+
+  onCleanup(
+    registerActiveGraphqlSoupQuery({
+      isEnabled: () => usesGraphql() && activeGraphqlQuery().isEnabled(),
+      refresh: async () => {
+        activeGraphqlQuery().resetToInitialPage();
+        options?.().onBeforeGraphqlRefresh?.();
+        await activeGraphqlQuery().refresh();
+      },
+    })
+  );
 
   const resetRestToInitialPage = () => {
     const { params, body, groupBy, transport } = args();

--- a/apps/web/src/lib/queries/soup/normalized-cache/operations.test.ts
+++ b/apps/web/src/lib/queries/soup/normalized-cache/operations.test.ts
@@ -11,6 +11,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let testQueryClient: QueryClient;
 
+const getSoupItemsMock = vi.hoisted(() => vi.fn());
+const refreshActiveGraphqlSoupQueriesMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@service-storage/client', () => ({
+  storageServiceClient: { getSoupItems: getSoupItemsMock },
+}));
+
+vi.mock('../graphql/active-queries', () => ({
+  refreshActiveGraphqlSoupQueries: refreshActiveGraphqlSoupQueriesMock,
+}));
+
 vi.mock('../../client', () => ({
   get queryClient() {
     return testQueryClient;
@@ -50,6 +61,7 @@ import {
   insertSoupEntity,
   optimisticUpdateSoupEntity,
   optimisticUpdateSoupItemUpdatedAt,
+  refetchSoupEntity,
   removeSearchEntities,
   removeSoupEntities,
   removeSoupEntitiesFromDoneFilteredQueries,
@@ -177,6 +189,11 @@ function getSearchQuery() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  getSoupItemsMock.mockResolvedValue({
+    isErr: () => false,
+    value: { items: [] },
+  });
+  refreshActiveGraphqlSoupQueriesMock.mockResolvedValue(undefined);
   testQueryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -267,6 +284,22 @@ describe('buildSingleEntityFilter', () => {
       includeRoot: true,
     });
     expect((filter as any).project_filters.include_root).toBe(true);
+  });
+});
+
+describe('refetchSoupEntity', () => {
+  it('refreshes active GraphQL Soup queries when requested', async () => {
+    await refetchSoupEntity('task-1', 'document', { refreshGraphql: true });
+
+    expect(refreshActiveGraphqlSoupQueriesMock).toHaveBeenCalledOnce();
+    expect(getSoupItemsMock).toHaveBeenCalledOnce();
+  });
+
+  it('does not refresh GraphQL Soup queries for legacy-only refetches', async () => {
+    await refetchSoupEntity('task-1', 'document');
+
+    expect(refreshActiveGraphqlSoupQueriesMock).not.toHaveBeenCalled();
+    expect(getSoupItemsMock).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/web/src/lib/queries/soup/normalized-cache/operations.ts
+++ b/apps/web/src/lib/queries/soup/normalized-cache/operations.ts
@@ -15,6 +15,7 @@ import {
 import { isAfter } from 'date-fns';
 import { match } from 'ts-pattern';
 import { queryClient } from '../../client';
+import { refreshActiveGraphqlSoupQueries } from '../graphql/active-queries';
 import type { SoupApiItemFilter, SoupAstItemsPage } from '../items';
 import { soupKeys } from '../keys';
 import {
@@ -552,12 +553,24 @@ export function removeSearchEntities(entityIds: Set<string>): SoupTransaction {
  * from the follow-up invalidation, which would replace their pages with
  * server state that can't include the entity until the activity consumer
  * catches up.
+ *
+ * `refreshGraphql` also network-refreshes mounted GraphQL Soup operations.
+ * REST's normalized entity insertion cannot change GraphQL list or grouped-bin
+ * membership, so creation callers must request this transport revalidation.
  */
 export async function refetchSoupEntity(
   entityId: string,
   entityType: SoupEntityTag,
-  options?: { includeRoot?: boolean; ownTouch?: boolean }
+  options?: {
+    includeRoot?: boolean;
+    ownTouch?: boolean;
+    refreshGraphql?: boolean;
+  }
 ): Promise<void> {
+  if (options?.refreshGraphql) {
+    void refreshActiveGraphqlSoupQueries();
+  }
+
   const { storageServiceClient } = await import('@service-storage/client');
 
   const filter = buildSingleEntityFilter(entityType, entityId, options);


### PR DESCRIPTION
This PR fixes an issue where group soup was only refetched on creation in REST backed environments. Now both gql and rest will refetch group soup on task creation