### PR TITLE
feat(web): draft surfaces interface (lib/surface)

### DIFF
--- a/apps/web/src/lib/surface/EntityFrame.tsx
+++ b/apps/web/src/lib/surface/EntityFrame.tsx
@@ -1,29 +1,22 @@
-import { useAnalytics } from '@app/lib/analytics/analytics-context';
 import { useSplitPanel } from '@components/app/split-layout/layoutUtils';
-import type { BlockName } from '@core/block';
 import {
   type EntityLoadError,
   EntityLoadGate,
   type EntityLoadResult,
   toEntityLoadError,
 } from '@core/component/EntityLoadGate';
-import { BlockOpenTrackingDelayContext } from '@core/context/blockOpenTracking';
 import { useHotkeyDOMScope } from '@core/hotkey/hotkeys';
 import { isTabFocused } from '@core/signal/tabFocus';
-import { useQueryClient } from '@queries/client';
 import { connectionGatewayClient } from '@service-connection/client';
 import {
   type Accessor,
   createContext,
   createEffect,
-  createSignal,
   type JSX,
   onCleanup,
   useContext,
 } from 'solid-js';
-import { match } from 'ts-pattern';
 import { useSurface } from './SurfaceProvider';
-import type { SurfaceName } from './specs';
 
 /** Re-exported so features import one module for the frame + its error type. */
 export type { EntityLoadError, EntityLoadResult };
@@ -56,19 +49,6 @@ export type EntityFrameProps<Data> = {
    * Default false — the feature opts in (replaces liveTrackingEnabled).
    */
   liveTracking?: boolean;
-  /**
-   * entity_type reported to the gateway. Defaults from the surface name via
-   * ts-pattern match: 'chat' → 'chat', 'channel' → 'channel',
-   * 'project' → 'project', otherwise 'document'.
-   */
-  trackAs?: 'document' | 'chat' | 'channel' | 'project';
-  /**
-   * Entity-open analytics + history recording on first data arrival
-   * (trackBlockOpened + pageView + open_entity), honoring
-   * BlockOpenTrackingDelayContext, skipped when nested.
-   * Default true (replaces openTrackingEnabled !== false).
-   */
-  openTracking?: boolean;
   /** Rendered once data is available, with a narrowed accessor. */
   children: (data: Accessor<Data>) => JSX.Element;
 };
