### PR TITLE
fix(cursor): close tool calls for every cancelled turn

### DIFF
--- a/crates/cursor_cloud_agents/src/domain/service.rs
+++ b/crates/cursor_cloud_agents/src/domain/service.rs
@@ -489,11 +489,21 @@ where
         };
         // A cancel that raced the stream's own ending still reports
         // Cancelled: ACP requires it once the client sent `session/cancel`.
-        match outcome {
+        let stop_reason = match outcome {
             _ if cancelled => Ok(StopReason::Cancelled),
             Ok(stop_reason) => Ok(stop_reason),
             Err(error) => Err(error),
+        };
+        // Centralized rather than duplicated at every place stream_turn or
+        // poll_turn can end in Cancelled (the client's cancel racing the
+        // stream, a quiet-stream poll, a busy-wait poll, Cursor's own record
+        // reporting the run cancelled): whatever ends a turn as Cancelled
+        // may have left a tool call open with no terminal frame ever coming,
+        // and this is the one place that always sees the final verdict.
+        if matches!(stop_reason, Ok(StopReason::Cancelled)) {
+            self.close_open_tool_calls(session_id, &session).await;
         }
+        stop_reason
     }
 
     /// Cancel the session's active turn, if any. Idempotent; a session with
@@ -687,7 +697,6 @@ where
             {
                 Ok(None) => {
                     tracing::info!(%agent, %run, "turn cancelled by the client; abandoning the stream");
-                    self.close_open_tool_calls(session_id, session).await;
                     return Ok(StopReason::Cancelled);
                 }
                 Ok(Some(next)) => next,
@@ -786,12 +795,14 @@ where
         }
     }
 
-    /// Close out every tool call left open when a turn ends on the client's
-    /// cancel rather than Cursor's own terminal event.
+    /// Close out every tool call left open when a turn ends `Cancelled`
+    /// rather than on Cursor's own terminal event for that call.
     ///
