### PR TITLE
feat(ai-editing): trace initial sync failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,6 +5244,7 @@ dependencies = [
  "foreign_entity",
  "futures",
  "hex",
+ "hmac 0.12.1",
  "http-body-util",
  "jsonwebtoken 10.3.0",
  "kafka_util",

--- a/crates/ai_tools/src/build_context.rs
+++ b/crates/ai_tools/src/build_context.rs
@@ -302,7 +302,8 @@ pub async fn build_tool_service_context_from_env(
         (*entity_access_service).clone(),
         lexical_client,
         sync_client.as_ref().clone(),
-        ReqwestEditingWorkerClient::new(ai_editing_worker_url, Arc::new(reqwest::Client::new())),
+        ReqwestEditingWorkerClient::new(ai_editing_worker_url, Arc::new(reqwest::Client::new()))
+            .with_internal_auth_key(Some(env.internal_api_key.to_string())),
         env.document_permission_jwt.to_string(),
     );
 

--- a/crates/documents/Cargo.toml
+++ b/crates/documents/Cargo.toml
@@ -14,6 +14,7 @@ ai_tools = [
   "dep:ai_toolset",
   "dep:ai_usage",
   "dep:async-trait",
+  "dep:hmac",
   "dep:macro_tower_layers",
   "dep:model_file_type",
   "dep:schemars",
@@ -147,6 +148,7 @@ urlencoding = { workspace = true }
 ai_toolset = { path = "../ai_toolset", optional = true }
 ai_usage = { path = "../ai_usage", optional = true }
 async-trait = { workspace = true, optional = true }
+hmac = { workspace = true, optional = true }
 lexical_client = { path = "../lexical_client", optional = true }
 macro_tower_layers = { path = "../macro_tower_layers", optional = true }
 model_file_type = { path = "../model_file_type", optional = true }

--- a/crates/documents/src/domain/ports/editing.rs
+++ b/crates/documents/src/domain/ports/editing.rs
@@ -28,9 +28,12 @@ pub struct EditUsage {
 /// Port for applying AI-driven edits to a document via the editing worker.
 #[cfg_attr(test, mockall::automock)]
 pub trait EditingWorkerService: Send + Sync + 'static {
-    /// Apply AI-driven edits to `document_id` using a pre-minted `document_token`.
+    /// Apply AI-driven edits using a pseudonymous `observability_user_id` and
+    /// a pre-minted `document_token`. The pseudonym is stable only while its
+    /// derivation secret remains unchanged.
     fn edit(
         &self,
+        observability_user_id: &str,
         document_id: &str,
         document_token: &DocumentPermissionToken,
         instructions: &str,

--- a/crates/documents/src/inbound/toolset/edit_document.rs
+++ b/crates/documents/src/inbound/toolset/edit_document.rs
@@ -11,10 +11,12 @@ use entity_access::domain::{
     models::{EditAccessLevel, EntityType},
     ports::EntityAccessService,
 };
+use hmac::{Hmac, Mac};
 use model::document::{DocumentBasic, FileType};
 use models_permissions::share_permission::access_level::AccessLevel;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 
 use super::DocumentToolContext;
 
@@ -61,6 +63,15 @@ fn ensure_markdown(document: &DocumentBasic) -> Result<(), ToolCallError> {
         ),
         internal_error: anyhow::anyhow!("document file type {file_type} is not markdown"),
     })
+}
+
+fn observability_user_id(user_id: &str, secret: &str) -> String {
+    let mut digest = Hmac::<Sha256>::new_from_slice(secret.as_bytes())
+        .expect("HMAC-SHA256 accepts keys of any length");
+    digest.update(b"ai-editing-trace-user\0");
+    digest.update(user_id.as_bytes());
+    let digest = digest.finalize().into_bytes();
+    format!("ai-edit:{digest:x}")
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -125,6 +136,12 @@ where
             description: "failed to mint document token".to_string(),
             internal_error: e.into(),
         })?;
+        // Macro user IDs contain email addresses. This backend-derived pseudonym
+        // remains stable only while the secret is unchanged.
+        let observability_user_id = observability_user_id(
+            request_context.user_id.as_ref(),
+            &ctx.document_permission_jwt_secret,
+        );
 
         // Honor user cancellation: if the request is cancelled mid-edit, drop the
         // in-flight worker call (closing the HTTP connection so the worker aborts
@@ -137,7 +154,12 @@ where
                     internal_error: anyhow::anyhow!("edit cancelled by user. document might be left in a partially edited state."),
                 });
             }
