### PR TITLE
fix(agent_harness): only enable latest Claude models in daytona harness

### DIFF
--- a/crates/agent_harness/container/opencode.json
+++ b/crates/agent_harness/container/opencode.json
@@ -4,6 +4,15 @@
     "anthropic"
   ],
   "model": "anthropic/claude-sonnet-5",
+  "provider": {
+    "anthropic": {
+      "whitelist": [
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-haiku-4-5"
+      ]
+    }
+  },
   "instructions": [
     "/etc/macro-agent/SYSTEM.md"
   ],


### PR DESCRIPTION
Whitelists the Daytona sandbox's opencode config to just the latest Claude model per tier (Opus 5, Sonnet 5, Haiku 4.5), pruning the older/dated duplicates the Anthropic model picker otherwise exposed.