### PR TITLE
fix(agent-harness): ECS health-check grace period for singleton deploys

### DIFF
--- a/infra/stacks/agent-harness-service/agent_harness_service.ts
+++ b/infra/stacks/agent-harness-service/agent_harness_service.ts
@@ -270,6 +270,11 @@ export class AgentHarnessService extends pulumi.ComponentResource {
         deploymentMinimumHealthyPercent: 0,
         deploymentMaximumPercent: 100,
         desiredCount: 1,
+        // ALB checks /health every 10s and fails the target after two
+        // misses (~20s). HTTP does not listen until after DB, AWS config,
+        // and JWT secrets, so a 0s grace period trips the circuit breaker
+        // on this stop-then-start replace. Ignore those checks until bind.
+        healthCheckGracePeriodSeconds: 120,
         taskDefinitionArgs: {
           taskRole: {
             roleArn: this.role.arn,


### PR DESCRIPTION
Huge TODO here, but agent harness service is a singleton that takes 2-3 minutes to deploy and the healthchck isn't long enough. We will make it scale horizontally SOON.