### PR TITLE
fix(agent-session): answer 409, not 500, when a runtime is not attached

### DIFF
--- a/crates/agent_session/src/inbound/axum_router.rs
+++ b/crates/agent_session/src/inbound/axum_router.rs
@@ -248,6 +248,20 @@ impl From<AgentSessionError> for AgentSessionApiError {
 impl IntoResponse for AgentSessionApiError {
     fn into_response(self) -> Response {
         match self {
+            // A session whose runtime is not attached is the everyday state of
+            // a self-hosted agent: the operator's daemon dials on a trigger and
+            // its bridge ends when the session goes quiet. Nothing is wrong
+            // here, and nothing the caller does again right now will land, so it
+            // answers 409 with a reason rather than a 500 that reads as a bug
+            // and buries the one fact worth showing a user.
+            Self::Domain(AgentSessionError::Disconnected(session_id)) => {
+                tracing::info!(%session_id, "action refused: the session's runtime is not connected");
+                (
+                    StatusCode::CONFLICT,
+                    "the agent's runtime is not connected to this session",
+                )
+                    .into_response()
+            }
             Self::Domain(AgentSessionError::Forbidden) => {
                 (StatusCode::FORBIDDEN, "forbidden").into_response()
             }

--- a/crates/agent_session/src/inbound/axum_router/test.rs
+++ b/crates/agent_session/src/inbound/axum_router/test.rs
@@ -389,3 +389,29 @@ async fn an_unknown_bot_is_a_404() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert!(opener.opened.lock().unwrap().is_empty());
 }
+
+#[tokio::test]
+async fn a_session_whose_runtime_is_gone_is_a_409() {
+    let error =
+        AgentSessionApiError::Domain(AgentSessionError::Disconnected(AgentSessionId::new()));
+
+    let response = error.into_response();
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(
+        body.as_ref(),
+        b"the agent's runtime is not connected to this session"
+    );
+}
+
+#[test]
+fn other_domain_failures_stay_500() {
+    let error = AgentSessionApiError::Domain(AgentSessionError::UnknownOwner);
+
+    let response = error.into_response();
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Rebase of #5821 onto `main`, resolving the conflict in `crates/agent_session/src/inbound/axum_router.rs`.

Prompting an agent session from the session view answers a bare `500` whenever the bot's runtime is not currently attached:

```
POST https://agent-harness-dev.macro.com/agent-sessions/01a024e0-.../control  ->  500
content-type: text/plain
internal server error
```

`AgentSessionApiError::into_response` maps *every* `AgentSessionError` to `500 "internal server error"`, so `Disconnected` — which is not a failure — is indistinguishable from a server fault. For a self-hosted (lazy-websocket) bot this is the resting state, not an edge case: the daemon dials on a webhook trigger and its bridge ends when the session goes quiet, so any session that has been idle answers 500 to the next prompt.

This maps `Disconnected` to `409 Conflict` with the reason, and logs it at `info` instead of `error`. Everything else keeps its existing mapping (`Forbidden` → 403, `InvalidName` → 400, other domain errors → 500).

## Rebase notes

#5821 conflicted with `main` because `IntoResponse` grew `Forbidden` → 403 and `InvalidName` → 400 after that branch was cut. This keeps those mappings and adds the `Disconnected` → 409 arm. The 409 test now also asserts the response body, per review on #5821.

## Repro

buzzbot1 on dev, served by `macrod` with `opencode acp`:

```
15:11:50.373  result -> stopReason end_turn
15:12:50.359  {"type":"event","event":"disconnected"}   <- bridge ended, 60s idle
15:23:44      POST .../control -> 500 internal server error
```

## Not fixed here

The reason a quiet session cannot be revived from the session view at all: `ensure_connected` is only reached from the daemon's webhook dispatcher, so a prompt that does not come from a channel mention has no way to summon an external runtime. The 409 makes that state legible; making it recoverable is a separate change (either the daemon holds its connection open, or the server gets a way to ask it to redial).

## Test plan

- `cargo test -p agent_session` including the two cases asserting `Disconnected` → 409 (status + body) and other domain errors → 500
- `cargo clippy -p agent_session --all-targets` clean, `cargo fmt`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67d61d24-67ca-4792-b58b-7d0072502f82?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67d61d24-67ca-4792-b58b-7d0072502f82&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

