### PR TITLE
fix(agent): make Cursor stop reliable

### DIFF
--- a/apps/web/src/features/block-agent/context/create-composer-controller.test.ts
+++ b/apps/web/src/features/block-agent/context/create-composer-controller.test.ts
@@ -7,24 +7,29 @@
  * fold's signal or on the timeout, whichever comes first.
  */
 
+import type { ControlRequest } from '@service-agent-harness/generated/schemas';
 import { createRoot, createSignal } from 'solid-js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ControlOutcome } from '../state/control-message';
 import {
   createComposerController,
+  STOP_SETTLE_TIMEOUT_MS,
   TURN_OBSERVE_TIMEOUT_MS,
 } from './create-composer-controller';
 
 const control = vi.hoisted(() => ({
-  calls: [] as { sessionId: string; action: unknown }[],
+  calls: [] as { sessionId: string; action: ControlRequest }[],
   /** What the next `control` calls resolve to. */
   outcome: 'ok' as 'ok' | 'err' | 'reject',
+  promptGate: undefined as Promise<void> | undefined,
+  releasePrompt: undefined as (() => void) | undefined,
 }));
 
 vi.mock('@service-agent-harness/client', () => ({
   agentHarnessServiceClient: {
-    control: vi.fn(async (sessionId: string, action: unknown) => {
+    control: vi.fn(async (sessionId: string, action: ControlRequest) => {
       control.calls.push({ sessionId, action });
+      if (action.type === 'prompt') await control.promptGate;
       if (control.outcome === 'reject') throw new Error('network');
       return {
         isErr: () => control.outcome === 'err',
@@ -44,9 +49,9 @@ vi.mock('@core/component/Toast/Toast', () => ({
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 const prompts = () =>
-  control.calls
-    .filter((c) => (c.action as { type: string }).type === 'prompt')
-    .map((c) => (c.action as { prompt: string }).prompt);
+  control.calls.flatMap((call) =>
+    call.action.type === 'prompt' ? [call.action.prompt] : []
+  );
 
 function setup(options?: {
   working?: boolean;
@@ -86,6 +91,8 @@ function setup(options?: {
 beforeEach(() => {
   control.calls = [];
   control.outcome = 'ok';
+  control.promptGate = undefined;
+  control.releasePrompt = undefined;
   vi.useRealTimers();
 });
 
@@ -264,6 +271,79 @@ describe('stop', () => {
     controller.stop();
     await flush();
     expect(control.calls.at(-1)?.action).toEqual({ type: 'stop' });
+    dispose();
+  });
+
+  it('posts only one stop until the running turn settles', async () => {
+    const { controller, setWorking, dispose } = setup({ working: true });
+
+    controller.stop();
+    controller.stop();
+    controller.stop();
+    await flush();
+
+    expect(
+      control.calls.filter((call) => call.action.type === 'stop')
+    ).toHaveLength(1);
+
+    setWorking(false);
+    await flush();
+    setWorking(true);
+    controller.stop();
+    await flush();
+
+    expect(
+      control.calls.filter((call) => call.action.type === 'stop')
+    ).toHaveLength(2);
+    dispose();
+  });
+
+  it('can stop a posted prompt before its turn is observed', async () => {
+    const { controller, dispose } = setup();
+    controller.send('starting');
+    await flush();
+    expect(controller.busy()).toBe(true); // awaiting_turn
+
+    controller.stop();
+    await flush();
+
+    expect(control.calls.at(-1)?.action).toEqual({ type: 'stop' });
+    dispose();
+  });
+
+  it('posts stop only after an in-flight prompt is accepted', async () => {
+    control.promptGate = new Promise<void>((resolve) => {
+      control.releasePrompt = resolve;
+    });
+    const { controller, dispose } = setup();
+    controller.send('starting');
+    await flush();
+
+    controller.stop();
+    await flush();
+    expect(control.calls.map((call) => call.action.type)).toEqual(['prompt']);
+
+    control.releasePrompt?.();
+    await flush();
+    expect(control.calls.map((call) => call.action.type)).toEqual([
+      'prompt',
+      'stop',
+    ]);
+    dispose();
+  });
+
+  it('releases a posted stop when the fold never settles', async () => {
+    vi.useFakeTimers();
+    const { controller, dispose } = setup({ working: true });
+    controller.stop();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(STOP_SETTLE_TIMEOUT_MS);
+
+    controller.stop();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(
+      control.calls.filter((call) => call.action.type === 'stop')
+    ).toHaveLength(2);
     dispose();
   });
 });

--- a/apps/web/src/features/block-agent/context/create-composer-controller.ts
+++ b/apps/web/src/features/block-agent/context/create-composer-controller.ts
@@ -63,6 +63,13 @@ export type ComposerController = {
  * the socket has genuinely gone quiet.
  */
 export const TURN_OBSERVE_TIMEOUT_MS = 10_000;
+export const STOP_SETTLE_TIMEOUT_MS = 10_000;
+
+type StopPhase =
+  | { type: 'idle' }
+  | { type: 'queued'; requestId: number }
+  | { type: 'posting'; requestId: number }
+  | { type: 'settling' };
 
 export function createComposerController(options: {
   /** The fold's current model, which is how a model change is seen to land. */
@@ -96,18 +103,30 @@ export function createComposerController(options: {
      * (nor an older refusal of the same model) can answer this request.
      */
     requestedActionId: string | undefined;
+    /** The one stop request holding the prompt drain, if any. */
+    stop: StopPhase;
   }>({
     queue: [],
     post: { type: 'idle' },
     requestedModel: undefined,
     requestedActionId: undefined,
+    stop: { type: 'idle' },
   });
+  let nextStopRequestId = 0;
 
   const postHead = async (sessionId: string, prompt: QueuedPrompt) => {
     setState('post', { type: 'posting', promptId: prompt.id });
     const result = await agentHarnessServiceClient
       .control(sessionId, { type: 'prompt', prompt: prompt.markdown })
       .catch(() => undefined);
+
+    if (
+      options.sessionId() !== sessionId ||
+      state.post.type !== 'posting' ||
+      state.post.promptId !== prompt.id
+    ) {
+      return;
+    }
 
     if (result === undefined || result.isErr()) {
       // The prompt stays at the head of the queue — visible and retryable,
@@ -145,13 +164,23 @@ export function createComposerController(options: {
     }
   };
 
-  const postStop = async (sessionId: string) => {
+  const postStop = async (sessionId: string, requestId: number) => {
     const result = await agentHarnessServiceClient
       .control(sessionId, { type: 'stop' })
       .catch(() => undefined);
-    if (result === undefined || result.isErr()) {
-      toast.failure('The agent could not be stopped');
+    if (
+      options.sessionId() !== sessionId ||
+      state.stop.type !== 'posting' ||
+      state.stop.requestId !== requestId
+    ) {
+      return;
     }
+    if (result === undefined || result.isErr()) {
+      setState('stop', { type: 'idle' });
+      toast.failure('The agent could not be stopped');
+      return;
+    }
+    setState('stop', { type: 'settling' });
     // Success is observed through the fold: the turn settles and `working`
     // flips false, which re-runs the drain.
   };
@@ -161,6 +190,7 @@ export function createComposerController(options: {
   // is what makes this wedge-proof: there is no exit event to miss.
   createEffect(() => {
     const sessionId = options.sessionId();
+    if (state.stop.type !== 'idle') return;
     const action = nextAction({
       post: state.post,
       head: state.queue[0],
@@ -224,6 +254,31 @@ export function createComposerController(options: {
     onCleanup(() => clearTimeout(timer));
   });
 
+  // Serialize stop behind a prompt POST, then keep it latched until that turn
+  // settles. Independent HTTP requests can arrive out of order, and the
+  // control itself has no response frame to deduplicate repeated clicks.
+  createEffect(() => {
+    const stop = state.stop;
+    if (stop.type === 'idle' || stop.type === 'posting') return;
+    if (stop.type === 'queued') {
+      if (state.post.type === 'posting') return;
+      const sessionId = options.sessionId();
+      if (!sessionId) return;
+      setState('stop', { type: 'posting', requestId: stop.requestId });
+      void postStop(sessionId, stop.requestId);
+      return;
+    }
+    if (!isBusy(state.post, options.working())) {
+      setState('stop', { type: 'idle' });
+      return;
+    }
+    const timer = setTimeout(
+      () => setState('stop', { type: 'idle' }),
+      STOP_SETTLE_TIMEOUT_MS
+    );
+    onCleanup(() => clearTimeout(timer));
+  });
+
   // A session switch resets the composer: queued prompts belong to the
   // session they were typed in, never the next one.
   //
@@ -246,6 +301,7 @@ export function createComposerController(options: {
       post: { type: 'idle' },
       requestedModel: undefined,
       requestedActionId: undefined,
+      stop: { type: 'idle' },
     });
   });
 
@@ -285,7 +341,11 @@ export function createComposerController(options: {
       const sessionId = options.sessionId();
       if (!sessionId) return;
       if (!isBusy(state.post, options.working())) return;
-      void postStop(sessionId);
+      if (state.stop.type !== 'idle') return;
+      setState('stop', {
+        type: 'queued',
+        requestId: ++nextStopRequestId,
+      });
     },
     setModel: (model) => {
       const sessionId = options.sessionId();

--- a/crates/agent_harness/src/outbound/cursor/manager.rs
+++ b/crates/agent_harness/src/outbound/cursor/manager.rs
@@ -241,11 +241,12 @@ where
                 tokio::select! {
                     () = pipe_closed.cancelled() => break,
                     _ = reaper.tick() => {
-                        let idle = last_activity
+                        let mut last_activity = last_activity
                             .lock()
-                            .expect("activity clock poisoned")
-                            .elapsed();
-                        if idle >= CURSOR_IDLE_TIMEOUT {
+                            .expect("activity clock poisoned");
+                        if sync_service.has_active_turn() {
+                            *last_activity = tokio::time::Instant::now();
+                        } else if last_activity.elapsed() >= CURSOR_IDLE_TIMEOUT {
                             tracing::info!(%session_id, "idle cursor session; closing its pipe");
                             reaper_shutdown.cancel();
                             break;

--- a/crates/agent_harness/src/outbound/cursor/manager/test.rs
+++ b/crates/agent_harness/src/outbound/cursor/manager/test.rs
@@ -11,6 +11,7 @@ use agent_session::domain::model::{
 };
 use bot_id::BotId;
 use cursor_api_key::cipher::CursorApiKey;
+use futures::StreamExt as _;
 use macro_user_id::user_id::MacroUserIdStr;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -275,6 +276,65 @@ async fn fake_cursor_api() -> (
         axum::serve(listener, app).await.expect("serve");
     });
     (base_url, archive_log, create_log)
+}
+
+/// A Cursor API whose run starts but stays quiet forever, matching the gap
+/// that previously let the host's ACP idle reaper kill a live turn.
+async fn quiet_cursor_api() -> (String, Arc<tokio::sync::Notify>) {
+    let stream_started = Arc::new(tokio::sync::Notify::new());
+    let app = axum::Router::new()
+        .route(
+            "/v1/agents",
+            axum::routing::post(|| async {
+                axum::Json(serde_json::json!({
+                    "agent": {
+                        "id": "bc-quiet-agent",
+                        "name": "Quiet agent",
+                        "status": "ACTIVE",
+                        "url": "https://cursor.com/agents/bc-quiet-agent",
+                    },
+                    "run": { "id": "run-quiet-1" },
+                }))
+            }),
+        )
+        .route(
+            "/v1/models",
+            axum::routing::get(|| async {
+                axum::Json(serde_json::json!({ "items": [] }))
+            }),
+        )
+        .route(
+            "/v1/agents/{id}/runs/{run}/stream",
+            axum::routing::get({
+                let stream_started = Arc::clone(&stream_started);
+                move || {
+                    let stream_started = Arc::clone(&stream_started);
+                    async move {
+                        stream_started.notify_one();
+                        let running = futures::stream::once(async {
+                            Ok::<_, std::convert::Infallible>(axum::body::Bytes::from_static(
+                                b"event: status\ndata: {\"runId\":\"run-quiet-1\",\"status\":\"RUNNING\"}\n\n",
+                            ))
+                        });
+                        let body = axum::body::Body::from_stream(
+                            running.chain(futures::stream::pending()),
+                        );
+                        (
+                            [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+                            body,
+                        )
+                    }
+                }
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let base_url = format!("http://{}", listener.local_addr().expect("addr"));
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve");
+    });
+    (base_url, stream_started)
 }
 
 /// A config source: `key` is `Some` for an owner who has connected Cursor,
@@ -618,6 +678,57 @@ async fn an_idle_pipe_is_shut_down() {
     assert!(
         receiver.recv().await.is_none(),
         "an idle pipe must close, not hang"
+    );
+}
+
+/// Silence on the ACP pipe is not idleness while Cursor is still running a
+/// turn. The pipe must remain available to carry its eventual completion.
+#[tokio::test(start_paused = true)]
+async fn an_active_quiet_turn_is_not_reaped() {
+    let (base_url, stream_started) = quiet_cursor_api().await;
+    let manager = manager(base_url, StubSessions::default());
+    let transport = manager
+        .spawn(SpawnContainer {
+            session_id: AgentSessionId::new(),
+            kind: AgentKind::Cursor,
+            repo_url: "https://github.com/macro-inc/macro".to_owned(),
+            size: SandboxSize::Default,
+        })
+        .await
+        .expect("spawn");
+    let (sender, mut receiver) = transport.split();
+
+    assert!(receiver.recv().await.is_some(), "acp ready arrives");
+    send_acp(
+        &sender,
+        serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}),
+    )
+    .await;
+    next_acp(&mut receiver).await;
+    send_acp(
+        &sender,
+        serde_json::json!({"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"/workspace","mcpServers":[]}}),
+    )
+    .await;
+    let opened = next_acp(&mut receiver).await;
+    let acp_session = opened["result"]["sessionId"]
+        .as_str()
+        .expect("a session id");
+    send_acp(
+        &sender,
+        serde_json::json!({"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{
+            "sessionId": acp_session,
+            "prompt": [{"type":"text","text":"work quietly"}],
+        }}),
+    )
+    .await;
+    stream_started.notified().await;
+
+    tokio::time::advance(CURSOR_IDLE_TIMEOUT + CURSOR_IDLE_CHECK_INTERVAL).await;
+    tokio::task::yield_now().await;
+    assert!(
+        !receiver.is_closed(),
+        "the idle reaper must preserve a pipe with an active turn"
     );
 }
 

--- a/crates/cursor_cloud_agents/src/domain/service.rs
+++ b/crates/cursor_cloud_agents/src/domain/service.rs
@@ -64,6 +64,9 @@ const POLL_ERROR_TOLERANCE: usize = 5;
 /// interval.
 const STREAM_QUIET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// Remote cancellation is best-effort; local cancellation must not wedge ACP.
+const REMOTE_CANCEL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// How long a prompt waits behind a run something else started (the same
 /// agent is drivable from cursor.com) before giving up, in poll intervals.
 const BUSY_ATTEMPTS: usize = 450;
@@ -98,17 +101,12 @@ struct SessionState {
     /// or restored session, whose history is already rendered or unknowable —
     /// so nothing is backfilled rather than everything replayed.
     last_run: Option<CursorRunId>,
-    /// Set by cancel; read by the turn when its stream ends.
-    ///
-    /// The *verdict*, not the mechanism: a cancel that raced the stream's own
-    /// ending still has to report `Cancelled`, so this outlives the token
-    /// below and is what the turn consults once it has stopped.
-    cancelled: bool,
     /// Fired by cancel; awaited by every wait a turn can be sitting in.
     ///
     /// The mechanism, and the reason a cancel is felt at once rather than
-    /// whenever Cursor happens to end the stream. Replaced per turn, so a
-    /// cancel can never carry into the next one.
+    /// whenever Cursor happens to end the stream. Replaced when cancel is
+    /// admitted, so prompts received afterward get a
+    /// fresh token while prompts received before it retain the fired one.
     cancel: tokio_util::sync::CancellationToken,
     /// The model this session's next run will use.
     ///
@@ -395,6 +393,36 @@ where
         session_id: &SessionId,
         prompt: &str,
     ) -> Result<StopReason, SessionError> {
+        let cancel = self.prompt_cancel_token(session_id)?;
+        self.prompt_with_cancel(session_id, prompt, cancel).await
+    }
+
+    /// Snapshot the cancellation token when an ACP prompt frame arrives.
+    ///
+    /// ACP handlers spawn prompt and cancel work independently. Carrying this
+    /// value into [`Self::prompt_with_cancel`] preserves their wire order if
+    /// the cancel task happens to run first.
+    pub(crate) fn prompt_cancel_token(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<tokio_util::sync::CancellationToken, SessionError> {
+        let session = self.session(session_id)?;
+        Ok(session
+            .state
+            .lock()
+            .expect("session state poisoned")
+            .cancel
+            .clone())
+    }
+
+    /// Run a prompt associated with the token captured when it was received.
+    #[tracing::instrument(skip(self, prompt), err)]
+    pub(crate) async fn prompt_with_cancel(
+        &self,
+        session_id: &SessionId,
+        prompt: &str,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> Result<StopReason, SessionError> {
         let session = self.session(session_id)?;
         // Wait behind an in-flight foreign-run mirror, so its frames and
         // this turn's never interleave — but never behind another turn: ACP
@@ -412,7 +440,11 @@ where
                 {
                     return Err(SessionError::TurnAlreadyActive(session_id.clone()));
                 }
-                session.turn_gate.lock().await
+                tokio::select! {
+                    biased;
+                    () = cancel.cancelled() => return Ok(StopReason::Cancelled),
+                    guard = session.turn_gate.lock() => guard,
+                }
             }
         };
 
@@ -421,40 +453,31 @@ where
         // Resolved before the turn commits to a path: both the create-agent
         // and the follow-up-run branch send it, and a mid-turn change must not
         // land on a run that is already going.
-        let model = self.effective_model(session_id).await?;
+        let model = tokio::select! {
+            biased;
+            () = cancel.cancelled() => return Ok(StopReason::Cancelled),
+            model = self.effective_model(session_id) => model?,
+        };
 
-        let (existing_agent, cancel) = {
-            let mut state = session.state.lock().expect("session state poisoned");
+        let existing_agent = {
+            let state = session.state.lock().expect("session state poisoned");
             if state.active_run.is_some() {
                 return Err(SessionError::TurnAlreadyActive(session_id.clone()));
             }
-            state.cancelled = false;
-            // A fresh token per turn: the previous one may already be fired,
-            // and reusing it would cancel this turn before it began.
-            state.cancel = tokio_util::sync::CancellationToken::new();
-            (state.agent.clone(), state.cancel.clone())
+            if cancel.is_cancelled() {
+                return Ok(StopReason::Cancelled);
+            }
+            state.agent.clone()
         };
 
-        let (agent, run) = match existing_agent {
+        let (agent, run, backfill) = match existing_agent {
             Some(agent) => {
                 // Queue behind any run still going (the same agent advances
                 // from cursor.com too) instead of failing the prompt.
                 let run = self
                     .create_run_when_free(&agent, prompt, model.as_ref(), &cancel)
                     .await?;
-                // Catch the session's view up on whatever it missed while it
-                // was not looking. After the create on purpose: creating
-                // proved the agent free, so every missed run is terminal and
-                // its text is readable — before it, a still-running
-                // cursor.com run is invisible to the backfill and the
-                // watermark then walks straight past it.
-                if let Err(error) = self
-                    .backfill_foreign_runs(session_id, &session, &agent, Some(&run))
-                    .await
-                {
-                    tracing::warn!(%agent, %error, "could not backfill cursor.com runs");
-                }
-                (agent, run)
+                (agent, run, true)
             }
             None => {
                 // Snapshotted out of the lock: `create_agent` is a network
@@ -465,9 +488,11 @@ where
                     .expect("session state poisoned")
                     .mcp_servers
                     .clone();
-                self.cursor
+                let created = self
+                    .cursor
                     .create_agent(prompt, session.repo.as_ref(), &mcp_servers, model.as_ref())
-                    .await?
+                    .await?;
+                (created.0, created.1, false)
             }
         };
         tracing::info!(%agent, %run, "cursor run started");
@@ -475,6 +500,36 @@ where
             let mut state = session.state.lock().expect("session state poisoned");
             state.agent = Some(agent.clone());
             state.active_run = Some(run.clone());
+        }
+
+        if backfill {
+            // Creating the run proved the agent free, so every missed run is
+            // terminal and readable. The active id is recorded first so a
+            // concurrent cancel targets the exact new run.
+            if let Err(error) = self
+                .backfill_foreign_runs(session_id, &session, &agent, Some(&run))
+                .await
+            {
+                tracing::warn!(%agent, %error, "could not backfill cursor.com runs");
+            }
+        }
+
+        if cancel.is_cancelled() {
+            match tokio::time::timeout(REMOTE_CANCEL_TIMEOUT, self.cursor.cancel_run(&agent, &run))
+                .await
+            {
+                Ok(Err(error)) => {
+                    tracing::warn!(%agent, %run, %error, "could not cancel a newly created cursor run");
+                }
+                Err(_) => {
+                    tracing::warn!(%agent, %run, "cancelling a newly created cursor run timed out");
+                }
+                Ok(Ok(())) => {}
+            }
+            let mut state = session.state.lock().expect("session state poisoned");
+            state.active_run = None;
+            state.last_run = Some(run);
+            return Ok(StopReason::Cancelled);
         }
 
         let outcome = self
@@ -485,7 +540,7 @@ where
             let mut state = session.state.lock().expect("session state poisoned");
             state.active_run = None;
             state.last_run = Some(run.clone());
-            state.cancelled
+            cancel.is_cancelled()
         };
         // A cancel that raced the stream's own ending still reports
         // Cancelled: ACP requires it once the client sent `session/cancel`.
@@ -511,32 +566,41 @@ where
         let session = self.session(session_id)?;
         let (agent, active_run) = {
             let mut state = session.state.lock().expect("session state poisoned");
-            state.cancelled = true;
             // Fired before the network call, and the turn ends on it alone:
             // whether Cursor honours the cancel decides only whether the run
             // keeps burning credits server-side, never whether this client
             // gets its turn back. A cancel Cursor refuses used to leave the
             // turn streaming to natural completion.
             state.cancel.cancel();
+            state.cancel = tokio_util::sync::CancellationToken::new();
             (state.agent.clone(), state.active_run.clone())
         };
         let Some(agent) = agent else {
             return Ok(());
         };
-        let runs = match active_run {
-            Some(run) => vec![run],
-            None => self.current_runs(&agent).await,
+        let remote = async {
+            let runs = match active_run {
+                Some(run) => vec![run],
+                None => self.current_runs(&agent).await,
+            };
+            // Concurrent rather than sequential so one failing cancel does
+            // not skip the rest.
+            let results = futures::future::join_all(
+                runs.iter().map(|run| self.cursor.cancel_run(&agent, run)),
+            )
+            .await;
+            for result in results {
+                result?;
+            }
+            Ok(())
         };
-        // Concurrent rather than sequential so one failing cancel does not
-        // skip the rest — every run found gets its own attempt regardless of
-        // how the others land.
-        let results =
-            futures::future::join_all(runs.iter().map(|run| self.cursor.cancel_run(&agent, run)))
-                .await;
-        for result in results {
-            result?;
+        match tokio::time::timeout(REMOTE_CANCEL_TIMEOUT, remote).await {
+            Ok(result) => result,
+            Err(_) => {
+                tracing::warn!(%agent, "cursor remote cancellation timed out");
+                Ok(())
+            }
         }
-        Ok(())
     }
 
     /// The agent's runs still in progress, per Cursor's own record.
@@ -631,6 +695,20 @@ where
             .lock()
             .expect("session map poisoned")
             .contains_key(session_id)
+    }
+
+    /// Whether this service is currently driving or preparing a Cursor turn.
+    ///
+    /// Used by the in-process host's idle reaper: a run can legitimately
+    /// produce no ACP frames while Cursor works or while a broken stream is
+    /// being polled, but that silence must not be mistaken for an idle pipe.
+    #[must_use]
+    pub fn has_active_turn(&self) -> bool {
+        self.sessions
+            .lock()
+            .expect("session map poisoned")
+            .values()
+            .any(|session| session.turn_gate.try_lock().is_err())
     }
 
     /// Stream one run, translating and delivering as events arrive.
@@ -826,7 +904,8 @@ where
                     "the prompt was cancelled while waiting for the agent to be free"
                 )));
             }
-            match self.cursor.create_run(agent, prompt, model).await {
+            let created = self.cursor.create_run(agent, prompt, model).await;
+            match created {
                 Ok(run) => return Ok(run),
                 Err(error) if error.to_string().contains("agent_busy") => {
                     tracing::info!(%agent, "agent busy (a run is active, possibly from cursor.com); waiting");

--- a/crates/cursor_cloud_agents/src/domain/service/test.rs
+++ b/crates/cursor_cloud_agents/src/domain/service/test.rs
@@ -31,6 +31,64 @@ fn finished(run: &str) -> CursorEvent {
 }
 
 #[tokio::test]
+async fn active_turn_is_visible_to_the_host_idle_reaper() {
+    let (service, _cursor, _notifier) = service(None);
+    let session_id = service.new_session(Path::new(""), Vec::new());
+    assert!(!service.has_active_turn());
+
+    let session = service.session(&session_id).expect("session exists");
+    let turn = session.turn_gate.lock().await;
+
+    assert!(service.has_active_turn());
+    drop(turn);
+    assert!(!service.has_active_turn());
+}
+
+#[tokio::test]
+async fn cancel_after_prompt_receipt_survives_spawn_ordering() {
+    let (service, cursor, _notifier) = service(None);
+    let session = service.new_session(Path::new(""), Vec::new());
+    let cancel = service
+        .prompt_cancel_token(&session)
+        .expect("session exists");
+
+    // ACP received prompt then cancel, but its independently spawned cancel
+    // task ran before the prompt task was first polled.
+    service.cancel(&session).await.expect("cancel works");
+    let stop = service
+        .prompt_with_cancel(&session, "do not start", cancel)
+        .await
+        .expect("prompt resolves");
+
+    assert_eq!(stop, StopReason::Cancelled);
+    assert!(
+        cursor.calls().is_empty(),
+        "the cancelled run was never created"
+    );
+}
+
+#[tokio::test]
+async fn prompt_after_cancel_receipt_starts_a_new_turn() {
+    let (service, cursor, _notifier) = service(None);
+    let session = service.new_session(Path::new(""), Vec::new());
+
+    service.cancel(&session).await.expect("cancel completes");
+    let cancel = service
+        .prompt_cancel_token(&session)
+        .expect("session exists");
+    let events = cursor.script_stream();
+    events.send(finished("run-fake-1")).expect("stream open");
+    events.send(CursorEvent::Done).expect("stream open");
+
+    let stop = service
+        .prompt_with_cancel(&session, "start now", cancel)
+        .await
+        .expect("prompt resolves");
+    assert_eq!(stop, StopReason::EndTurn);
+    assert!(matches!(cursor.calls()[0], CursorCall::CreateAgent(..)));
+}
+
+#[tokio::test]
 async fn first_prompt_creates_the_agent_with_the_session_repo() {
     let repo = RepoUrl::parse("https://github.com/macro-inc/macro").expect("valid repo");
     let (service, cursor, notifier) = service(Some(repo.clone()));

--- a/crates/cursor_cloud_agents/src/inbound/acp.rs
+++ b/crates/cursor_cloud_agents/src/inbound/acp.rs
@@ -317,16 +317,23 @@ where
             {
                 let service = Arc::clone(&service);
                 async move |request: PromptRequest, responder, connection| {
+                    let session = request.session_id;
+                    let cancel = match service.prompt_cancel_token(&session) {
+                        Ok(cancel) => cancel,
+                        Err(error) => {
+                            return responder
+                                .respond_with_error(AcpError::new(-32603, error.to_string()));
+                        }
+                    };
                     // On its own task so the event loop keeps servicing
                     // cancels while the turn streams.
                     let service = Arc::clone(&service);
                     connection.spawn(async move {
-                        let session = request.session_id;
                         let text = prompt_text(&request.prompt);
                         // A failed respond means the client is gone; failing
                         // the spawned task would tear down the (already
                         // closing) connection, so it is dropped instead.
-                        match service.prompt(&session, &text).await {
+                        match service.prompt_with_cancel(&session, &text, cancel).await {
                             Ok(stop_reason) => {
                                 let _ = responder.respond(PromptResponse::new(stop_reason));
                             }
@@ -420,18 +427,14 @@ where
         .on_receive_notification(
             {
                 let service = Arc::clone(&service);
-                async move |notification: CancelNotification, connection| {
-                    // Spawned for the same reason prompts are: cancelling is a
-                    // Cursor API round trip, and the event loop must not wait
-                    // on it.
-                    let service = Arc::clone(&service);
-                    connection.spawn(async move {
-                        let session = notification.session_id;
-                        if let Err(error) = service.cancel(&session).await {
-                            tracing::error!(error = %error, "cancel failed");
-                        }
-                        Ok(())
-                    })
+                async move |notification: CancelNotification, _connection| {
+                    // Awaiting here preserves wire order: local cancellation
+                    // fires before the first network await, and the next ACP
+                    // frame is not admitted until the remote target is fixed.
+                    if let Err(error) = service.cancel(&notification.session_id).await {
+                        tracing::error!(error = %error, "cancel failed");
+                    }
+                    Ok(())
                 }
             },
             on_receive_notification!(),


### PR DESCRIPTION
## Summary
- keep in-process Cursor ACP pipes alive while a turn owns the turn gate and refresh the idle deadline during quiet work
- preserve prompt/cancel wire ordering with per-prompt cancellation tokens, cancellation-aware waits, and bounded best-effort remote cleanup
- serialize Stop behind prompt admission, deduplicate repeated clicks, and hold queued prompts until cancellation settles

## Root cause
A Cursor run can be actively working or polling without emitting ACP frames. After five minutes of frame silence, the harness idle reaper closed the in-process pipe even though the turn was still active. That dropped the terminal/cancelled prompt response, so the frontend fold continued to report the turn as working. Repeated Stop clicks then posted duplicate controls and queued prompts could remain wedged or race cancellation.

Datadog evidence:
- affected prompt trace: `05828bf2c0432765c6a40b73d34fde27` (`run-757411ab-2f9a-40d1-8018-ff2432559c45`)
- Stop trace: `63e45b346361c56107c0743900428445`
- Macro session: `01a043c9-95b3-71cb-8419-0b2103227b27`

## Verification
- `cargo fmt --check`
- `cargo test -p cursor_cloud_agents` (86 passed)
- `cargo test -p agent_harness` (119 passed)
- `bunx --bun biome check src/features/block-agent/context/create-composer-controller.ts src/features/block-agent/context/create-composer-controller.test.ts`
- `bun run test -- src/features/block-agent/context/create-composer-controller.test.ts` (24 passed)
- `git diff --check`

Full web type-check remains blocked by unrelated missing workspace dependencies (`@pierre/diffs`, `effect/*`).

## Tradeoff
An unresolved Stop POST remains single-flight instead of timing out. This preserves ordering and avoids a late request cancelling a newer turn; request-level retry would require backend idempotency/admission semantics.