-            r = ctx.editing.edit(&self.document_id, &document_token, &self.instructions) => r,
+            r = ctx.editing.edit(
+                &observability_user_id,
+                &self.document_id,
+                &document_token,
+                &self.instructions,
+            ) => r,
         }
         .map_err(|e| ToolCallError {
             description: e.to_string(),

--- a/crates/documents/src/inbound/toolset/edit_document/test.rs
+++ b/crates/documents/src/inbound/toolset/edit_document/test.rs
@@ -390,12 +390,13 @@ impl EntityAccessService for FakeEntityAccessService {
 
 #[derive(Clone, Default)]
 struct FakeEditingWorker {
-    edit_calls: Arc<Mutex<Vec<String>>>,
+    edit_calls: Arc<Mutex<Vec<(String, String)>>>,
 }
 
 impl EditingWorkerService for FakeEditingWorker {
     async fn edit(
         &self,
+        observability_user_id: &str,
         document_id: &str,
         _document_token: &DocumentPermissionToken,
         _instructions: &str,
@@ -403,7 +404,7 @@ impl EditingWorkerService for FakeEditingWorker {
         self.edit_calls
             .lock()
             .expect("edit calls lock poisoned")
-            .push(document_id.to_string());
+            .push((observability_user_id.to_string(), document_id.to_string()));
 
         Ok(EditResult {
             edits_applied: 1,
@@ -503,8 +504,27 @@ async fn allows_markdown_document() {
     assert_eq!(response.summary, "Applied 1 edit(s) to the document.");
     assert_eq!(
         *editing.edit_calls.lock().expect("edit calls lock poisoned"),
-        vec![TEST_DOCUMENT_ID.to_string()]
+        vec![(
+            observability_user_id(TEST_USER_ID, "unused-jwt-secret"),
+            TEST_DOCUMENT_ID.to_string()
+        )]
     );
+    assert!(!observability_user_id(TEST_USER_ID, "unused-jwt-secret").contains('@'));
+}
+
+#[test]
+fn observability_user_id_is_pseudonymous_and_secret_scoped() {
+    let first = observability_user_id(TEST_USER_ID, "trace-secret");
+
+    assert_eq!(first, observability_user_id(TEST_USER_ID, "trace-secret"));
+    assert_ne!(
+        first,
+        observability_user_id("macro|other@example.com", "trace-secret")
+    );
+    assert_ne!(first, observability_user_id(TEST_USER_ID, "other-secret"));
+    assert_eq!(first.len(), "ai-edit:".len() + 64);
+    assert!(!first.contains("editor"));
+    assert!(!first.contains('@'));
 }
 
 #[test]

--- a/crates/documents/src/outbound/editing_worker_client.rs
+++ b/crates/documents/src/outbound/editing_worker_client.rs
@@ -5,6 +5,9 @@ use macro_sync_service_jwt::DocumentPermissionToken;
 use reqwest::Client;
 use std::sync::Arc;
 
+#[cfg(test)]
+mod test;
+
 /// Reqwest-backed client for the AI editing worker.
 #[derive(Clone)]
 pub struct ReqwestEditingWorkerClient {
@@ -28,7 +31,8 @@ impl ReqwestEditingWorkerClient {
         Self::new(worker_url, Arc::new(Client::new()))
     }
 
-    /// Set the internal auth key used to authenticate `delete_traces` calls.
+    /// Set the internal auth key used to authenticate trace deletion and AI
+    /// edit attribution. Without a key, edits remain supported but unattributed.
     pub fn with_internal_auth_key(mut self, internal_auth_key: Option<String>) -> Self {
         self.internal_auth_key = internal_auth_key;
         self
@@ -39,11 +43,12 @@ impl EditingWorkerService for ReqwestEditingWorkerClient {
     #[tracing::instrument(skip_all, fields(document_id), err)]
     async fn edit(
         &self,
+        observability_user_id: &str,
         document_id: &str,
         document_token: &DocumentPermissionToken,
         instructions: &str,
     ) -> anyhow::Result<EditResult> {
-        let request_body = serde_json::json!({
+        let mut request_body = serde_json::json!({
             "documentToken": document_token.as_str(),
             "documentId": document_id,
             "prompt": instructions,
@@ -75,19 +80,24 @@ impl EditingWorkerService for ReqwestEditingWorkerClient {
             },
             "interpret": false,
         });
+        if self.internal_auth_key.is_some() {
+            request_body["userId"] = observability_user_id.into();
+        }
 
         // Propagate the current trace so the worker's spans join this
         // service's trace instead of rooting their own.
         let mut headers = reqwest::header::HeaderMap::new();
         macro_tower_layers::inject_trace_headers(&mut headers);
 
-        let edit_resp = self
+        let mut request = self
             .client
             .post(format!("{}/edit", self.worker_url))
             .headers(headers)
-            .json(&request_body)
-            .send()
-            .await?;
+            .json(&request_body);
+        if let Some(internal_auth_key) = self.internal_auth_key.as_deref() {
+            request = request.header("x-internal-auth-key", internal_auth_key);
+        }
+        let edit_resp = request.send().await?;
 
         let status = edit_resp.status();
         if !status.is_success() {

--- a/crates/documents/src/outbound/editing_worker_client/test.rs
+++ b/crates/documents/src/outbound/editing_worker_client/test.rs
@@ -1,0 +1,48 @@
+use super::*;
+use axum::{Json, Router, extract::State, http::HeaderMap, routing::post};
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+async fn capture_request(
+    State(sender): State<mpsc::UnboundedSender<(HeaderMap, Value)>>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    sender
+        .send((headers, body))
+        .expect("receiver should remain open");
+    Json(serde_json::json!({ "ops": [], "usage": [] }))
+}
+
+#[tokio::test]
+async fn edit_attribution_requires_an_internal_key() {
+    let (sender, mut receiver) = mpsc::unbounded_channel();
+    let app = Router::new()
+        .route("/edit", post(capture_request))
+        .with_state(sender);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("test listener should bind");
+    let worker_url = format!("http://{}", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let token = DocumentPermissionToken::from("document-token".to_string());
+
+    ReqwestEditingWorkerClient::from_url(worker_url.clone())
+        .edit("ai-edit:opaque", "document-id", &token, "instructions")
+        .await
+        .expect("unattributed edit should succeed");
+    let (headers, body) = receiver.recv().await.expect("request should be captured");
+    assert!(!headers.contains_key("x-internal-auth-key"));
+    assert!(body.get("userId").is_none());
+
+    ReqwestEditingWorkerClient::from_url(worker_url)
+        .with_internal_auth_key(Some("internal-key".to_string()))
+        .edit("ai-edit:opaque", "document-id", &token, "instructions")
+        .await
+        .expect("attributed edit should succeed");
+    let (headers, body) = receiver.recv().await.expect("request should be captured");
+    assert_eq!(headers["x-internal-auth-key"], "internal-key");
+    assert_eq!(body["userId"], "ai-edit:opaque");
+
+    server.abort();
+}

--- a/docker/ai-editing-worker.Dockerfile
+++ b/docker/ai-editing-worker.Dockerfile
@@ -10,10 +10,11 @@ EXPOSE 8933
 
 CMD ["sh", "-c", "\
   bun scripts/generate-sandbox.ts && \
-  printf 'OPENAI_API_KEY=%s\\nANTHROPIC_API_KEY=%s\\nCEREBRAS_API_KEY=%s\\n' \
+  printf 'OPENAI_API_KEY=%s\\nANTHROPIC_API_KEY=%s\\nCEREBRAS_API_KEY=%s\\nINTERNAL_API_KEY=%s\\n' \
     \"${OPENAI_API_KEY}\" \
     \"${ANTHROPIC_API_KEY}\" \
     \"${CEREBRAS_API_KEY}\" \
+    \"${INTERNAL_API_KEY}\" \
     > .dev.vars && \
   npx wrangler dev \
     --env local \

--- a/services/ai-editing-worker/scripts/typer.ts
+++ b/services/ai-editing-worker/scripts/typer.ts
@@ -33,8 +33,9 @@ const argv = await yargs(hideBin(process.argv)).usage("$0 <wss-url>").help().par
 const wssUrl = argv._[0] as string | undefined;
 if (!wssUrl) { yargs().showHelp(); process.exit(1); }
 
-const source = createWorkerSyncSource(wssUrl, "", undefined);
+const { source, diagnostics } = createWorkerSyncSource(wssUrl, "", undefined);
 const initial = await source.doInitialSync();
+diagnostics.finish();
 if (initial.isErr()) throw new Error(`initial sync failed: ${initial.error.type}`);
 const { snapshot } = initial.value;
 

--- a/services/ai-editing-worker/src/endpoints/edit.ts
+++ b/services/ai-editing-worker/src/endpoints/edit.ts
@@ -8,7 +8,13 @@ import { createFallback } from 'ai-fallback';
 import { Hono } from 'hono';
 import * as z from 'zod';
 import { type Bindings, getEnv } from '../env';
-import { type Model, type ResolvedModels, runEditSession } from '../run-edit';
+import { authorizeEditRequestIdentity } from '../request-identity';
+import {
+  type Model,
+  type ResolvedModels,
+  type RunEditResult,
+  runEditSession,
+} from '../run-edit';
 import { runInSandbox } from '../sandbox';
 import { watchPresenceSpeed } from '../service-clients';
 import { createWorkerSyncSource } from '../sources';
@@ -57,6 +63,10 @@ const ModelListSchema = z.array(ModelSchema).min(1);
 const EditBody = z.object({
   documentToken: z.string(),
   documentId: z.string(),
+  userId: z
+    .string()
+    .regex(/^ai-edit:[0-9a-f]{64}$/)
+    .optional(),
   prompt: z.string(),
   models: z.object({
     supervisor: ModelListSchema,
@@ -115,6 +125,7 @@ edit.post('/', zValidator('json', EditBody), async (c) => {
   const {
     documentToken,
     documentId,
+    userId,
     prompt,
     models,
     typingAnimations,
@@ -124,6 +135,16 @@ edit.post('/', zValidator('json', EditBody), async (c) => {
     propagate,
   } = c.req.valid('json');
 
+  const identity = authorizeEditRequestIdentity(
+    userId,
+    c.req.header('x-internal-auth-key'),
+    env.INTERNAL_API_KEY
+  );
+  if (!identity.allowed) {
+    return c.json({ error: 'unauthorized user identity' }, 401);
+  }
+  const { pseudonymousUserId } = identity;
+
   // FYI cancellation only works on live cloudflare not workerd. And it requires enable_request_signal.
   const signal = c.req.raw.signal;
   signal.addEventListener('abort', () => {
@@ -132,7 +153,6 @@ edit.post('/', zValidator('json', EditBody), async (c) => {
 
   try {
     const wsUrl = `${env.SYNC_WS_BASE}/document/${documentId}/connect?token=${documentToken}`;
-    const source = createWorkerSyncSource(wsUrl, documentId, signal);
 
     // Animations play at 1x while a human is watching and speed up to
     // `unwatchedSpeed` when nobody is, so unseen edits finish faster without
@@ -154,23 +174,39 @@ edit.post('/', zValidator('json', EditBody), async (c) => {
       'edit.session',
       async (span) => {
         span.setAttr('document.id', documentId);
+        if (pseudonymousUserId !== undefined) {
+          span.setAttr('usr.id', pseudonymousUserId);
+        }
         span.setAttr('edit.interpret', interpret);
         span.setAttr('edit.propagate', propagate);
         let modelFallbacks = 0;
         try {
-          const result = await runEditSession({
-            source,
-            documentId,
-            prompt,
-            models: buildModels(env, models, () => modelFallbacks++),
-            typingAnimations,
-            sleep,
-            interpret,
-            debug,
-            propagate,
-            runner: runInSandbox,
-            signal,
-          }).finally(presence.stop);
+          let result: RunEditResult;
+          try {
+            const { source, diagnostics: syncDiagnostics } =
+              createWorkerSyncSource(
+                wsUrl,
+                documentId,
+                signal,
+                pseudonymousUserId
+              );
+            result = await runEditSession({
+              source,
+              syncDiagnostics,
+              documentId,
+              prompt,
+              models: buildModels(env, models, () => modelFallbacks++),
+              typingAnimations,
+              sleep,
+              interpret,
+              debug,
+              propagate,
+              runner: runInSandbox,
+              signal,
+            });
+          } finally {
+            presence.stop();
+          }
           span.setAttr(
             'edit.dispatch_count',
             result.session.dispatchEditTraces?.length ?? 0

--- a/services/ai-editing-worker/src/env.ts
+++ b/services/ai-editing-worker/src/env.ts
@@ -17,8 +17,8 @@ export type Bindings = {
   TRACES_DB: D1Database | undefined;
   /** Shared admin key gating the trace-read endpoint; validated via getEnv. */
   TRACE_ADMIN_KEY: string | undefined;
-  /** Org internal service-to-service key; accepted on the trace endpoints via
-   * the `x-internal-auth-key` header (used by the delete-document worker). */
+  /** Org internal service-to-service key; authenticates trace administration
+   * and pseudonymous edit attribution via `x-internal-auth-key`. */
   INTERNAL_API_KEY: string | undefined;
 };
 

--- a/services/ai-editing-worker/src/request-identity.test.ts
+++ b/services/ai-editing-worker/src/request-identity.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { authorizeEditRequestIdentity } from './request-identity';
+
+describe('edit endpoint identity policy', () => {
+  it('accepts pseudonymous identity only from an authenticated internal caller', () => {
+    const opaqueId = `ai-edit:${'a'.repeat(64)}`;
+    expect(authorizeEditRequestIdentity(opaqueId, 'shared', 'shared')).toEqual({
+      allowed: true,
+      pseudonymousUserId: opaqueId,
+    });
+    expect(authorizeEditRequestIdentity(opaqueId, undefined, 'shared')).toEqual(
+      {
+        allowed: false,
+      }
+    );
+    expect(authorizeEditRequestIdentity(opaqueId, 'wrong', 'shared')).toEqual({
+      allowed: false,
+    });
+    expect(authorizeEditRequestIdentity(opaqueId, '', '')).toEqual({
+      allowed: false,
+    });
+  });
+
+  it('keeps browser requests compatible and unattributed', () => {
+    expect(
+      authorizeEditRequestIdentity(undefined, undefined, 'shared')
+    ).toEqual({ allowed: true });
+  });
+});

--- a/services/ai-editing-worker/src/request-identity.ts
+++ b/services/ai-editing-worker/src/request-identity.ts
@@ -1,0 +1,20 @@
+export type EditRequestIdentity =
+  | { allowed: true; pseudonymousUserId?: string }
+  | { allowed: false };
+
+/** Authorize an optional backend-provided pseudonym. Browser requests without
+ * one remain supported but unattributed. */
+export function authorizeEditRequestIdentity(
+  userId: string | undefined,
+  presentedInternalKey: string | undefined,
+  expectedInternalKey: string
+): EditRequestIdentity {
+  if (userId === undefined) return { allowed: true };
+  if (
+    expectedInternalKey.length === 0 ||
+    presentedInternalKey !== expectedInternalKey
+  ) {
+    return { allowed: false };
+  }
+  return { allowed: true, pseudonymousUserId: userId };
+}

--- a/services/ai-editing-worker/src/run-edit.ts
+++ b/services/ai-editing-worker/src/run-edit.ts
@@ -19,6 +19,7 @@ import type { UsageEntry } from './ai-editing/token-tracker';
 import type { CoderRunCode, DispatchEditTrace } from './ai-editing/tools';
 import { serializeWithXml } from './ai-editing/utils';
 import { EditingWorkspace } from './editing-workspace';
+import type { InitialSyncDiagnostics } from './sources';
 import { buildTraceSession, type TraceSession } from './trace-log';
 
 export type Model = {
@@ -41,6 +42,8 @@ export type ResolvedModels = {
 export type RunEditArgs = {
   /** Live sync source, already constructed by the caller (ws in prod). */
   source: SyncServiceSource;
+  /** Worker-only WebSocket lifecycle diagnostics for the initial sync span. */
+  syncDiagnostics?: InitialSyncDiagnostics;
   documentId: string;
   prompt: string;
   models: ResolvedModels;
@@ -82,25 +85,36 @@ export async function runEditSession(
   });
 
   await Telemetry.span('edit.sync_init', async (span) => {
-    const initialResult = await source.doInitialSync();
-    if (initialResult.isErr()) {
-      source.cleanup();
-      const e = initialResult.error;
-      const err = new Error(`initial sync failed: ${e.type} (${e.duration}ms)`);
-      span.error(err);
-      throw err;
-    }
-    const initial = initialResult.value;
-    span.setAttr('snapshot.bytes', initial.snapshot.byteLength);
+    args.syncDiagnostics?.attach(span);
+    try {
+      const initialResult = await source.doInitialSync();
+      if (initialResult.isErr()) {
+        source.cleanup();
+        const e = initialResult.error;
+        span.setAttr('sync.outcome', e.type);
+        span.event('sync.initial_sync.timeout');
+        const err = new Error(
+          `initial sync failed: ${e.type} (${e.duration}ms)`
+        );
+        span.error(err);
+        throw err;
+      }
+      const initial = initialResult.value;
+      span.setAttr('sync.outcome', 'success');
+      span.setAttr('snapshot.bytes', initial.snapshot.byteLength);
 
-    const initResult = await manager.initializeFromSnapshot(initial.snapshot);
-    if (initResult.isErr()) {
-      source.cleanup();
-      const err = new Error(
-        `failed to initialize from snapshot: ${initResult.error[0]?.message}`
-      );
-      span.error(err);
-      throw err;
+      const initResult = await manager.initializeFromSnapshot(initial.snapshot);
+      if (initResult.isErr()) {
+        source.cleanup();
+        span.setAttr('sync.outcome', 'invalid_snapshot');
+        const err = new Error(
+          `failed to initialize from snapshot: ${initResult.error[0]?.message}`
+        );
+        span.error(err);
+        throw err;
+      }
+    } finally {
+      args.syncDiagnostics?.finish();
     }
   });
 

--- a/services/ai-editing-worker/src/sources.test.ts
+++ b/services/ai-editing-worker/src/sources.test.ts
@@ -1,0 +1,115 @@
+import type {
+  FromRemote,
+  IFromPeer,
+} from '@macro-inc/collaboration/sync-service/generated/schema';
+import type { SyncSocket } from '@macro-inc/collaboration/sync-service/socket';
+import {
+  WebsocketConnectionState,
+  WebsocketEvent,
+  type WebsocketEventListener,
+} from '@macro-inc/collaboration/websocket';
+import type { Span } from '@macro-inc/observability';
+import { describe, expect, it, vi } from 'vitest';
+import { InitialSyncDiagnostics } from './sources';
+
+type Listener = WebsocketEventListener<WebsocketEvent, IFromPeer, FromRemote>;
+
+class FakeSocket implements SyncSocket {
+  connectionState = WebsocketConnectionState.Connecting;
+  private readonly listeners = new Map<WebsocketEvent, Set<Listener>>();
+
+  send(): boolean {
+    return true;
+  }
+  startHeartbeat(): void {}
+  reconnectIfDisconnected(): void {}
+  close(): void {}
+
+  addEventListener<K extends WebsocketEvent>(
+    type: K,
+    listener: WebsocketEventListener<K, IFromPeer, FromRemote>
+  ): void {
+    const listeners = this.listeners.get(type) ?? new Set<Listener>();
+    listeners.add(listener as Listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener<K extends WebsocketEvent>(
+    type: K,
+    listener: WebsocketEventListener<K, IFromPeer, FromRemote>
+  ): void {
+    this.listeners.get(type)?.delete(listener as Listener);
+  }
+
+  fire(type: WebsocketEvent, event: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(this as never, event as never);
+    }
+  }
+}
+
+describe('InitialSyncDiagnostics', () => {
+  it('records lifecycle state without URL, token, or close reason', () => {
+    const socket = new FakeSocket();
+    const pseudonymousUserId = `ai-edit:${'a'.repeat(64)}`;
+    const diagnostics = new InitialSyncDiagnostics(socket, pseudonymousUserId);
+    const setAttr = vi.fn();
+    const event = vi.fn();
+    const span = { setAttr, event } as unknown as Span;
+
+    // URL resolution and open commonly happen before edit.sync_init starts.
+    socket.fire(WebsocketEvent.UrlResolved, {
+      detail: { url: 'wss://sync.example/connect?token=secret' },
+    });
+    socket.connectionState = WebsocketConnectionState.Open;
+    socket.fire(WebsocketEvent.Open, {});
+    diagnostics.attach(span);
+
+    expect(setAttr).toHaveBeenCalledWith('usr.id', pseudonymousUserId);
+    expect(setAttr).toHaveBeenCalledWith('ws.state', 'open');
+    expect(event).toHaveBeenCalledWith('websocket.constructed', undefined);
+    expect(event).toHaveBeenCalledWith('websocket.url_resolved', undefined);
+    expect(event).toHaveBeenCalledWith('websocket.open', undefined);
+
+    socket.fire(WebsocketEvent.Error, {});
+    socket.connectionState = WebsocketConnectionState.Reconnecting;
+    socket.fire(WebsocketEvent.retry, {
+      detail: {
+        retries: 2,
+        backoff: 1_000,
+        url: 'wss://sync.example/connect?token=secret',
+      },
+    });
+    socket.fire(WebsocketEvent.Close, {
+      code: 1006,
+      wasClean: false,
+      reason: 'token=secret',
+    });
+
+    expect(setAttr).toHaveBeenCalledWith('ws.url_resolved', true);
+    expect(setAttr).toHaveBeenCalledWith('ws.opened', true);
+    expect(setAttr).toHaveBeenCalledWith('ws.error_count', 1);
+    expect(setAttr).toHaveBeenCalledWith('ws.retry_count', 1);
+    expect(setAttr).toHaveBeenCalledWith('ws.close_count', 1);
+    expect(setAttr).toHaveBeenCalledWith('ws.state', 'open');
+    expect(setAttr).toHaveBeenCalledWith('ws.state', 'reconnecting');
+    expect(setAttr).toHaveBeenCalledWith('ws.state', 'closed');
+    expect(event).toHaveBeenCalledWith('websocket.error', {
+      'ws.state': 'open',
+    });
+    expect(event).toHaveBeenCalledWith('websocket.retry', {
+      'ws.retry.attempt': 2,
+      'ws.retry.backoff_ms': 1_000,
+    });
+    expect(event).toHaveBeenCalledWith('websocket.close', {
+      'ws.close.code': 1006,
+      'ws.close.clean': false,
+    });
+    expect(JSON.stringify(event.mock.calls)).not.toContain('secret');
+
+    const attributeCalls = setAttr.mock.calls.length;
+    diagnostics.finish();
+    socket.fire(WebsocketEvent.Error, {});
+    expect(setAttr).toHaveBeenCalledTimes(attributeCalls);
+  });
+});

--- a/services/ai-editing-worker/src/sources.ts
+++ b/services/ai-editing-worker/src/sources.ts
@@ -6,9 +6,134 @@
  */
 
 import type { Awareness } from '@macro-inc/collaboration/collab/awareness';
+import type { SyncSocket } from '@macro-inc/collaboration/sync-service/socket';
 import { createSyncSocket } from '@macro-inc/collaboration/sync-service/socket';
 import { SyncServiceSource } from '@macro-inc/collaboration/sync-service/source';
+import {
+  WebsocketConnectionState,
+  WebsocketEvent,
+} from '@macro-inc/collaboration/websocket';
+import type { Span } from '@macro-inc/observability';
 import { EphemeralStore, type PeerID } from 'loro-crdt';
+
+type DiagnosticEvent = {
+  name: string;
+  attributes?: Record<string, boolean | number | string>;
+};
+
+function socketState(state: WebsocketConnectionState): string {
+  switch (state) {
+    case WebsocketConnectionState.Connecting:
+      return 'connecting';
+    case WebsocketConnectionState.Open:
+      return 'open';
+    case WebsocketConnectionState.Closing:
+      return 'closing';
+    case WebsocketConnectionState.Closed:
+      return 'closed';
+    case WebsocketConnectionState.Reconnecting:
+      return 'reconnecting';
+  }
+}
+
+/** Buffers safe WebSocket lifecycle events until the initial-sync span starts. */
+export class InitialSyncDiagnostics {
+  private span: Span | undefined;
+  private pending: DiagnosticEvent[] = [];
+  private retries = 0;
+  private closes = 0;
+  private errors = 0;
+  private urlResolved = false;
+  private opened = false;
+
+  private readonly onUrlResolved = () => {
+    this.urlResolved = true;
+    this.record('websocket.url_resolved');
+    this.span?.setAttr('ws.url_resolved', true);
+  };
+  private readonly onOpen = () => {
+    this.opened = true;
+    this.record('websocket.open');
+    this.span?.setAttr('ws.opened', true);
+    this.span?.setAttr('ws.state', 'open');
+  };
+  private readonly onClose = (_ws: unknown, event: CloseEvent) => {
+    this.closes++;
+    this.record('websocket.close', {
+      'ws.close.code': event.code,
+      'ws.close.clean': event.wasClean,
+    });
+    this.span?.setAttr('ws.close_count', this.closes);
+    this.span?.setAttr('ws.state', 'closed');
+  };
+  private readonly onError = () => {
+    this.errors++;
+    this.record('websocket.error', {
+      'ws.state': socketState(this.ws.connectionState),
+    });
+    this.span?.setAttr('ws.error_count', this.errors);
+  };
+  private readonly onRetry = (
+    _ws: unknown,
+    event: CustomEvent<{ retries: number; backoff: number }>
+  ) => {
+    this.retries++;
+    this.record('websocket.retry', {
+      'ws.retry.attempt': event.detail.retries,
+      'ws.retry.backoff_ms': event.detail.backoff,
+    });
+    this.span?.setAttr('ws.retry_count', this.retries);
+    this.span?.setAttr('ws.state', 'reconnecting');
+  };
+
+  public constructor(
+    private readonly ws: SyncSocket,
+    private readonly pseudonymousUserId?: string
+  ) {
+    this.record('websocket.constructed');
+    ws.addEventListener(WebsocketEvent.UrlResolved, this.onUrlResolved);
+    ws.addEventListener(WebsocketEvent.Open, this.onOpen);
+    ws.addEventListener(WebsocketEvent.Close, this.onClose);
+    ws.addEventListener(WebsocketEvent.Error, this.onError);
+    ws.addEventListener(WebsocketEvent.retry, this.onRetry);
+  }
+
+  /** Attach the initial-sync span and replay lifecycle events already observed. */
+  public attach(span: Span): void {
+    this.span = span;
+    if (this.pseudonymousUserId !== undefined) {
+      span.setAttr('usr.id', this.pseudonymousUserId);
+    }
+    span.setAttr('ws.constructed', true);
+    span.setAttr('ws.state', socketState(this.ws.connectionState));
+    span.setAttr('ws.url_resolved', this.urlResolved);
+    span.setAttr('ws.opened', this.opened);
+    span.setAttr('ws.close_count', this.closes);
+    span.setAttr('ws.error_count', this.errors);
+    span.setAttr('ws.retry_count', this.retries);
+    for (const event of this.pending) span.event(event.name, event.attributes);
+    this.pending = [];
+  }
+
+  /** Stop observing once initial sync has completed or failed. */
+  public finish(): void {
+    this.ws.removeEventListener(WebsocketEvent.UrlResolved, this.onUrlResolved);
+    this.ws.removeEventListener(WebsocketEvent.Open, this.onOpen);
+    this.ws.removeEventListener(WebsocketEvent.Close, this.onClose);
+    this.ws.removeEventListener(WebsocketEvent.Error, this.onError);
+    this.ws.removeEventListener(WebsocketEvent.retry, this.onRetry);
+    this.span = undefined;
+    this.pending = [];
+  }
+
+  private record(
+    name: string,
+    attributes?: DiagnosticEvent['attributes']
+  ): void {
+    if (this.span) this.span.event(name, attributes);
+    else this.pending.push({ name, attributes });
+  }
+}
 
 /**
  * A {@link SyncServiceSource} bound to a fixed, token-bearing URL. A worker
@@ -18,12 +143,14 @@ import { EphemeralStore, type PeerID } from 'loro-crdt';
 export function createWorkerSyncSource(
   wsUrl: string,
   documentId: string,
-  signal?: AbortSignal
-): SyncServiceSource {
+  signal?: AbortSignal,
+  pseudonymousUserId?: string
+): { source: SyncServiceSource; diagnostics: InitialSyncDiagnostics } {
   const ws = createSyncSocket(() => wsUrl);
+  const diagnostics = new InitialSyncDiagnostics(ws, pseudonymousUserId);
   const source = new SyncServiceSource(ws, documentId);
   signal?.addEventListener('abort', () => source.cleanup());
-  return source;
+  return { source, diagnostics };
 }
 
 export function createWorkerAwareness(peerId: PeerID): Awareness<unknown> {

--- a/services/document_cognition_service/src/main.rs
+++ b/services/document_cognition_service/src/main.rs
@@ -327,7 +327,8 @@ async fn main() -> anyhow::Result<()> {
         documents::outbound::editing_worker_client::ReqwestEditingWorkerClient::new(
             config.ai_editing_worker_url.clone(),
             std::sync::Arc::new(reqwest::Client::new()),
-        ),
+        )
+        .with_internal_auth_key(Some(config.internal_api_key.to_string())),
         config.document_permission_jwt.as_ref().to_string(),
     );
 

--- a/services/mcp_service/src/context.rs
+++ b/services/mcp_service/src/context.rs
@@ -269,7 +269,8 @@ async fn build_tool_context(args: ToolContextBuildArgs<'_>) -> anyhow::Result<To
         (*entity_access_service).clone(),
         lexical_client_for_tools,
         sync_service_client.clone(),
-        ReqwestEditingWorkerClient::from_url(ai_editing_worker_url),
+        ReqwestEditingWorkerClient::from_url(ai_editing_worker_url)
+            .with_internal_auth_key(Some(config.internal_api_key.to_string())),
         config.document_permission_jwt.to_string(),
     );
 


### PR DESCRIPTION
## Summary
- propagate an authenticated HMAC-derived user pseudonym to AI editing spans as `usr.id`
- record safe WebSocket lifecycle state, retries, errors, and closes on `edit.sync_init`
- keep browser and unkeyed client edits compatible and unattributed

## Context
Production AI edits intermittently time out after 10 seconds waiting for the initial sync snapshot, before model execution. Existing traces identify the document but cannot distinguish affected users or whether the Worker socket resolved, opened, retried, errored, or closed.

The new attribution contains no email or raw Macro user ID. The Worker accepts it only when the request carries the existing internal service key. WebSocket diagnostics exclude URLs, document tokens, and close reasons.

## Verification
- `cargo test -p documents` (161 passed)
- `cargo check -p ai_tools -p mcp_service -p document_cognition_service`
- `cargo fmt --all -- --check`
- `bun run type-check` in `services/ai-editing-worker`
- `bunx vitest run src/request-identity.test.ts src/sources.test.ts` (3 passed)