-    /// The abandoned stream (see the `Ok(None)` arm above) means Cursor may
-    /// still be mid-call and will never get the chance to say how it ended,
-    /// so without this the client renders that call running forever.
+    /// Called once from [`Self::prompt`], after the verdict is final: a
+    /// cancelled stream is abandoned rather than drained, and a cancelled
+    /// poll gives up rather than waiting out the run, so either way Cursor
+    /// may still be mid-call and will never get the chance to say how it
+    /// ended. Without this the client renders that call running forever.
     async fn close_open_tool_calls(&self, session_id: &SessionId, session: &Session) {
         let updates = session
             .state

--- a/crates/cursor_cloud_agents/src/domain/service/test.rs
+++ b/crates/cursor_cloud_agents/src/domain/service/test.rs
@@ -481,10 +481,20 @@ async fn a_truncated_stream_is_finished_by_the_poll_without_repeating_text() {
 /// the result, not the envelope's end-of-turn marker.
 #[tokio::test]
 async fn a_cancelled_run_reports_cancelled_from_its_result() {
-    let (service, cursor, _notifier) = service(None);
+    let (service, cursor, notifier) = service(None);
     let session = service.new_session(Path::new(""), Vec::new());
 
     let events = cursor.script_stream();
+    events
+        .send(CursorEvent::ToolCall(ToolCallEvent {
+            call_id: "call-1".to_owned(),
+            name: "run_terminal_cmd".to_owned(),
+            status: Some("running".to_owned()),
+            args: None,
+            result: None,
+            truncated: Truncation::default(),
+        }))
+        .expect("stream open");
     events
         .send(CursorEvent::Result {
             run_id: CursorRunId::new("run-fake-1"),
@@ -502,6 +512,12 @@ async fn a_cancelled_run_reports_cancelled_from_its_result() {
             .expect("prompt answers"),
         StopReason::Cancelled
     );
+    assert!(notifier.updates().iter().any(|(_, update)| matches!(
+        update,
+        SessionUpdate::ToolCallUpdate(update)
+            if &*update.tool_call_id.0 == "call-1"
+                && update.fields.status == Some(ToolCallStatus::Failed)
+    )));
 }
 
 /// MCP servers named at `session/new` reach agent creation.

--- a/crates/cursor_cloud_agents/src/domain/translate.rs
+++ b/crates/cursor_cloud_agents/src/domain/translate.rs
@@ -113,6 +113,12 @@ impl TranslateMachine {
         let is_new = self.open.insert(call_id.clone());
         if matches!(status, ToolCallStatus::Completed | ToolCallStatus::Failed) {
             self.open.remove(&call_id);
+            // A finished call's learned kind must not outlive it: if Cursor
+            // ever reuses a call id, `learned_kinds` reapplying a stale kind
+            // (a shell call's `Execute` sticking to a later `read` reusing
+            // its id) would be worse than the unrefined name-only guess a
+            // truly fresh id gets.
+            self.learned_kinds.remove(&call_id);
         }
 
         if is_new {
@@ -159,6 +165,7 @@ impl TranslateMachine {
     /// status, and Cursor never actually reported an outcome for these, so
     /// `Completed` would claim a success nobody witnessed.
     pub fn close_open_calls(&mut self) -> Vec<SessionUpdate> {
+        self.learned_kinds.clear();
         self.open
             .drain()
             .map(|call_id| {
@@ -175,9 +182,14 @@ impl TranslateMachine {
         match update {
             InteractionUpdate::ToolCallStarted { call_id, tool_type }
             | InteractionUpdate::ToolCallCompleted { call_id, tool_type } => {
-                if let Some(kind) = tool_type.as_deref().and_then(kind_from_cursor_type) {
-                    self.learned_kinds
-                        .insert(collapse_whitespace(call_id), kind);
+                let call_id = collapse_whitespace(call_id);
+                // Real streams put `tool-call-completed` after the terminal
+                // `tool_call` frame. Do not resurrect metadata that the
+                // terminal frame already removed.
+                if self.open.contains(&call_id)
+                    && let Some(kind) = tool_type.as_deref().and_then(kind_from_cursor_type)
+                {
+                    self.learned_kinds.insert(call_id, kind);
                 }
             }
             InteractionUpdate::UserMessage { .. }

--- a/crates/cursor_cloud_agents/src/domain/translate/test.rs
+++ b/crates/cursor_cloud_agents/src/domain/translate/test.rs
@@ -1,10 +1,14 @@
 use super::*;
-use crate::domain::event::Truncation;
+use crate::domain::event::{InteractionUpdate, Truncation};
 
 fn tool_call(call_id: &str, status: &str) -> CursorEvent {
+    named_tool_call(call_id, "run_terminal_cmd", status)
+}
+
+fn named_tool_call(call_id: &str, name: &str, status: &str) -> CursorEvent {
     CursorEvent::ToolCall(ToolCallEvent {
         call_id: call_id.to_owned(),
-        name: "run_terminal_cmd".to_owned(),
+        name: name.to_owned(),
         status: Some(status.to_owned()),
         args: None,
         result: None,
@@ -48,6 +52,40 @@ fn only_calls_still_open_are_closed() {
         panic!("expected a tool_call_update, got {updates:?}");
     };
     assert_eq!(&*update.tool_call_id.0, "call-2");
+}
+
+/// A finished call's learned kind must not leak onto a later call that
+/// reuses its id — the fresh call gets classified from its own name, not the
+/// old call's typed descriptor.
+#[test]
+fn a_reused_call_id_does_not_inherit_a_finished_calls_kind() {
+    let mut machine = TranslateMachine::new();
+    machine.push(named_tool_call("call-1", "run_terminal_cmd", "running"));
+    machine.push(CursorEvent::Interaction(
+        InteractionUpdate::ToolCallStarted {
+            call_id: "call-1".to_owned(),
+            tool_type: Some("shell".to_owned()),
+        },
+    ));
+    machine.push(named_tool_call("call-1", "run_terminal_cmd", "completed"));
+    // Cursor's recorded ordering puts this descriptor after the terminal
+    // tool-call frame. It must not recreate metadata for the finished call.
+    machine.push(CursorEvent::Interaction(
+        InteractionUpdate::ToolCallCompleted {
+            call_id: "call-1".to_owned(),
+            tool_type: Some("shell".to_owned()),
+        },
+    ));
+
+    let update = machine.push(named_tool_call("call-1", "read_file", "running"));
+    let SessionUpdate::ToolCall(announcement) = &update[0] else {
+        panic!("a reused id is a fresh announcement, got {update:?}");
+    };
+    assert_eq!(
+        announcement.kind,
+        ToolKind::Read,
+        "must classify from read_file's own name, not shell's stale learned kind"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to #5960.

## Summary
- centralize open tool-call cleanup after the final cancelled verdict so client, Cursor-reported, and polled cancellations all close lingering calls
- discard learned tool kinds when calls finish or are force-closed, without resurrecting them from Cursor's late completion descriptor
- cover Cursor-reported cancellation with an open call and call-ID reuse using recorded event ordering

## Testing
- `cargo fmt --check`
- `cargo test -p cursor_cloud_agents`