@@ -77,21 +57,9 @@ export type EntityFrameProps<Data> = {
 export type SurfaceChrome = {
   /** The active hotkey scope id (split scope or the frame's own DOM scope). */
   hotkeyScope: Accessor<string>;
-  /** The frame's root element once mounted. */
-  rootElement: Accessor<HTMLElement | undefined>;
 };
 
 const SurfaceChromeContext = createContext<SurfaceChrome>();
-
-function defaultTrackAs(
-  name: SurfaceName
-): NonNullable<EntityFrameProps<unknown>['trackAs']> {
-  return match(name as string)
-    .with('chat', () => 'chat' as const)
-    .with('channel', () => 'channel' as const)
-    .with('project', () => 'project' as const)
-    .otherwise(() => 'document' as const);
-}
 
 /**
  * Opt-in chrome for entity surfaces: load gate, live tracking, hotkey scope,
@@ -99,10 +67,7 @@ function defaultTrackAs(
  */
 export function EntityFrame<Data>(props: EntityFrameProps<Data>): JSX.Element {
   const surface = useSurface();
-  const analytics = useAnalytics();
-  const openTrackingDelayMs = useContext(BlockOpenTrackingDelayContext);
   const split = useSplitPanel();
-  const [rootElement, setRootElement] = createSignal<HTMLElement | undefined>();
 
   // Block commands register on the split scope: it covers the whole panel
   // (header, toolbar, the focusable panel div), so block hotkeys keep working
@@ -131,13 +96,14 @@ export function EntityFrame<Data>(props: EntityFrameProps<Data>): JSX.Element {
 
   const chrome: SurfaceChrome = {
     hotkeyScope,
-    rootElement,
   };
 
   createEffect(() => {
     if (!props.liveTracking || surface.nested) return;
     const entityId = surface.id();
-    const entityType = props.trackAs ?? defaultTrackAs(surface.name);
+    // Every draft entity surface is a document; the chat/channel/project
+    // mapping returns when those surfaces migrate.
+    const entityType = 'document' as const;
     connectionGatewayClient.trackEntity({
       entity_type: entityType,
       entity_id: entityId,
@@ -162,45 +128,13 @@ export function EntityFrame<Data>(props: EntityFrameProps<Data>): JSX.Element {
     });
   });
 
-  createEffect(() => {
-    if (props.openTracking === false || surface.nested) return;
-    const data = props.result.data();
-    if (data === undefined) return;
-    const itemId = surface.id();
-    const entityType = surface.name;
-    const trackOpened = () => {
-      void import('@core/internal/trackBlockOpened').then(({ track }) => {
-        track({
-          itemId,
-          blockName: entityType as BlockName,
-          client: useQueryClient,
-        });
-      });
-      analytics.pageView(entityType);
-      analytics.track('open_entity', {
-        entityType,
-        entityId: itemId,
-      });
-    };
-    if (openTrackingDelayMs > 0) {
-      const timer = setTimeout(trackOpened, openTrackingDelayMs);
-      onCleanup(() => clearTimeout(timer));
-    } else {
-      trackOpened();
-    }
-  });
-
   return (
     <SurfaceChromeContext.Provider value={chrome}>
       <div
         class="relative size-full portal-scope"
         id={`surface-${surface.id()}`}
         data-surface={surface.name}
-        data-surface-alias={surface.alias}
-        ref={(el) => {
-          setRootElement(el);
-          attachFallbackHotkeyScope?.(el);
-        }}
+        ref={(el) => attachFallbackHotkeyScope?.(el)}
       >
         <div class="overflow-hidden size-full">
           <EntityLoadGate result={props.result}>
@@ -222,9 +156,4 @@ export function useSurfaceChrome(): SurfaceChrome {
     throw new Error('useSurfaceChrome() called outside an EntityFrame');
   }
   return ctx;
-}
-
-/** Chrome facts owned by the enclosing EntityFrame, or undefined outside one. */
-export function useMaybeSurfaceChrome(): SurfaceChrome | undefined {
-  return useContext(SurfaceChromeContext);
 }

--- a/apps/web/src/lib/surface/EntityFrame.tsx
+++ b/apps/web/src/lib/surface/EntityFrame.tsx
@@ -1,0 +1,230 @@
+import { useAnalytics } from '@app/lib/analytics/analytics-context';
+import { useSplitPanel } from '@components/app/split-layout/layoutUtils';
+import type { BlockName } from '@core/block';
+import {
+  type EntityLoadError,
+  EntityLoadGate,
+  type EntityLoadResult,
+  toEntityLoadError,
+} from '@core/component/EntityLoadGate';
+import { BlockOpenTrackingDelayContext } from '@core/context/blockOpenTracking';
+import { useHotkeyDOMScope } from '@core/hotkey/hotkeys';
+import { isTabFocused } from '@core/signal/tabFocus';
+import { useQueryClient } from '@queries/client';
+import { connectionGatewayClient } from '@service-connection/client';
+import {
+  type Accessor,
+  createContext,
+  createEffect,
+  createSignal,
+  type JSX,
+  onCleanup,
+  useContext,
+} from 'solid-js';
+import { match } from 'ts-pattern';
+import { useSurface } from './SurfaceProvider';
+import type { SurfaceName } from './specs';
+
+/** Re-exported so features import one module for the frame + its error type. */
+export type { EntityLoadError, EntityLoadResult };
+
+const PING_INTERVAL_MS = 20_000;
+
+/**
+ * Adapt a TanStack solid-query result (reactive store) to EntityLoadResult.
+ * Error normalization delegates to toEntityLoadError (ThrownResultError codes
+ * UNAUTHORIZED/FORBIDDEN/NOT_FOUND/GONE; everything else → 'UNEXPECTED').
+ */
+export function queryLoadResult<Data>(query: {
+  data: Data | undefined;
+  error: unknown;
+  isPending: boolean;
+}): EntityLoadResult<Data> {
+  return {
+    data: () => query.data,
+    error: () => toEntityLoadError(query.error),
+    isPending: () => query.isPending,
+  };
+}
+
+/** Props for the opt-in entity-surface chrome. */
+export type EntityFrameProps<Data> = {
+  /** Drives loading / access-error / content states. */
+  result: EntityLoadResult<Data>;
+  /**
+   * Presence tracking via the connection gateway (open/ping/close).
+   * Default false — the feature opts in (replaces liveTrackingEnabled).
+   */
+  liveTracking?: boolean;
+  /**
+   * entity_type reported to the gateway. Defaults from the surface name via
+   * ts-pattern match: 'chat' → 'chat', 'channel' → 'channel',
+   * 'project' → 'project', otherwise 'document'.
+   */
+  trackAs?: 'document' | 'chat' | 'channel' | 'project';
+  /**
+   * Entity-open analytics + history recording on first data arrival
+   * (trackBlockOpened + pageView + open_entity), honoring
+   * BlockOpenTrackingDelayContext, skipped when nested.
+   * Default true (replaces openTrackingEnabled !== false).
+   */
+  openTracking?: boolean;
+  /** Rendered once data is available, with a narrowed accessor. */
+  children: (data: Accessor<Data>) => JSX.Element;
+};
+
+/** Chrome facts EntityFrame owns, for feature code beneath it. */
+export type SurfaceChrome = {
+  /** The active hotkey scope id (split scope or the frame's own DOM scope). */
+  hotkeyScope: Accessor<string>;
+  /** The frame's root element once mounted. */
+  rootElement: Accessor<HTMLElement | undefined>;
+};
+
+const SurfaceChromeContext = createContext<SurfaceChrome>();
+
+function defaultTrackAs(
+  name: SurfaceName
+): NonNullable<EntityFrameProps<unknown>['trackAs']> {
+  return match(name as string)
+    .with('chat', () => 'chat' as const)
+    .with('channel', () => 'channel' as const)
+    .with('project', () => 'project' as const)
+    .otherwise(() => 'document' as const);
+}
+
+/**
+ * Opt-in chrome for entity surfaces: load gate, live tracking, hotkey scope,
+ * and DOM identity attributes.
+ */
+export function EntityFrame<Data>(props: EntityFrameProps<Data>): JSX.Element {
+  const surface = useSurface();
+  const analytics = useAnalytics();
+  const openTrackingDelayMs = useContext(BlockOpenTrackingDelayContext);
+  const split = useSplitPanel();
+  const [rootElement, setRootElement] = createSignal<HTMLElement | undefined>();
+
+  // Block commands register on the split scope: it covers the whole panel
+  // (header, toolbar, the focusable panel div), so block hotkeys keep working
+  // while focus sits on split chrome outside the block element, and it stays
+  // active across in-split navigation. The block gets no DOM scope of its
+  // own. Registrations must
+  // dispose with their owner (registerHotkey does this automatically) since
+  // the split scope survives split navigation.
+  //
+  // Only a block rendered without a split panel gets its own DOM scope,
+  // attached to the block element — a scope that is never attached can never
+  // activate, so commands registered to it would silently never run.
+  let attachFallbackHotkeyScope: ((el: Element) => void) | undefined;
+  let fallbackScopeId: string | undefined;
+  if (split) {
+    fallbackScopeId = split.splitHotkeyScope;
+  } else {
+    const [attachHotkeys, scopeId] = useHotkeyDOMScope(surface.name);
+    attachFallbackHotkeyScope = attachHotkeys;
+    fallbackScopeId = scopeId;
+  }
+
+  const hotkeyScope: Accessor<string> = split
+    ? () => split.splitHotkeyScope
+    : () => fallbackScopeId!;
+
+  const chrome: SurfaceChrome = {
+    hotkeyScope,
+    rootElement,
+  };
+
+  createEffect(() => {
+    if (!props.liveTracking || surface.nested) return;
+    const entityId = surface.id();
+    const entityType = props.trackAs ?? defaultTrackAs(surface.name);
+    connectionGatewayClient.trackEntity({
+      entity_type: entityType,
+      entity_id: entityId,
+      action: 'open',
+    });
+    const pingInterval = setInterval(() => {
+      if (isTabFocused()) {
+        connectionGatewayClient.trackEntity({
+          entity_type: entityType,
+          entity_id: entityId,
+          action: 'ping',
+        });
+      }
+    }, PING_INTERVAL_MS);
+    onCleanup(() => {
+      connectionGatewayClient.trackEntity({
+        entity_type: entityType,
+        entity_id: entityId,
+        action: 'close',
+      });
+      clearInterval(pingInterval);
+    });
+  });
+
+  createEffect(() => {
+    if (props.openTracking === false || surface.nested) return;
+    const data = props.result.data();
+    if (data === undefined) return;
+    const itemId = surface.id();
+    const entityType = surface.name;
+    const trackOpened = () => {
+      void import('@core/internal/trackBlockOpened').then(({ track }) => {
+        track({
+          itemId,
+          blockName: entityType as BlockName,
+          client: useQueryClient,
+        });
+      });
+      analytics.pageView(entityType);
+      analytics.track('open_entity', {
+        entityType,
+        entityId: itemId,
+      });
+    };
+    if (openTrackingDelayMs > 0) {
+      const timer = setTimeout(trackOpened, openTrackingDelayMs);
+      onCleanup(() => clearTimeout(timer));
+    } else {
+      trackOpened();
+    }
+  });
+
+  return (
+    <SurfaceChromeContext.Provider value={chrome}>
+      <div
+        class="relative size-full portal-scope"
+        id={`surface-${surface.id()}`}
+        data-surface={surface.name}
+        data-surface-alias={surface.alias}
+        ref={(el) => {
+          setRootElement(el);
+          attachFallbackHotkeyScope?.(el);
+        }}
+      >
+        <div class="overflow-hidden size-full">
+          <EntityLoadGate result={props.result}>
+            {props.children(() => props.result.data() as Data)}
+          </EntityLoadGate>
+        </div>
+      </div>
+    </SurfaceChromeContext.Provider>
+  );
+}
+
+/**
+ * Chrome facts owned by the enclosing EntityFrame.
+ * @throws outside an EntityFrame subtree.
+ */
+export function useSurfaceChrome(): SurfaceChrome {
+  const ctx = useContext(SurfaceChromeContext);
+  if (!ctx) {
+    throw new Error('useSurfaceChrome() called outside an EntityFrame');
+  }
+  return ctx;
+}
+
+/** Chrome facts owned by the enclosing EntityFrame, or undefined outside one. */
+export function useMaybeSurfaceChrome(): SurfaceChrome | undefined {
+  return useContext(SurfaceChromeContext);
+}

--- a/apps/web/src/lib/surface/EntityFrame.tsx
+++ b/apps/web/src/lib/surface/EntityFrame.tsx
@@ -6,22 +6,11 @@ import {
   toEntityLoadError,
 } from '@core/component/EntityLoadGate';
 import { useHotkeyDOMScope } from '@core/hotkey/hotkeys';
-import { isTabFocused } from '@core/signal/tabFocus';
-import { connectionGatewayClient } from '@service-connection/client';
-import {
-  type Accessor,
-  createContext,
-  createEffect,
-  type JSX,
-  onCleanup,
-  useContext,
-} from 'solid-js';
+import { type Accessor, createContext, type JSX, useContext } from 'solid-js';
 import { useSurface } from './SurfaceProvider';
 
 /** Re-exported so features import one module for the frame + its error type. */
 export type { EntityLoadError, EntityLoadResult };
-
-const PING_INTERVAL_MS = 20_000;
 
 /**
  * Adapt a TanStack solid-query result (reactive store) to EntityLoadResult.
@@ -44,11 +33,6 @@ export function queryLoadResult<Data>(query: {
 export type EntityFrameProps<Data> = {
   /** Drives loading / access-error / content states. */
   result: EntityLoadResult<Data>;
-  /**
-   * Presence tracking via the connection gateway (open/ping/close).
-   * Default false — the feature opts in (replaces liveTrackingEnabled).
-   */
-  liveTracking?: boolean;
   /** Rendered once data is available, with a narrowed accessor. */
   children: (data: Accessor<Data>) => JSX.Element;
 };
@@ -62,8 +46,8 @@ export type SurfaceChrome = {
 const SurfaceChromeContext = createContext<SurfaceChrome>();
 
 /**
- * Opt-in chrome for entity surfaces: load gate, live tracking, hotkey scope,
- * and DOM identity attributes.
+ * Opt-in chrome for entity surfaces: load gate, hotkey scope, and DOM
+ * identity.
  */
 export function EntityFrame<Data>(props: EntityFrameProps<Data>): JSX.Element {
   const surface = useSurface();
@@ -85,7 +69,7 @@ export function EntityFrame<Data>(props: EntityFrameProps<Data>): JSX.Element {
   if (split) {
     fallbackScopeId = split.splitHotkeyScope;
   } else {
-    const [attachHotkeys, scopeId] = useHotkeyDOMScope(surface.name);
+    const [attachHotkeys, scopeId] = useHotkeyDOMScope('surface');
     attachFallbackHotkeyScope = attachHotkeys;
     fallbackScopeId = scopeId;
   }
@@ -98,42 +82,11 @@ export function EntityFrame<Data>(props: EntityFrameProps<Data>): JSX.Element {
     hotkeyScope,
   };
 
-  createEffect(() => {
-    if (!props.liveTracking || surface.nested) return;
-    const entityId = surface.id();
-    // Every draft entity surface is a document; the chat/channel/project
-    // mapping returns when those surfaces migrate.
-    const entityType = 'document' as const;
-    connectionGatewayClient.trackEntity({
-      entity_type: entityType,
-      entity_id: entityId,
-      action: 'open',
-    });
-    const pingInterval = setInterval(() => {
-      if (isTabFocused()) {
-        connectionGatewayClient.trackEntity({
-          entity_type: entityType,
-          entity_id: entityId,
-          action: 'ping',
-        });
-      }
-    }, PING_INTERVAL_MS);
-    onCleanup(() => {
-      connectionGatewayClient.trackEntity({
-        entity_type: entityType,
-        entity_id: entityId,
-        action: 'close',
-      });
-      clearInterval(pingInterval);
-    });
-  });
-
   return (
     <SurfaceChromeContext.Provider value={chrome}>
       <div
         class="relative size-full portal-scope"
         id={`surface-${surface.id()}`}
-        data-surface={surface.name}
         ref={(el) => attachFallbackHotkeyScope?.(el)}
       >
         <div class="overflow-hidden size-full">

--- a/apps/web/src/lib/surface/SurfaceProvider.test.tsx
+++ b/apps/web/src/lib/surface/SurfaceProvider.test.tsx
@@ -51,19 +51,7 @@ describe('SurfaceProvider', () => {
     expect(maybe).toBeUndefined();
   });
 
-  it('announces on mount and disposes on unmount', () => {
-    const directory = createSurfaceDirectory();
-    const view = renderView(() => (
-      <SurfaceProvider name="image" id={() => 'mounted'} directory={directory}>
-        <div />
-      </SurfaceProvider>
-    ));
-    expect(directory.isLive('image', 'mounted')).toBe(true);
-    view.unmount();
-    expect(directory.isLive('image', 'mounted')).toBe(false);
-  });
-
-  it('nested provider sets nested and neither announces nor provides', async () => {
+  it('nested provider sets nested and does not provide', async () => {
     vi.useFakeTimers();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const directory = createSurfaceDirectory();
@@ -74,7 +62,7 @@ describe('SurfaceProvider', () => {
     const Inner = () => {
       const surface = useSurface();
       nested = surface.nested;
-      useSurfaceMethods('image', {
+      useSurfaceMethods({
         goToLatest: () => {
           innerRan = true;
         },
@@ -83,33 +71,31 @@ describe('SurfaceProvider', () => {
     };
 
     const Outer = () => {
-      useSurfaceMethods('image', {
+      useSurfaceMethods({
         goToLatest: () => {
           outerRan = true;
         },
       });
       return (
-        <SurfaceProvider name="image" id={() => 'inner'} directory={directory}>
+        <SurfaceProvider id={() => 'inner'} directory={directory}>
           <Inner />
         </SurfaceProvider>
       );
     };
 
     renderView(() => (
-      <SurfaceProvider name="image" id={() => 'outer'} directory={directory}>
+      <SurfaceProvider id={() => 'outer'} directory={directory}>
         <Outer />
       </SurfaceProvider>
     ));
 
     expect(nested).toBe(true);
-    expect(directory.isLive('image', 'outer')).toBe(true);
-    expect(directory.isLive('image', 'inner')).toBe(false);
 
-    await directory.handle('image', 'outer').goToLatest();
+    await directory.handle('outer').goToLatest();
     expect(outerRan).toBe(true);
     expect(innerRan).toBe(false);
 
-    const innerCall = directory.handle('image', 'inner').goToLatest();
+    const innerCall = directory.handle('inner').goToLatest();
     await vi.advanceTimersByTimeAsync(DEFAULT_METHOD_TIMEOUT_MS);
     await expect(innerCall).resolves.toBeUndefined();
   });
@@ -122,7 +108,7 @@ describe('SurfaceProvider', () => {
     const [show, setShow] = createSignal(true);
 
     const Child = () => {
-      useSurfaceMethods('image', {
+      useSurfaceMethods({
         goToLatest: () => {
           ran = true;
         },
@@ -131,29 +117,29 @@ describe('SurfaceProvider', () => {
     };
 
     renderView(() => (
-      <SurfaceProvider name="image" id={() => 'owner'} directory={directory}>
+      <SurfaceProvider id={() => 'owner'} directory={directory}>
         {show() ? <Child /> : null}
       </SurfaceProvider>
     ));
 
-    await directory.handle('image', 'owner').goToLatest();
+    await directory.handle('owner').goToLatest();
     expect(ran).toBe(true);
 
     ran = false;
     setShow(false);
-    const gone = directory.handle('image', 'owner').goToLatest();
+    const gone = directory.handle('owner').goToLatest();
     await vi.advanceTimersByTimeAsync(DEFAULT_METHOD_TIMEOUT_MS);
     await expect(gone).resolves.toBeUndefined();
     expect(ran).toBe(false);
   });
 
-  it('rekeys reactively: old key dies, new key is live and answers, and a pre-flip call on the new key resolves', async () => {
+  it('rekeys reactively: old key dies, new key answers, and a pre-flip call on the new key resolves', async () => {
     const directory = createSurfaceDirectory();
     const [id, setId] = createSignal('pending-x');
     let ranOn: string | undefined;
 
     const Methods = () => {
-      useSurfaceMethods('image', {
+      useSurfaceMethods({
         goToLatest: () => {
           ranOn = id();
         },
@@ -162,20 +148,17 @@ describe('SurfaceProvider', () => {
     };
 
     renderView(() => (
-      <SurfaceProvider name="image" id={id} directory={directory}>
+      <SurfaceProvider id={id} directory={directory}>
         <Methods />
       </SurfaceProvider>
     ));
 
-    expect(directory.isLive('image', 'pending-x')).toBe(true);
-    const pendingNew = directory.handle('image', 'session-y').goToLatest();
+    const pendingNew = directory.handle('session-y').goToLatest();
     setId('session-y');
     await pendingNew;
     expect(ranOn).toBe('session-y');
-    expect(directory.isLive('image', 'pending-x')).toBe(false);
-    expect(directory.isLive('image', 'session-y')).toBe(true);
     ranOn = undefined;
-    await directory.handle('image', 'session-y').goToLatest();
+    await directory.handle('session-y').goToLatest();
     expect(ranOn).toBe('session-y');
   });
 
@@ -187,7 +170,7 @@ describe('SurfaceProvider', () => {
     const [tick, setTick] = createSignal(0);
 
     const Consumer = () => {
-      const snapshot = useSurfaceParams('image');
+      const snapshot = useSurfaceParams<'image'>();
       createEffect(
         on(snapshot, (value) => {
           last = value;
@@ -202,7 +185,6 @@ describe('SurfaceProvider', () => {
 
     renderView(() => (
       <SurfaceProvider
-        name="image"
         id={() => 'params'}
         params={params}
         directory={directory}
@@ -218,33 +200,5 @@ describe('SurfaceProvider', () => {
     await Promise.resolve();
     expect(reads).toBe(1);
     expect(last).toEqual({});
-  });
-
-  it('DEV-throws on useSurfaceParams / useSurfaceMethods name mismatch', () => {
-    const directory = createSurfaceDirectory();
-
-    const BadParams = () => {
-      useSurfaceParams('inbox');
-      return null;
-    };
-    expect(() =>
-      renderView(() => (
-        <SurfaceProvider name="image" id={() => 'x'} directory={directory}>
-          <BadParams />
-        </SurfaceProvider>
-      ))
-    ).toThrow(/useSurfaceParams\('inbox'\) called inside surface 'image'/);
-
-    const BadMethods = () => {
-      useSurfaceMethods('inbox', {});
-      return null;
-    };
-    expect(() =>
-      renderView(() => (
-        <SurfaceProvider name="image" id={() => 'y'} directory={directory}>
-          <BadMethods />
-        </SurfaceProvider>
-      ))
-    ).toThrow(/useSurfaceMethods\('inbox'\) called inside surface 'image'/);
   });
 });

--- a/apps/web/src/lib/surface/SurfaceProvider.test.tsx
+++ b/apps/web/src/lib/surface/SurfaceProvider.test.tsx
@@ -5,7 +5,7 @@
 import { createEffect, createSignal, type JSX, on } from 'solid-js';
 import { render } from 'solid-js/web';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createSurfaceDirectory } from './directory';
+import { createSurfaceDirectory, DEFAULT_METHOD_TIMEOUT_MS } from './directory';
 import {
   SurfaceProvider,
   useMaybeSurface,
@@ -63,21 +63,17 @@ describe('SurfaceProvider', () => {
     expect(directory.isLive('image', 'mounted')).toBe(false);
   });
 
-  it('nested provider sets nested/parent and neither announces nor provides', async () => {
+  it('nested provider sets nested and neither announces nor provides', async () => {
     vi.useFakeTimers();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const directory = createSurfaceDirectory();
     let outerRan = false;
     let innerRan = false;
     let nested = false;
-    let parentName: string | undefined;
-    let parentId: string | undefined;
 
     const Inner = () => {
       const surface = useSurface();
       nested = surface.nested;
-      parentName = surface.parent?.name;
-      parentId = surface.parent?.id();
       useSurfaceMethods('image', {
         goToLatest: () => {
           innerRan = true;
@@ -106,8 +102,6 @@ describe('SurfaceProvider', () => {
     ));
 
     expect(nested).toBe(true);
-    expect(parentName).toBe('image');
-    expect(parentId).toBe('outer');
     expect(directory.isLive('image', 'outer')).toBe(true);
     expect(directory.isLive('image', 'inner')).toBe(false);
 
@@ -115,10 +109,8 @@ describe('SurfaceProvider', () => {
     expect(outerRan).toBe(true);
     expect(innerRan).toBe(false);
 
-    const innerCall = directory
-      .handle('image', 'inner', { timeoutMs: 20 })
-      .goToLatest();
-    await vi.advanceTimersByTimeAsync(20);
+    const innerCall = directory.handle('image', 'inner').goToLatest();
+    await vi.advanceTimersByTimeAsync(DEFAULT_METHOD_TIMEOUT_MS);
     await expect(innerCall).resolves.toBeUndefined();
   });
 
@@ -149,10 +141,8 @@ describe('SurfaceProvider', () => {
 
     ran = false;
     setShow(false);
-    const gone = directory
-      .handle('image', 'owner', { timeoutMs: 20 })
-      .goToLatest();
-    await vi.advanceTimersByTimeAsync(20);
+    const gone = directory.handle('image', 'owner').goToLatest();
+    await vi.advanceTimersByTimeAsync(DEFAULT_METHOD_TIMEOUT_MS);
     await expect(gone).resolves.toBeUndefined();
     expect(ran).toBe(false);
   });

--- a/apps/web/src/lib/surface/SurfaceProvider.test.tsx
+++ b/apps/web/src/lib/surface/SurfaceProvider.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { createEffect, createSignal, type JSX, on } from 'solid-js';
+import { render } from 'solid-js/web';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createSurfaceDirectory } from './directory';
+import {
+  SurfaceProvider,
+  useMaybeSurface,
+  useSurface,
+  useSurfaceMethods,
+  useSurfaceParams,
+} from './SurfaceProvider';
+
+let disposeView: (() => void) | undefined;
+
+function renderView(fn: () => JSX.Element) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const dispose = render(fn, container);
+  disposeView = () => {
+    dispose();
+    container.remove();
+  };
+  return { unmount: disposeView };
+}
+
+afterEach(() => {
+  disposeView?.();
+  disposeView = undefined;
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('SurfaceProvider', () => {
+  it('useSurface throws outside a provider; useMaybeSurface returns undefined', () => {
+    expect(() =>
+      renderView(() => {
+        useSurface();
+        return null;
+      })
+    ).toThrow(/useSurface\(\) called outside a SurfaceProvider/);
+
+    let maybe: ReturnType<typeof useMaybeSurface> | undefined;
+    renderView(() => {
+      maybe = useMaybeSurface();
+      return null;
+    });
+    expect(maybe).toBeUndefined();
+  });
+
+  it('announces on mount and disposes on unmount', () => {
+    const directory = createSurfaceDirectory();
+    const view = renderView(() => (
+      <SurfaceProvider name="image" id={() => 'mounted'} directory={directory}>
+        <div />
+      </SurfaceProvider>
+    ));
+    expect(directory.isLive('image', 'mounted')).toBe(true);
+    view.unmount();
+    expect(directory.isLive('image', 'mounted')).toBe(false);
+  });
+
+  it('nested provider sets nested/parent and neither announces nor provides', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const directory = createSurfaceDirectory();
+    let outerRan = false;
+    let innerRan = false;
+    let nested = false;
+    let parentName: string | undefined;
+    let parentId: string | undefined;
+
+    const Inner = () => {
+      const surface = useSurface();
+      nested = surface.nested;
+      parentName = surface.parent?.name;
+      parentId = surface.parent?.id();
+      useSurfaceMethods('image', {
+        goToLatest: () => {
+          innerRan = true;
+        },
+      });
+      return null;
+    };
+
+    const Outer = () => {
+      useSurfaceMethods('image', {
+        goToLatest: () => {
+          outerRan = true;
+        },
+      });
+      return (
+        <SurfaceProvider name="image" id={() => 'inner'} directory={directory}>
+          <Inner />
+        </SurfaceProvider>
+      );
+    };
+
+    renderView(() => (
+      <SurfaceProvider name="image" id={() => 'outer'} directory={directory}>
+        <Outer />
+      </SurfaceProvider>
+    ));
+
+    expect(nested).toBe(true);
+    expect(parentName).toBe('image');
+    expect(parentId).toBe('outer');
+    expect(directory.isLive('image', 'outer')).toBe(true);
+    expect(directory.isLive('image', 'inner')).toBe(false);
+
+    await directory.handle('image', 'outer').goToLatest();
+    expect(outerRan).toBe(true);
+    expect(innerRan).toBe(false);
+
+    const innerCall = directory
+      .handle('image', 'inner', { timeoutMs: 20 })
+      .goToLatest();
+    await vi.advanceTimersByTimeAsync(20);
+    await expect(innerCall).resolves.toBeUndefined();
+  });
+
+  it('useSurfaceMethods registers into the directory and deregisters on owner cleanup', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const directory = createSurfaceDirectory();
+    let ran = false;
+    const [show, setShow] = createSignal(true);
+
+    const Child = () => {
+      useSurfaceMethods('image', {
+        goToLatest: () => {
+          ran = true;
+        },
+      });
+      return null;
+    };
+
+    renderView(() => (
+      <SurfaceProvider name="image" id={() => 'owner'} directory={directory}>
+        {show() ? <Child /> : null}
+      </SurfaceProvider>
+    ));
+
+    await directory.handle('image', 'owner').goToLatest();
+    expect(ran).toBe(true);
+
+    ran = false;
+    setShow(false);
+    const gone = directory
+      .handle('image', 'owner', { timeoutMs: 20 })
+      .goToLatest();
+    await vi.advanceTimersByTimeAsync(20);
+    await expect(gone).resolves.toBeUndefined();
+    expect(ran).toBe(false);
+  });
+
+  it('rekeys reactively: old key dies, new key is live and answers, and a pre-flip call on the new key resolves', async () => {
+    const directory = createSurfaceDirectory();
+    const [id, setId] = createSignal('pending-x');
+    let ranOn: string | undefined;
+
+    const Methods = () => {
+      useSurfaceMethods('image', {
+        goToLatest: () => {
+          ranOn = id();
+        },
+      });
+      return null;
+    };
+
+    renderView(() => (
+      <SurfaceProvider name="image" id={id} directory={directory}>
+        <Methods />
+      </SurfaceProvider>
+    ));
+
+    expect(directory.isLive('image', 'pending-x')).toBe(true);
+    const pendingNew = directory.handle('image', 'session-y').goToLatest();
+    setId('session-y');
+    await pendingNew;
+    expect(ranOn).toBe('session-y');
+    expect(directory.isLive('image', 'pending-x')).toBe(false);
+    expect(directory.isLive('image', 'session-y')).toBe(true);
+    ranOn = undefined;
+    await directory.handle('image', 'session-y').goToLatest();
+    expect(ranOn).toBe('session-y');
+  });
+
+  it('useSurfaceParams returns the mount-time snapshot and the accessor never re-fires', async () => {
+    const directory = createSurfaceDirectory();
+    const params: Record<string, never> = {};
+    let reads = 0;
+    let last: unknown;
+    const [tick, setTick] = createSignal(0);
+
+    const Consumer = () => {
+      const snapshot = useSurfaceParams('image');
+      createEffect(
+        on(snapshot, (value) => {
+          last = value;
+          reads++;
+        })
+      );
+      createEffect(() => {
+        tick();
+      });
+      return null;
+    };
+
+    renderView(() => (
+      <SurfaceProvider
+        name="image"
+        id={() => 'params'}
+        params={params}
+        directory={directory}
+      >
+        <Consumer />
+      </SurfaceProvider>
+    ));
+
+    expect(reads).toBe(1);
+    expect(last).toEqual({});
+    Object.assign(params, { marker: 'b' });
+    setTick(1);
+    await Promise.resolve();
+    expect(reads).toBe(1);
+    expect(last).toEqual({});
+  });
+
+  it('DEV-throws on useSurfaceParams / useSurfaceMethods name mismatch', () => {
+    const directory = createSurfaceDirectory();
+
+    const BadParams = () => {
+      useSurfaceParams('inbox');
+      return null;
+    };
+    expect(() =>
+      renderView(() => (
+        <SurfaceProvider name="image" id={() => 'x'} directory={directory}>
+          <BadParams />
+        </SurfaceProvider>
+      ))
+    ).toThrow(/useSurfaceParams\('inbox'\) called inside surface 'image'/);
+
+    const BadMethods = () => {
+      useSurfaceMethods('inbox', {});
+      return null;
+    };
+    expect(() =>
+      renderView(() => (
+        <SurfaceProvider name="image" id={() => 'y'} directory={directory}>
+          <BadMethods />
+        </SurfaceProvider>
+      ))
+    ).toThrow(/useSurfaceMethods\('inbox'\) called inside surface 'image'/);
+  });
+});

--- a/apps/web/src/lib/surface/SurfaceProvider.tsx
+++ b/apps/web/src/lib/surface/SurfaceProvider.tsx
@@ -1,0 +1,153 @@
+import {
+  type Accessor,
+  createContext,
+  createEffect,
+  type FlowProps,
+  type JSX,
+  onCleanup,
+  untrack,
+  useContext,
+} from 'solid-js';
+import {
+  surfaceDirectory as appSurfaceDirectory,
+  type SurfaceDirectory,
+} from './directory';
+import type {
+  AsProvidedMethods,
+  MethodsFor,
+  ParamsFor,
+  SurfaceAliasName,
+  SurfaceName,
+} from './specs';
+
+/** Context value established by SurfaceProvider for a mounted surface. */
+export type SurfaceContextValue<N extends SurfaceName = SurfaceName> = {
+  readonly name: N;
+  readonly alias: SurfaceAliasName | undefined;
+  /** Reactive: changes in place on adoptContentId (placeholder → real id). */
+  readonly id: Accessor<string>;
+  /** Stable accessor over the mount-time params snapshot (§4.4). */
+  readonly params: Accessor<ParamsFor<N> | undefined>;
+  /** True when mounted inside another SurfaceProvider (derived, §4.5). */
+  readonly nested: boolean;
+  /** The enclosing surface's context, when nested. Replaces NestedState. */
+  readonly parent: SurfaceContextValue | undefined;
+};
+
+type InternalSurfaceContextValue<N extends SurfaceName = SurfaceName> =
+  SurfaceContextValue<N> & {
+    directory: SurfaceDirectory;
+  };
+
+const SurfaceContext = createContext<InternalSurfaceContextValue>();
+
+function directoryOf(surface: SurfaceContextValue): SurfaceDirectory {
+  return (
+    (surface as InternalSurfaceContextValue).directory ?? appSurfaceDirectory
+  );
+}
+
+/**
+ * Establishes surface identity, params, and directory announcement for a
+ * mount. Renders no DOM of its own.
+ */
+export function SurfaceProvider<N extends SurfaceName>(
+  props: FlowProps<{
+    name: N;
+    /** Reactive id. The mount creator passes an accessor into the split
+     *  content id (e.g. () => contentId()). */
+    id: Accessor<string>;
+    /** One-shot mount params. Snapshotted at setup; never re-read. */
+    params?: ParamsFor<N>;
+    /** Alias this mount was opened under, from surfaceAliasContextFor. */
+    alias?: SurfaceAliasName;
+    /** Injectable for tests. Defaults to the app-wide surfaceDirectory. */
+    directory?: SurfaceDirectory;
+  }>
+): JSX.Element {
+  const parent = useContext(SurfaceContext);
+  const nested = parent !== undefined;
+  const directory = untrack(() => props.directory) ?? appSurfaceDirectory;
+  const paramsSnapshot: ParamsFor<N> | undefined = untrack(() => {
+    const params = props.params;
+    if (params === undefined) return undefined;
+    return { ...params };
+  });
+
+  const value: InternalSurfaceContextValue<N> = {
+    name: untrack(() => props.name),
+    alias: untrack(() => props.alias),
+    id: () => props.id(),
+    params: () => paramsSnapshot,
+    nested,
+    parent,
+    directory,
+  };
+
+  createEffect(() => {
+    if (nested) return;
+    const dispose = directory.announce(props.name, props.id());
+    onCleanup(dispose);
+  });
+
+  return (
+    <SurfaceContext.Provider value={value as InternalSurfaceContextValue}>
+      {props.children}
+    </SurfaceContext.Provider>
+  );
+}
+
+/**
+ * The enclosing surface's context.
+ * @throws outside a SurfaceProvider subtree.
+ */
+export function useSurface(): SurfaceContextValue {
+  const ctx = useContext(SurfaceContext);
+  if (!ctx) {
+    throw new Error('useSurface() called outside a SurfaceProvider');
+  }
+  return ctx;
+}
+
+/** The enclosing surface's context, or undefined outside a provider. */
+export function useMaybeSurface(): SurfaceContextValue | undefined {
+  return useContext(SurfaceContext);
+}
+
+/**
+ * Typed params for the named surface. DEV-throws when the enclosing
+ * provider's name !== `name` (the cast would be a lie).
+ */
+export function useSurfaceParams<N extends SurfaceName>(
+  name: N
+): Accessor<ParamsFor<N> | undefined> {
+  const surface = useSurface();
+  if (import.meta.env.DEV && surface.name !== name) {
+    throw new Error(
+      `useSurfaceParams('${name}') called inside surface '${surface.name}'`
+    );
+  }
+  return surface.params as Accessor<ParamsFor<N> | undefined>;
+}
+
+/**
+ * Register public methods for the enclosing surface. No-op when nested.
+ * DEV-throws on name mismatch with the enclosing provider.
+ */
+export function useSurfaceMethods<N extends SurfaceName>(
+  name: N,
+  methods: AsProvidedMethods<MethodsFor<N>>
+): void {
+  const surface = useSurface();
+  if (import.meta.env.DEV && surface.name !== name) {
+    throw new Error(
+      `useSurfaceMethods('${name}') called inside surface '${surface.name}'`
+    );
+  }
+  if (surface.nested) return;
+  const directory = directoryOf(surface);
+  createEffect(() => {
+    const dispose = directory.provide(name, surface.id(), methods);
+    onCleanup(dispose);
+  });
+}

--- a/apps/web/src/lib/surface/SurfaceProvider.tsx
+++ b/apps/web/src/lib/surface/SurfaceProvider.tsx
@@ -15,20 +15,18 @@ import {
 import type { MethodsFor, ParamsFor, SurfaceName } from './specs';
 
 /** Context value established by SurfaceProvider for a mounted surface. */
-export type SurfaceContextValue<N extends SurfaceName = SurfaceName> = {
-  readonly name: N;
+export type SurfaceContextValue = {
   /** Reactive: changes in place on adoptContentId (placeholder → real id). */
   readonly id: Accessor<string>;
   /** Stable accessor over the mount-time params snapshot; never re-fires. */
-  readonly params: Accessor<ParamsFor<N> | undefined>;
+  readonly params: Accessor<Record<string, unknown> | undefined>;
   /** True when mounted inside another SurfaceProvider (derived from context). */
   readonly nested: boolean;
 };
 
-type InternalSurfaceContextValue<N extends SurfaceName = SurfaceName> =
-  SurfaceContextValue<N> & {
-    directory: SurfaceDirectory;
-  };
+type InternalSurfaceContextValue = SurfaceContextValue & {
+  directory: SurfaceDirectory;
+};
 
 const SurfaceContext = createContext<InternalSurfaceContextValue>();
 
@@ -39,15 +37,16 @@ function directoryOf(surface: SurfaceContextValue): SurfaceDirectory {
 }
 
 /**
- * Establishes surface identity, params, and directory announcement for a
- * mount. Renders no DOM of its own.
+ * Establishes surface identity and params for a mount, and carries the
+ * directory used by useSurfaceMethods. Renders no DOM of its own. Takes no
+ * `name`: the mount creator only has runtime content.type, so identity is the
+ * id; the typed edge is consumer-side (useSurfaceParams / useSurfaceMethods).
  */
-export function SurfaceProvider<N extends SurfaceName>(
+export function SurfaceProvider(
   props: FlowProps<{
-    name: N;
     id: Accessor<string>;
     /** One-shot mount params. Snapshotted at setup; never re-read. */
-    params?: ParamsFor<N>;
+    params?: Record<string, unknown>;
     /** Injectable for tests. Defaults to the app-wide surfaceDirectory. */
     directory?: SurfaceDirectory;
   }>
@@ -55,28 +54,21 @@ export function SurfaceProvider<N extends SurfaceName>(
   const parent = useContext(SurfaceContext);
   const nested = parent !== undefined;
   const directory = untrack(() => props.directory) ?? appSurfaceDirectory;
-  const paramsSnapshot: ParamsFor<N> | undefined = untrack(() => {
+  const paramsSnapshot: Record<string, unknown> | undefined = untrack(() => {
     const params = props.params;
     if (params === undefined) return undefined;
     return { ...params };
   });
 
-  const value: InternalSurfaceContextValue<N> = {
-    name: untrack(() => props.name),
+  const value: InternalSurfaceContextValue = {
     id: () => props.id(),
     params: () => paramsSnapshot,
     nested,
     directory,
   };
 
-  createEffect(() => {
-    if (nested) return;
-    const dispose = directory.announce(props.name, props.id());
-    onCleanup(dispose);
-  });
-
   return (
-    <SurfaceContext.Provider value={value as InternalSurfaceContextValue}>
+    <SurfaceContext.Provider value={value}>
       {props.children}
     </SurfaceContext.Provider>
   );
@@ -100,39 +92,29 @@ export function useMaybeSurface(): SurfaceContextValue | undefined {
 }
 
 /**
- * Typed params for the named surface. DEV-throws when the enclosing
- * provider's name !== `name` (the cast would be a lie).
+ * Typed params for the enclosing surface. `N` is a compile-time witness; the
+ * cast is unchecked at runtime (the surface component names its own N — the
+ * same trust the legacy BlockComponentProps lookup extended).
  */
-export function useSurfaceParams<N extends SurfaceName>(
-  name: N
-): Accessor<ParamsFor<N> | undefined> {
-  const surface = useSurface();
-  if (import.meta.env.DEV && surface.name !== name) {
-    throw new Error(
-      `useSurfaceParams('${name}') called inside surface '${surface.name}'`
-    );
-  }
-  return surface.params as Accessor<ParamsFor<N> | undefined>;
+export function useSurfaceParams<N extends SurfaceName>(): Accessor<
+  ParamsFor<N> | undefined
+> {
+  return useSurface().params as Accessor<ParamsFor<N> | undefined>;
 }
 
 /**
  * Register public methods for the enclosing surface. No-op when nested.
- * DEV-throws on name mismatch with the enclosing provider.
+ * Pass `N` explicitly to register surface-specific methods; without it,
+ * inference falls back to the shared methods.
  */
-export function useSurfaceMethods<N extends SurfaceName>(
-  name: N,
+export function useSurfaceMethods<N extends SurfaceName = SurfaceName>(
   methods: Partial<MethodsFor<N>>
 ): void {
   const surface = useSurface();
-  if (import.meta.env.DEV && surface.name !== name) {
-    throw new Error(
-      `useSurfaceMethods('${name}') called inside surface '${surface.name}'`
-    );
-  }
   if (surface.nested) return;
   const directory = directoryOf(surface);
   createEffect(() => {
-    const dispose = directory.provide(name, surface.id(), methods);
+    const dispose = directory.provide<N>(surface.id(), methods);
     onCleanup(dispose);
   });
 }

--- a/apps/web/src/lib/surface/SurfaceProvider.tsx
+++ b/apps/web/src/lib/surface/SurfaceProvider.tsx
@@ -12,26 +12,17 @@ import {
   surfaceDirectory as appSurfaceDirectory,
   type SurfaceDirectory,
 } from './directory';
-import type {
-  AsProvidedMethods,
-  MethodsFor,
-  ParamsFor,
-  SurfaceAliasName,
-  SurfaceName,
-} from './specs';
+import type { MethodsFor, ParamsFor, SurfaceName } from './specs';
 
 /** Context value established by SurfaceProvider for a mounted surface. */
 export type SurfaceContextValue<N extends SurfaceName = SurfaceName> = {
   readonly name: N;
-  readonly alias: SurfaceAliasName | undefined;
   /** Reactive: changes in place on adoptContentId (placeholder → real id). */
   readonly id: Accessor<string>;
-  /** Stable accessor over the mount-time params snapshot (§4.4). */
+  /** Stable accessor over the mount-time params snapshot; never re-fires. */
   readonly params: Accessor<ParamsFor<N> | undefined>;
-  /** True when mounted inside another SurfaceProvider (derived, §4.5). */
+  /** True when mounted inside another SurfaceProvider (derived from context). */
   readonly nested: boolean;
-  /** The enclosing surface's context, when nested. Replaces NestedState. */
-  readonly parent: SurfaceContextValue | undefined;
 };
 
 type InternalSurfaceContextValue<N extends SurfaceName = SurfaceName> =
@@ -54,13 +45,9 @@ function directoryOf(surface: SurfaceContextValue): SurfaceDirectory {
 export function SurfaceProvider<N extends SurfaceName>(
   props: FlowProps<{
     name: N;
-    /** Reactive id. The mount creator passes an accessor into the split
-     *  content id (e.g. () => contentId()). */
     id: Accessor<string>;
     /** One-shot mount params. Snapshotted at setup; never re-read. */
     params?: ParamsFor<N>;
-    /** Alias this mount was opened under, from surfaceAliasContextFor. */
-    alias?: SurfaceAliasName;
     /** Injectable for tests. Defaults to the app-wide surfaceDirectory. */
     directory?: SurfaceDirectory;
   }>
@@ -76,11 +63,9 @@ export function SurfaceProvider<N extends SurfaceName>(
 
   const value: InternalSurfaceContextValue<N> = {
     name: untrack(() => props.name),
-    alias: untrack(() => props.alias),
     id: () => props.id(),
     params: () => paramsSnapshot,
     nested,
-    parent,
     directory,
   };
 
@@ -136,7 +121,7 @@ export function useSurfaceParams<N extends SurfaceName>(
  */
 export function useSurfaceMethods<N extends SurfaceName>(
   name: N,
-  methods: AsProvidedMethods<MethodsFor<N>>
+  methods: Partial<MethodsFor<N>>
 ): void {
   const surface = useSurface();
   if (import.meta.env.DEV && surface.name !== name) {

--- a/apps/web/src/lib/surface/catalog.ts
+++ b/apps/web/src/lib/surface/catalog.ts
@@ -1,55 +1,29 @@
-import { ENABLE_DOCX_TO_PDF } from '@core/constant/featureFlags';
-import { DefaultFilename } from '@core/constant/filename';
 import { type Component, lazy } from 'solid-js';
-import type {
-  SurfaceAliasContext,
-  SurfaceAliasName,
-  SurfaceName,
-} from './specs';
+import type { SurfaceName } from './specs';
 
 /** Whether the surface names a server-side entity or an app instance. */
 export type SurfaceKind = 'entity' | 'app';
-
-/** An alias name routable to a catalog surface, with optional default filename. */
-export type SurfaceAliasDef = {
-  name: SurfaceAliasName;
-  /** Default filename for new entities created under this alias
-   *  (e.g. task → 'To-do'). Ports BlockDefinition.aliases[].defaultFileName. */
-  defaultFilename?: string;
-};
 
 /** Static definition of a mountable surface. */
 export type SurfaceDefinition = {
   /**
    * The mount component. Takes NO props; features read identity/params via
-   * useSurface()/useSurfaceParams(). Always a lazy component here:
-   * component: lazy(() => import('@app/features/block-image/component/Block')).
+   * useSurface()/useSurfaceParams(). Always a lazy component here.
    */
   component: Component;
   /**
-   * 'entity': id names a server-side entity. Dedupes on (resolved name, id),
-   *   round-trips through the URL, eligible for EntityFrame/open-tracking.
-   * 'app': id is an instance discriminator chosen by the app (usually the
-   *   surface name itself, e.g. 'settings'; or a draft id for composers).
-   *   Never dedupes unless `singleton`.
+   * 'entity': id names a server-side entity; dedupes on (name, id).
+   * 'app': id is an instance discriminator; never dedupes unless `singleton`.
    */
   kind: SurfaceKind;
-  /** At most one live instance per layout; dedupe ignores id (§2.3). */
+  /** At most one live instance per layout; dedupe ignores id. */
   singleton?: boolean;
-  aliases?: readonly SurfaceAliasDef[];
   /**
-   * file-extension → mime-type. Entity surfaces only. Drives upload routing,
-   * file pickers, and icon resolution (§2.5). Same shape as
-   * BlockDefinition.accepted today.
+   * file-extension → mime-type. Entity surfaces only. Declared source of
+   * truth for upload routing / pickers / icons; the derived indexes
+   * (successors of the blockAccepted* maps) arrive with that migration.
    */
   accepted?: Readonly<Record<string, string>>;
-  /**
-   * Surfaces inside which this surface may mount as a nested preview.
-   * Ports ValidNestingCombinations (only non-empty rows: canvas/pdf/code → ['md']).
-   */
-  nestableIn?: readonly SurfaceName[];
-  /** Default display name for unnamed entities of this surface. */
-  defaultFilename?: string;
 };
 
 /** Pure static data. Explicit entries, no import.meta.glob, no load(). */
@@ -77,148 +51,14 @@ export const surfaceCatalog: Readonly<Record<SurfaceName, SurfaceDefinition>> =
     },
   };
 
-const aliasToOwner = new Map<string, SurfaceName>();
-const aliasDefaultFilename = new Map<string, string>();
-
-for (const name of Object.keys(surfaceCatalog) as SurfaceName[]) {
-  for (const alias of surfaceCatalog[name].aliases ?? []) {
-    aliasToOwner.set(alias.name, name);
-    if (alias.defaultFilename !== undefined) {
-      aliasDefaultFilename.set(alias.name, alias.defaultFilename);
-    }
-  }
-}
-
-/**
- * True when `name` is a declared surface alias.
- */
-export function isSurfaceAlias(name: string): name is SurfaceAliasName {
-  return aliasToOwner.has(name);
-}
-
-/**
- * Alias → base name; identity for non-aliases. Handles the flag-conditional
- * 'write' → 'pdf' virtual name exactly as fileTypeToBlockName does today
- * (gated on ENABLE_DOCX_TO_PDF).
- */
-export function resolveSurfaceAlias(
-  name: SurfaceName | SurfaceAliasName
-): SurfaceName {
-  // Flag-conditional virtual name: 'write' → 'pdf' when ENABLE_DOCX_TO_PDF.
-  // Unreachable until `write` is typed as a SurfaceAliasName of `pdf`.
-  if (ENABLE_DOCX_TO_PDF && (name as string) === 'write') {
-    return 'pdf' as SurfaceName;
-  }
-  return aliasToOwner.get(name) ?? (name as SurfaceName);
-}
-
-/**
- * The alias round-trip record for a content type, or undefined when `name`
- * is not an alias. Replaces layoutManager's attachAliasContext computation.
- */
-export function surfaceAliasContextFor(
-  name: string
-): SurfaceAliasContext | undefined {
-  if (!isSurfaceAlias(name)) return undefined;
-  return {
-    alias: name,
-    baseName: resolveSurfaceAlias(name),
-  };
-}
-
-/**
- * 'junk' → undefined in the draft; migration changes the fallback to
- * 'unknown' once the unknown surface is registered (parity with
- * verifyBlockName).
- */
-export function verifySurfaceName(
-  name: string | undefined
-): SurfaceName | SurfaceAliasName | undefined {
-  if (!name) return undefined;
-  if (ENABLE_DOCX_TO_PDF && name === 'write') {
-    return resolveSurfaceAlias(name as SurfaceAliasName);
-  }
-  if (isSurfaceAlias(name)) return name;
-  if (Object.hasOwn(surfaceCatalog, name)) return name as SurfaceName;
-  return undefined;
-}
-
-/**
- * Identity predicate for layout dedupe. Replaces sameNonComponentIdentity.
- */
+/** Identity predicate for layout dedupe. Replaces sameNonComponentIdentity. */
 export function sameSurfaceIdentity(
-  a: { name: SurfaceName | SurfaceAliasName; id: string },
-  b: { name: SurfaceName | SurfaceAliasName; id: string }
+  a: { name: SurfaceName; id: string },
+  b: { name: SurfaceName; id: string }
 ): boolean {
-  const an = resolveSurfaceAlias(a.name);
-  const bn = resolveSurfaceAlias(b.name);
-  if (an !== bn) return false; // includes alias flattening: md vs task/<same id> collide
-  const def = surfaceCatalog[an];
-  if (def?.singleton) return true; // one instance per layout, id ignored
-  if (def?.kind === 'app') return false; // app surfaces never dedupe (today: components exempt)
+  if (a.name !== b.name) return false;
+  const def = surfaceCatalog[a.name];
+  if (def.singleton) return true; // one instance per layout, id ignored
+  if (def.kind === 'app') return false; // app surfaces never dedupe
   return a.id === b.id; // entity surfaces dedupe on id
-}
-
-const extensionToMime: Record<string, string> = {};
-const mimeToExtension: Record<string, string> = {};
-const nameToExtensions = {} as Record<SurfaceName, string[]>;
-const extensionToSurface: Record<string, SurfaceName> = {};
-
-for (const name of Object.keys(surfaceCatalog) as SurfaceName[]) {
-  const accepted = surfaceCatalog[name].accepted;
-  const extensions: string[] = [];
-  if (accepted) {
-    for (const [ext, mime] of Object.entries(accepted)) {
-      extensions.push(ext);
-      extensionToMime[ext] ??= mime;
-      mimeToExtension[mime] ??= ext;
-      extensionToSurface[ext] ??= name;
-    }
-  }
-  nameToExtensions[name] = extensions;
-}
-
-/** Extension → mime, first-wins on collision. Successor of blockAcceptedFileExtensionToMimeType. */
-export const surfaceAcceptedExtensionToMime: Readonly<Record<string, string>> =
-  extensionToMime;
-
-/** Mime → extension, first-wins on collision. Successor of blockAcceptedMimetypeToFileExtension. */
-export const surfaceAcceptedMimeToExtension: Readonly<Record<string, string>> =
-  mimeToExtension;
-
-/** Per-surface accepted file extensions. Successor of blockNameToFileExtensions. */
-export const surfaceNameToFileExtensions: Readonly<
-  Record<SurfaceName, readonly string[]>
-> = nameToExtensions;
-
-/**
- * Reverse lookup of a file extension to the surface that accepts it.
- * Successor of the fileTypeToBlockName_ reverse map.
- */
-export function surfaceForFileExtension(ext: string): SurfaceName | undefined {
-  return extensionToSurface[ext];
-}
-
-/**
- * Whether the named surface accepts the given file extension.
- */
-export function surfaceAcceptsFileExtension(
-  name: SurfaceName,
-  ext: string
-): boolean {
-  return surfaceNameToFileExtensions[name]?.includes(ext) ?? false;
-}
-
-/**
- * Default display name for unnamed entities of this surface (or alias).
- * Falls back to DefaultFilename from @core/constant/filename.
- */
-export function surfaceDefaultFilename(
-  name: SurfaceName | SurfaceAliasName | undefined
-): string {
-  if (!name) return DefaultFilename;
-  const aliasFilename = aliasDefaultFilename.get(name);
-  if (aliasFilename !== undefined) return aliasFilename;
-  const resolved = resolveSurfaceAlias(name);
-  return surfaceCatalog[resolved]?.defaultFilename ?? DefaultFilename;
 }

--- a/apps/web/src/lib/surface/catalog.ts
+++ b/apps/web/src/lib/surface/catalog.ts
@@ -1,0 +1,224 @@
+import { ENABLE_DOCX_TO_PDF } from '@core/constant/featureFlags';
+import { DefaultFilename } from '@core/constant/filename';
+import { type Component, lazy } from 'solid-js';
+import type {
+  SurfaceAliasContext,
+  SurfaceAliasName,
+  SurfaceName,
+} from './specs';
+
+/** Whether the surface names a server-side entity or an app instance. */
+export type SurfaceKind = 'entity' | 'app';
+
+/** An alias name routable to a catalog surface, with optional default filename. */
+export type SurfaceAliasDef = {
+  name: SurfaceAliasName;
+  /** Default filename for new entities created under this alias
+   *  (e.g. task → 'To-do'). Ports BlockDefinition.aliases[].defaultFileName. */
+  defaultFilename?: string;
+};
+
+/** Static definition of a mountable surface. */
+export type SurfaceDefinition = {
+  /**
+   * The mount component. Takes NO props; features read identity/params via
+   * useSurface()/useSurfaceParams(). Always a lazy component here:
+   * component: lazy(() => import('@app/features/block-image/component/Block')).
+   */
+  component: Component;
+  /**
+   * 'entity': id names a server-side entity. Dedupes on (resolved name, id),
+   *   round-trips through the URL, eligible for EntityFrame/open-tracking.
+   * 'app': id is an instance discriminator chosen by the app (usually the
+   *   surface name itself, e.g. 'settings'; or a draft id for composers).
+   *   Never dedupes unless `singleton`.
+   */
+  kind: SurfaceKind;
+  /** At most one live instance per layout; dedupe ignores id (§2.3). */
+  singleton?: boolean;
+  aliases?: readonly SurfaceAliasDef[];
+  /**
+   * file-extension → mime-type. Entity surfaces only. Drives upload routing,
+   * file pickers, and icon resolution (§2.5). Same shape as
+   * BlockDefinition.accepted today.
+   */
+  accepted?: Readonly<Record<string, string>>;
+  /**
+   * Surfaces inside which this surface may mount as a nested preview.
+   * Ports ValidNestingCombinations (only non-empty rows: canvas/pdf/code → ['md']).
+   */
+  nestableIn?: readonly SurfaceName[];
+  /** Default display name for unnamed entities of this surface. */
+  defaultFilename?: string;
+};
+
+/** Pure static data. Explicit entries, no import.meta.glob, no load(). */
+export const surfaceCatalog: Readonly<Record<SurfaceName, SurfaceDefinition>> =
+  {
+    image: {
+      component: lazy(
+        () => import('@app/features/block-image/component/Block')
+      ),
+      kind: 'entity',
+      accepted: {
+        png: 'image/png',
+        jpg: 'image/jpeg',
+        jpeg: 'image/jpeg',
+        gif: 'image/gif',
+        svg: 'image/svg+xml',
+        webp: 'image/webp',
+      },
+    },
+    inbox: {
+      // TODO(migration): real SoupView factory
+      component: () => null,
+      kind: 'app',
+      singleton: false,
+    },
+  };
+
+const aliasToOwner = new Map<string, SurfaceName>();
+const aliasDefaultFilename = new Map<string, string>();
+
+for (const name of Object.keys(surfaceCatalog) as SurfaceName[]) {
+  for (const alias of surfaceCatalog[name].aliases ?? []) {
+    aliasToOwner.set(alias.name, name);
+    if (alias.defaultFilename !== undefined) {
+      aliasDefaultFilename.set(alias.name, alias.defaultFilename);
+    }
+  }
+}
+
+/**
+ * True when `name` is a declared surface alias.
+ */
+export function isSurfaceAlias(name: string): name is SurfaceAliasName {
+  return aliasToOwner.has(name);
+}
+
+/**
+ * Alias → base name; identity for non-aliases. Handles the flag-conditional
+ * 'write' → 'pdf' virtual name exactly as fileTypeToBlockName does today
+ * (gated on ENABLE_DOCX_TO_PDF).
+ */
+export function resolveSurfaceAlias(
+  name: SurfaceName | SurfaceAliasName
+): SurfaceName {
+  // Flag-conditional virtual name: 'write' → 'pdf' when ENABLE_DOCX_TO_PDF.
+  // Unreachable until `write` is typed as a SurfaceAliasName of `pdf`.
+  if (ENABLE_DOCX_TO_PDF && (name as string) === 'write') {
+    return 'pdf' as SurfaceName;
+  }
+  return aliasToOwner.get(name) ?? (name as SurfaceName);
+}
+
+/**
+ * The alias round-trip record for a content type, or undefined when `name`
+ * is not an alias. Replaces layoutManager's attachAliasContext computation.
+ */
+export function surfaceAliasContextFor(
+  name: string
+): SurfaceAliasContext | undefined {
+  if (!isSurfaceAlias(name)) return undefined;
+  return {
+    alias: name,
+    baseName: resolveSurfaceAlias(name),
+  };
+}
+
+/**
+ * 'junk' → undefined in the draft; migration changes the fallback to
+ * 'unknown' once the unknown surface is registered (parity with
+ * verifyBlockName).
+ */
+export function verifySurfaceName(
+  name: string | undefined
+): SurfaceName | SurfaceAliasName | undefined {
+  if (!name) return undefined;
+  if (ENABLE_DOCX_TO_PDF && name === 'write') {
+    return resolveSurfaceAlias(name as SurfaceAliasName);
+  }
+  if (isSurfaceAlias(name)) return name;
+  if (Object.hasOwn(surfaceCatalog, name)) return name as SurfaceName;
+  return undefined;
+}
+
+/**
+ * Identity predicate for layout dedupe. Replaces sameNonComponentIdentity.
+ */
+export function sameSurfaceIdentity(
+  a: { name: SurfaceName | SurfaceAliasName; id: string },
+  b: { name: SurfaceName | SurfaceAliasName; id: string }
+): boolean {
+  const an = resolveSurfaceAlias(a.name);
+  const bn = resolveSurfaceAlias(b.name);
+  if (an !== bn) return false; // includes alias flattening: md vs task/<same id> collide
+  const def = surfaceCatalog[an];
+  if (def?.singleton) return true; // one instance per layout, id ignored
+  if (def?.kind === 'app') return false; // app surfaces never dedupe (today: components exempt)
+  return a.id === b.id; // entity surfaces dedupe on id
+}
+
+const extensionToMime: Record<string, string> = {};
+const mimeToExtension: Record<string, string> = {};
+const nameToExtensions = {} as Record<SurfaceName, string[]>;
+const extensionToSurface: Record<string, SurfaceName> = {};
+
+for (const name of Object.keys(surfaceCatalog) as SurfaceName[]) {
+  const accepted = surfaceCatalog[name].accepted;
+  const extensions: string[] = [];
+  if (accepted) {
+    for (const [ext, mime] of Object.entries(accepted)) {
+      extensions.push(ext);
+      extensionToMime[ext] ??= mime;
+      mimeToExtension[mime] ??= ext;
+      extensionToSurface[ext] ??= name;
+    }
+  }
+  nameToExtensions[name] = extensions;
+}
+
+/** Extension → mime, first-wins on collision. Successor of blockAcceptedFileExtensionToMimeType. */
+export const surfaceAcceptedExtensionToMime: Readonly<Record<string, string>> =
+  extensionToMime;
+
+/** Mime → extension, first-wins on collision. Successor of blockAcceptedMimetypeToFileExtension. */
+export const surfaceAcceptedMimeToExtension: Readonly<Record<string, string>> =
+  mimeToExtension;
+
+/** Per-surface accepted file extensions. Successor of blockNameToFileExtensions. */
+export const surfaceNameToFileExtensions: Readonly<
+  Record<SurfaceName, readonly string[]>
+> = nameToExtensions;
+
+/**
+ * Reverse lookup of a file extension to the surface that accepts it.
+ * Successor of the fileTypeToBlockName_ reverse map.
+ */
+export function surfaceForFileExtension(ext: string): SurfaceName | undefined {
+  return extensionToSurface[ext];
+}
+
+/**
+ * Whether the named surface accepts the given file extension.
+ */
+export function surfaceAcceptsFileExtension(
+  name: SurfaceName,
+  ext: string
+): boolean {
+  return surfaceNameToFileExtensions[name]?.includes(ext) ?? false;
+}
+
+/**
+ * Default display name for unnamed entities of this surface (or alias).
+ * Falls back to DefaultFilename from @core/constant/filename.
+ */
+export function surfaceDefaultFilename(
+  name: SurfaceName | SurfaceAliasName | undefined
+): string {
+  if (!name) return DefaultFilename;
+  const aliasFilename = aliasDefaultFilename.get(name);
+  if (aliasFilename !== undefined) return aliasFilename;
+  const resolved = resolveSurfaceAlias(name);
+  return surfaceCatalog[resolved]?.defaultFilename ?? DefaultFilename;
+}

--- a/apps/web/src/lib/surface/directory.test.ts
+++ b/apps/web/src/lib/surface/directory.test.ts
@@ -1,0 +1,353 @@
+import { createEffect, createRoot } from 'solid-js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  isSurfaceAlias,
+  resolveSurfaceAlias,
+  surfaceCatalog,
+  verifySurfaceName,
+} from './catalog';
+import {
+  awaitCondition,
+  createSurfaceDirectory,
+  DEFAULT_METHOD_TIMEOUT_MS,
+  type SurfaceDirectory,
+} from './directory';
+import type { SurfaceAliasName, SurfaceName } from './specs';
+
+function provideLatest(
+  directory: SurfaceDirectory,
+  name: SurfaceName,
+  id: string,
+  fn: () => void | Promise<void>
+) {
+  return directory.provide(name, id, { goToLatest: fn });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('surface directory await semantics', () => {
+  it('runs a method provided before the call, wrapping sync and awaiting async', async () => {
+    const directory = createSurfaceDirectory();
+    const forwarded: Record<string, string>[] = [];
+    directory.provide('image', 'a', {
+      goToLocationFromParams: (params) => {
+        forwarded.push(params);
+      },
+    });
+    await directory.handle('image', 'a').goToLocationFromParams({ foo: 'hi' });
+    expect(forwarded).toEqual([{ foo: 'hi' }]);
+
+    let asyncValue = 0;
+    directory.provide('image', 'b', {
+      goToLatest: async () => {
+        await Promise.resolve();
+        asyncValue = 2;
+      },
+    });
+    await directory.handle('image', 'b').goToLatest();
+    expect(asyncValue).toBe(2);
+  });
+
+  it('resolves a call issued before registration once provide lands', async () => {
+    const directory = createSurfaceDirectory();
+    let received: Record<string, string> | undefined;
+    const pending = directory
+      .handle('image', 'late')
+      .goToLocationFromParams({ k: 'arg' });
+    directory.provide('image', 'late', {
+      goToLocationFromParams: (params) => {
+        received = params;
+      },
+    });
+    await pending;
+    expect(received).toEqual({ k: 'arg' });
+  });
+
+  it('runs the newest fn when a re-provide lands while a call waits', async () => {
+    const directory = createSurfaceDirectory();
+    let winner = '';
+    const pending = directory.handle('image', 'race').goToLatest();
+    provideLatest(directory, 'image', 'race', () => {
+      winner = 'first';
+    });
+    provideLatest(directory, 'image', 'race', () => {
+      winner = 'second';
+    });
+    await pending;
+    expect(winner).toBe('second');
+  });
+
+  it('lets a handle created before registration resolve later (pin-key/late-resolve)', async () => {
+    const directory = createSurfaceDirectory();
+    const handle = directory.handle('image', 'pinned');
+    let value = '';
+    provideLatest(directory, 'image', 'pinned', () => {
+      value = 'late';
+    });
+    await handle.goToLatest();
+    expect(value).toBe('late');
+  });
+
+  it('is not a thenable: then/catch/finally are undefined and await does not recurse', async () => {
+    const directory = createSurfaceDirectory();
+    const handle = directory.handle('image', 'thenable');
+    expect(Reflect.get(handle, 'then')).toBeUndefined();
+    expect(Reflect.get(handle, 'catch')).toBeUndefined();
+    expect(Reflect.get(handle, 'finally')).toBeUndefined();
+    expect(await handle).toBe(handle);
+  });
+});
+
+describe('surface directory timeout', () => {
+  it('never-provided method resolves undefined after timeoutMs without throwing or rejecting', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const directory = createSurfaceDirectory();
+    const pending = directory
+      .handle('image', 'missing', { timeoutMs: 50 })
+      .goToLatest();
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(pending).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'surface method timed out: image:missing.goToLatest'
+      )
+    );
+  });
+
+  it('respects options.timeoutMs and uses DEFAULT_METHOD_TIMEOUT_MS otherwise', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const directory = createSurfaceDirectory();
+
+    let customSettled = false;
+    const custom = directory
+      .handle('image', 'custom', { timeoutMs: 100 })
+      .goToLatest();
+    void custom.then(() => {
+      customSettled = true;
+    });
+    await vi.advanceTimersByTimeAsync(99);
+    expect(customSettled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(customSettled).toBe(true);
+    await expect(custom).resolves.toBeUndefined();
+
+    let defaultSettled = false;
+    const fallback = directory.handle('image', 'default').goToLatest();
+    void fallback.then(() => {
+      defaultSettled = true;
+    });
+    await vi.advanceTimersByTimeAsync(DEFAULT_METHOD_TIMEOUT_MS - 1);
+    expect(defaultSettled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(defaultSettled).toBe(true);
+    await expect(fallback).resolves.toBeUndefined();
+    expect(DEFAULT_METHOD_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it('re-checks awaitCondition at timer expiry before rejecting', async () => {
+    vi.useFakeTimers();
+    let ready = false;
+    const pending = awaitCondition(() => ready, 1000);
+    ready = true;
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(pending).resolves.toBeUndefined();
+  });
+});
+
+describe('surface directory dispose ordering', () => {
+  it('provide disposer removes exactly its methods; other keys and providers stay', async () => {
+    const directory = createSurfaceDirectory();
+    let a = '';
+    let inbox = '';
+    provideLatest(directory, 'image', 'a', () => {
+      a = 'a';
+    });
+    const disposeB = provideLatest(directory, 'image', 'b', () => {
+      /* removed */
+    });
+    provideLatest(directory, 'inbox', 'a', () => {
+      inbox = 'inbox';
+    });
+    disposeB();
+    await directory.handle('image', 'a').goToLatest();
+    await directory.handle('inbox', 'a').goToLatest();
+    expect(a).toBe('a');
+    expect(inbox).toBe('inbox');
+
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const gone = directory.handle('image', 'b', { timeoutMs: 20 }).goToLatest();
+    await vi.advanceTimersByTimeAsync(20);
+    await expect(gone).resolves.toBeUndefined();
+  });
+
+  it('overlapping provides: second wins; first disposer does not remove it; second disposer does', async () => {
+    const directory = createSurfaceDirectory();
+    let winner = '';
+    const first = provideLatest(directory, 'image', 'x', () => {
+      winner = 'first';
+    });
+    const second = provideLatest(directory, 'image', 'x', () => {
+      winner = 'second';
+    });
+    await directory.handle('image', 'x').goToLatest();
+    expect(winner).toBe('second');
+    first();
+    winner = '';
+    await directory.handle('image', 'x').goToLatest();
+    expect(winner).toBe('second');
+    second();
+
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const gone = directory.handle('image', 'x', { timeoutMs: 20 }).goToLatest();
+    await vi.advanceTimersByTimeAsync(20);
+    await expect(gone).resolves.toBeUndefined();
+  });
+
+  it('removes the entry only when announceCount is 0 and no methods remain', () => {
+    const directory = createSurfaceDirectory();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const disposeAnnounce = directory.announce('image', 'prune');
+    const disposeProvide = provideLatest(directory, 'image', 'prune', () => {
+      /* present */
+    });
+    expect(directory.isLive('image', 'prune')).toBe(true);
+    disposeAnnounce();
+    expect(directory.isLive('image', 'prune')).toBe(false);
+    disposeProvide();
+    warn.mockClear();
+    const disposeAgain = directory.announce('image', 'prune');
+    expect(directory.isLive('image', 'prune')).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+    disposeAgain();
+    expect(directory.isLive('image', 'prune')).toBe(false);
+  });
+});
+
+describe('surface directory announce / isLive', () => {
+  it('isLive is false then true on announce then false after dispose, and is reactive', () => {
+    const directory = createSurfaceDirectory();
+    const seen: boolean[] = [];
+    let disposeRoot!: () => void;
+    createRoot((dispose) => {
+      disposeRoot = dispose;
+      createEffect(() => {
+        seen.push(directory.isLive('image', 'live'));
+      });
+    });
+    expect(seen).toEqual([false]);
+    const stop = directory.announce('image', 'live');
+    expect(seen).toEqual([false, true]);
+    stop();
+    expect(seen).toEqual([false, true, false]);
+    disposeRoot();
+  });
+
+  it('double-announce stays live after one dispose; second dispose dies; excess dispose never goes negative', () => {
+    const directory = createSurfaceDirectory();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const first = directory.announce('image', 'dup');
+    const second = directory.announce('image', 'dup');
+    expect(directory.isLive('image', 'dup')).toBe(true);
+    first();
+    expect(directory.isLive('image', 'dup')).toBe(true);
+    second();
+    expect(directory.isLive('image', 'dup')).toBe(false);
+    second();
+    expect(directory.isLive('image', 'dup')).toBe(false);
+    const third = directory.announce('image', 'dup');
+    expect(directory.isLive('image', 'dup')).toBe(true);
+    third();
+    expect(directory.isLive('image', 'dup')).toBe(false);
+  });
+
+  it('DEV-warns when announce count exceeds 1', () => {
+    const directory = createSurfaceDirectory();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const first = directory.announce('image', 'warn');
+    expect(warn).not.toHaveBeenCalled();
+    const second = directory.announce('image', 'warn');
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('two live mounts share `image:warn`')
+    );
+    first();
+    second();
+  });
+});
+
+describe('surface directory reactive rekey', () => {
+  it('a call against B issued before a disposeA/announceB/provideB batch resolves once the batch lands, and A is gone', async () => {
+    const directory = createSurfaceDirectory();
+    const disposeAnnounceA = directory.announce('image', 'pending-x');
+    const disposeProvideA = provideLatest(
+      directory,
+      'image',
+      'pending-x',
+      () => {
+        /* old */
+      }
+    );
+
+    let value = '';
+    const pendingB = directory.handle('image', 'session-y').goToLatest();
+    disposeAnnounceA();
+    disposeProvideA();
+    directory.announce('image', 'session-y');
+    provideLatest(directory, 'image', 'session-y', () => {
+      value = 'new';
+    });
+
+    await pendingB;
+    expect(value).toBe('new');
+    expect(directory.isLive('image', 'pending-x')).toBe(false);
+    expect(directory.isLive('image', 'session-y')).toBe(true);
+  });
+
+  it('a call against A after the rekey batch times out to undefined', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const directory = createSurfaceDirectory();
+    const disposeAnnounceA = directory.announce('image', 'pending-x');
+    const disposeProvideA = provideLatest(
+      directory,
+      'image',
+      'pending-x',
+      () => {
+        /* old */
+      }
+    );
+    disposeAnnounceA();
+    disposeProvideA();
+    directory.announce('image', 'session-y');
+    provideLatest(directory, 'image', 'session-y', () => {
+      /* new */
+    });
+
+    const stale = directory
+      .handle('image', 'pending-x', { timeoutMs: 30 })
+      .goToLatest();
+    await vi.advanceTimersByTimeAsync(30);
+    await expect(stale).resolves.toBeUndefined();
+  });
+});
+
+describe('catalog alias sync', () => {
+  it('every catalog alias is a SurfaceAliasName and round-trips to its owner', () => {
+    for (const name of Object.keys(surfaceCatalog) as SurfaceName[]) {
+      for (const alias of surfaceCatalog[name].aliases ?? []) {
+        expect(isSurfaceAlias(alias.name)).toBe(true);
+        const aliasName: SurfaceAliasName = alias.name;
+        expect(resolveSurfaceAlias(aliasName)).toBe(name);
+      }
+    }
+    expect(verifySurfaceName('junk')).toBeUndefined();
+    expect(verifySurfaceName('image')).toBe('image');
+    expect(isSurfaceAlias('image')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/surface/directory.test.ts
+++ b/apps/web/src/lib/surface/directory.test.ts
@@ -1,18 +1,13 @@
 import { createEffect, createRoot } from 'solid-js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import {
-  isSurfaceAlias,
-  resolveSurfaceAlias,
-  surfaceCatalog,
-  verifySurfaceName,
-} from './catalog';
+import { sameSurfaceIdentity } from './catalog';
 import {
   awaitCondition,
   createSurfaceDirectory,
   DEFAULT_METHOD_TIMEOUT_MS,
   type SurfaceDirectory,
 } from './directory';
-import type { SurfaceAliasName, SurfaceName } from './specs';
+import type { SurfaceName } from './specs';
 
 function provideLatest(
   directory: SurfaceDirectory,
@@ -102,51 +97,18 @@ describe('surface directory await semantics', () => {
 });
 
 describe('surface directory timeout', () => {
-  it('never-provided method resolves undefined after timeoutMs without throwing or rejecting', async () => {
+  it('never-provided method resolves undefined after DEFAULT_METHOD_TIMEOUT_MS without throwing or rejecting', async () => {
     vi.useFakeTimers();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const directory = createSurfaceDirectory();
-    const pending = directory
-      .handle('image', 'missing', { timeoutMs: 50 })
-      .goToLatest();
-    await vi.advanceTimersByTimeAsync(50);
+    const pending = directory.handle('image', 'missing').goToLatest();
+    await vi.advanceTimersByTimeAsync(DEFAULT_METHOD_TIMEOUT_MS);
     await expect(pending).resolves.toBeUndefined();
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining(
         'surface method timed out: image:missing.goToLatest'
       )
     );
-  });
-
-  it('respects options.timeoutMs and uses DEFAULT_METHOD_TIMEOUT_MS otherwise', async () => {
-    vi.useFakeTimers();
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const directory = createSurfaceDirectory();
-
-    let customSettled = false;
-    const custom = directory
-      .handle('image', 'custom', { timeoutMs: 100 })
-      .goToLatest();
-    void custom.then(() => {
-      customSettled = true;
-    });
-    await vi.advanceTimersByTimeAsync(99);
-    expect(customSettled).toBe(false);
-    await vi.advanceTimersByTimeAsync(1);
-    expect(customSettled).toBe(true);
-    await expect(custom).resolves.toBeUndefined();
-
-    let defaultSettled = false;
-    const fallback = directory.handle('image', 'default').goToLatest();
-    void fallback.then(() => {
-      defaultSettled = true;
-    });
-    await vi.advanceTimersByTimeAsync(DEFAULT_METHOD_TIMEOUT_MS - 1);
-    expect(defaultSettled).toBe(false);
-    await vi.advanceTimersByTimeAsync(1);
-    expect(defaultSettled).toBe(true);
-    await expect(fallback).resolves.toBeUndefined();
-    expect(DEFAULT_METHOD_TIMEOUT_MS).toBe(10_000);
   });
 
   it('re-checks awaitCondition at timer expiry before rejecting', async () => {
@@ -181,8 +143,8 @@ describe('surface directory dispose ordering', () => {
 
     vi.useFakeTimers();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const gone = directory.handle('image', 'b', { timeoutMs: 20 }).goToLatest();
-    await vi.advanceTimersByTimeAsync(20);
+    const gone = directory.handle('image', 'b').goToLatest();
+    await vi.advanceTimersByTimeAsync(DEFAULT_METHOD_TIMEOUT_MS);
     await expect(gone).resolves.toBeUndefined();
   });
 
@@ -205,8 +167,8 @@ describe('surface directory dispose ordering', () => {
 
     vi.useFakeTimers();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const gone = directory.handle('image', 'x', { timeoutMs: 20 }).goToLatest();
-    await vi.advanceTimersByTimeAsync(20);
+    const gone = directory.handle('image', 'x').goToLatest();
+    await vi.advanceTimersByTimeAsync(DEFAULT_METHOD_TIMEOUT_MS);
     await expect(gone).resolves.toBeUndefined();
   });
 
@@ -329,25 +291,38 @@ describe('surface directory reactive rekey', () => {
       /* new */
     });
 
-    const stale = directory
-      .handle('image', 'pending-x', { timeoutMs: 30 })
-      .goToLatest();
-    await vi.advanceTimersByTimeAsync(30);
+    const stale = directory.handle('image', 'pending-x').goToLatest();
+    await vi.advanceTimersByTimeAsync(DEFAULT_METHOD_TIMEOUT_MS);
     await expect(stale).resolves.toBeUndefined();
   });
 });
 
-describe('catalog alias sync', () => {
-  it('every catalog alias is a SurfaceAliasName and round-trips to its owner', () => {
-    for (const name of Object.keys(surfaceCatalog) as SurfaceName[]) {
-      for (const alias of surfaceCatalog[name].aliases ?? []) {
-        expect(isSurfaceAlias(alias.name)).toBe(true);
-        const aliasName: SurfaceAliasName = alias.name;
-        expect(resolveSurfaceAlias(aliasName)).toBe(name);
-      }
-    }
-    expect(verifySurfaceName('junk')).toBeUndefined();
-    expect(verifySurfaceName('image')).toBe('image');
-    expect(isSurfaceAlias('image')).toBe(false);
+describe('catalog dedupe identity', () => {
+  // The singleton branch stays uncovered until a singleton catalog entry exists.
+  it('entity surfaces dedupe on id; app surfaces never dedupe; names must match', () => {
+    expect(
+      sameSurfaceIdentity(
+        { name: 'image', id: 'a' },
+        { name: 'image', id: 'a' }
+      )
+    ).toBe(true);
+    expect(
+      sameSurfaceIdentity(
+        { name: 'image', id: 'a' },
+        { name: 'image', id: 'b' }
+      )
+    ).toBe(false);
+    expect(
+      sameSurfaceIdentity(
+        { name: 'image', id: 'a' },
+        { name: 'inbox', id: 'a' }
+      )
+    ).toBe(false);
+    expect(
+      sameSurfaceIdentity(
+        { name: 'inbox', id: 'a' },
+        { name: 'inbox', id: 'a' }
+      )
+    ).toBe(false);
   });
 });

--- a/apps/web/src/lib/surface/directory.test.ts
+++ b/apps/web/src/lib/surface/directory.test.ts
@@ -1,4 +1,3 @@
-import { createEffect, createRoot } from 'solid-js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { sameSurfaceIdentity } from './catalog';
 import {
@@ -7,15 +6,13 @@ import {
   DEFAULT_METHOD_TIMEOUT_MS,
   type SurfaceDirectory,
 } from './directory';
-import type { SurfaceName } from './specs';
 
 function provideLatest(
   directory: SurfaceDirectory,
-  name: SurfaceName,
   id: string,
   fn: () => void | Promise<void>
 ) {
-  return directory.provide(name, id, { goToLatest: fn });
+  return directory.provide(id, { goToLatest: fn });
 }
 
 afterEach(() => {
@@ -27,22 +24,22 @@ describe('surface directory await semantics', () => {
   it('runs a method provided before the call, wrapping sync and awaiting async', async () => {
     const directory = createSurfaceDirectory();
     const forwarded: Record<string, string>[] = [];
-    directory.provide('image', 'a', {
+    directory.provide('a', {
       goToLocationFromParams: (params) => {
         forwarded.push(params);
       },
     });
-    await directory.handle('image', 'a').goToLocationFromParams({ foo: 'hi' });
+    await directory.handle('a').goToLocationFromParams({ foo: 'hi' });
     expect(forwarded).toEqual([{ foo: 'hi' }]);
 
     let asyncValue = 0;
-    directory.provide('image', 'b', {
+    directory.provide('b', {
       goToLatest: async () => {
         await Promise.resolve();
         asyncValue = 2;
       },
     });
-    await directory.handle('image', 'b').goToLatest();
+    await directory.handle('b').goToLatest();
     expect(asyncValue).toBe(2);
   });
 
@@ -50,9 +47,9 @@ describe('surface directory await semantics', () => {
     const directory = createSurfaceDirectory();
     let received: Record<string, string> | undefined;
     const pending = directory
-      .handle('image', 'late')
+      .handle('late')
       .goToLocationFromParams({ k: 'arg' });
-    directory.provide('image', 'late', {
+    directory.provide('late', {
       goToLocationFromParams: (params) => {
         received = params;
       },
@@ -64,11 +61,11 @@ describe('surface directory await semantics', () => {
   it('runs the newest fn when a re-provide lands while a call waits', async () => {
     const directory = createSurfaceDirectory();
     let winner = '';
-    const pending = directory.handle('image', 'race').goToLatest();
-    provideLatest(directory, 'image', 'race', () => {
+    const pending = directory.handle('race').goToLatest();
+    provideLatest(directory, 'race', () => {
       winner = 'first';
     });
-    provideLatest(directory, 'image', 'race', () => {
+    provideLatest(directory, 'race', () => {
       winner = 'second';
     });
     await pending;
@@ -77,9 +74,9 @@ describe('surface directory await semantics', () => {
 
   it('lets a handle created before registration resolve later (pin-key/late-resolve)', async () => {
     const directory = createSurfaceDirectory();
-    const handle = directory.handle('image', 'pinned');
+    const handle = directory.handle('pinned');
     let value = '';
-    provideLatest(directory, 'image', 'pinned', () => {
+    provideLatest(directory, 'pinned', () => {
       value = 'late';
     });
     await handle.goToLatest();
@@ -88,7 +85,7 @@ describe('surface directory await semantics', () => {
 
   it('is not a thenable: then/catch/finally are undefined and await does not recurse', async () => {
     const directory = createSurfaceDirectory();
-    const handle = directory.handle('image', 'thenable');
+    const handle = directory.handle('thenable');
     expect(Reflect.get(handle, 'then')).toBeUndefined();
     expect(Reflect.get(handle, 'catch')).toBeUndefined();
     expect(Reflect.get(handle, 'finally')).toBeUndefined();
@@ -101,13 +98,11 @@ describe('surface directory timeout', () => {
     vi.useFakeTimers();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const directory = createSurfaceDirectory();
-    const pending = directory.handle('image', 'missing').goToLatest();
+    const pending = directory.handle('missing').goToLatest();
     await vi.advanceTimersByTimeAsync(DEFAULT_METHOD_TIMEOUT_MS);
     await expect(pending).resolves.toBeUndefined();
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'surface method timed out: image:missing.goToLatest'
-      )
+      expect.stringContaining('surface method timed out: missing.goToLatest')
     );
   });
 
@@ -125,25 +120,25 @@ describe('surface directory dispose ordering', () => {
   it('provide disposer removes exactly its methods; other keys and providers stay', async () => {
     const directory = createSurfaceDirectory();
     let a = '';
-    let inbox = '';
-    provideLatest(directory, 'image', 'a', () => {
+    let c = '';
+    provideLatest(directory, 'a', () => {
       a = 'a';
     });
-    const disposeB = provideLatest(directory, 'image', 'b', () => {
+    const disposeB = provideLatest(directory, 'b', () => {
       /* removed */
     });
-    provideLatest(directory, 'inbox', 'a', () => {
-      inbox = 'inbox';
+    provideLatest(directory, 'c', () => {
+      c = 'c';
     });
     disposeB();
-    await directory.handle('image', 'a').goToLatest();
-    await directory.handle('inbox', 'a').goToLatest();
+    await directory.handle('a').goToLatest();
+    await directory.handle('c').goToLatest();
     expect(a).toBe('a');
-    expect(inbox).toBe('inbox');
+    expect(c).toBe('c');
 
     vi.useFakeTimers();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const gone = directory.handle('image', 'b').goToLatest();
+    const gone = directory.handle('b').goToLatest();
     await vi.advanceTimersByTimeAsync(DEFAULT_METHOD_TIMEOUT_MS);
     await expect(gone).resolves.toBeUndefined();
   });
@@ -151,147 +146,59 @@ describe('surface directory dispose ordering', () => {
   it('overlapping provides: second wins; first disposer does not remove it; second disposer does', async () => {
     const directory = createSurfaceDirectory();
     let winner = '';
-    const first = provideLatest(directory, 'image', 'x', () => {
+    const first = provideLatest(directory, 'x', () => {
       winner = 'first';
     });
-    const second = provideLatest(directory, 'image', 'x', () => {
+    const second = provideLatest(directory, 'x', () => {
       winner = 'second';
     });
-    await directory.handle('image', 'x').goToLatest();
+    await directory.handle('x').goToLatest();
     expect(winner).toBe('second');
     first();
     winner = '';
-    await directory.handle('image', 'x').goToLatest();
+    await directory.handle('x').goToLatest();
     expect(winner).toBe('second');
     second();
 
     vi.useFakeTimers();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const gone = directory.handle('image', 'x').goToLatest();
+    const gone = directory.handle('x').goToLatest();
     await vi.advanceTimersByTimeAsync(DEFAULT_METHOD_TIMEOUT_MS);
     await expect(gone).resolves.toBeUndefined();
-  });
-
-  it('removes the entry only when announceCount is 0 and no methods remain', () => {
-    const directory = createSurfaceDirectory();
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const disposeAnnounce = directory.announce('image', 'prune');
-    const disposeProvide = provideLatest(directory, 'image', 'prune', () => {
-      /* present */
-    });
-    expect(directory.isLive('image', 'prune')).toBe(true);
-    disposeAnnounce();
-    expect(directory.isLive('image', 'prune')).toBe(false);
-    disposeProvide();
-    warn.mockClear();
-    const disposeAgain = directory.announce('image', 'prune');
-    expect(directory.isLive('image', 'prune')).toBe(true);
-    expect(warn).not.toHaveBeenCalled();
-    disposeAgain();
-    expect(directory.isLive('image', 'prune')).toBe(false);
-  });
-});
-
-describe('surface directory announce / isLive', () => {
-  it('isLive is false then true on announce then false after dispose, and is reactive', () => {
-    const directory = createSurfaceDirectory();
-    const seen: boolean[] = [];
-    let disposeRoot!: () => void;
-    createRoot((dispose) => {
-      disposeRoot = dispose;
-      createEffect(() => {
-        seen.push(directory.isLive('image', 'live'));
-      });
-    });
-    expect(seen).toEqual([false]);
-    const stop = directory.announce('image', 'live');
-    expect(seen).toEqual([false, true]);
-    stop();
-    expect(seen).toEqual([false, true, false]);
-    disposeRoot();
-  });
-
-  it('double-announce stays live after one dispose; second dispose dies; excess dispose never goes negative', () => {
-    const directory = createSurfaceDirectory();
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const first = directory.announce('image', 'dup');
-    const second = directory.announce('image', 'dup');
-    expect(directory.isLive('image', 'dup')).toBe(true);
-    first();
-    expect(directory.isLive('image', 'dup')).toBe(true);
-    second();
-    expect(directory.isLive('image', 'dup')).toBe(false);
-    second();
-    expect(directory.isLive('image', 'dup')).toBe(false);
-    const third = directory.announce('image', 'dup');
-    expect(directory.isLive('image', 'dup')).toBe(true);
-    third();
-    expect(directory.isLive('image', 'dup')).toBe(false);
-  });
-
-  it('DEV-warns when announce count exceeds 1', () => {
-    const directory = createSurfaceDirectory();
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const first = directory.announce('image', 'warn');
-    expect(warn).not.toHaveBeenCalled();
-    const second = directory.announce('image', 'warn');
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('two live mounts share `image:warn`')
-    );
-    first();
-    second();
   });
 });
 
 describe('surface directory reactive rekey', () => {
-  it('a call against B issued before a disposeA/announceB/provideB batch resolves once the batch lands, and A is gone', async () => {
+  it('a call against B issued before a disposeA/provideB batch resolves once the batch lands', async () => {
     const directory = createSurfaceDirectory();
-    const disposeAnnounceA = directory.announce('image', 'pending-x');
-    const disposeProvideA = provideLatest(
-      directory,
-      'image',
-      'pending-x',
-      () => {
-        /* old */
-      }
-    );
+    const disposeProvideA = provideLatest(directory, 'pending-x', () => {
+      /* old */
+    });
 
     let value = '';
-    const pendingB = directory.handle('image', 'session-y').goToLatest();
-    disposeAnnounceA();
+    const pendingB = directory.handle('session-y').goToLatest();
     disposeProvideA();
-    directory.announce('image', 'session-y');
-    provideLatest(directory, 'image', 'session-y', () => {
+    provideLatest(directory, 'session-y', () => {
       value = 'new';
     });
 
     await pendingB;
     expect(value).toBe('new');
-    expect(directory.isLive('image', 'pending-x')).toBe(false);
-    expect(directory.isLive('image', 'session-y')).toBe(true);
   });
 
   it('a call against A after the rekey batch times out to undefined', async () => {
     vi.useFakeTimers();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const directory = createSurfaceDirectory();
-    const disposeAnnounceA = directory.announce('image', 'pending-x');
-    const disposeProvideA = provideLatest(
-      directory,
-      'image',
-      'pending-x',
-      () => {
-        /* old */
-      }
-    );
-    disposeAnnounceA();
+    const disposeProvideA = provideLatest(directory, 'pending-x', () => {
+      /* old */
+    });
     disposeProvideA();
-    directory.announce('image', 'session-y');
-    provideLatest(directory, 'image', 'session-y', () => {
+    provideLatest(directory, 'session-y', () => {
       /* new */
     });
 
-    const stale = directory.handle('image', 'pending-x').goToLatest();
+    const stale = directory.handle('pending-x').goToLatest();
     await vi.advanceTimersByTimeAsync(DEFAULT_METHOD_TIMEOUT_MS);
     await expect(stale).resolves.toBeUndefined();
   });

--- a/apps/web/src/lib/surface/directory.ts
+++ b/apps/web/src/lib/surface/directory.ts
@@ -1,11 +1,6 @@
 import { createEffect, createRoot, untrack } from 'solid-js';
 import { createStore } from 'solid-js/store';
-import type {
-  AsHandleMethods,
-  AsProvidedMethods,
-  MethodsFor,
-  SurfaceName,
-} from './specs';
+import type { AsHandleMethods, MethodsFor, SurfaceName } from './specs';
 
 /** Composite key identifying a live surface instance. */
 export type SurfaceKey = `${SurfaceName}:${string}`;
@@ -22,41 +17,31 @@ export type SurfaceHandle<N extends SurfaceName> = {
   readonly surface: { readonly name: N; readonly id: string };
 } & AsHandleMethods<MethodsFor<N>>;
 
-/** Options for a handle's per-call bounded await. */
-export type SurfaceHandleOptions = {
-  /** Per-method-call bounded await. Default DEFAULT_METHOD_TIMEOUT_MS. */
-  timeoutMs?: number;
-};
-
 /** Runtime registry of live surface instances and their public methods. */
 export type SurfaceDirectory = {
   /**
    * Declare that a live, non-nested instance of (name, id) exists.
-   * Returns a disposer. Refcounted (§3.5).
+   * Returns a disposer (refcounted; see announce disposer).
    */
   announce(name: SurfaceName, id: string): Disposer;
 
   /**
    * Merge typed methods for (name, id). Independent of announce — neither
    * requires the other, in either order. Returns a disposer that removes
-   * exactly the methods this call registered, guarded by registration
-   * identity (§3.6). Later provides win per method name.
+   * exactly the methods this call registered (guarded by the registration
+   * token below). Later provides win per method name.
    */
   provide<N extends SurfaceName>(
     name: N,
     id: string,
-    methods: AsProvidedMethods<MethodsFor<N>> // every key optional by construction
+    methods: Partial<MethodsFor<N>>
   ): Disposer;
 
   /**
-   * Synchronous, infallible, cheap. Pins (name, id) at creation; resolves
-   * registrations lazily at each method call (§3.7).
+   * Synchronous, infallible, cheap. Pins (name, id) at creation; method
+   * lookups are resolved lazily at each call.
    */
-  handle<N extends SurfaceName>(
-    name: N,
-    id: string,
-    options?: SurfaceHandleOptions
-  ): SurfaceHandle<N>;
+  handle<N extends SurfaceName>(name: N, id: string): SurfaceHandle<N>;
 
   /** Reactive: true while announce-count > 0 for (name, id). */
   isLive(name: SurfaceName, id: string): boolean;
@@ -64,7 +49,7 @@ export type SurfaceDirectory = {
 
 const DEFAULT_AWAIT_TIMEOUT_MS = 5_000;
 
-/** Per-method-call bounded await used when the caller does not pass timeoutMs. */
+/** Per-method-call bounded await used by handle(). */
 export const DEFAULT_METHOD_TIMEOUT_MS = 10_000;
 
 type RegisteredMethod = {
@@ -80,8 +65,9 @@ type DirectoryEntry = {
 /**
  * Moved verbatim from orchestrator.tsx (createRoot + createEffect + timer;
  * re-checks the condition at timeout before rejecting). Default 5_000ms.
- * Exported because features use it directly (e.g. NewChannelBlockAdapter's
- * messagesHandle wait).
+ * Exported so the re-check-at-expiry path can be unit-tested directly
+ * (unreachable through the reactive handle) and as the landing spot for
+ * orchestrator callers at migration time.
  */
 export function awaitCondition(
   condition: () => boolean,
@@ -205,9 +191,8 @@ export function createSurfaceDirectory(): SurfaceDirectory {
       };
     },
 
-    handle(name, id, options) {
+    handle(name, id) {
       const key = surfaceKey(name, id);
-      const timeoutMs = options?.timeoutMs ?? DEFAULT_METHOD_TIMEOUT_MS;
       const surface = { name, id };
       return new Proxy({} as SurfaceHandle<typeof name>, {
         get(_, prop) {
@@ -219,7 +204,7 @@ export function createSurfaceDirectory(): SurfaceDirectory {
           return async (...args: unknown[]) => {
             await awaitCondition(
               () => entries[key]?.methods[prop] !== undefined,
-              timeoutMs
+              DEFAULT_METHOD_TIMEOUT_MS
             ).catch(() => {
               if (import.meta.env.DEV) {
                 console.warn(`surface method timed out: ${key}.${prop}`);

--- a/apps/web/src/lib/surface/directory.ts
+++ b/apps/web/src/lib/surface/directory.ts
@@ -1,0 +1,244 @@
+import { createEffect, createRoot, untrack } from 'solid-js';
+import { createStore } from 'solid-js/store';
+import type {
+  AsHandleMethods,
+  AsProvidedMethods,
+  MethodsFor,
+  SurfaceName,
+} from './specs';
+
+/** Composite key identifying a live surface instance. */
+export type SurfaceKey = `${SurfaceName}:${string}`;
+
+/** Build the directory key for `(name, id)`. */
+export const surfaceKey = (name: SurfaceName, id: string): SurfaceKey =>
+  `${name}:${id}`;
+
+/** Cleanup function returned by announce/provide. */
+export type Disposer = () => void;
+
+/** Typed handle pinned to a `(name, id)` pair; method lookups resolve per call. */
+export type SurfaceHandle<N extends SurfaceName> = {
+  readonly surface: { readonly name: N; readonly id: string };
+} & AsHandleMethods<MethodsFor<N>>;
+
+/** Options for a handle's per-call bounded await. */
+export type SurfaceHandleOptions = {
+  /** Per-method-call bounded await. Default DEFAULT_METHOD_TIMEOUT_MS. */
+  timeoutMs?: number;
+};
+
+/** Runtime registry of live surface instances and their public methods. */
+export type SurfaceDirectory = {
+  /**
+   * Declare that a live, non-nested instance of (name, id) exists.
+   * Returns a disposer. Refcounted (§3.5).
+   */
+  announce(name: SurfaceName, id: string): Disposer;
+
+  /**
+   * Merge typed methods for (name, id). Independent of announce — neither
+   * requires the other, in either order. Returns a disposer that removes
+   * exactly the methods this call registered, guarded by registration
+   * identity (§3.6). Later provides win per method name.
+   */
+  provide<N extends SurfaceName>(
+    name: N,
+    id: string,
+    methods: AsProvidedMethods<MethodsFor<N>> // every key optional by construction
+  ): Disposer;
+
+  /**
+   * Synchronous, infallible, cheap. Pins (name, id) at creation; resolves
+   * registrations lazily at each method call (§3.7).
+   */
+  handle<N extends SurfaceName>(
+    name: N,
+    id: string,
+    options?: SurfaceHandleOptions
+  ): SurfaceHandle<N>;
+
+  /** Reactive: true while announce-count > 0 for (name, id). */
+  isLive(name: SurfaceName, id: string): boolean;
+};
+
+const DEFAULT_AWAIT_TIMEOUT_MS = 5_000;
+
+/** Per-method-call bounded await used when the caller does not pass timeoutMs. */
+export const DEFAULT_METHOD_TIMEOUT_MS = 10_000;
+
+type RegisteredMethod = {
+  fn: (...args: unknown[]) => unknown;
+  /** identity of the provide() call that registered it */
+  token: symbol;
+};
+type DirectoryEntry = {
+  announceCount: number;
+  methods: Record<string, RegisteredMethod | undefined>;
+};
+
+/**
+ * Moved verbatim from orchestrator.tsx (createRoot + createEffect + timer;
+ * re-checks the condition at timeout before rejecting). Default 5_000ms.
+ * Exported because features use it directly (e.g. NewChannelBlockAdapter's
+ * messagesHandle wait).
+ */
+export function awaitCondition(
+  condition: () => boolean,
+  timeoutMs = DEFAULT_AWAIT_TIMEOUT_MS
+): Promise<void> {
+  if (condition()) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    createRoot((dispose) => {
+      const timer = setTimeout(() => {
+        if (condition()) return resolve();
+        else reject(new Error('Timeout'));
+        dispose();
+      }, timeoutMs);
+      createEffect(() => {
+        if (condition()) {
+          clearTimeout(timer);
+          dispose();
+          resolve();
+        }
+      });
+    });
+  });
+}
+
+function hasRegisteredMethods(entry: DirectoryEntry): boolean {
+  for (const value of Object.values(entry.methods)) {
+    if (value !== undefined) return true;
+  }
+  return false;
+}
+
+/**
+ * Create an isolated surface directory. Tests use this; the app uses
+ * `surfaceDirectory`.
+ */
+export function createSurfaceDirectory(): SurfaceDirectory {
+  const [entries, setEntries] = createStore<
+    Record<SurfaceKey, DirectoryEntry | undefined>
+  >({});
+
+  const ensureEntry = (key: SurfaceKey) => {
+    if (entries[key] === undefined) {
+      setEntries(key, { announceCount: 0, methods: {} });
+    }
+  };
+
+  const prune = (key: SurfaceKey) => {
+    const entry = entries[key];
+    if (!entry) return;
+    if (entry.announceCount === 0 && !hasRegisteredMethods(entry)) {
+      setEntries(key, undefined);
+    }
+  };
+
+  return {
+    announce(name, id) {
+      const key = surfaceKey(name, id);
+      // Registry mutations must not subscribe the caller's effect (provider
+      // announce/provide effects would loop on their own store writes).
+      untrack(() => {
+        const current = entries[key];
+        if (current === undefined) {
+          setEntries(key, { announceCount: 1, methods: {} });
+          return;
+        }
+        setEntries(key, 'announceCount', (count) => {
+          const next = count + 1;
+          if (import.meta.env.DEV && next > 1) {
+            console.warn(
+              `two live mounts share \`${key}\`; expected only transiently during a remount in the same tick`
+            );
+          }
+          return next;
+        });
+      });
+      return () => {
+        untrack(() => {
+          const entry = entries[key];
+          if (entry === undefined) return;
+          const next = Math.max(0, entry.announceCount - 1);
+          if (next === 0 && !hasRegisteredMethods(entry)) {
+            setEntries(key, undefined);
+            return;
+          }
+          setEntries(key, 'announceCount', next);
+        });
+      };
+    },
+
+    provide(name, id, methods) {
+      const key = surfaceKey(name, id);
+      const token = Symbol();
+      const registeredNames: string[] = [];
+      untrack(() => {
+        ensureEntry(key);
+        for (const [methodName, fn] of Object.entries(methods)) {
+          if (!fn) continue;
+          registeredNames.push(methodName);
+          if (import.meta.env.DEV) {
+            const existing = entries[key]?.methods[methodName];
+            if (existing !== undefined && existing.token !== token) {
+              console.warn(`surface method overwritten: ${key}.${methodName}`);
+            }
+          }
+          setEntries(key, 'methods', methodName, {
+            fn: fn as (...args: unknown[]) => unknown,
+            token,
+          });
+        }
+      });
+      return () => {
+        untrack(() => {
+          if (entries[key] === undefined) return;
+          for (const methodName of registeredNames) {
+            setEntries(key, 'methods', methodName, (current) =>
+              current?.token === token ? undefined : current
+            );
+          }
+          prune(key);
+        });
+      };
+    },
+
+    handle(name, id, options) {
+      const key = surfaceKey(name, id);
+      const timeoutMs = options?.timeoutMs ?? DEFAULT_METHOD_TIMEOUT_MS;
+      const surface = { name, id };
+      return new Proxy({} as SurfaceHandle<typeof name>, {
+        get(_, prop) {
+          if (prop === 'surface') return surface;
+          if (prop === 'then' || prop === 'catch' || prop === 'finally') {
+            return undefined;
+          }
+          if (typeof prop !== 'string') return undefined;
+          return async (...args: unknown[]) => {
+            await awaitCondition(
+              () => entries[key]?.methods[prop] !== undefined,
+              timeoutMs
+            ).catch(() => {
+              if (import.meta.env.DEV) {
+                console.warn(`surface method timed out: ${key}.${prop}`);
+              }
+            });
+            const entry = entries[key]?.methods[prop];
+            if (!entry) return undefined;
+            return (await entry.fn(...args)) as never;
+          };
+        },
+      });
+    },
+
+    isLive(name, id) {
+      return (entries[surfaceKey(name, id)]?.announceCount ?? 0) > 0;
+    },
+  };
+}
+
+/** The app-wide instance. SurfaceProvider/useSurfaceMethods default to it;
+ *  tests build their own via createSurfaceDirectory(). */
+export const surfaceDirectory: SurfaceDirectory = createSurfaceDirectory();

--- a/apps/web/src/lib/surface/directory.ts
+++ b/apps/web/src/lib/surface/directory.ts
@@ -2,49 +2,40 @@ import { createEffect, createRoot, untrack } from 'solid-js';
 import { createStore } from 'solid-js/store';
 import type { AsHandleMethods, MethodsFor, SurfaceName } from './specs';
 
-/** Composite key identifying a live surface instance. */
-export type SurfaceKey = `${SurfaceName}:${string}`;
-
-/** Build the directory key for `(name, id)`. */
-export const surfaceKey = (name: SurfaceName, id: string): SurfaceKey =>
-  `${name}:${id}`;
-
-/** Cleanup function returned by announce/provide. */
+/** Cleanup function returned by provide. */
 export type Disposer = () => void;
 
-/** Typed handle pinned to a `(name, id)` pair; method lookups resolve per call. */
-export type SurfaceHandle<N extends SurfaceName> = {
-  readonly surface: { readonly name: N; readonly id: string };
-} & AsHandleMethods<MethodsFor<N>>;
+/** Typed handle pinned to an id; method lookups resolve per call. */
+export type SurfaceHandle<N extends SurfaceName> = AsHandleMethods<
+  MethodsFor<N>
+>;
 
-/** Runtime registry of live surface instances and their public methods. */
+/**
+ * Typed method bus for live surface instances, keyed by id alone — the model
+ * the block orchestrator has always used (its registry is `setBlocks(id, …)`).
+ * CONTRACT: ids are unique across live surfaces. Entity ids are server-issued
+ * UUIDs, placeholder ids are `pending-<uuid>`, and app surfaces choose
+ * distinctive slugs; the DEV overwrite warn in provide() is the alarm if two
+ * providers ever share an id. `N` is a compile-time witness selecting the
+ * method map; it is not part of runtime identity.
+ */
 export type SurfaceDirectory = {
   /**
-   * Declare that a live, non-nested instance of (name, id) exists.
-   * Returns a disposer (refcounted; see announce disposer).
+   * Merge typed methods for `id`. Returns a disposer that removes exactly the
+   * methods this call registered (guarded by the registration token below).
+   * Later provides win per method name.
    */
-  announce(name: SurfaceName, id: string): Disposer;
-
-  /**
-   * Merge typed methods for (name, id). Independent of announce — neither
-   * requires the other, in either order. Returns a disposer that removes
-   * exactly the methods this call registered (guarded by the registration
-   * token below). Later provides win per method name.
-   */
-  provide<N extends SurfaceName>(
-    name: N,
+  provide<N extends SurfaceName = SurfaceName>(
     id: string,
     methods: Partial<MethodsFor<N>>
   ): Disposer;
 
   /**
-   * Synchronous, infallible, cheap. Pins (name, id) at creation; method
-   * lookups are resolved lazily at each call.
+   * Synchronous, infallible, cheap. Pins `id` at creation; each method call
+   * bounded-awaits registration (DEFAULT_METHOD_TIMEOUT_MS), then resolves
+   * `undefined` as a no-op if the method never arrives.
    */
-  handle<N extends SurfaceName>(name: N, id: string): SurfaceHandle<N>;
-
-  /** Reactive: true while announce-count > 0 for (name, id). */
-  isLive(name: SurfaceName, id: string): boolean;
+  handle<N extends SurfaceName = SurfaceName>(id: string): SurfaceHandle<N>;
 };
 
 const DEFAULT_AWAIT_TIMEOUT_MS = 5_000;
@@ -56,10 +47,6 @@ type RegisteredMethod = {
   fn: (...args: unknown[]) => unknown;
   /** identity of the provide() call that registered it */
   token: symbol;
-};
-type DirectoryEntry = {
-  announceCount: number;
-  methods: Record<string, RegisteredMethod | undefined>;
 };
 
 /**
@@ -92,8 +79,10 @@ export function awaitCondition(
   });
 }
 
-function hasRegisteredMethods(entry: DirectoryEntry): boolean {
-  for (const value of Object.values(entry.methods)) {
+function hasRegisteredMethods(
+  methods: Record<string, RegisteredMethod | undefined>
+): boolean {
+  for (const value of Object.values(methods)) {
     if (value !== undefined) return true;
   }
   return false;
@@ -105,74 +94,39 @@ function hasRegisteredMethods(entry: DirectoryEntry): boolean {
  */
 export function createSurfaceDirectory(): SurfaceDirectory {
   const [entries, setEntries] = createStore<
-    Record<SurfaceKey, DirectoryEntry | undefined>
+    Record<string, Record<string, RegisteredMethod | undefined> | undefined>
   >({});
 
-  const ensureEntry = (key: SurfaceKey) => {
-    if (entries[key] === undefined) {
-      setEntries(key, { announceCount: 0, methods: {} });
+  const ensureEntry = (id: string) => {
+    if (entries[id] === undefined) {
+      setEntries(id, {});
     }
   };
 
-  const prune = (key: SurfaceKey) => {
-    const entry = entries[key];
+  const prune = (id: string) => {
+    const entry = entries[id];
     if (!entry) return;
-    if (entry.announceCount === 0 && !hasRegisteredMethods(entry)) {
-      setEntries(key, undefined);
+    if (!hasRegisteredMethods(entry)) {
+      setEntries(id, undefined);
     }
   };
 
   return {
-    announce(name, id) {
-      const key = surfaceKey(name, id);
-      // Registry mutations must not subscribe the caller's effect (provider
-      // announce/provide effects would loop on their own store writes).
-      untrack(() => {
-        const current = entries[key];
-        if (current === undefined) {
-          setEntries(key, { announceCount: 1, methods: {} });
-          return;
-        }
-        setEntries(key, 'announceCount', (count) => {
-          const next = count + 1;
-          if (import.meta.env.DEV && next > 1) {
-            console.warn(
-              `two live mounts share \`${key}\`; expected only transiently during a remount in the same tick`
-            );
-          }
-          return next;
-        });
-      });
-      return () => {
-        untrack(() => {
-          const entry = entries[key];
-          if (entry === undefined) return;
-          const next = Math.max(0, entry.announceCount - 1);
-          if (next === 0 && !hasRegisteredMethods(entry)) {
-            setEntries(key, undefined);
-            return;
-          }
-          setEntries(key, 'announceCount', next);
-        });
-      };
-    },
-
-    provide(name, id, methods) {
-      const key = surfaceKey(name, id);
+    provide(id, methods) {
       const token = Symbol();
       const registeredNames: string[] = [];
       untrack(() => {
-        ensureEntry(key);
+        ensureEntry(id);
         for (const [methodName, fn] of Object.entries(methods)) {
           if (!fn) continue;
           registeredNames.push(methodName);
           if (import.meta.env.DEV) {
-            const existing = entries[key]?.methods[methodName];
+            const existing = entries[id]?.[methodName];
             if (existing !== undefined && existing.token !== token) {
-              console.warn(`surface method overwritten: ${key}.${methodName}`);
+              console.warn(`surface method overwritten: ${id}.${methodName}`);
             }
           }
-          setEntries(key, 'methods', methodName, {
+          setEntries(id, methodName, {
             fn: fn as (...args: unknown[]) => unknown,
             token,
           });
@@ -180,46 +134,39 @@ export function createSurfaceDirectory(): SurfaceDirectory {
       });
       return () => {
         untrack(() => {
-          if (entries[key] === undefined) return;
+          if (entries[id] === undefined) return;
           for (const methodName of registeredNames) {
-            setEntries(key, 'methods', methodName, (current) =>
+            setEntries(id, methodName, (current) =>
               current?.token === token ? undefined : current
             );
           }
-          prune(key);
+          prune(id);
         });
       };
     },
 
-    handle(name, id) {
-      const key = surfaceKey(name, id);
-      const surface = { name, id };
-      return new Proxy({} as SurfaceHandle<typeof name>, {
+    handle(id) {
+      return new Proxy({} as SurfaceHandle<SurfaceName>, {
         get(_, prop) {
-          if (prop === 'surface') return surface;
           if (prop === 'then' || prop === 'catch' || prop === 'finally') {
             return undefined;
           }
           if (typeof prop !== 'string') return undefined;
           return async (...args: unknown[]) => {
             await awaitCondition(
-              () => entries[key]?.methods[prop] !== undefined,
+              () => entries[id]?.[prop] !== undefined,
               DEFAULT_METHOD_TIMEOUT_MS
             ).catch(() => {
               if (import.meta.env.DEV) {
-                console.warn(`surface method timed out: ${key}.${prop}`);
+                console.warn(`surface method timed out: ${id}.${prop}`);
               }
             });
-            const entry = entries[key]?.methods[prop];
+            const entry = entries[id]?.[prop];
             if (!entry) return undefined;
             return (await entry.fn(...args)) as never;
           };
         },
       });
-    },
-
-    isLive(name, id) {
-      return (entries[surfaceKey(name, id)]?.announceCount ?? 0) > 0;
     },
   };
 }

--- a/apps/web/src/lib/surface/specs.ts
+++ b/apps/web/src/lib/surface/specs.ts
@@ -14,6 +14,9 @@ export type SurfaceMethod = (...args: never[]) => unknown;
  * asynchronously must be declared with a `T | Promise<T>` return (see
  * SharedSurfaceMethods). Providers then pass plain implementations checked
  * against Partial<MethodsFor<N>> — no provider-side mapped type exists.
+ * Surface-specific methods are selected by an explicit type argument
+ * (`useSurfaceMethods<'md'>(…)`); when it is omitted, inference falls back
+ * to the shared methods.
  */
 export type SurfaceMethodMap = Record<string, SurfaceMethod>;
 

--- a/apps/web/src/lib/surface/specs.ts
+++ b/apps/web/src/lib/surface/specs.ts
@@ -1,0 +1,128 @@
+// apps/web/src/lib/surface/specs.ts
+//
+// Type-level catalog of every surface: mount params and public methods.
+// TYPE-ONLY imports from feature directories are allowed (they erase at
+// compile time). Value imports from features are forbidden here.
+
+/** A surface method in its natural, possibly-synchronous form. */
+export type SurfaceMethod = (...args: never[]) => unknown;
+
+/** A named map of surface methods in natural form. */
+export type SurfaceMethodMap = Record<string, SurfaceMethod>;
+
+/**
+ * Methods every surface handle exposes without the surface declaring them.
+ * Declared in natural form; the handle side async-wraps (see AsHandleMethods).
+ * A surface that never provides them yields the bounded-await/no-op behavior
+ * described in §3.4.
+ */
+export type SharedSurfaceMethods = {
+  /** Re-aim an already-mounted surface at a location described by params. */
+  goToLocationFromParams: (
+    params: Record<string, string>
+  ) => void | Promise<void>;
+  /** Land the surface on its latest content (e.g. newest channel messages). */
+  goToLatest: () => void | Promise<void>;
+};
+
+/** Shape every SurfaceSpecs entry must conform to. */
+export type SurfaceSpec = {
+  /** One-shot mount params delivered through SplitContent.params. */
+  params: Record<string, unknown>;
+  /** Surface-specific public methods, in natural (possibly sync) form. */
+  methods: SurfaceMethodMap;
+};
+
+/**
+ * Empty method map for a surface that declares no surface-specific methods.
+ * Must be `Record<never, SurfaceMethod>`, not `Record<string, never>`:
+ * intersecting SharedSurfaceMethods with a `string` index of `never` collapses
+ * every method (including goToLatest / goToLocationFromParams) to `never`.
+ * `Record<never, SurfaceMethod>` still conforms to SurfaceMethodMap.
+ */
+export type EmptySurfaceMethods = Record<never, SurfaceMethod>;
+
+/** Empty params map for a surface that declares no mount params. */
+export type EmptySurfaceParams = Record<string, never>;
+
+/**
+ * The catalog. Migration PRs add one entry per migrated surface, importing
+ * param/method types type-only from the owning feature, e.g.:
+ *
+ *   import type { CalendarBlockProps } from '@block-calendar/types';
+ *   calendar: { params: CalendarBlockProps; methods: {} };
+ *   chat: { params: {}; methods: BlockChatSpec };            // @block-chat/blockClient
+ *   md: { params: BlockMarkdownProps; methods: MarkdownBlockSpec };
+ *
+ * DRAFT: one real entity surface ('image') + one app surface stub ('inbox').
+ */
+export interface SurfaceSpecs {
+  image: {
+    params: EmptySurfaceParams;
+    methods: EmptySurfaceMethods;
+  };
+  inbox: {
+    params: EmptySurfaceParams;
+    methods: EmptySurfaceMethods;
+  };
+}
+
+// Compile-time conformance check: fails to typecheck when any SurfaceSpecs
+// entry deviates from SurfaceSpec (unlike the old AssertSpec pattern in
+// blockMethodRegistry.ts, which silently degraded to an empty spec).
+declare const _surfaceSpecsConform: SurfaceSpecs extends Record<
+  keyof SurfaceSpecs,
+  SurfaceSpec
+>
+  ? true
+  : never;
+
+/** Catalog keys; every registered surface name. */
+export type SurfaceName = keyof SurfaceSpecs & string;
+
+/**
+ * Alias names routable to a base surface (URL-visible, dedupe-transparent).
+ * Must stay in sync with `aliases` declared in catalog.ts — directory.test.ts
+ * asserts the sync (§7). DRAFT: empty; migration adds
+ * 'task' | 'snippet' | 'skill' | 'csv' | 'write'.
+ */
+export type SurfaceAliasName = never;
+
+/** The alias used in the URL together with the catalog surface it resolves to. */
+export type SurfaceAliasContext = {
+  /** The alias used in the URL / SplitContent.type (e.g. 'task'). */
+  alias: SurfaceAliasName;
+  /** The catalog surface it resolves to (e.g. 'md'). */
+  baseName: SurfaceName;
+};
+
+/** Mount params for the named surface. */
+export type ParamsFor<N extends SurfaceName> = SurfaceSpecs[N]['params'];
+
+/** Public methods for the named surface, including shared methods. */
+export type MethodsFor<N extends SurfaceName> = SharedSurfaceMethods &
+  SurfaceSpecs[N]['methods'];
+
+/**
+ * Handle-side view of a method map. Exactly the orchestrator BlockHandle
+ * mapped type, with one honesty fix: the promise can resolve `undefined`
+ * when the surface never provides the method within the timeout (§3.4) —
+ * the legacy type claimed `Promise<Awaited<ReturnType<...>>>` but resolved
+ * undefined in that case anyway.
+ */
+export type AsHandleMethods<M extends SurfaceMethodMap> = {
+  [K in keyof M]: (
+    ...args: Parameters<M[K]>
+  ) => Promise<Awaited<ReturnType<M[K]>> | undefined>;
+};
+
+/**
+ * Provider-side view: a feature may register a subset, and may implement an
+ * async-declared method synchronously or vice versa (successor of the
+ * orchestrator's MakeOptionalAsyncMethod).
+ */
+export type AsProvidedMethods<M extends SurfaceMethodMap> = {
+  [K in keyof M]?: (
+    ...args: Parameters<M[K]>
+  ) => ReturnType<M[K]> | Promise<Awaited<ReturnType<M[K]>>>;
+};

--- a/apps/web/src/lib/surface/specs.ts
+++ b/apps/web/src/lib/surface/specs.ts
@@ -7,14 +7,21 @@
 /** A surface method in its natural, possibly-synchronous form. */
 export type SurfaceMethod = (...args: never[]) => unknown;
 
-/** A named map of surface methods in natural form. */
+/**
+ * A named map of surface methods in natural form.
+ *
+ * Convention: a method that a feature may implement either synchronously or
+ * asynchronously must be declared with a `T | Promise<T>` return (see
+ * SharedSurfaceMethods). Providers then pass plain implementations checked
+ * against Partial<MethodsFor<N>> — no provider-side mapped type exists.
+ */
 export type SurfaceMethodMap = Record<string, SurfaceMethod>;
 
 /**
  * Methods every surface handle exposes without the surface declaring them.
  * Declared in natural form; the handle side async-wraps (see AsHandleMethods).
  * A surface that never provides them yields the bounded-await/no-op behavior
- * described in §3.4.
+ * documented on SurfaceDirectory.handle.
  */
 export type SharedSurfaceMethods = {
   /** Re-aim an already-mounted surface at a location described by params. */
@@ -80,22 +87,6 @@ declare const _surfaceSpecsConform: SurfaceSpecs extends Record<
 /** Catalog keys; every registered surface name. */
 export type SurfaceName = keyof SurfaceSpecs & string;
 
-/**
- * Alias names routable to a base surface (URL-visible, dedupe-transparent).
- * Must stay in sync with `aliases` declared in catalog.ts — directory.test.ts
- * asserts the sync (§7). DRAFT: empty; migration adds
- * 'task' | 'snippet' | 'skill' | 'csv' | 'write'.
- */
-export type SurfaceAliasName = never;
-
-/** The alias used in the URL together with the catalog surface it resolves to. */
-export type SurfaceAliasContext = {
-  /** The alias used in the URL / SplitContent.type (e.g. 'task'). */
-  alias: SurfaceAliasName;
-  /** The catalog surface it resolves to (e.g. 'md'). */
-  baseName: SurfaceName;
-};
-
 /** Mount params for the named surface. */
 export type ParamsFor<N extends SurfaceName> = SurfaceSpecs[N]['params'];
 
@@ -106,23 +97,13 @@ export type MethodsFor<N extends SurfaceName> = SharedSurfaceMethods &
 /**
  * Handle-side view of a method map. Exactly the orchestrator BlockHandle
  * mapped type, with one honesty fix: the promise can resolve `undefined`
- * when the surface never provides the method within the timeout (§3.4) —
- * the legacy type claimed `Promise<Awaited<ReturnType<...>>>` but resolved
+ * when the surface never provides the method within the timeout — the
+ * bounded-await/no-op behavior documented on SurfaceDirectory.handle.
+ * The legacy type claimed `Promise<Awaited<ReturnType<...>>>` but resolved
  * undefined in that case anyway.
  */
 export type AsHandleMethods<M extends SurfaceMethodMap> = {
   [K in keyof M]: (
     ...args: Parameters<M[K]>
   ) => Promise<Awaited<ReturnType<M[K]>> | undefined>;
-};
-
-/**
- * Provider-side view: a feature may register a subset, and may implement an
- * async-declared method synchronously or vice versa (successor of the
- * orchestrator's MakeOptionalAsyncMethod).
- */
-export type AsProvidedMethods<M extends SurfaceMethodMap> = {
-  [K in keyof M]?: (
-    ...args: Parameters<M[K]>
-  ) => ReturnType<M[K]> | Promise<Awaited<ReturnType<M[K]>>>;
 };

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -77,6 +77,19 @@ export default defineConfig({
         },
       },
       {
+        plugins: [tsconfigPaths(), solidPlugin()],
+        ssr: {
+          resolve: {
+            conditions: ['browser', 'development'],
+          },
+        },
+        test: {
+          environment: 'jsdom',
+          include: ['src/lib/surface/**/*.{test,spec}.{ts,tsx}'],
+          name: 'surface',
+        },
+      },
+      {
         test: {
           include: ['scripts/**/*.{test,spec}.{ts,tsx}'],
           name: 'scripts',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Additive draft of the **surface** abstraction that will replace the block framework (`@core/block`, orchestrator, `BlockLoader`/`BlockEffectRunner`, `definition.ts`) and unify it with the split-layout `componentRegistry`. Nothing existing changes: no layoutManager/orchestrator edits, no feature migrations — this PR exists to review the interface itself.

A surface is anything mountable in a split. **Runtime identity is the id alone** — the same invariant the block orchestrator has always relied on (its registry is keyed `setBlocks(id, ...)`); surface *names* exist only at compile time (spec/type selection) and in the layout-side catalog (type → component). Blocks and componentRegistry entries become the same thing with different `kind`.

~585 implementation lines, deliberately the minimal reviewable core: every capability a draft consumer cannot exercise was cut and returns with the migration PR that needs it (alias system → md migration; derived file-ext maps → upload routing; `nestableIn` → nested previews; presence tracking → a feature-owned hook when channel/chat/calls migrate; instance-existence discovery (`announce`/`isLive`) → only if a consumer ever materializes).

## Files (`apps/web/src/lib/surface/`)

- **`specs.ts`** (~110) — `SurfaceSpecs` interface: `{ params, methods }` per surface name via type-only feature imports (successor of `blockMethodRegistry.ts` + `BlockComponentProps`). `SharedSurfaceMethods` (`goToLocationFromParams`, `goToLatest`), `AsHandleMethods` (async-wrapped caller view, honest `| undefined` on timeout), compile-time conformance check instead of the silently-degrading `AssertSpec`. Methods are declared in natural `T | Promise<T>` form, so providers pass plain `Partial<MethodsFor<N>>`.
- **`catalog.ts`** (~65) — static `surfaceCatalog` (`kind: 'entity' | 'app'`, `singleton`, `accepted` ext→mime) plus `sameSurfaceIdentity`, the dedupe predicate replacing `sameNonComponentIdentity` (dedupe is the one place names legitimately remain, and it's layout-side).
- **`directory.ts`** (~175) — a typed method bus keyed by id, succeeding the orchestrator: `provide(id, methods)` (token-guarded disposal so a stale disposer can never clobber a newer registration; last-wins per method; DEV overwrite warn as the id-collision alarm) and `handle<N>(id)` (Proxy with bounded await-until-registered per call — preserves the "open then command" semantics used by notifications/next-soup/BlockLink; `N` is a pure type witness). **`rekeyBlockInstance` is not ported**: ids are reactive accessors, so the agent placeholder→real-session flow re-registers automatically.
- **`SurfaceProvider.tsx`** (~120) — pure context: `{ id, params, nested }` (reactive id, one-shot params snapshot, `nested` derived from provider nesting — nested previews never register methods, the unmanaged-instance rule). Hooks: `useSurface`, `useMaybeSurface`, `useSurfaceParams<N>`, `useSurfaceMethods<N>` (successor of `createMethodRegistration`; the only directory writer).
- **`EntityFrame.tsx`** (~110) — opt-in entity chrome composing the existing `EntityLoadGate`: loading/error states plus hotkey scope (split scope, DOM-scope fallback) via `SurfaceChrome` context, root element `id="surface-<id>"`.

Draft registers one real surface (`image`) and one app-surface stub (`inbox`); the full catalog arrives with migration.

## Tests

17 unit tests (12 directory + 5 provider) wired in as a new `surface` vitest project: bounded-await semantics + timeout, last-wins registration, disposal ordering/token guards, reactive id re-registration (the rekey replacement), nested no-registration, params snapshot semantics, `sameSurfaceIdentity` dedupe branches.

Verified: `bun run type-check` clean, `biome check` clean, 17/17 tests pass. Note: the full `vitest run` fails in the dev sandbox on a pre-existing `tsconfigPaths({ root: '../../../' })` filesystem-root walk (`EINVAL scandir //proc/...`) that also breaks the existing `core` project there; the surface project was verified with an exact standalone mirror of its config entry.

## Design provenance

Interface spec was produced against the real legacy code and pressure-tested against call sites: all twelve `getBlockHandle` consumers resolve by id and fire one method through `?.` (none branches on existence), `isMethodAvailable`/`awaitMethodAvailable` have zero feature call sites, and id-uniqueness across types is today's production invariant (`pending-<uuid>` placeholders and `CALENDAR_BLOCK_ID='view'` already coexist in the id-keyed store). `ComponentMeta` was found to be dead plumbing (zero consumers) and dropped; the orchestrator's declared-but-unused `mutex`/`queue` were not ported.

Part of the block-technology removal effort; the migration itself (catalog fill-in, layoutManager cutover, feature state contexts, framework deletion) lands separately on an integration branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c08a4d1-be7d-4089-aef4-d7d932b37482?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c08a4d1-be7d-4089-aef4-d7d932b37482&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

