### PR TITLE
feat(email): polish thread layout and keyboard UX

### DIFF
--- a/apps/web/src/features/block-email/component/CollapsedMessage.tsx
+++ b/apps/web/src/features/block-email/component/CollapsedMessage.tsx
@@ -78,7 +78,10 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
           onFocus={props.onFocus}
           onKeyDown={handleKeyDown}
         >
-          <div data-slot="sender" class="flex items-center gap-2 min-w-0 text-sm">
+          <div
+            data-slot="sender"
+            class="flex items-center gap-2 min-w-0 text-sm"
+          >
             <div class="shrink-0 flex justify-center items-center size-6">
               <UserIcon
                 {...senderIconProps()}

--- a/apps/web/src/features/block-email/component/CollapsedMessage.tsx
+++ b/apps/web/src/features/block-email/component/CollapsedMessage.tsx
@@ -2,10 +2,10 @@ import { UserIcon, type UserIconProps } from '@core/component/UserIcon';
 import { useEmail } from '@core/context/user';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import type { ApiMessage } from '@service-email/generated/schemas';
-import { cn } from '@ui/utils/classname';
+import { cn, Tooltip } from '@ui';
 import { createMemo, Show } from 'solid-js';
 import { getSenderDisplayName, getSenderMacroId } from '../util/emailUser';
-import { formatShortDate } from './EmailMessageTopBar';
+import { formatFullDate, formatShortDate } from './EmailMessageTopBar';
 import { EmailUserTooltip } from './EmailUserTooltip';
 
 interface CollapsedMessageProps {
@@ -91,9 +91,14 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
             {snippet()}
           </div>
           <Show when={props.message.internal_date_ts}>
-            <span class="justify-self-end text-sm text-ink-extra-muted/60 tabular-nums">
-              {formatShortDate(props.message.internal_date_ts!)}
-            </span>
+            <Tooltip
+              class="justify-self-end"
+              label={formatFullDate(props.message.internal_date_ts!)}
+            >
+              <span class="text-sm text-ink-extra-muted/60 tabular-nums cursor-default">
+                {formatShortDate(props.message.internal_date_ts!)}
+              </span>
+            </Tooltip>
           </Show>
         </div>
       </div>

--- a/apps/web/src/features/block-email/component/CollapsedMessage.tsx
+++ b/apps/web/src/features/block-email/component/CollapsedMessage.tsx
@@ -61,7 +61,7 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
 
   return (
     <div class="shrink-0 flex justify-center w-full">
-      <div class="macro-message-width macro-message-padding w-full">
+      <div class="@container macro-message-width macro-message-padding w-full">
         <div
           class={cn(
             'relative macro-thread-collapsed-row p-4 min-w-0 border bg-message rounded-lg',
@@ -93,7 +93,7 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
               </EmailUserTooltip>
             </div>
           </div>
-          <div class="min-w-0 text-sm text-ink-extra-muted truncate">
+          <div class="min-w-0 text-sm text-ink-extra-muted">
             {snippet()}
           </div>
           <Show when={props.message.internal_date_ts}>

--- a/apps/web/src/features/block-email/component/CollapsedMessage.tsx
+++ b/apps/web/src/features/block-email/component/CollapsedMessage.tsx
@@ -78,7 +78,7 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
           onFocus={props.onFocus}
           onKeyDown={handleKeyDown}
         >
-          <div class="flex items-center gap-2 min-w-0 text-sm">
+          <div data-slot="sender" class="flex items-center gap-2 min-w-0 text-sm">
             <div class="shrink-0 flex justify-center items-center size-6">
               <UserIcon
                 {...senderIconProps()}
@@ -93,19 +93,20 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
               </EmailUserTooltip>
             </div>
           </div>
-          <div class="min-w-0 text-sm text-ink-extra-muted">
+          <div data-slot="snippet" class="min-w-0 text-sm text-ink-extra-muted">
             {snippet()}
           </div>
           <Show when={props.message.internal_date_ts}>
-            <Tooltip
-              as="span"
-              class="justify-self-end"
-              label={formatFullDate(props.message.internal_date_ts!)}
-            >
-              <span class="text-sm text-ink-extra-muted/60 tabular-nums">
-                {formatShortDate(props.message.internal_date_ts!)}
-              </span>
-            </Tooltip>
+            <span data-slot="date" class="justify-self-end">
+              <Tooltip
+                as="span"
+                label={formatFullDate(props.message.internal_date_ts!)}
+              >
+                <span class="text-sm text-ink-extra-muted/60 tabular-nums">
+                  {formatShortDate(props.message.internal_date_ts!)}
+                </span>
+              </Tooltip>
+            </span>
           </Show>
         </div>
       </div>

--- a/apps/web/src/features/block-email/component/CollapsedMessage.tsx
+++ b/apps/web/src/features/block-email/component/CollapsedMessage.tsx
@@ -53,12 +53,23 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
     }
   };
 
+  const handleRowClick = (e: MouseEvent) => {
+    const target = e.target;
+    if (
+      target instanceof Element &&
+      target.closest('[data-button], a[href]')
+    ) {
+      return;
+    }
+    props.onClick();
+  };
+
   return (
     <div class="shrink-0 flex justify-center w-full">
       <div class="macro-message-width macro-message-padding w-full">
         <div
           class={cn(
-            'relative macro-thread-collapsed-row p-4 min-w-0 border border-transparent macro-thread-card-outdent',
+            'relative macro-thread-collapsed-row p-4 min-w-0 border border-transparent cursor-pointer macro-thread-card-outdent',
             props.showBottomBorder && 'border-b-edge-muted',
             props.isFocused && !isTouchDevice() && 'bg-list-highlighted',
             !props.isFocused && !isTouchDevice() && 'hover:bg-list-hover'
@@ -68,7 +79,8 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
           }}
           data-message-body-id={props.message.db_id}
           tabIndex={0}
-          onClick={props.onClick}
+          onClick={handleRowClick}
+          onClickCapture={handleRowClick}
           onFocus={props.onFocus}
           onKeyDown={handleKeyDown}
         >
@@ -81,21 +93,22 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
                 suppressClick={true}
               />
             </div>
-            <EmailUserTooltip recipient={props.message.from}>
-              <span class="text-ink truncate cursor-default min-w-0">
-                {senderDisplay()}
-              </span>
-            </EmailUserTooltip>
+            <div class="min-w-0">
+              <EmailUserTooltip recipient={props.message.from}>
+                <span class="text-ink line-clamp-1">{senderDisplay()}</span>
+              </EmailUserTooltip>
+            </div>
           </div>
           <div class="min-w-0 text-sm text-ink-extra-muted truncate">
             {snippet()}
           </div>
           <Show when={props.message.internal_date_ts}>
             <Tooltip
+              as="span"
               class="justify-self-end"
               label={formatFullDate(props.message.internal_date_ts!)}
             >
-              <span class="text-sm text-ink-extra-muted/60 tabular-nums cursor-default">
+              <span class="text-sm text-ink-extra-muted/60 tabular-nums">
                 {formatShortDate(props.message.internal_date_ts!)}
               </span>
             </Tooltip>

--- a/apps/web/src/features/block-email/component/CollapsedMessage.tsx
+++ b/apps/web/src/features/block-email/component/CollapsedMessage.tsx
@@ -53,10 +53,7 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
 
   const handleRowClick = (e: MouseEvent) => {
     const target = e.target;
-    if (
-      target instanceof Element &&
-      target.closest('[data-button], a[href]')
-    ) {
+    if (target instanceof Element && target.closest('[data-button], a[href]')) {
       return;
     }
     props.onClick();
@@ -67,7 +64,7 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
       <div class="macro-message-width macro-message-padding w-full">
         <div
           class={cn(
-            'relative macro-thread-collapsed-row p-4 min-w-0 border bg-surface cursor-pointer macro-thread-card-outdent',
+            'relative macro-thread-collapsed-row p-4 min-w-0 border bg-message macro-thread-card-outdent',
             props.isFocused
               ? 'z-1 border-rail shadow-md shadow-drop-shadow'
               : 'border-edge-muted'
@@ -78,7 +75,6 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
           data-message-body-id={props.message.db_id}
           tabIndex={0}
           onClick={handleRowClick}
-          onClickCapture={handleRowClick}
           onFocus={props.onFocus}
           onKeyDown={handleKeyDown}
         >

--- a/apps/web/src/features/block-email/component/CollapsedMessage.tsx
+++ b/apps/web/src/features/block-email/component/CollapsedMessage.tsx
@@ -1,6 +1,5 @@
 import { UserIcon, type UserIconProps } from '@core/component/UserIcon';
 import { useEmail } from '@core/context/user';
-import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import type { ApiMessage } from '@service-email/generated/schemas';
 import { cn, Tooltip } from '@ui';
 import { createMemo, Show } from 'solid-js';
@@ -11,7 +10,6 @@ import { EmailUserTooltip } from './EmailUserTooltip';
 interface CollapsedMessageProps {
   message: ApiMessage;
   isFocused: boolean;
-  showBottomBorder?: boolean;
   onClick: () => void;
   onFocus?: () => void;
 }
@@ -69,10 +67,10 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
       <div class="macro-message-width macro-message-padding w-full">
         <div
           class={cn(
-            'relative macro-thread-collapsed-row p-4 min-w-0 border border-transparent cursor-pointer macro-thread-card-outdent',
-            props.showBottomBorder && 'border-b-edge-muted',
-            props.isFocused && !isTouchDevice() && 'bg-list-highlighted',
-            !props.isFocused && !isTouchDevice() && 'hover:bg-list-hover'
+            'relative macro-thread-collapsed-row p-4 min-w-0 border bg-surface cursor-pointer macro-thread-card-outdent',
+            props.isFocused
+              ? 'z-1 border-edge shadow-md shadow-drop-shadow'
+              : 'border-edge-muted'
           )}
           style={{
             '--user-icon-width': '1rem',

--- a/apps/web/src/features/block-email/component/CollapsedMessage.tsx
+++ b/apps/web/src/features/block-email/component/CollapsedMessage.tsx
@@ -64,7 +64,7 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
       <div class="macro-message-width macro-message-padding w-full">
         <div
           class={cn(
-            'relative macro-thread-collapsed-row p-4 min-w-0 border bg-message macro-thread-card-outdent',
+            'relative macro-thread-collapsed-row p-4 min-w-0 border bg-message rounded-lg',
             props.isFocused
               ? 'z-1 border-rail shadow-md shadow-drop-shadow'
               : 'border-edge-muted'

--- a/apps/web/src/features/block-email/component/CollapsedMessage.tsx
+++ b/apps/web/src/features/block-email/component/CollapsedMessage.tsx
@@ -1,5 +1,6 @@
 import { UserIcon, type UserIconProps } from '@core/component/UserIcon';
 import { useEmail } from '@core/context/user';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import type { ApiMessage } from '@service-email/generated/schemas';
 import { cn } from '@ui/utils/classname';
 import { createMemo, Show } from 'solid-js';
@@ -10,6 +11,7 @@ import { EmailUserTooltip } from './EmailUserTooltip';
 interface CollapsedMessageProps {
   message: ApiMessage;
   isFocused: boolean;
+  showBottomBorder?: boolean;
   onClick: () => void;
   onFocus?: () => void;
 }
@@ -21,10 +23,6 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
     getSenderDisplayName(props.message, currentUserEmail())
   );
   const senderMacroId = createMemo(() => getSenderMacroId(props.message));
-  const _allRecipients = createMemo(() => [
-    ...props.message.to,
-    ...props.message.cc,
-  ]);
   const senderIconProps = createMemo<UserIconProps>(() => {
     const senderId = senderMacroId();
     const photoUrl = props.message.from?.photo_url ?? undefined;
@@ -60,10 +58,10 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
       <div class="macro-message-width macro-message-padding w-full">
         <div
           class={cn(
-            'relative flex flex-col gap-2 p-4 rounded-lg min-w-0 border',
-            props.isFocused
-              ? 'bg-active border-edge'
-              : 'bg-hover hover:bg-active hover:border-edge border-transparent'
+            'relative macro-thread-collapsed-row p-4 min-w-0 border border-transparent macro-thread-card-outdent',
+            props.showBottomBorder && 'border-b-edge-muted',
+            props.isFocused && !isTouchDevice() && 'bg-list-highlighted',
+            !props.isFocused && !isTouchDevice() && 'hover:bg-list-hover'
           )}
           style={{
             '--user-icon-width': '1rem',
@@ -74,7 +72,7 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
           onFocus={props.onFocus}
           onKeyDown={handleKeyDown}
         >
-          <div class="flex items-center gap-2 min-w-0 text-xs">
+          <div class="flex items-center gap-2 min-w-0 text-sm">
             <div class="shrink-0 flex justify-center items-center size-6">
               <UserIcon
                 {...senderIconProps()}
@@ -84,17 +82,19 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
               />
             </div>
             <EmailUserTooltip recipient={props.message.from}>
-              <span class="text-ink truncate cursor-default shrink-0 max-w-32">
+              <span class="text-ink truncate cursor-default min-w-0">
                 {senderDisplay()}
               </span>
             </EmailUserTooltip>
-            <Show when={props.message.internal_date_ts}>
-              <span class="shrink-0 text-ink-extra-muted/60 tabular-nums">
-                {formatShortDate(props.message.internal_date_ts!)}
-              </span>
-            </Show>
           </div>
-          <div class="min-w-0 text-sm text-ink-muted truncate">{snippet()}</div>
+          <div class="min-w-0 text-sm text-ink-extra-muted truncate">
+            {snippet()}
+          </div>
+          <Show when={props.message.internal_date_ts}>
+            <span class="justify-self-end text-sm text-ink-extra-muted/60 tabular-nums">
+              {formatShortDate(props.message.internal_date_ts!)}
+            </span>
+          </Show>
         </div>
       </div>
     </div>

--- a/apps/web/src/features/block-email/component/CollapsedMessage.tsx
+++ b/apps/web/src/features/block-email/component/CollapsedMessage.tsx
@@ -66,7 +66,7 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
           class={cn(
             'relative macro-thread-collapsed-row p-4 min-w-0 border bg-message rounded-lg',
             props.isFocused
-              ? 'z-1 border-rail shadow-md shadow-drop-shadow'
+              ? 'z-1 border-edge shadow-md shadow-drop-shadow'
               : 'border-edge-muted'
           )}
           style={{

--- a/apps/web/src/features/block-email/component/CollapsedMessage.tsx
+++ b/apps/web/src/features/block-email/component/CollapsedMessage.tsx
@@ -69,7 +69,7 @@ export function CollapsedMessage(props: CollapsedMessageProps) {
           class={cn(
             'relative macro-thread-collapsed-row p-4 min-w-0 border bg-surface cursor-pointer macro-thread-card-outdent',
             props.isFocused
-              ? 'z-1 border-edge shadow-md shadow-drop-shadow'
+              ? 'z-1 border-rail shadow-md shadow-drop-shadow'
               : 'border-edge-muted'
           )}
           style={{

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -39,21 +39,23 @@ import { isPersonalMessage } from '../util/isPersonalMessage';
 import type { ReplyType } from '../util/replyType';
 import {
   hiddenMessagesControl,
-  hiddenMessagesFollowsShownIndex,
-  hiddenMessagesPrecedesShownIndex,
   isTruncatedMiddleMessage,
   isUnreadMessage,
   messageElement,
   nearestDelta,
-  nextShownChronologicalIndex,
   pageThenAdvanceDelta,
-  prevShownChronologicalIndex,
-  scrollToListStartDelta,
   revealMessageAfterLayout,
   type ScrollAlign,
+  scrollToListStartDelta,
   scrollToMessage,
   threadMessageIsExpanded,
 } from '../util/scrollToMessage';
+import {
+  adjacentStop,
+  enterListStop,
+  shownStops,
+  type ThreadStop,
+} from '../util/threadStops';
 import { BottomReplyButtons } from './BottomReplyButtons';
 import { EmailFormContextProvider } from './EmailFormContext';
 import { openEmailReplyComposerForMessage } from './emailReplyActions';
@@ -282,6 +284,16 @@ function EmailContent(props: EmailViewProps) {
     return false;
   });
 
+  let markdownDomRef!: HTMLDivElement;
+
+  const animateListScroll = (list: HTMLElement, top: number) => {
+    if (top === 0) return false;
+    setIsScrollingToMessage(true);
+    list.scrollBy({ top, behavior: 'smooth' });
+    setTimeout(() => setIsScrollingToMessage(false), SCROLL_ANIMATION_MS);
+    return true;
+  };
+
   const focusHiddenMessages = () => {
     const list = untrack(context.messagesListRef);
     if (!list) return false;
@@ -289,13 +301,43 @@ function EmailContent(props: EmailViewProps) {
     if (!button) return false;
     context.messages.setFocused(undefined);
     setHiddenChipFocused(true);
-    const delta = nearestDelta(list, button);
-    if (delta !== 0) {
-      setIsScrollingToMessage(true);
-      list.scrollBy({ top: delta, behavior: 'smooth' });
-      setTimeout(() => setIsScrollingToMessage(false), SCROLL_ANIMATION_MS);
-    }
+    animateListScroll(list, nearestDelta(list, button));
     return true;
+  };
+
+  const applyStop = (
+    stop: ThreadStop | undefined,
+    messages: ApiMessage[],
+    list: HTMLElement
+  ) => {
+    if (!stop) return true;
+    switch (stop.kind) {
+      case 'title': {
+        const startDelta = scrollToListStartDelta(list);
+        if (startDelta !== 0) return animateListScroll(list, startDelta);
+        context.messages.setFocused(undefined);
+        return true;
+      }
+      case 'hidden-chip':
+        return focusHiddenMessages();
+      case 'message': {
+        const id = messages[stop.index]?.db_id;
+        if (!id) return false;
+        return performScrollToMessage(id, {
+          behavior: 'smooth',
+          focus: true,
+        });
+      }
+      case 'composer':
+        leaveHiddenChip();
+        context.messages.setFocused(undefined);
+        markdownDomRef.focus();
+        return true;
+      default: {
+        const _exhaustive: never = stop;
+        return _exhaustive;
+      }
+    }
   };
 
   const navigateMessage = createCallback((dir: 'prev' | 'next') => {
@@ -303,108 +345,41 @@ function EmailContent(props: EmailViewProps) {
     const list = context.messagesListRef();
     if (!messages?.length || !list) return false;
 
-    const currentFocusedId = context.messages.focusedID();
-    const showMiddle = showMiddleMessages();
+    const stops = shownStops({
+      length: messages.length,
+      showMiddle: showMiddleMessages(),
+      hasComposer: Boolean(markdownDomRef),
+    });
 
     if (hiddenChipFocused()) {
-      const target =
-        dir === 'next' ? messages[messages.length - 2] : messages[0];
-      if (!target?.db_id) return false;
-      return performScrollToMessage(target.db_id, {
-        behavior: 'smooth',
-        focus: true,
-      });
+      return applyStop(
+        adjacentStop(stops, { kind: 'hidden-chip' }, dir),
+        messages,
+        list
+      );
     }
 
-    if (currentFocusedId) {
-      const focusedEl = messageElement(list, messages, currentFocusedId);
-      if (focusedEl) {
-        const pageDelta = pageThenAdvanceDelta(list, focusedEl, dir);
-        if (pageDelta !== 0) {
-          setIsScrollingToMessage(true);
-          list.scrollBy({ top: pageDelta, behavior: 'smooth' });
-          setTimeout(() => setIsScrollingToMessage(false), SCROLL_ANIMATION_MS);
-          return true;
-        }
-      }
-    }
-
+    const currentFocusedId = context.messages.focusedID();
     if (!currentFocusedId) {
-      const target =
-        dir === 'prev' ? messages[messages.length - 1] : messages[0];
-      if (!target?.db_id) return false;
-      return performScrollToMessage(target.db_id, {
-        behavior: 'smooth',
-        focus: true,
-      });
+      return applyStop(enterListStop(stops, dir), messages, list);
+    }
+
+    const focusedEl = messageElement(list, messages, currentFocusedId);
+    if (focusedEl) {
+      const pageDelta = pageThenAdvanceDelta(list, focusedEl, dir);
+      if (pageDelta !== 0) return animateListScroll(list, pageDelta);
     }
 
     const currentIndex = messages.findIndex(
-      (m) => m.db_id === currentFocusedId
+      (message) => message.db_id === currentFocusedId
     );
     if (currentIndex < 0) return false;
 
-    const targetIndex =
-      dir === 'next'
-        ? nextShownChronologicalIndex(currentIndex, messages.length, showMiddle)
-        : prevShownChronologicalIndex(
-            currentIndex,
-            messages.length,
-            showMiddle
-          );
-
-    if (targetIndex === null) {
-      if (
-        dir === 'next' &&
-        hiddenMessagesFollowsShownIndex(
-          currentIndex,
-          messages.length,
-          showMiddle
-        )
-      ) {
-        return focusHiddenMessages();
-      }
-      if (
-        dir === 'prev' &&
-        hiddenMessagesPrecedesShownIndex(
-          currentIndex,
-          messages.length,
-          showMiddle
-        )
-      ) {
-        return focusHiddenMessages();
-      }
-      if (
-        dir === 'next' &&
-        currentIndex === messages.length - 1 &&
-        markdownDomRef
-      ) {
-        leaveHiddenChip();
-        context.messages.setFocused(undefined);
-        markdownDomRef.focus();
-        return true;
-      }
-      if (dir === 'prev' && currentIndex === 0) {
-        const startDelta = scrollToListStartDelta(list);
-        if (startDelta !== 0) {
-          setIsScrollingToMessage(true);
-          list.scrollBy({ top: startDelta, behavior: 'smooth' });
-          setTimeout(() => setIsScrollingToMessage(false), SCROLL_ANIMATION_MS);
-          return true;
-        }
-        context.messages.setFocused(undefined);
-        return true;
-      }
-      return true;
-    }
-
-    const targetMsg = messages[targetIndex];
-    if (!targetMsg?.db_id) return false;
-
-    return performScrollToMessage(targetMsg.db_id, {
-      behavior: 'smooth',
-      focus: true,
-    });
+    return applyStop(
+      adjacentStop(stops, { kind: 'message', index: currentIndex }, dir),
+      messages,
+      list
+    );
   });
 
   const navigateToPreviousMessage = () => navigateMessage('prev');
@@ -421,8 +396,6 @@ function EmailContent(props: EmailViewProps) {
     blockElement()?.focus({ preventScroll: true });
     hasRun = true;
   });
-
-  let markdownDomRef!: HTMLDivElement;
 
   const getHotkeyTarget = () => {
     const messages = context.messages.list();
@@ -447,10 +420,6 @@ function EmailContent(props: EmailViewProps) {
     const messageId = target.message.db_id;
     if (!messageId) return false;
 
-    const isNewMessage = target.message.labels.some(
-      (label) => label.provider_label_id === 'UNREAD'
-    );
-
     const list = context.messages.list();
     const chronologicalIndex = list.findIndex(
       (message) => message.db_id === messageId
@@ -461,7 +430,7 @@ function EmailContent(props: EmailViewProps) {
       chronologicalIndex,
       listLength: list.length,
       expansionOverride: context.messages.expandedBodyIds[messageId],
-      isUnread: isNewMessage,
+      isUnread: isUnreadMessage(target.message),
       hasDraft:
         !isTouchDevice() && !!context.drafts.getDraftForMessage(messageId),
     });
@@ -504,13 +473,13 @@ function EmailContent(props: EmailViewProps) {
     keyDownHandler: () => {
       if (hiddenChipFocused()) {
         const messages = untrack(context.messages.list);
-        const nextIndex = nextShownChronologicalIndex(
-          0,
-          messages.length,
-          true
+        const next = adjacentStop(
+          shownStops({ length: messages.length, showMiddle: true }),
+          { kind: 'message', index: 0 },
+          'next'
         );
         const nextId =
-          nextIndex !== null ? messages[nextIndex]?.db_id : undefined;
+          next?.kind === 'message' ? messages[next.index]?.db_id : undefined;
         setUserOpenedMiddle(true);
         if (!nextId) {
           leaveHiddenChip();

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -387,7 +387,7 @@ function EmailContent(props: EmailViewProps) {
 
   registerScopeSignalHotkey(scopeId, {
     hotkey: 'escape',
-    description: 'Collapse message',
+    description: 'Collapse or unselect message',
     keyDownHandler: () => {
       // Skip if focus is in an editable area (compose input handles its own Escape)
       const activeEl = document.activeElement;
@@ -413,7 +413,15 @@ function EmailContent(props: EmailViewProps) {
         context.messages.setExpandedBodyId(focusedId, false);
         return true;
       }
-      return false;
+
+      context.messages.setFocused(undefined);
+      if (
+        activeEl instanceof HTMLElement &&
+        activeEl.closest(`[data-message-body-id="${CSS.escape(focusedId)}"]`)
+      ) {
+        activeEl.blur();
+      }
+      return true;
     },
     hotkeyToken: TOKENS.email.cancelReply,
     hide: true,

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -39,11 +39,12 @@ import { isScrollingToMessage } from '../signal/scrollState';
 import { registerEmailHotkeys } from '../util/emailHotkeys';
 import { isPersonalMessage } from '../util/isPersonalMessage';
 import type { ReplyType } from '../util/replyType';
-import { scrollToMessage } from '../util/scrollToMessage';
+import {
+  type ScrollAlign,
+  scrollToMessage,
+} from '../util/scrollToMessage';
 import { BottomReplyButtons } from './BottomReplyButtons';
 import { EmailFormContextProvider } from './EmailFormContext';
-import { EmailParticipants } from './EmailParticipants';
-import { EmailThreadTitle } from './EmailThreadTitle';
 import { openEmailReplyComposerForMessage } from './emailReplyActions';
 import { MessageList } from './MessageList';
 import { MobileEmailComposeDrawer } from './MobileEmailComposeDrawer';
@@ -53,9 +54,6 @@ import { TopBar } from './TopBar';
 
 const TARGET_MESSAGE_HIGHLIGHT_MS = 800;
 const SCROLL_ANIMATION_MS = 1000;
-const SCROLL_AFTER_SEND_DELAY_MS = 100;
-const SCROLL_SETTLE_STABLE_FRAMES = 15;
-const SCROLL_SETTLE_MAX_MS = 2000;
 
 type EmailViewProps = {
   title: string;
@@ -88,12 +86,6 @@ function EmailContent(props: EmailViewProps) {
   const canAutofocusSplitContent = useCanAutofocusSplitContent();
   const { isLoading: isUserLoading } = useUserContext();
   const userEmail = useEmail();
-
-  const [isScrolled, setIsScrolled] = createSignal(false);
-
-  const handleScrollPositionChange = (scrollFromTop: number) => {
-    setIsScrolled(scrollFromTop > 1);
-  };
 
   const openTaskCompose = () => {
     const threadId = context.thread()?.db_id;
@@ -155,26 +147,20 @@ function EmailContent(props: EmailViewProps) {
   };
 
   /**
-   * Loads the next page only when there is more data to load and
-   * it's not already fetching
-   */
-  const fetchNextPage = () => {
-    if (context.query.hasMore() && !context.query.isFetching()) {
-      context.query.fetchNextPage();
-    }
-  };
-
-  /**
    * Performs scrolling to a message and updates focus.
    */
   const performScrollToMessage = (
     messageId: string,
-    opts: { behavior?: ScrollBehavior; focus?: boolean } = {
+    opts: {
+      behavior?: ScrollBehavior;
+      focus?: boolean;
+      align?: ScrollAlign;
+    } = {
       behavior: 'smooth',
       focus: true,
     }
   ) => {
-    opts = { focus: true, behavior: 'smooth', ...opts };
+    opts = { focus: true, behavior: 'smooth', align: 'start', ...opts };
     const messages = untrack(context.messages.list);
     const container = untrack(context.messagesListRef);
 
@@ -188,7 +174,7 @@ function EmailContent(props: EmailViewProps) {
 
     const success = scrollToMessage(messageId, messages, container, {
       behavior: opts.behavior,
-      reversed: true,
+      align: opts.align,
     });
 
     if (!success) {
@@ -202,203 +188,43 @@ function EmailContent(props: EmailViewProps) {
       }, TARGET_MESSAGE_HIGHLIGHT_MS);
     }
 
-    // Clear scrolling flag after animation
     setTimeout(() => setIsScrollingToMessage(false), SCROLL_ANIMATION_MS);
 
     return true;
   };
 
-  // Message bodies keep resizing briefly after render (images load, inline
-  // cid: images fail and collapse), so a scroll computed against that
-  // transient layout gets displaced — browser scroll anchoring can clamp it
-  // to the very top of the thread. Re-assert the initial scroll whenever the
-  // content height changes until layout settles or the user scrolls.
-  let cancelActiveScrollPin: (() => void) | undefined;
-  const pinInitialScroll = (messageId: string) => {
-    cancelActiveScrollPin?.();
-    const list = untrack(context.messagesListRef);
-    if (!list) return;
-
-    let cancelled = false;
-    let stableFrames = 0;
-    let lastHeight = list.scrollHeight;
-    const startedAt = performance.now();
-
-    const cancel = () => {
-      cancelled = true;
-      list.removeEventListener('wheel', cancel);
-      list.removeEventListener('touchstart', cancel);
-      list.removeEventListener('pointerdown', cancel);
-    };
-    cancelActiveScrollPin = cancel;
-    list.addEventListener('wheel', cancel, { passive: true });
-    list.addEventListener('touchstart', cancel, { passive: true });
-    list.addEventListener('pointerdown', cancel, { passive: true });
-
-    const tick = () => {
-      if (cancelled || !list.isConnected) return cancel();
-      if (list.scrollHeight !== lastHeight) {
-        lastHeight = list.scrollHeight;
-        stableFrames = 0;
-        performScrollToMessage(messageId, {
-          behavior: 'instant',
-          focus: false,
-        });
-      } else {
-        stableFrames++;
-      }
-      if (
-        stableFrames >= SCROLL_SETTLE_STABLE_FRAMES ||
-        performance.now() - startedAt > SCROLL_SETTLE_MAX_MS
-      ) {
-        return cancel();
-      }
-      requestAnimationFrame(tick);
-    };
-    requestAnimationFrame(tick);
-  };
-
-  const scrollToLastMessage = (
-    behavior: ScrollBehavior = 'instant',
-    focus = false
-  ) => {
-    const messages = context.messages.list();
-    if (!messages?.length) return;
-
-    const lastMessage = messages[messages.length - 1];
-
-    if (!lastMessage.db_id) return;
-
-    performScrollToMessage(lastMessage.db_id, { behavior, focus });
-  };
-
-  const firstUnreadMessageId = createMemo(() => {
-    const messages = context.messages.list().toSorted((a, b) => {
-      if (a.internal_date_ts && b.internal_date_ts) {
-        return (
-          new Date(a.internal_date_ts).getTime() -
-          new Date(b.internal_date_ts).getTime()
-        );
-      } else if (a.sent_at && b.sent_at) {
-        return new Date(a.sent_at).getTime() - new Date(b.sent_at).getTime();
-      }
-      return 0;
-    });
-    return messages?.find((m) =>
-      m.labels.some((l) => l.provider_label_id === 'UNREAD')
-    )?.db_id;
-  });
-
   const canRunInitialEmailScroll = () =>
     !isTouchDevice() || splitPanel?.isPanelActive() !== false;
 
-  // ============================================
-  // PHASE 2: HANDLE TARGET MESSAGE SCROLLING
-  // ============================================
-  // This effect handles scrolling to a specific message (if provided via URL) or scrolling to the last message by default
-  // This effect should only run once.
+  // Open at the visual top. Do not hunt a message or pin the list.
   context.onInitialDataLoad(() => {
-    // Initial scroll positioning visibly shifts the email panel if it runs
-    // while the split is swiping in on touch devices.
     if (!canRunInitialEmailScroll()) return false;
 
-    // Check for target message
+    const list = untrack(context.messagesListRef);
+    if (!list) return false;
+
     const targetMessageId_ = context.messages.targetMessageID();
-
     if (targetMessageId_ && typeof targetMessageId_ !== 'string') return true;
-
-    if (targetMessageId_) {
-      handleTargetMessage(targetMessageId_);
-    } else {
-      const lastUnreadMessageId_ = untrack(firstUnreadMessageId);
-      // Check if there is an unread message
-      if (lastUnreadMessageId_) {
-        setTimeout(() => {
-          performScrollToMessage(lastUnreadMessageId_!, {
-            behavior: 'instant',
-          });
-          pinInitialScroll(lastUnreadMessageId_!);
-        });
-        context.messages.setFocused(lastUnreadMessageId_!);
-      } else {
-        scrollToLastMessage('instant', false);
-        const lastMessageId = untrack(context.messages.list).at(-1)?.db_id;
-        if (lastMessageId) pinInitialScroll(lastMessageId);
-      }
+    if (typeof targetMessageId_ === 'string') {
+      void revealTargetMessage(targetMessageId_);
     }
 
+    // col-reverse: scrollTop 0 is the newest (visual bottom).
+    list.scrollTop = list.clientHeight - list.scrollHeight;
     return true;
   });
 
-  /**
-   * Handles scrolling to a specific message ID from URL
-   */
-  async function handleTargetMessage(messageId: string) {
+  async function revealTargetMessage(messageId: string) {
+    context.messages.setExpandedBodyId(messageId, true);
     const messages = untrack(context.messages.list);
     if (!messages) return;
-    // Expand the target so the navigated-to hit isn't a collapsed row
-    context.messages.setExpandedBodyId(messageId, true);
-    const targetIndex = messages.findIndex((m) => m.db_id === messageId);
-
-    // Case 1: Message not in current loaded batch - need to load more
-    if (targetIndex < 0) {
-      try {
-        const found = await loadMessagesUntilFound(messageId);
-        if (found) {
-          // Load one more batch for scroll context
-          fetchNextPage();
-          await waitForQueryLoad();
-          // Scroll to the message after DOM updates
-          setTimeout(() => {
-            performScrollToMessage(messageId, { behavior: 'instant' });
-            pinInitialScroll(messageId);
-          });
-        } else {
-          // Message not found, fallback to last message
-          setTimeout(() => scrollToLastMessage('instant', true));
-        }
-      } catch (error) {
-        console.error('Error loading target message:', error);
-        setTimeout(() => scrollToLastMessage('instant', true));
-      }
-    }
-    // Case 2: Message is first in current batch - load more for context
-    else if (targetIndex === 0) {
-      fetchNextPage();
-      await waitForQueryLoad();
-      setTimeout(() => {
-        performScrollToMessage(messageId, { behavior: 'instant' });
-        pinInitialScroll(messageId);
-      });
-    }
-    // Case 3: Message is in current batch with sufficient context
-    else {
-      setTimeout(() => {
-        performScrollToMessage(messageId, { behavior: 'instant' });
-        pinInitialScroll(messageId);
-      });
+    if (messages.some((message) => message.db_id === messageId)) return;
+    try {
+      await loadMessagesUntilFound(messageId);
+    } catch (error) {
+      console.error('Error loading target message:', error);
     }
   }
-
-  // If there is a focused message id, but it does not currently exist in the message list, it is because the user has just sent a message. When it does come into existence, we want to scroll to the bottom.
-  createEffect((prev: boolean | undefined) => {
-    const currentFocusedId = context.messages.focusedID();
-    const messages = context.messages.list();
-
-    if (!currentFocusedId || !messages) return true;
-
-    const currentIndex = messages.findIndex(
-      (m) => m.db_id === currentFocusedId
-    );
-    if (currentIndex < 0) return false;
-
-    if (prev === false) {
-      setTimeout(() => {
-        scrollToLastMessage('smooth');
-      }, SCROLL_AFTER_SEND_DELAY_MS);
-    }
-    return true;
-  });
 
   const navigateMessage = createCallback((dir: 'prev' | 'next') => {
     const messages = context.messages.list();
@@ -743,33 +569,11 @@ function EmailContent(props: EmailViewProps) {
                   class="w-full flex-1 flex flex-col items-center overflow-hidden"
                   ref={context.registerMessagesContainer}
                 >
-                  <Show when={!isTouchDevice()}>
-                    <div class="shrink-0 w-full flex justify-center">
-                      <div
-                        class="macro-message-width macro-message-padding w-full border-b"
-                        classList={{
-                          'border-edge-muted/50': isScrolled(),
-                          'border-transparent': !isScrolled(),
-                        }}
-                      >
-                        <div class="h-12" />
-                        <EmailThreadTitle
-                          title={props.title}
-                          copyReveal="hover"
-                          class="text-2xl pb-1.5"
-                        />
-                        <div class="pb-2.5">
-                          <EmailParticipants />
-                        </div>
-                      </div>
-                    </div>
-                  </Show>
                   <MessageList
                     initialLoadComplete={context.initialLoadComplete()}
                     markdownDomRef={(el) => {
                       markdownDomRef = el;
                     }}
-                    onScrollPositionChange={handleScrollPositionChange}
                     title={props.title}
                     underScrollsBottom={!replyInputInFlow()}
                   />

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -48,6 +48,7 @@ import {
   nextShownChronologicalIndex,
   pageThenAdvanceDelta,
   prevShownChronologicalIndex,
+  scrollToListStartDelta,
   revealMessageAfterLayout,
   type ScrollAlign,
   scrollToMessage,
@@ -381,6 +382,17 @@ function EmailContent(props: EmailViewProps) {
         leaveHiddenChip();
         context.messages.setFocused(undefined);
         markdownDomRef.focus();
+        return true;
+      }
+      if (dir === 'prev' && currentIndex === 0) {
+        const startDelta = scrollToListStartDelta(list);
+        if (startDelta !== 0) {
+          setIsScrollingToMessage(true);
+          list.scrollBy({ top: startDelta, behavior: 'smooth' });
+          setTimeout(() => setIsScrollingToMessage(false), SCROLL_ANIMATION_MS);
+          return true;
+        }
+        context.messages.setFocused(undefined);
         return true;
       }
       return true;

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -6,10 +6,7 @@ import {
 } from '@block-email/component/EmailContext';
 import { SidePanel } from '@components/app/side-panel';
 import { useSplitLayout } from '@components/app/split-layout/layout';
-import {
-  useCanAutofocusSplitContent,
-  useSplitPanel,
-} from '@components/app/split-layout/layoutUtils';
+import { useCanAutofocusSplitContent } from '@components/app/split-layout/layoutUtils';
 import { CustomScrollbar } from '@core/component/CustomScrollbar';
 import { useEmail, useUserContext } from '@core/context/user';
 import { TOKENS } from '@core/hotkey/tokens';
@@ -42,6 +39,7 @@ import type { ReplyType } from '../util/replyType';
 import {
   type ScrollAlign,
   scrollToMessage,
+  threadMessageIsExpanded,
 } from '../util/scrollToMessage';
 import { BottomReplyButtons } from './BottomReplyButtons';
 import { EmailFormContextProvider } from './EmailFormContext';
@@ -82,7 +80,6 @@ function EmailContent(props: EmailViewProps) {
   const blockElement = blockElementSignal.get;
 
   const context = useEmailContext();
-  const splitPanel = useSplitPanel();
   const canAutofocusSplitContent = useCanAutofocusSplitContent();
   const { isLoading: isUserLoading } = useUserContext();
   const userEmail = useEmail();
@@ -193,15 +190,8 @@ function EmailContent(props: EmailViewProps) {
     return true;
   };
 
-  const canRunInitialEmailScroll = () =>
-    !isTouchDevice() || splitPanel?.isPanelActive() !== false;
-
-  // Open at the visual top. Do not hunt a message or pin the list.
   context.onInitialDataLoad(() => {
-    if (!canRunInitialEmailScroll()) return false;
-
-    const list = untrack(context.messagesListRef);
-    if (!list) return false;
+    if (!untrack(context.messagesListRef)) return false;
 
     const targetMessageId_ = context.messages.targetMessageID();
     if (targetMessageId_ && typeof targetMessageId_ !== 'string') return true;
@@ -209,8 +199,6 @@ function EmailContent(props: EmailViewProps) {
       void revealTargetMessage(targetMessageId_);
     }
 
-    // col-reverse: scrollTop 0 is the newest (visual bottom).
-    list.scrollTop = list.clientHeight - list.scrollHeight;
     return true;
   });
 
@@ -316,11 +304,20 @@ function EmailContent(props: EmailViewProps) {
       (label) => label.provider_label_id === 'UNREAD'
     );
 
-    return (
-      context.messages.isBodyExpanded(messageId) ||
-      target.isLastMessage ||
-      isNewMessage
+    const list = context.messages.list();
+    const chronologicalIndex = list.findIndex(
+      (message) => message.db_id === messageId
     );
+    if (chronologicalIndex < 0) return false;
+
+    return threadMessageIsExpanded({
+      chronologicalIndex,
+      listLength: list.length,
+      expansionOverride: context.messages.expandedBodyIds[messageId],
+      isUnread: isNewMessage,
+      hasDraft:
+        !isTouchDevice() && !!context.drafts.getDraftForMessage(messageId),
+    });
   };
 
   const openHotkeyTarget = (replyType: ReplyType) => {
@@ -405,14 +402,10 @@ function EmailContent(props: EmailViewProps) {
         return true;
       }
 
-      // If message is expanded and not the last message, collapse it
-      if (context.messages.isBodyExpanded(focusedId)) {
-        const messages = context.messages.list();
-        const lastMessage = messages[messages.length - 1];
-        if (lastMessage?.db_id !== focusedId) {
-          context.messages.setExpandedBodyId(focusedId, false);
-          return true;
-        }
+      const target = getHotkeyTarget();
+      if (target && isMessageRenderedExpanded(target)) {
+        context.messages.setExpandedBodyId(focusedId, false);
+        return true;
       }
       return false;
     },
@@ -577,10 +570,7 @@ function EmailContent(props: EmailViewProps) {
                     title={props.title}
                     underScrollsBottom={!replyInputInFlow()}
                   />
-                  <CustomScrollbar
-                    reverse
-                    scrollContainer={context.messagesListRef}
-                  />
+                  <CustomScrollbar scrollContainer={context.messagesListRef} />
                 </div>
                 <Show when={isTouchDevice() && mobileBottomReplyMessage()}>
                   {(lastMessage) => (

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -33,6 +33,7 @@ import {
   Switch,
   untrack,
 } from 'solid-js';
+import { match } from 'ts-pattern';
 import { isScrollingToMessage } from '../signal/scrollState';
 import { registerEmailHotkeys } from '../util/emailHotkeys';
 import { isPersonalMessage } from '../util/isPersonalMessage';
@@ -311,33 +312,29 @@ function EmailContent(props: EmailViewProps) {
     list: HTMLElement
   ) => {
     if (!stop) return true;
-    switch (stop.kind) {
-      case 'title': {
+    return match(stop)
+      .with({ kind: 'title' }, () => {
         const startDelta = scrollToListStartDelta(list);
         if (startDelta !== 0) return animateListScroll(list, startDelta);
         context.messages.setFocused(undefined);
         return true;
-      }
-      case 'hidden-chip':
-        return focusHiddenMessages();
-      case 'message': {
-        const id = messages[stop.index]?.db_id;
+      })
+      .with({ kind: 'hidden-chip' }, () => focusHiddenMessages())
+      .with({ kind: 'message' }, ({ index }) => {
+        const id = messages[index]?.db_id;
         if (!id) return false;
         return performScrollToMessage(id, {
           behavior: 'smooth',
           focus: true,
         });
-      }
-      case 'composer':
+      })
+      .with({ kind: 'composer' }, () => {
         leaveHiddenChip();
         context.messages.setFocused(undefined);
         markdownDomRef.focus();
         return true;
-      default: {
-        const _exhaustive: never = stop;
-        return _exhaustive;
-      }
-    }
+      })
+      .exhaustive();
   };
 
   const navigateMessage = createCallback((dir: 'prev' | 'next') => {

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -38,9 +38,13 @@ import { registerEmailHotkeys } from '../util/emailHotkeys';
 import { isPersonalMessage } from '../util/isPersonalMessage';
 import type { ReplyType } from '../util/replyType';
 import {
+  hiddenMessagesControl,
+  hiddenMessagesFollowsShownIndex,
+  hiddenMessagesPrecedesShownIndex,
   isTruncatedMiddleMessage,
   isUnreadMessage,
   messageElement,
+  nearestDelta,
   nextShownChronologicalIndex,
   pageThenAdvanceDelta,
   prevShownChronologicalIndex,
@@ -151,6 +155,24 @@ function EmailContent(props: EmailViewProps) {
     }
   };
 
+  const [hiddenChipFocused, setHiddenChipFocused] = createSignal(false);
+
+  const leaveHiddenChip = () => {
+    setHiddenChipFocused(false);
+    const list = untrack(context.messagesListRef);
+    const button = list ? hiddenMessagesControl(list) : undefined;
+    if (button && document.activeElement === button) {
+      button.blur();
+      blockElement()?.focus({ preventScroll: true });
+    }
+  };
+
+  createEffect(() => {
+    if (context.messages.focusedID()) {
+      untrack(leaveHiddenChip);
+    }
+  });
+
   /**
    * Performs scrolling to a message and updates focus.
    */
@@ -184,6 +206,7 @@ function EmailContent(props: EmailViewProps) {
     }
 
     if (opts.focus) {
+      leaveHiddenChip();
       context.messages.setFocused(messageId);
     }
 
@@ -235,7 +258,10 @@ function EmailContent(props: EmailViewProps) {
   createEffect(
     on(
       () => context.thread()?.db_id,
-      () => setUserOpenedMiddle(false)
+      () => {
+        setUserOpenedMiddle(false);
+        leaveHiddenChip();
+      }
     )
   );
 
@@ -255,12 +281,39 @@ function EmailContent(props: EmailViewProps) {
     return false;
   });
 
+  const focusHiddenMessages = () => {
+    const list = untrack(context.messagesListRef);
+    if (!list) return false;
+    const button = hiddenMessagesControl(list);
+    if (!button) return false;
+    context.messages.setFocused(undefined);
+    setHiddenChipFocused(true);
+    const delta = nearestDelta(list, button);
+    if (delta !== 0) {
+      setIsScrollingToMessage(true);
+      list.scrollBy({ top: delta, behavior: 'smooth' });
+      setTimeout(() => setIsScrollingToMessage(false), SCROLL_ANIMATION_MS);
+    }
+    return true;
+  };
+
   const navigateMessage = createCallback((dir: 'prev' | 'next') => {
     const messages = context.messages.list();
     const list = context.messagesListRef();
     if (!messages?.length || !list) return false;
 
     const currentFocusedId = context.messages.focusedID();
+    const showMiddle = showMiddleMessages();
+
+    if (hiddenChipFocused()) {
+      const target =
+        dir === 'next' ? messages[messages.length - 2] : messages[0];
+      if (!target?.db_id) return false;
+      return performScrollToMessage(target.db_id, {
+        behavior: 'smooth',
+        focus: true,
+      });
+    }
 
     if (currentFocusedId) {
       const focusedEl = messageElement(list, messages, currentFocusedId);
@@ -290,7 +343,6 @@ function EmailContent(props: EmailViewProps) {
     );
     if (currentIndex < 0) return false;
 
-    const showMiddle = showMiddleMessages();
     const targetIndex =
       dir === 'next'
         ? nextShownChronologicalIndex(currentIndex, messages.length, showMiddle)
@@ -303,9 +355,30 @@ function EmailContent(props: EmailViewProps) {
     if (targetIndex === null) {
       if (
         dir === 'next' &&
+        hiddenMessagesFollowsShownIndex(
+          currentIndex,
+          messages.length,
+          showMiddle
+        )
+      ) {
+        return focusHiddenMessages();
+      }
+      if (
+        dir === 'prev' &&
+        hiddenMessagesPrecedesShownIndex(
+          currentIndex,
+          messages.length,
+          showMiddle
+        )
+      ) {
+        return focusHiddenMessages();
+      }
+      if (
+        dir === 'next' &&
         currentIndex === messages.length - 1 &&
         markdownDomRef
       ) {
+        leaveHiddenChip();
         context.messages.setFocused(undefined);
         markdownDomRef.focus();
         return true;
@@ -417,6 +490,13 @@ function EmailContent(props: EmailViewProps) {
     hotkey: 'enter',
     description: 'Reply to message',
     keyDownHandler: () => {
+      if (hiddenChipFocused()) {
+        const list = untrack(context.messagesListRef);
+        hiddenMessagesControl(list ?? document.body)?.click();
+        leaveHiddenChip();
+        return true;
+      }
+
       const focusedId = context.messages.focusedID();
       const target = getHotkeyTarget();
 
@@ -458,6 +538,11 @@ function EmailContent(props: EmailViewProps) {
         activeEl?.getAttribute('contenteditable') === 'true'
       ) {
         return false;
+      }
+
+      if (hiddenChipFocused()) {
+        leaveHiddenChip();
+        return true;
       }
 
       const focusedId = context.messages.focusedID();
@@ -661,7 +746,15 @@ function EmailContent(props: EmailViewProps) {
                     title={props.title}
                     underScrollsBottom={!replyInputInFlow()}
                     showMiddleMessages={showMiddleMessages()}
-                    onOpenMiddle={() => setUserOpenedMiddle(true)}
+                    hiddenChipFocused={hiddenChipFocused()}
+                    onHiddenChipFocus={() => {
+                      context.messages.setFocused(undefined);
+                      setHiddenChipFocused(true);
+                    }}
+                    onOpenMiddle={() => {
+                      leaveHiddenChip();
+                      setUserOpenedMiddle(true);
+                    }}
                   />
                   <CustomScrollbar scrollContainer={context.messagesListRef} />
                 </div>

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -27,6 +27,7 @@ import {
   createMemo,
   createSignal,
   Match,
+  on,
   onMount,
   Show,
   Switch,
@@ -37,10 +38,14 @@ import { registerEmailHotkeys } from '../util/emailHotkeys';
 import { isPersonalMessage } from '../util/isPersonalMessage';
 import type { ReplyType } from '../util/replyType';
 import {
-  type ScrollAlign,
+  isTruncatedMiddleMessage,
+  isUnreadMessage,
   messageElement,
+  nextShownChronologicalIndex,
   pageThenAdvanceDelta,
+  prevShownChronologicalIndex,
   revealMessageAfterLayout,
+  type ScrollAlign,
   scrollToMessage,
   threadMessageIsExpanded,
 } from '../util/scrollToMessage';
@@ -166,10 +171,6 @@ function EmailContent(props: EmailViewProps) {
 
     if (!messages || !container) return false;
 
-    if (opts.focus) {
-      context.messages.setFocused(messageId);
-    }
-
     setIsScrollingToMessage(true);
 
     const success = scrollToMessage(messageId, messages, container, {
@@ -180,6 +181,10 @@ function EmailContent(props: EmailViewProps) {
     if (!success) {
       setIsScrollingToMessage(false);
       return false;
+    }
+
+    if (opts.focus) {
+      context.messages.setFocused(messageId);
     }
 
     if (context.messages.targetMessageID() === messageId) {
@@ -209,13 +214,46 @@ function EmailContent(props: EmailViewProps) {
     context.messages.setExpandedBodyId(messageId, true);
     const messages = untrack(context.messages.list);
     if (!messages) return;
-    if (messages.some((message) => message.db_id === messageId)) return;
-    try {
-      await loadMessagesUntilFound(messageId);
-    } catch (error) {
-      console.error('Error loading target message:', error);
+    if (!messages.some((message) => message.db_id === messageId)) {
+      try {
+        await loadMessagesUntilFound(messageId);
+      } catch (error) {
+        console.error('Error loading target message:', error);
+      }
     }
+
+    requestAnimationFrame(() => {
+      performScrollToMessage(messageId, {
+        behavior: 'instant',
+        focus: true,
+        align: 'nearest',
+      });
+    });
   }
+
+  const [userOpenedMiddle, setUserOpenedMiddle] = createSignal(false);
+  createEffect(
+    on(
+      () => context.thread()?.db_id,
+      () => setUserOpenedMiddle(false)
+    )
+  );
+
+  const showMiddleMessages = createMemo(() => {
+    if (userOpenedMiddle()) return true;
+    const messages = context.messages.list();
+    const focus = context.messages.focusedID();
+    const target = context.messages.targetMessageID();
+    for (let i = 0; i < messages.length; i++) {
+      if (!isTruncatedMiddleMessage(i, messages.length)) continue;
+      const id = messages[i]?.db_id;
+      if (id && (id === focus || id === target)) return true;
+      if (isUnreadMessage(messages[i])) return true;
+      if (!isTouchDevice() && id && context.drafts.getDraftForMessage(id))
+        return true;
+    }
+    return false;
+  });
 
   const navigateMessage = createCallback((dir: 'prev' | 'next') => {
     const messages = context.messages.list();
@@ -241,11 +279,10 @@ function EmailContent(props: EmailViewProps) {
       const target =
         dir === 'prev' ? messages[messages.length - 1] : messages[0];
       if (!target?.db_id) return false;
-      performScrollToMessage(target.db_id, {
+      return performScrollToMessage(target.db_id, {
         behavior: 'smooth',
         focus: true,
       });
-      return true;
     }
 
     const currentIndex = messages.findIndex(
@@ -253,27 +290,36 @@ function EmailContent(props: EmailViewProps) {
     );
     if (currentIndex < 0) return false;
 
-    const delta = dir === 'prev' ? -1 : 1;
-    const targetIndex = currentIndex + delta;
+    const showMiddle = showMiddleMessages();
+    const targetIndex =
+      dir === 'next'
+        ? nextShownChronologicalIndex(currentIndex, messages.length, showMiddle)
+        : prevShownChronologicalIndex(
+            currentIndex,
+            messages.length,
+            showMiddle
+          );
 
-    if (targetIndex < 0 || targetIndex >= messages.length) {
-      if (dir === 'next' && markdownDomRef) {
+    if (targetIndex === null) {
+      if (
+        dir === 'next' &&
+        currentIndex === messages.length - 1 &&
+        markdownDomRef
+      ) {
         context.messages.setFocused(undefined);
         markdownDomRef.focus();
         return true;
       }
-      return false;
+      return true;
     }
 
     const targetMsg = messages[targetIndex];
     if (!targetMsg?.db_id) return false;
 
-    performScrollToMessage(targetMsg.db_id, {
+    return performScrollToMessage(targetMsg.db_id, {
       behavior: 'smooth',
       focus: true,
     });
-
-    return true;
   });
 
   const navigateToPreviousMessage = () => navigateMessage('prev');
@@ -468,6 +514,22 @@ function EmailContent(props: EmailViewProps) {
     }
   });
 
+  createEffect((prev: boolean | undefined) => {
+    const currentFocusedId = context.messages.focusedID();
+    const messages = context.messages.list();
+    if (!currentFocusedId || !messages.length) return true;
+    const exists = messages.some((m) => m.db_id === currentFocusedId);
+    if (!exists) return false;
+    if (prev === false) {
+      revealMessageAfterLayout(
+        currentFocusedId,
+        messages,
+        untrack(context.messagesListRef)
+      );
+    }
+    return true;
+  });
+
   const emailReplyInfo = createMemo(() => {
     const filtered = context.messages.list();
 
@@ -598,6 +660,8 @@ function EmailContent(props: EmailViewProps) {
                     }}
                     title={props.title}
                     underScrollsBottom={!replyInputInFlow()}
+                    showMiddleMessages={showMiddleMessages()}
+                    onOpenMiddle={() => setUserOpenedMiddle(true)}
                   />
                   <CustomScrollbar scrollContainer={context.messagesListRef} />
                 </div>

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -226,7 +226,7 @@ function EmailContent(props: EmailViewProps) {
       performScrollToMessage(messageId, {
         behavior: 'instant',
         focus: true,
-        align: 'nearest',
+        align: 'start',
       });
     });
   }

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -491,9 +491,25 @@ function EmailContent(props: EmailViewProps) {
     description: 'Reply to message',
     keyDownHandler: () => {
       if (hiddenChipFocused()) {
-        const list = untrack(context.messagesListRef);
-        hiddenMessagesControl(list ?? document.body)?.click();
-        leaveHiddenChip();
+        const messages = untrack(context.messages.list);
+        const nextIndex = nextShownChronologicalIndex(
+          0,
+          messages.length,
+          true
+        );
+        const nextId =
+          nextIndex !== null ? messages[nextIndex]?.db_id : undefined;
+        setUserOpenedMiddle(true);
+        if (!nextId) {
+          leaveHiddenChip();
+          return true;
+        }
+        context.messages.setFocused(nextId);
+        revealMessageAfterLayout(
+          nextId,
+          messages,
+          untrack(context.messagesListRef)
+        );
         return true;
       }
 

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -38,6 +38,7 @@ import { isPersonalMessage } from '../util/isPersonalMessage';
 import type { ReplyType } from '../util/replyType';
 import {
   type ScrollAlign,
+  revealMessageAfterLayout,
   scrollToMessage,
   threadMessageIsExpanded,
 } from '../util/scrollToMessage';
@@ -361,6 +362,11 @@ function EmailContent(props: EmailViewProps) {
       if (focusedId && target?.message.db_id === focusedId) {
         if (!isMessageRenderedExpanded(target)) {
           context.messages.setExpandedBodyId(focusedId, true);
+          revealMessageAfterLayout(
+            focusedId,
+            untrack(context.messages.list),
+            untrack(context.messagesListRef)
+          );
           return true;
         }
 

--- a/apps/web/src/features/block-email/component/Email.tsx
+++ b/apps/web/src/features/block-email/component/Email.tsx
@@ -38,6 +38,8 @@ import { isPersonalMessage } from '../util/isPersonalMessage';
 import type { ReplyType } from '../util/replyType';
 import {
   type ScrollAlign,
+  messageElement,
+  pageThenAdvanceDelta,
   revealMessageAfterLayout,
   scrollToMessage,
   threadMessageIsExpanded,
@@ -158,7 +160,7 @@ function EmailContent(props: EmailViewProps) {
       focus: true,
     }
   ) => {
-    opts = { focus: true, behavior: 'smooth', align: 'start', ...opts };
+    opts = { focus: true, behavior: 'smooth', align: 'nearest', ...opts };
     const messages = untrack(context.messages.list);
     const container = untrack(context.messagesListRef);
 
@@ -221,6 +223,19 @@ function EmailContent(props: EmailViewProps) {
     if (!messages?.length || !list) return false;
 
     const currentFocusedId = context.messages.focusedID();
+
+    if (currentFocusedId) {
+      const focusedEl = messageElement(list, messages, currentFocusedId);
+      if (focusedEl) {
+        const pageDelta = pageThenAdvanceDelta(list, focusedEl, dir);
+        if (pageDelta !== 0) {
+          setIsScrollingToMessage(true);
+          list.scrollBy({ top: pageDelta, behavior: 'smooth' });
+          setTimeout(() => setIsScrollingToMessage(false), SCROLL_ANIMATION_MS);
+          return true;
+        }
+      }
+    }
 
     if (!currentFocusedId) {
       const target =

--- a/apps/web/src/features/block-email/component/EmailContext.tsx
+++ b/apps/web/src/features/block-email/component/EmailContext.tsx
@@ -817,40 +817,19 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
     HTMLDivElement | undefined
   >(undefined);
 
-  let containerFilled = false;
   const isContainerFilled = () => {
     const messageList = messagesListRef();
     const containerRef = messagesContainerRef();
 
-    // Skip if dependencies not ready
     if (
       !messageList ||
       !containerRef ||
-      !untrack(() => threadQuery.data)?.db_id
+      !untrack(() => threadQuery.data)?.db_id ||
+      threadQuery.isFetching
     ) {
-      containerFilled = false;
       return false;
     }
 
-    // Skip if still loading or already filled
-    if (threadQuery.isFetching || containerFilled) {
-      return containerFilled;
-    }
-
-    const messageListHeight = messageList.getBoundingClientRect().height;
-    const containerHeight = containerRef.getBoundingClientRect().height;
-
-    // Load more if container isn't filled
-    if (
-      messageListHeight < containerHeight &&
-      threadQuery.hasNextPage &&
-      !threadQuery.isFetching
-    ) {
-      threadQuery.fetchNextPage();
-      containerFilled = false;
-      return false;
-    }
-    containerFilled = true;
     return true;
   };
 

--- a/apps/web/src/features/block-email/component/EmailContext.tsx
+++ b/apps/web/src/features/block-email/component/EmailContext.tsx
@@ -876,31 +876,7 @@ export function EmailProvider(props: FlowProps<{ threadID: string }>) {
   };
 
   const onExpandMessageBody = (messageID: string, expanded: boolean) => {
-    const listContainer = messagesListRef();
-
-    const lastScrollPosition = listContainer?.scrollTop;
-    const lastScrollHeight = listContainer?.scrollHeight;
-
     setExpandedMessageBodyIds(messageID, expanded);
-
-    if (
-      !listContainer ||
-      lastScrollPosition == null ||
-      lastScrollHeight == null
-    )
-      return;
-
-    // Maintain the scroll position when expansion changes
-    queueMicrotask(() => {
-      const lastPos = lastScrollHeight + lastScrollPosition;
-      const currentPos = listContainer.scrollHeight + listContainer.scrollTop;
-
-      // List is reversed, we need a negative value to maintain scroll
-      // position
-      const diff = lastPos - currentPos;
-
-      messagesListRef()?.scrollBy({ top: diff });
-    });
   };
 
   // When the provider unmounts (user navigates away), clear the thread query

--- a/apps/web/src/features/block-email/component/EmailMessageTopBar.tsx
+++ b/apps/web/src/features/block-email/component/EmailMessageTopBar.tsx
@@ -16,7 +16,6 @@ import {
   getRecipientDisplayName,
   getSenderDisplayName,
 } from '../util/emailUser';
-import { useEmailContext } from './EmailContext';
 import { EmailUserTooltip } from './EmailUserTooltip';
 import { type EmailMessageAction, MessageActions } from './MessageActions';
 
@@ -179,7 +178,7 @@ function HeaderTopRow(props: {
     <div class="flex flex-row w-full min-w-0 flex-1 items-center gap-2 text-sm">
       <div class="flex flex-row items-center gap-1.5 min-w-0 flex-1">
         <EmailUserTooltip recipient={props.message.from}>
-          <span class="text-ink font-medium cursor-default">
+          <span class="text-ink font-medium">
             {props.senderName}
           </span>
         </EmailUserTooltip>
@@ -231,8 +230,11 @@ function HeaderTopRow(props: {
         />
       </div>
       <Show when={props.message.internal_date_ts}>
-        <Tooltip label={formatFullDate(props.message.internal_date_ts!)}>
-          <span class="text-ink-extra-muted/60 tabular-nums cursor-default shrink-0">
+        <Tooltip
+          as="span"
+          label={formatFullDate(props.message.internal_date_ts!)}
+        >
+          <span class="text-ink-extra-muted/60 tabular-nums shrink-0">
             {formatShortDate(props.message.internal_date_ts!)}
           </span>
         </Tooltip>
@@ -244,43 +246,22 @@ function HeaderTopRow(props: {
 export function EmailMessageTopBar(props: EmailMessageTopBarProps) {
   const [isHovering, setIsHovering] = createSignal(false);
   const userEmail = useEmail();
-  const context = useEmailContext();
-
-  // Wraps setExpandedHeader with scroll compensation.
-  // The message list uses flex-col-reverse, so expanding the header
-  // shifts content above upward. This adjusts scrollTop to keep the
-  // visual position stable.
-  const toggleExpandedHeader = (expanded: boolean) => {
-    const scrollContainer = context.messagesListRef();
-    if (!scrollContainer) {
-      props.setExpandedHeader(expanded);
-      return;
-    }
-    const prevScrollHeight = scrollContainer.scrollHeight;
-    const prevScrollTop = scrollContainer.scrollTop;
-    props.setExpandedHeader(expanded);
-    requestAnimationFrame(() => {
-      const delta = scrollContainer.scrollHeight - prevScrollHeight;
-      scrollContainer.scrollTop = prevScrollTop - delta;
-    });
-  };
 
   const senderName = createMemo(() =>
     getSenderDisplayName(props.message, userEmail())
   );
 
-  const shouldIgnoreClick = (target: Element) =>
-    target.localName === 'button' ||
-    target.localName === 'svg' ||
-    target.localName === 'path' ||
-    target.tagName === 'SPAN' ||
-    target.closest('[role="tooltip"]');
-
-  const handleClick = (e: MouseEvent) => {
+  const handleHeaderClick = (e: MouseEvent) => {
     const id = props.message.db_id;
     if (id) props.setFocusedMessageId(id);
-    if (shouldIgnoreClick(e.target as Element)) return;
-    if (id) props.setExpandedBodyId(id, !props.isBodyExpanded());
+    const target = e.target;
+    if (
+      target instanceof Element &&
+      target.closest('[data-button], a[href]')
+    ) {
+      return;
+    }
+    if (id) props.setExpandedBodyId(id, false);
   };
 
   return (
@@ -289,16 +270,19 @@ export function EmailMessageTopBar(props: EmailMessageTopBarProps) {
       style={{ 'min-height': 'var(--user-icon-width)' }}
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
-      onClick={handleClick}
     >
       <Show when={props.isBodyExpanded()}>
-        <div class="flex items-center gap-2">
+        <div
+          class="flex items-center gap-2 cursor-pointer"
+          onClick={handleHeaderClick}
+          onClickCapture={handleHeaderClick}
+        >
           {props.avatar}
           <HeaderTopRow
             senderName={senderName()}
             isHovering={isHovering()}
             isExpanded={props.expandedHeader()}
-            onToggle={() => toggleExpandedHeader(!props.expandedHeader())}
+            onToggle={() => props.setExpandedHeader(!props.expandedHeader())}
             message={props.message}
             focused={props.focused}
             setShowReply={props.setShowReply}

--- a/apps/web/src/features/block-email/component/EmailMessageTopBar.tsx
+++ b/apps/web/src/features/block-email/component/EmailMessageTopBar.tsx
@@ -178,9 +178,7 @@ function HeaderTopRow(props: {
     <div class="flex flex-row w-full min-w-0 flex-1 items-center gap-2 text-sm">
       <div class="flex flex-row items-center gap-1.5 min-w-0 flex-1">
         <EmailUserTooltip recipient={props.message.from}>
-          <span class="text-ink font-medium">
-            {props.senderName}
-          </span>
+          <span class="text-ink font-medium">{props.senderName}</span>
         </EmailUserTooltip>
         <span class="text-ink-extra-muted/60 truncate">
           to{' '}
@@ -255,10 +253,7 @@ export function EmailMessageTopBar(props: EmailMessageTopBarProps) {
     const id = props.message.db_id;
     if (id) props.setFocusedMessageId(id);
     const target = e.target;
-    if (
-      target instanceof Element &&
-      target.closest('[data-button], a[href]')
-    ) {
+    if (target instanceof Element && target.closest('[data-button], a[href]')) {
       return;
     }
     if (id) props.setExpandedBodyId(id, false);
@@ -272,11 +267,7 @@ export function EmailMessageTopBar(props: EmailMessageTopBarProps) {
       onMouseLeave={() => setIsHovering(false)}
     >
       <Show when={props.isBodyExpanded()}>
-        <div
-          class="flex items-center gap-2 cursor-pointer"
-          onClick={handleHeaderClick}
-          onClickCapture={handleHeaderClick}
-        >
+        <div class="flex items-center gap-2" onClick={handleHeaderClick}>
           {props.avatar}
           <HeaderTopRow
             senderName={senderName()}

--- a/apps/web/src/features/block-email/component/EmailMessageTopBar.tsx
+++ b/apps/web/src/features/block-email/component/EmailMessageTopBar.tsx
@@ -245,9 +245,7 @@ export function EmailMessageTopBar(props: EmailMessageTopBarProps) {
   const [isHovering, setIsHovering] = createSignal(false);
   const userEmail = useEmail();
 
-  const senderName = createMemo(() =>
-    getSenderDisplayName(props.message, userEmail())
-  );
+  const senderName = () => getSenderDisplayName(props.message, userEmail());
 
   const handleHeaderClick = (e: MouseEvent) => {
     const id = props.message.db_id;

--- a/apps/web/src/features/block-email/component/EmailMessageTopBar.tsx
+++ b/apps/web/src/features/block-email/component/EmailMessageTopBar.tsx
@@ -176,8 +176,8 @@ function HeaderTopRow(props: {
   ]);
 
   return (
-    <div class="flex flex-row w-full items-center justify-between gap-2 text-xs min-w-0">
-      <div class="flex flex-row items-center gap-1.5 min-w-0">
+    <div class="flex flex-row w-full min-w-0 flex-1 items-center gap-2 text-sm">
+      <div class="flex flex-row items-center gap-1.5 min-w-0 flex-1">
         <EmailUserTooltip recipient={props.message.from}>
           <span class="text-ink font-medium cursor-default">
             {props.senderName}
@@ -190,13 +190,6 @@ function HeaderTopRow(props: {
             currentUserEmail={props.currentUserEmail}
           />
         </span>
-        <Show when={props.message.internal_date_ts}>
-          <Tooltip label={formatFullDate(props.message.internal_date_ts!)}>
-            <span class="text-xs text-ink-extra-muted/60 tabular-nums cursor-default shrink-0">
-              {formatShortDate(props.message.internal_date_ts!)}
-            </span>
-          </Tooltip>
-        </Show>
         <div
           classList={{
             'opacity-0': !props.isHovering && !props.isExpanded,
@@ -237,6 +230,13 @@ function HeaderTopRow(props: {
           hiddenActions={props.hiddenActions}
         />
       </div>
+      <Show when={props.message.internal_date_ts}>
+        <Tooltip label={formatFullDate(props.message.internal_date_ts!)}>
+          <span class="text-ink-extra-muted/60 tabular-nums cursor-default shrink-0">
+            {formatShortDate(props.message.internal_date_ts!)}
+          </span>
+        </Tooltip>
+      </Show>
     </div>
   );
 }

--- a/apps/web/src/features/block-email/component/EmailMessageTopBar.tsx
+++ b/apps/web/src/features/block-email/component/EmailMessageTopBar.tsx
@@ -39,7 +39,7 @@ interface Recipient {
   email?: string | null;
 }
 
-function formatFullDate(date: DateValue): string {
+export function formatFullDate(date: DateValue): string {
   return new Date(date)
     .toLocaleString('en-US', {
       weekday: 'long',

--- a/apps/web/src/features/block-email/component/MessageContainer.tsx
+++ b/apps/web/src/features/block-email/component/MessageContainer.tsx
@@ -29,6 +29,9 @@ interface MessageContainerProps {
   isFocused: boolean;
   isTarget: boolean;
   isExpanded: boolean;
+  flushTop?: boolean;
+  flushBottom?: boolean;
+  showBottomBorder?: boolean;
   markdownDomRef?: (ref: HTMLDivElement) => void | HTMLDivElement;
 }
 
@@ -212,6 +215,7 @@ export function MessageContainer(props: MessageContainerProps) {
         <CollapsedMessage
           message={props.message}
           isFocused={props.isFocused}
+          showBottomBorder={props.showBottomBorder}
           onClick={handleExpand}
           onFocus={() => {
             if (props.message.db_id) {
@@ -225,13 +229,15 @@ export function MessageContainer(props: MessageContainerProps) {
       <div class="shrink-0 flex justify-center w-full">
         <div class="macro-message-width macro-message-padding w-full">
           <div
-            class="relative rounded-lg overflow-hidden p-4 border"
+            class="relative overflow-hidden p-4 border macro-thread-card-outdent"
             style={{ '--user-icon-width': '1rem' }}
             classList={{
-              'bg-accent border-transparent': props.isTarget,
-              'bg-active border-edge': !props.isTarget && props.isFocused,
-              'bg-ink-muted/4 border-transparent':
-                !props.isTarget && !props.isFocused,
+              'border-edge': props.isTarget || props.isFocused,
+              'border-edge-muted': !props.isTarget && !props.isFocused,
+              'bg-list-highlighted': props.isFocused && !isTouchDevice(),
+              'hover:bg-list-hover': !props.isFocused && !isTouchDevice(),
+              'macro-thread-card-flush-top': props.flushTop,
+              'macro-thread-card-flush-bottom': props.flushBottom,
             }}
             data-message-body-id={props.message.db_id}
             tabIndex={0}

--- a/apps/web/src/features/block-email/component/MessageContainer.tsx
+++ b/apps/web/src/features/block-email/component/MessageContainer.tsx
@@ -28,7 +28,6 @@ interface MessageContainerProps {
   isFirstMessage: boolean;
   isLastMessage: boolean;
   isFocused: boolean;
-  isTarget: boolean;
   isExpanded: boolean;
   markdownDomRef?: (ref: HTMLDivElement) => void | HTMLDivElement;
 }
@@ -231,7 +230,7 @@ export function MessageContainer(props: MessageContainerProps) {
       <div class="shrink-0 flex justify-center w-full">
         <div class="macro-message-width macro-message-padding w-full">
           <div
-            class="relative p-4 border bg-surface macro-thread-card-outdent"
+            class="relative p-4 border bg-message macro-thread-card-outdent"
             style={{ '--user-icon-width': '1rem' }}
             classList={{
               'border-rail': props.isFocused,

--- a/apps/web/src/features/block-email/component/MessageContainer.tsx
+++ b/apps/web/src/features/block-email/component/MessageContainer.tsx
@@ -5,6 +5,7 @@ import { EmailInput } from '@block-email/component/EmailInput';
 import { EmailMessageBody } from '@block-email/component/EmailMessageBody';
 import { EmailMessageTopBar } from '@block-email/component/EmailMessageTopBar';
 import { getSenderMacroId } from '@block-email/util/emailUser';
+import { revealMessageAfterLayout } from '@block-email/util/scrollToMessage';
 import { useSplitLayout } from '@components/app/split-layout/layout';
 import { FloatingInputLoader } from '@core/component/FloatingInputLoader';
 import { ImageGalleryPreview } from '@core/component/ImageGalleryPreview';
@@ -199,10 +200,15 @@ export function MessageContainer(props: MessageContainerProps) {
   };
 
   const handleExpand = () => {
-    if (props.message.db_id) {
-      context.messages.setExpandedBodyId(props.message.db_id, true);
-      context.messages.setFocused(props.message.db_id);
-    }
+    const messageId = props.message.db_id;
+    if (!messageId) return;
+    context.messages.setExpandedBodyId(messageId, true);
+    context.messages.setFocused(messageId);
+    revealMessageAfterLayout(
+      messageId,
+      context.messages.list(),
+      context.messagesListRef()
+    );
   };
 
   return (

--- a/apps/web/src/features/block-email/component/MessageContainer.tsx
+++ b/apps/web/src/features/block-email/component/MessageContainer.tsx
@@ -29,9 +29,6 @@ interface MessageContainerProps {
   isFocused: boolean;
   isTarget: boolean;
   isExpanded: boolean;
-  flushTop?: boolean;
-  flushBottom?: boolean;
-  showBottomBorder?: boolean;
   markdownDomRef?: (ref: HTMLDivElement) => void | HTMLDivElement;
 }
 
@@ -215,7 +212,6 @@ export function MessageContainer(props: MessageContainerProps) {
         <CollapsedMessage
           message={props.message}
           isFocused={props.isFocused}
-          showBottomBorder={props.showBottomBorder}
           onClick={handleExpand}
           onFocus={() => {
             if (props.message.db_id) {
@@ -229,20 +225,19 @@ export function MessageContainer(props: MessageContainerProps) {
       <div class="shrink-0 flex justify-center w-full">
         <div class="macro-message-width macro-message-padding w-full">
           <div
-            class="relative overflow-hidden p-4 border macro-thread-card-outdent"
+            class="relative p-4 border bg-surface macro-thread-card-outdent"
             style={{ '--user-icon-width': '1rem' }}
             classList={{
-              'border-edge': props.isTarget || props.isFocused,
-              'border-edge-muted': !props.isTarget && !props.isFocused,
-              'bg-list-highlighted': props.isFocused && !isTouchDevice(),
-              'hover:bg-list-hover': !props.isFocused && !isTouchDevice(),
-              'macro-thread-card-flush-top': props.flushTop,
-              'macro-thread-card-flush-bottom': props.flushBottom,
+              'border-edge': props.isFocused,
+              'border-edge-muted': !props.isFocused,
+              'z-1': props.isFocused,
+              'shadow-md': props.isFocused,
+              'shadow-drop-shadow': props.isFocused,
             }}
             data-message-body-id={props.message.db_id}
             tabIndex={0}
           >
-            <div class="flex flex-col min-w-0 gap-2">
+            <div class="flex flex-col min-w-0 gap-2 overflow-hidden">
               <EmailMessageTopBar
                 message={props.message}
                 focused={props.isFocused}

--- a/apps/web/src/features/block-email/component/MessageContainer.tsx
+++ b/apps/web/src/features/block-email/component/MessageContainer.tsx
@@ -230,7 +230,7 @@ export function MessageContainer(props: MessageContainerProps) {
       <div class="shrink-0 flex justify-center w-full">
         <div class="macro-message-width macro-message-padding w-full">
           <div
-            class="relative p-4 border bg-message macro-thread-card-outdent"
+            class="relative p-4 border bg-message rounded-lg"
             style={{ '--user-icon-width': '1rem' }}
             classList={{
               'border-rail': props.isFocused,

--- a/apps/web/src/features/block-email/component/MessageContainer.tsx
+++ b/apps/web/src/features/block-email/component/MessageContainer.tsx
@@ -233,7 +233,7 @@ export function MessageContainer(props: MessageContainerProps) {
             class="relative p-4 border bg-message rounded-lg"
             style={{ '--user-icon-width': '1rem' }}
             classList={{
-              'border-rail': props.isFocused,
+              'border-edge': props.isFocused,
               'border-edge-muted': !props.isFocused,
               'z-1': props.isFocused,
               'shadow-md': props.isFocused,

--- a/apps/web/src/features/block-email/component/MessageContainer.tsx
+++ b/apps/web/src/features/block-email/component/MessageContainer.tsx
@@ -228,7 +228,7 @@ export function MessageContainer(props: MessageContainerProps) {
             class="relative p-4 border bg-surface macro-thread-card-outdent"
             style={{ '--user-icon-width': '1rem' }}
             classList={{
-              'border-edge': props.isFocused,
+              'border-rail': props.isFocused,
               'border-edge-muted': !props.isFocused,
               'z-1': props.isFocused,
               'shadow-md': props.isFocused,

--- a/apps/web/src/features/block-email/component/MessageList.tsx
+++ b/apps/web/src/features/block-email/component/MessageList.tsx
@@ -33,6 +33,8 @@ interface MessageListProps {
    */
   underScrollsBottom?: boolean;
   showMiddleMessages: boolean;
+  hiddenChipFocused: boolean;
+  onHiddenChipFocus: () => void;
   onOpenMiddle: () => void;
 }
 
@@ -204,7 +206,12 @@ export function MessageList(props: MessageListProps) {
                         <Button
                           variant="ghost"
                           size="sm"
-                          class="relative bg-panel px-2 text-xs font-medium text-ink-muted"
+                          class={cn(
+                            'relative bg-panel px-2 text-xs font-medium text-ink-muted outline-none',
+                            props.hiddenChipFocused && 'bg-active text-ink'
+                          )}
+                          data-hidden-messages
+                          onFocus={() => props.onHiddenChipFocus()}
                           onClick={() => props.onOpenMiddle()}
                         >
                           Show {hiddenCount()} hidden{' '}

--- a/apps/web/src/features/block-email/component/MessageList.tsx
+++ b/apps/web/src/features/block-email/component/MessageList.tsx
@@ -2,19 +2,18 @@ import { useEmailContext } from '@block-email/component/EmailContext';
 import { isScrollingToMessage } from '@block-email/signal/scrollState';
 import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
+import { Key } from '@solid-primitives/keyed';
 import { Button, cn } from '@ui';
 import {
   createEffect,
   createMemo,
   createSelector,
-  createSignal,
-  Index,
-  on,
   onCleanup,
   Show,
 } from 'solid-js';
 import {
   isTruncatedMiddleMessage,
+  isUnreadMessage,
   threadMessageIsExpanded,
   truncatedMiddleCount,
 } from '../util/scrollToMessage';
@@ -25,7 +24,6 @@ import { MessageContainer } from './MessageContainer';
 interface MessageListProps {
   initialLoadComplete: boolean;
   markdownDomRef?: (ref: HTMLDivElement) => void | HTMLDivElement;
-  onScrollPositionChange?: (scrollFromTop: number) => void;
   title?: string;
   /**
    * Full-frame mobile: when nothing is in flow below the list (the collapsed
@@ -33,6 +31,8 @@ interface MessageListProps {
    * inset in-scroll so the last message rests above the floating chrome.
    */
   underScrollsBottom?: boolean;
+  showMiddleMessages: boolean;
+  onOpenMiddle: () => void;
 }
 
 export function MessageList(props: MessageListProps) {
@@ -42,37 +42,6 @@ export function MessageList(props: MessageListProps) {
     context.messages.focusedID,
     (a, b) => !!a && !!b && a === b
   );
-  const isTargetSelector = createSelector(
-    context.messages.targetMessageID,
-    (a, b) => a === b
-  );
-  const [showMiddleMessages, setShowMiddleMessages] = createSignal(false);
-
-  createEffect(
-    on(
-      () => context.thread()?.db_id,
-      () => setShowMiddleMessages(false)
-    )
-  );
-
-  createEffect(() => {
-    const messages = context.messages.list();
-    const ids = [
-      context.messages.targetMessageID(),
-      context.messages.focusedID(),
-    ];
-    for (const id of ids) {
-      if (typeof id !== 'string') continue;
-      const chronologicalIndex = messages.findIndex(
-        (message) => message.db_id === id
-      );
-      if (isTruncatedMiddleMessage(chronologicalIndex, messages.length)) {
-        setShowMiddleMessages(true);
-        return;
-      }
-    }
-  });
-
   createEffect(() => {
     const list = context.messagesListRef();
     if (!list) return;
@@ -98,7 +67,6 @@ export function MessageList(props: MessageListProps) {
       ref={context.registerMessagesList}
       onscroll={(e) => {
         const scrollFromTop = e.currentTarget.scrollTop;
-        props.onScrollPositionChange?.(scrollFromTop);
 
         if (getIsScrollingToMessage() || !props.initialLoadComplete) return;
 
@@ -133,41 +101,39 @@ export function MessageList(props: MessageListProps) {
         </div>
       </Show>
       <StaticMarkdownContext>
-        {/* We use Index because the index of the messages should always be stable and
-          only the value changes. This also helps prevent nested inputs from rerendering
-        */}
-        <Index each={context.messages.list()}>
-          {(message, index) => {
+        {/* Key by db_id so prepends and refetches keep per-row state. */}
+        <Key each={context.messages.list()} by="db_id">
+          {(message) => {
+            const chronologicalIndex = createMemo(() =>
+              context.messages
+                .list()
+                .findIndex((item) => item.db_id === message().db_id)
+            );
             const normalizedIndex = createMemo(() => {
               // The element at the 0th index isn't actually the first message
               // if there is more data to load so we return -1 so that `isFirstMessage`
               // evaluates to false. This fixes an issue with the "first" message' full
               // html to show in `EmailMessageBody`
-              if (index === 0 && context.query.hasMore()) {
+              if (chronologicalIndex() === 0 && context.query.hasMore()) {
                 return -1;
               }
 
-              return index;
+              return chronologicalIndex();
             });
 
             const isLastMessage = createMemo(() => {
-              return index === (context.messages.list().length ?? 0) - 1;
+              return (
+                chronologicalIndex() ===
+                (context.messages.list().length ?? 0) - 1
+              );
             });
             const hideMiddle = createMemo(() => {
               return (
-                !showMiddleMessages() &&
+                !props.showMiddleMessages &&
                 isTruncatedMiddleMessage(
-                  index,
+                  chronologicalIndex(),
                   context.messages.list().length
                 )
-              );
-            });
-
-            const isNewMessage = createMemo(() => {
-              return (
-                message().labels.find(
-                  (l) => l.provider_label_id === 'UNREAD'
-                ) !== undefined
               );
             });
 
@@ -184,10 +150,10 @@ export function MessageList(props: MessageListProps) {
               const messageID = message().db_id;
               if (!messageID) return false;
               return threadMessageIsExpanded({
-                chronologicalIndex: index,
+                chronologicalIndex: chronologicalIndex(),
                 listLength: context.messages.list().length,
                 expansionOverride: context.messages.expandedBodyIds[messageID],
-                isUnread: isNewMessage(),
+                isUnread: isUnreadMessage(message()),
                 hasDraft: hasDraft(),
               });
             });
@@ -199,7 +165,6 @@ export function MessageList(props: MessageListProps) {
                     isFirstMessage={normalizedIndex() === 0}
                     isLastMessage={isLastMessage()}
                     isFocused={isFocusedSelector(message().db_id ?? undefined)}
-                    isTarget={isTargetSelector(message().db_id ?? undefined)}
                     message={message()}
                     isExpanded={isExpanded()}
                     markdownDomRef={
@@ -209,8 +174,8 @@ export function MessageList(props: MessageListProps) {
                 </Show>
                 <Show
                   when={
-                    index === 0 &&
-                    !showMiddleMessages() &&
+                    chronologicalIndex() === 0 &&
+                    !props.showMiddleMessages &&
                     truncatedMiddleCount(context.messages.list().length) > 0
                   }
                 >
@@ -225,12 +190,10 @@ export function MessageList(props: MessageListProps) {
                           variant="ghost"
                           size="sm"
                           class="relative bg-panel px-2 text-xs font-medium text-ink-muted"
-                          onClick={() => setShowMiddleMessages(true)}
+                          onClick={() => props.onOpenMiddle()}
                         >
                           Show{' '}
-                          {truncatedMiddleCount(
-                            context.messages.list().length
-                          )}{' '}
+                          {truncatedMiddleCount(context.messages.list().length)}{' '}
                           hidden messages
                         </Button>
                       </div>
@@ -240,7 +203,7 @@ export function MessageList(props: MessageListProps) {
               </>
             );
           }}
-        </Index>
+        </Key>
       </StaticMarkdownContext>
     </div>
   );

--- a/apps/web/src/features/block-email/component/MessageList.tsx
+++ b/apps/web/src/features/block-email/component/MessageList.tsx
@@ -216,26 +216,24 @@ export function MessageList(props: MessageListProps) {
                 >
                   <div class="shrink-0 w-full flex justify-center">
                     <div class="macro-message-width macro-message-padding w-full">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        fullWidth
-                        class="relative h-6 justify-center px-0 text-xs font-medium text-ink-muted"
-                        label={`Show ${truncatedMiddleCount(context.messages.list().length)} hidden messages`}
-                        onClick={() => setShowMiddleMessages(true)}
-                      >
+                      <div class="relative flex h-6 items-center justify-center">
                         <span
                           aria-hidden="true"
                           class="absolute inset-x-0 top-1/2 border-t border-edge-muted"
                         />
-                        <span class="relative bg-panel px-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          class="relative bg-panel px-2 text-xs font-medium text-ink-muted"
+                          onClick={() => setShowMiddleMessages(true)}
+                        >
                           Show{' '}
                           {truncatedMiddleCount(
                             context.messages.list().length
                           )}{' '}
                           hidden messages
-                        </span>
-                      </Button>
+                        </Button>
+                      </div>
                     </div>
                   </div>
                 </Show>

--- a/apps/web/src/features/block-email/component/MessageList.tsx
+++ b/apps/web/src/features/block-email/component/MessageList.tsx
@@ -101,7 +101,7 @@ export function MessageList(props: MessageListProps) {
               'macro-message-width macro-message-padding w-full',
               isTouchDevice()
                 ? 'pt-6 pb-3'
-                : 'border-b border-edge-muted/50 pt-12 pb-2.5'
+                : 'pt-12 pb-2.5'
             )}
           >
             <EmailThreadTitle

--- a/apps/web/src/features/block-email/component/MessageList.tsx
+++ b/apps/web/src/features/block-email/component/MessageList.tsx
@@ -2,7 +2,6 @@ import { useEmailContext } from '@block-email/component/EmailContext';
 import { isScrollingToMessage } from '@block-email/signal/scrollState';
 import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
-import CaretUpDownIcon from '@phosphor-icons/core/regular/caret-up-down.svg?component-solid';
 import { Button, cn } from '@ui';
 import {
   createEffect,
@@ -15,11 +14,7 @@ import {
   Show,
 } from 'solid-js';
 import {
-  collapsedRowShowsDivider,
   isTruncatedMiddleMessage,
-  isUnreadMessage,
-  nextShownChronologicalIndex,
-  shownOpenCardFlush,
   threadMessageIsExpanded,
   truncatedMiddleCount,
 } from '../util/scrollToMessage';
@@ -95,7 +90,7 @@ export function MessageList(props: MessageListProps) {
   return (
     <div
       class={cn(
-        'pt-1 pb-6 w-full flex flex-col items-center overflow-y-scroll overflow-x-hidden scrollbar-hidden text-sm',
+        'pt-1 pb-6 w-full flex flex-col items-center gap-2 overflow-y-scroll overflow-x-hidden scrollbar-hidden text-sm',
         'touch:pt-[calc(var(--mobile-content-inset-top,0)+0.5rem)]',
         props.underScrollsBottom &&
           'touch:pb-[calc(var(--mobile-content-inset-bottom,0)+1.5rem)]'
@@ -197,61 +192,6 @@ export function MessageList(props: MessageListProps) {
               });
             });
 
-            const cardFlush = createMemo(() => {
-              const list = context.messages.list();
-              return shownOpenCardFlush(
-                index,
-                list.length,
-                showMiddleMessages(),
-                (neighborIndex) => {
-                  const neighbor = list[neighborIndex];
-                  const neighborId = neighbor?.db_id;
-                  if (!neighbor || !neighborId) return false;
-                  return threadMessageIsExpanded({
-                    chronologicalIndex: neighborIndex,
-                    listLength: list.length,
-                    expansionOverride:
-                      context.messages.expandedBodyIds[neighborId],
-                    isUnread: isUnreadMessage(neighbor),
-                    hasDraft:
-                      !isTouchDevice() &&
-                      !!context.drafts.getDraftForMessage(neighborId),
-                  });
-                }
-              );
-            });
-
-            const showBottomBorder = createMemo(() => {
-              if (isExpanded()) return false;
-              const list = context.messages.list();
-              const nextIndex = nextShownChronologicalIndex(
-                index,
-                list.length,
-                showMiddleMessages()
-              );
-              const next = nextIndex != null ? list[nextIndex] : undefined;
-              const nextId = next?.db_id;
-              const nextIsCollapsed =
-                nextIndex != null &&
-                !!next &&
-                !!nextId &&
-                !threadMessageIsExpanded({
-                  chronologicalIndex: nextIndex,
-                  listLength: list.length,
-                  expansionOverride: context.messages.expandedBodyIds[nextId],
-                  isUnread: isUnreadMessage(next),
-                  hasDraft:
-                    !isTouchDevice() &&
-                    !!context.drafts.getDraftForMessage(nextId),
-                });
-              return collapsedRowShowsDivider(
-                index,
-                list.length,
-                showMiddleMessages(),
-                nextIsCollapsed
-              );
-            });
-
             return (
               <>
                 <Show when={!hideMiddle()}>
@@ -262,9 +202,6 @@ export function MessageList(props: MessageListProps) {
                     isTarget={isTargetSelector(message().db_id ?? undefined)}
                     message={message()}
                     isExpanded={isExpanded()}
-                    flushTop={cardFlush().top}
-                    flushBottom={cardFlush().bottom}
-                    showBottomBorder={showBottomBorder()}
                     markdownDomRef={
                       isLastMessage() ? props.markdownDomRef : undefined
                     }
@@ -283,22 +220,21 @@ export function MessageList(props: MessageListProps) {
                         variant="ghost"
                         size="sm"
                         fullWidth
-                        class="group justify-start gap-0 px-0 font-semibold macro-thread-avatar-axis"
+                        class="relative h-6 justify-center px-0 text-xs font-medium text-ink-muted"
                         label={`Show ${truncatedMiddleCount(context.messages.list().length)} hidden messages`}
                         onClick={() => setShowMiddleMessages(true)}
                       >
-                        <span class="relative shrink-0 size-6 flex items-center justify-center border border-edge-muted bg-panel text-xs font-semibold text-ink rounded-sm">
-                          <span class="group-hover:invisible">
-                            {truncatedMiddleCount(
-                              context.messages.list().length
-                            )}
-                          </span>
-                          <CaretUpDownIcon class="absolute inset-0 m-auto size-3 opacity-0 group-hover:opacity-100" />
-                        </span>
-                        <div
+                        <span
                           aria-hidden="true"
-                          class="h-1.5 min-w-0 flex-1 border-y border-edge-muted bg-ink-muted/4"
+                          class="absolute inset-x-0 top-1/2 border-t border-edge-muted"
                         />
+                        <span class="relative bg-panel px-2">
+                          Show{' '}
+                          {truncatedMiddleCount(
+                            context.messages.list().length
+                          )}{' '}
+                          hidden messages
+                        </span>
                       </Button>
                     </div>
                   </div>

--- a/apps/web/src/features/block-email/component/MessageList.tsx
+++ b/apps/web/src/features/block-email/component/MessageList.tsx
@@ -278,7 +278,7 @@ export function MessageList(props: MessageListProps) {
                         label={`Show ${truncatedMiddleCount(context.messages.list().length)} hidden messages`}
                         onClick={() => setShowMiddleMessages(true)}
                       >
-                        <span class="relative shrink-0 size-6 flex items-center justify-center bg-panel text-xs font-semibold text-ink rounded-sm">
+                        <span class="relative shrink-0 size-6 flex items-center justify-center border border-edge-muted bg-panel text-xs font-semibold text-ink rounded-sm">
                           <span class="group-hover:invisible">
                             {truncatedMiddleCount(
                               context.messages.list().length

--- a/apps/web/src/features/block-email/component/MessageList.tsx
+++ b/apps/web/src/features/block-email/component/MessageList.tsx
@@ -12,6 +12,7 @@ import {
   Show,
 } from 'solid-js';
 import {
+  adjustScrollAfterPrepend,
   isTruncatedMiddleMessage,
   isUnreadMessage,
   threadMessageIsExpanded,
@@ -42,6 +43,9 @@ export function MessageList(props: MessageListProps) {
     context.messages.focusedID,
     (a, b) => !!a && !!b && a === b
   );
+  const hiddenCount = createMemo(() =>
+    truncatedMiddleCount(context.messages.list().length)
+  );
   createEffect(() => {
     const list = context.messagesListRef();
     if (!list) return;
@@ -66,7 +70,8 @@ export function MessageList(props: MessageListProps) {
       )}
       ref={context.registerMessagesList}
       onscroll={(e) => {
-        const scrollFromTop = e.currentTarget.scrollTop;
+        const list = e.currentTarget;
+        const scrollFromTop = list.scrollTop;
 
         if (getIsScrollingToMessage() || !props.initialLoadComplete) return;
 
@@ -75,7 +80,17 @@ export function MessageList(props: MessageListProps) {
           !context.query.isFetching() &&
           context.query.hasMore()
         ) {
-          context.query.fetchNextPage();
+          const previousScrollHeight = list.scrollHeight;
+          const previousScrollTop = list.scrollTop;
+          void Promise.resolve(context.query.fetchNextPage()).then(() => {
+            requestAnimationFrame(() => {
+              adjustScrollAfterPrepend(
+                list,
+                previousScrollHeight,
+                previousScrollTop
+              );
+            });
+          });
         }
       }}
     >
@@ -176,7 +191,7 @@ export function MessageList(props: MessageListProps) {
                   when={
                     chronologicalIndex() === 0 &&
                     !props.showMiddleMessages &&
-                    truncatedMiddleCount(context.messages.list().length) > 0
+                    hiddenCount() > 0
                   }
                 >
                   <div class="shrink-0 w-full flex justify-center">
@@ -192,9 +207,8 @@ export function MessageList(props: MessageListProps) {
                           class="relative bg-panel px-2 text-xs font-medium text-ink-muted"
                           onClick={() => props.onOpenMiddle()}
                         >
-                          Show{' '}
-                          {truncatedMiddleCount(context.messages.list().length)}{' '}
-                          hidden messages
+                          Show {hiddenCount()} hidden{' '}
+                          {hiddenCount() === 1 ? 'message' : 'messages'}
                         </Button>
                       </div>
                     </div>

--- a/apps/web/src/features/block-email/component/MessageList.tsx
+++ b/apps/web/src/features/block-email/component/MessageList.tsx
@@ -90,7 +90,7 @@ export function MessageList(props: MessageListProps) {
   return (
     <div
       class={cn(
-        'pt-1 pb-6 w-full flex flex-col items-center gap-2 overflow-y-scroll overflow-x-hidden scrollbar-hidden text-sm',
+        'pt-1 pb-6 w-full flex flex-col items-center gap-2 overflow-y-scroll overflow-x-hidden [overflow-anchor:none] scrollbar-hidden text-sm',
         'touch:pt-[calc(var(--mobile-content-inset-top,0)+0.5rem)]',
         props.underScrollsBottom &&
           'touch:pb-[calc(var(--mobile-content-inset-bottom,0)+1.5rem)]'

--- a/apps/web/src/features/block-email/component/MessageList.tsx
+++ b/apps/web/src/features/block-email/component/MessageList.tsx
@@ -2,15 +2,28 @@ import { useEmailContext } from '@block-email/component/EmailContext';
 import { isScrollingToMessage } from '@block-email/signal/scrollState';
 import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
-import { cn } from '@ui';
+import CaretUpDownIcon from '@phosphor-icons/core/regular/caret-up-down.svg?component-solid';
+import { Button, cn } from '@ui';
 import {
   createEffect,
   createMemo,
   createSelector,
+  createSignal,
   Index,
+  on,
   onCleanup,
   Show,
 } from 'solid-js';
+import {
+  collapsedRowShowsDivider,
+  isTruncatedMiddleMessage,
+  isUnreadMessage,
+  nextShownChronologicalIndex,
+  shownOpenCardFlush,
+  threadMessageIsExpanded,
+  truncatedMiddleCount,
+} from '../util/scrollToMessage';
+import { EmailParticipants } from './EmailParticipants';
 import { EmailThreadTitle } from './EmailThreadTitle';
 import { MessageContainer } from './MessageContainer';
 
@@ -42,6 +55,32 @@ export function MessageList(props: MessageListProps) {
     context.messages.targetMessageID,
     (a, b) => a === b
   );
+  const [showMiddleMessages, setShowMiddleMessages] = createSignal(false);
+
+  createEffect(
+    on(
+      () => context.thread()?.db_id,
+      () => setShowMiddleMessages(false)
+    )
+  );
+
+  createEffect(() => {
+    const messages = context.messages.list();
+    const ids = [
+      context.messages.targetMessageID(),
+      context.messages.focusedID(),
+    ];
+    for (const id of ids) {
+      if (typeof id !== 'string') continue;
+      const chronologicalIndex = messages.findIndex(
+        (message) => message.db_id === id
+      );
+      if (isTruncatedMiddleMessage(chronologicalIndex, messages.length)) {
+        setShowMiddleMessages(true);
+        return;
+      }
+    }
+  });
 
   // Since the list is bottom-anchored (col-reverse), extra bottom padding is
   // the only way to let the newest message rest above the bottom edge. A
@@ -51,14 +90,17 @@ export function MessageList(props: MessageListProps) {
   createEffect(() => {
     const list = context.messagesListRef();
     if (!list || isTouchDevice()) return;
-    const observer = new ResizeObserver(() => {
-      list.style.setProperty(
-        '--thread-bottom-pad',
-        `${Math.round(list.clientHeight * LAST_MESSAGE_REST_FRACTION)}px`
+
+    const applyPad = () => {
+      const restPad = Math.round(
+        list.clientHeight * LAST_MESSAGE_REST_FRACTION
       );
-      // Lets the inline composer cap its height to the visible thread area
+      list.style.setProperty('--thread-bottom-pad', `${restPad}px`);
       list.style.setProperty('--thread-height', `${list.clientHeight}px`);
-    });
+    };
+
+    applyPad();
+    const observer = new ResizeObserver(applyPad);
     observer.observe(list);
     onCleanup(() => observer.disconnect());
   });
@@ -66,7 +108,7 @@ export function MessageList(props: MessageListProps) {
   return (
     <div
       class={cn(
-        'pt-1 pb-[calc(1.5rem+var(--thread-bottom-pad,0px))] w-full flex flex-col-reverse items-center overflow-y-scroll overflow-x-hidden scrollbar-hidden text-sm gap-1.5',
+        'pt-1 pb-[calc(1.5rem+var(--thread-bottom-pad,0px))] w-full flex flex-col-reverse items-center overflow-y-scroll overflow-x-hidden scrollbar-hidden text-sm',
         // In-scroll top inset: messages rest below the floating split chrome
         // but under-scroll it.
         'touch:pt-[calc(var(--mobile-content-inset-top,0)+0.5rem)]',
@@ -126,6 +168,13 @@ export function MessageList(props: MessageListProps) {
                 normalizedIndex() === (context.messages.list().length ?? 0) - 1
               );
             });
+            const hideMiddle = createMemo(() => {
+              const listLength = context.messages.list().length;
+              return (
+                !showMiddleMessages() &&
+                isTruncatedMiddleMessage(listLength - 1 - index, listLength)
+              );
+            });
 
             const isNewMessage = createMemo(() => {
               return (
@@ -146,43 +195,144 @@ export function MessageList(props: MessageListProps) {
 
             const isExpanded = createMemo(() => {
               const messageID = message().db_id;
-
               if (!messageID) return false;
-              const manuallyExpanded =
-                context.messages.isBodyExpanded(messageID);
+              return threadMessageIsExpanded({
+                chronologicalIndex: context.messages.list().length - 1 - index,
+                listLength: context.messages.list().length,
+                isManuallyExpanded: context.messages.isBodyExpanded(messageID),
+                isUnread: isNewMessage(),
+                hasDraft: hasDraft(),
+              });
+            });
 
-              return (
-                manuallyExpanded ||
-                isLastMessage() ||
-                isNewMessage() ||
-                hasDraft()
+            const cardFlush = createMemo(() => {
+              const list = context.messages.list();
+              const chronologicalIndex = list.length - 1 - index;
+              return shownOpenCardFlush(
+                chronologicalIndex,
+                list.length,
+                showMiddleMessages(),
+                (neighborIndex) => {
+                  const neighbor = list[neighborIndex];
+                  const neighborId = neighbor?.db_id;
+                  if (!neighbor || !neighborId) return false;
+                  return threadMessageIsExpanded({
+                    chronologicalIndex: neighborIndex,
+                    listLength: list.length,
+                    isManuallyExpanded:
+                      context.messages.isBodyExpanded(neighborId),
+                    isUnread: isUnreadMessage(neighbor),
+                    hasDraft:
+                      !isTouchDevice() &&
+                      !!context.drafts.getDraftForMessage(neighborId),
+                  });
+                }
+              );
+            });
+
+            const showBottomBorder = createMemo(() => {
+              if (isExpanded()) return false;
+              const list = context.messages.list();
+              const chronologicalIndex = list.length - 1 - index;
+              const nextIndex = nextShownChronologicalIndex(
+                chronologicalIndex,
+                list.length,
+                showMiddleMessages()
+              );
+              const next = nextIndex != null ? list[nextIndex] : undefined;
+              const nextId = next?.db_id;
+              const nextIsCollapsed =
+                nextIndex != null &&
+                !!next &&
+                !!nextId &&
+                !context.messages.isBodyExpanded(nextId) &&
+                nextIndex !== list.length - 1 &&
+                !next.labels.some((l) => l.provider_label_id === 'UNREAD') &&
+                !(
+                  !isTouchDevice() && !!context.drafts.getDraftForMessage(nextId)
+                );
+              return collapsedRowShowsDivider(
+                chronologicalIndex,
+                list.length,
+                showMiddleMessages(),
+                nextIsCollapsed
               );
             });
 
             return (
-              <MessageContainer
-                isFirstMessage={normalizedIndex() === 0}
-                isLastMessage={isLastMessage()}
-                isFocused={isFocusedSelector(message().db_id ?? undefined)}
-                isTarget={isTargetSelector(message().db_id ?? undefined)}
-                message={message()}
-                isExpanded={isExpanded()}
-                markdownDomRef={
-                  isLastMessage() ? props.markdownDomRef : undefined
-                }
-              />
+              <>
+                <Show
+                  when={
+                    context.messages.list().length - 1 - index === 0 &&
+                    !showMiddleMessages() &&
+                    truncatedMiddleCount(context.messages.list().length) > 0
+                  }
+                >
+                  <div class="shrink-0 w-full flex justify-center">
+                    <div class="macro-message-width macro-message-padding w-full">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        fullWidth
+                        class="group h-auto min-h-6 justify-start gap-0 px-0 py-1 font-semibold macro-thread-avatar-axis"
+                        label={`Show ${truncatedMiddleCount(context.messages.list().length)} hidden messages`}
+                        onClick={() => setShowMiddleMessages(true)}
+                      >
+                        <span class="relative shrink-0 size-6 flex items-center justify-center bg-panel text-xs font-semibold text-ink rounded-sm">
+                          <span class="group-hover:invisible">
+                            {truncatedMiddleCount(
+                              context.messages.list().length
+                            )}
+                          </span>
+                          <CaretUpDownIcon class="absolute inset-0 m-auto size-3 opacity-0 group-hover:opacity-100" />
+                        </span>
+                        <div
+                          aria-hidden="true"
+                          class="h-1.5 min-w-0 flex-1 border-y border-edge-muted bg-ink-muted/4"
+                        />
+                      </Button>
+                    </div>
+                  </div>
+                </Show>
+                <Show when={!hideMiddle()}>
+                  <MessageContainer
+                    isFirstMessage={normalizedIndex() === 0}
+                    isLastMessage={isLastMessage()}
+                    isFocused={isFocusedSelector(message().db_id ?? undefined)}
+                    isTarget={isTargetSelector(message().db_id ?? undefined)}
+                    message={message()}
+                    isExpanded={isExpanded()}
+                    flushTop={cardFlush().top}
+                    flushBottom={cardFlush().bottom}
+                    showBottomBorder={showBottomBorder()}
+                    markdownDomRef={
+                      isLastMessage() ? props.markdownDomRef : undefined
+                    }
+                  />
+                </Show>
+              </>
             );
           }}
         </Index>
       </StaticMarkdownContext>
-      <Show when={isTouchDevice() && props.title}>
-        <div class="shrink-0 w-full flex justify-center pb-3">
-          <div class="macro-message-width macro-message-padding w-full">
+      <Show when={props.title}>
+        <div class="shrink-0 w-full flex justify-center">
+          <div
+            class={cn(
+              'macro-message-width macro-message-padding w-full',
+              isTouchDevice()
+                ? 'pt-6 pb-3'
+                : 'border-b border-edge-muted/50 pt-12 pb-2.5'
+            )}
+          >
             <EmailThreadTitle
               title={props.title ?? ''}
-              copyReveal="always"
-              class="text-xl pt-1 pb-0"
+              copyReveal={isTouchDevice() ? 'always' : 'hover'}
+              class={isTouchDevice() ? 'text-xl pt-1 pb-0' : 'text-2xl pb-1.5'}
             />
+            <Show when={!isTouchDevice()}>
+              <EmailParticipants />
+            </Show>
           </div>
         </div>
       </Show>

--- a/apps/web/src/features/block-email/component/MessageList.tsx
+++ b/apps/web/src/features/block-email/component/MessageList.tsx
@@ -27,10 +27,6 @@ import { EmailParticipants } from './EmailParticipants';
 import { EmailThreadTitle } from './EmailThreadTitle';
 import { MessageContainer } from './MessageContainer';
 
-// Fraction of the list height reserved below the newest message so it rests
-// toward the middle of the view instead of pinned to the bottom edge.
-const LAST_MESSAGE_REST_FRACTION = 0.4;
-
 interface MessageListProps {
   initialLoadComplete: boolean;
   markdownDomRef?: (ref: HTMLDivElement) => void | HTMLDivElement;
@@ -82,25 +78,16 @@ export function MessageList(props: MessageListProps) {
     }
   });
 
-  // Since the list is bottom-anchored (col-reverse), extra bottom padding is
-  // the only way to let the newest message rest above the bottom edge. A
-  // thread that fills the screen gets its oldest messages pushed above the
-  // fold (still one scroll away) — the newest message resting at a
-  // consistent height wins over keeping the whole thread in view.
   createEffect(() => {
     const list = context.messagesListRef();
-    if (!list || isTouchDevice()) return;
+    if (!list) return;
 
-    const applyPad = () => {
-      const restPad = Math.round(
-        list.clientHeight * LAST_MESSAGE_REST_FRACTION
-      );
-      list.style.setProperty('--thread-bottom-pad', `${restPad}px`);
+    const applyHeight = () => {
       list.style.setProperty('--thread-height', `${list.clientHeight}px`);
     };
 
-    applyPad();
-    const observer = new ResizeObserver(applyPad);
+    applyHeight();
+    const observer = new ResizeObserver(applyHeight);
     observer.observe(list);
     onCleanup(() => observer.disconnect());
   });
@@ -108,31 +95,20 @@ export function MessageList(props: MessageListProps) {
   return (
     <div
       class={cn(
-        'pt-1 pb-[calc(1.5rem+var(--thread-bottom-pad,0px))] w-full flex flex-col-reverse items-center overflow-y-scroll overflow-x-hidden scrollbar-hidden text-sm',
-        // In-scroll top inset: messages rest below the floating split chrome
-        // but under-scroll it.
+        'pt-1 pb-6 w-full flex flex-col items-center overflow-y-scroll overflow-x-hidden scrollbar-hidden text-sm',
         'touch:pt-[calc(var(--mobile-content-inset-top,0)+0.5rem)]',
         props.underScrollsBottom &&
           'touch:pb-[calc(var(--mobile-content-inset-bottom,0)+1.5rem)]'
       )}
       ref={context.registerMessagesList}
       onscroll={(e) => {
-        // Since the list is reversed, calculate scroll from visual top
-        const scrollFromTop =
-          e.currentTarget.scrollHeight +
-          e.currentTarget.scrollTop -
-          e.currentTarget.clientHeight;
-
+        const scrollFromTop = e.currentTarget.scrollTop;
         props.onScrollPositionChange?.(scrollFromTop);
 
-        // Don't load more if we're programmatically scrolling to a message
         if (getIsScrollingToMessage() || !props.initialLoadComplete) return;
 
-        const threshold = 300;
-        const isNearBeginning = scrollFromTop <= threshold;
-
         if (
-          isNearBeginning &&
+          scrollFromTop <= 300 &&
           !context.query.isFetching() &&
           context.query.hasMore()
         ) {
@@ -140,39 +116,55 @@ export function MessageList(props: MessageListProps) {
         }
       }}
     >
+      <Show when={props.title}>
+        <div class="shrink-0 w-full flex justify-center">
+          <div
+            class={cn(
+              'macro-message-width macro-message-padding w-full',
+              isTouchDevice()
+                ? 'pt-6 pb-3'
+                : 'border-b border-edge-muted/50 pt-12 pb-2.5'
+            )}
+          >
+            <EmailThreadTitle
+              title={props.title ?? ''}
+              copyReveal={isTouchDevice() ? 'always' : 'hover'}
+              class={isTouchDevice() ? 'text-xl pt-1 pb-0' : 'text-2xl pb-1.5'}
+            />
+            <Show when={!isTouchDevice()}>
+              <EmailParticipants />
+            </Show>
+          </div>
+        </div>
+      </Show>
       <StaticMarkdownContext>
         {/* We use Index because the index of the messages should always be stable and
           only the value changes. This also helps prevent nested inputs from rerendering
         */}
-        <Index each={context.messages.list().toReversed()}>
+        <Index each={context.messages.list()}>
           {(message, index) => {
-            // We need the index as if the list was not reversed
             const normalizedIndex = createMemo(() => {
-              const listLength = context.messages.list().length;
-
-              const normalized = listLength - 1 - index;
-
               // The element at the 0th index isn't actually the first message
               // if there is more data to load so we return -1 so that `isFirstMessage`
               // evaluates to false. This fixes an issue with the "first" message' full
               // html to show in `EmailMessageBody`
-              if (normalized === 0 && context.query.hasMore()) {
+              if (index === 0 && context.query.hasMore()) {
                 return -1;
               }
 
-              return normalized;
+              return index;
             });
 
             const isLastMessage = createMemo(() => {
-              return (
-                normalizedIndex() === (context.messages.list().length ?? 0) - 1
-              );
+              return index === (context.messages.list().length ?? 0) - 1;
             });
             const hideMiddle = createMemo(() => {
-              const listLength = context.messages.list().length;
               return (
                 !showMiddleMessages() &&
-                isTruncatedMiddleMessage(listLength - 1 - index, listLength)
+                isTruncatedMiddleMessage(
+                  index,
+                  context.messages.list().length
+                )
               );
             });
 
@@ -197,9 +189,9 @@ export function MessageList(props: MessageListProps) {
               const messageID = message().db_id;
               if (!messageID) return false;
               return threadMessageIsExpanded({
-                chronologicalIndex: context.messages.list().length - 1 - index,
+                chronologicalIndex: index,
                 listLength: context.messages.list().length,
-                isManuallyExpanded: context.messages.isBodyExpanded(messageID),
+                expansionOverride: context.messages.expandedBodyIds[messageID],
                 isUnread: isNewMessage(),
                 hasDraft: hasDraft(),
               });
@@ -207,9 +199,8 @@ export function MessageList(props: MessageListProps) {
 
             const cardFlush = createMemo(() => {
               const list = context.messages.list();
-              const chronologicalIndex = list.length - 1 - index;
               return shownOpenCardFlush(
-                chronologicalIndex,
+                index,
                 list.length,
                 showMiddleMessages(),
                 (neighborIndex) => {
@@ -219,8 +210,8 @@ export function MessageList(props: MessageListProps) {
                   return threadMessageIsExpanded({
                     chronologicalIndex: neighborIndex,
                     listLength: list.length,
-                    isManuallyExpanded:
-                      context.messages.isBodyExpanded(neighborId),
+                    expansionOverride:
+                      context.messages.expandedBodyIds[neighborId],
                     isUnread: isUnreadMessage(neighbor),
                     hasDraft:
                       !isTouchDevice() &&
@@ -233,9 +224,8 @@ export function MessageList(props: MessageListProps) {
             const showBottomBorder = createMemo(() => {
               if (isExpanded()) return false;
               const list = context.messages.list();
-              const chronologicalIndex = list.length - 1 - index;
               const nextIndex = nextShownChronologicalIndex(
-                chronologicalIndex,
+                index,
                 list.length,
                 showMiddleMessages()
               );
@@ -245,14 +235,17 @@ export function MessageList(props: MessageListProps) {
                 nextIndex != null &&
                 !!next &&
                 !!nextId &&
-                !context.messages.isBodyExpanded(nextId) &&
-                nextIndex !== list.length - 1 &&
-                !next.labels.some((l) => l.provider_label_id === 'UNREAD') &&
-                !(
-                  !isTouchDevice() && !!context.drafts.getDraftForMessage(nextId)
-                );
+                !threadMessageIsExpanded({
+                  chronologicalIndex: nextIndex,
+                  listLength: list.length,
+                  expansionOverride: context.messages.expandedBodyIds[nextId],
+                  isUnread: isUnreadMessage(next),
+                  hasDraft:
+                    !isTouchDevice() &&
+                    !!context.drafts.getDraftForMessage(nextId),
+                });
               return collapsedRowShowsDivider(
-                chronologicalIndex,
+                index,
                 list.length,
                 showMiddleMessages(),
                 nextIsCollapsed
@@ -261,9 +254,25 @@ export function MessageList(props: MessageListProps) {
 
             return (
               <>
+                <Show when={!hideMiddle()}>
+                  <MessageContainer
+                    isFirstMessage={normalizedIndex() === 0}
+                    isLastMessage={isLastMessage()}
+                    isFocused={isFocusedSelector(message().db_id ?? undefined)}
+                    isTarget={isTargetSelector(message().db_id ?? undefined)}
+                    message={message()}
+                    isExpanded={isExpanded()}
+                    flushTop={cardFlush().top}
+                    flushBottom={cardFlush().bottom}
+                    showBottomBorder={showBottomBorder()}
+                    markdownDomRef={
+                      isLastMessage() ? props.markdownDomRef : undefined
+                    }
+                  />
+                </Show>
                 <Show
                   when={
-                    context.messages.list().length - 1 - index === 0 &&
+                    index === 0 &&
                     !showMiddleMessages() &&
                     truncatedMiddleCount(context.messages.list().length) > 0
                   }
@@ -274,7 +283,7 @@ export function MessageList(props: MessageListProps) {
                         variant="ghost"
                         size="sm"
                         fullWidth
-                        class="group h-auto min-h-6 justify-start gap-0 px-0 py-1 font-semibold macro-thread-avatar-axis"
+                        class="group justify-start gap-0 px-0 font-semibold macro-thread-avatar-axis"
                         label={`Show ${truncatedMiddleCount(context.messages.list().length)} hidden messages`}
                         onClick={() => setShowMiddleMessages(true)}
                       >
@@ -294,48 +303,11 @@ export function MessageList(props: MessageListProps) {
                     </div>
                   </div>
                 </Show>
-                <Show when={!hideMiddle()}>
-                  <MessageContainer
-                    isFirstMessage={normalizedIndex() === 0}
-                    isLastMessage={isLastMessage()}
-                    isFocused={isFocusedSelector(message().db_id ?? undefined)}
-                    isTarget={isTargetSelector(message().db_id ?? undefined)}
-                    message={message()}
-                    isExpanded={isExpanded()}
-                    flushTop={cardFlush().top}
-                    flushBottom={cardFlush().bottom}
-                    showBottomBorder={showBottomBorder()}
-                    markdownDomRef={
-                      isLastMessage() ? props.markdownDomRef : undefined
-                    }
-                  />
-                </Show>
               </>
             );
           }}
         </Index>
       </StaticMarkdownContext>
-      <Show when={props.title}>
-        <div class="shrink-0 w-full flex justify-center">
-          <div
-            class={cn(
-              'macro-message-width macro-message-padding w-full',
-              isTouchDevice()
-                ? 'pt-6 pb-3'
-                : 'border-b border-edge-muted/50 pt-12 pb-2.5'
-            )}
-          >
-            <EmailThreadTitle
-              title={props.title ?? ''}
-              copyReveal={isTouchDevice() ? 'always' : 'hover'}
-              class={isTouchDevice() ? 'text-xl pt-1 pb-0' : 'text-2xl pb-1.5'}
-            />
-            <Show when={!isTouchDevice()}>
-              <EmailParticipants />
-            </Show>
-          </div>
-        </div>
-      </Show>
     </div>
   );
 }

--- a/apps/web/src/features/block-email/component/MessageList.tsx
+++ b/apps/web/src/features/block-email/component/MessageList.tsx
@@ -101,9 +101,7 @@ export function MessageList(props: MessageListProps) {
           <div
             class={cn(
               'macro-message-width macro-message-padding w-full',
-              isTouchDevice()
-                ? 'pt-6 pb-3'
-                : 'pt-12 pb-2.5'
+              isTouchDevice() ? 'pt-6 pb-3' : 'pt-12 pb-2.5'
             )}
           >
             <EmailThreadTitle

--- a/apps/web/src/features/block-email/util/scrollToMessage.test.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.test.ts
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import {
+  alignmentDelta,
+  type OpenTargetMessage,
+  openTargetMessageId,
+  reversedChildIndex,
+  shouldPageForOldestUnread,
+  collapsedRowShowsDivider,
+  isTruncatedMiddleMessage,
+  nextShownChronologicalIndex,
+  prevShownChronologicalIndex,
+  shownOpenCardFlush,
+  threadMessageIsExpanded,
+  truncatedMiddleCount,
+} from './scrollToMessage';
+
+function msg(id: string, unread = false): OpenTargetMessage {
+  return {
+    db_id: id,
+    labels: unread ? [{ provider_label_id: 'UNREAD' }] : [],
+  };
+}
+
+function box(
+  element: HTMLElement,
+  top: number,
+  bottom: number
+): void {
+  vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+    top,
+    bottom,
+    left: 0,
+    right: 0,
+    width: 0,
+    height: bottom - top,
+    x: 0,
+    y: top,
+    toJSON() {
+      return {};
+    },
+  });
+}
+
+describe('reversedChildIndex', () => {
+  it('maps oldest-first index onto a reversed DOM list', () => {
+    expect(reversedChildIndex(0, 3)).toBe(2);
+    expect(reversedChildIndex(2, 3)).toBe(0);
+    expect(reversedChildIndex(1, 3)).toBe(1);
+  });
+
+  it('returns -1 when the message is missing', () => {
+    expect(reversedChildIndex(-1, 3)).toBe(-1);
+  });
+});
+
+describe('openTargetMessageId', () => {
+  it('returns newest when every message is unread', () => {
+    expect(openTargetMessageId([msg('a', true), msg('b', true), msg('c', true)])).toBe(
+      'c'
+    );
+  });
+
+  it('skips older read messages to the first unread', () => {
+    expect(openTargetMessageId([msg('a'), msg('b', true), msg('c', true)])).toBe(
+      'b'
+    );
+  });
+
+  it('falls back to newest when nothing is unread', () => {
+    expect(openTargetMessageId([msg('a'), msg('b'), msg('c')])).toBe('c');
+  });
+
+  it('returns undefined for an empty list', () => {
+    expect(openTargetMessageId([])).toBeUndefined();
+  });
+});
+
+describe('shouldPageForOldestUnread', () => {
+  it('pages while the oldest loaded message is unread and more exist', () => {
+    expect(shouldPageForOldestUnread([msg('b', true), msg('c', true)], true)).toBe(
+      true
+    );
+  });
+
+  it('stops when a read message is older than every unread', () => {
+    expect(shouldPageForOldestUnread([msg('a'), msg('b', true)], true)).toBe(
+      false
+    );
+  });
+
+  it('stops at the start of the thread', () => {
+    expect(shouldPageForOldestUnread([msg('a', true)], false)).toBe(false);
+  });
+});
+
+describe('isTruncatedMiddleMessage', () => {
+  it('hides only the middle when there are more than three messages', () => {
+    expect(truncatedMiddleCount(3)).toBe(0);
+    expect(truncatedMiddleCount(6)).toBe(3);
+    expect(isTruncatedMiddleMessage(0, 6)).toBe(false);
+    expect(isTruncatedMiddleMessage(1, 6)).toBe(true);
+    expect(isTruncatedMiddleMessage(3, 6)).toBe(true);
+    expect(isTruncatedMiddleMessage(4, 6)).toBe(false);
+    expect(isTruncatedMiddleMessage(5, 6)).toBe(false);
+  });
+});
+
+describe('collapsedRowShowsDivider', () => {
+  it('hides the divider when the expand control is next', () => {
+    expect(nextShownChronologicalIndex(0, 6, false)).toBeNull();
+    expect(collapsedRowShowsDivider(0, 6, false, true)).toBe(false);
+  });
+
+  it('hides the divider when the next shown message is an opened card', () => {
+    expect(nextShownChronologicalIndex(4, 6, false)).toBe(5);
+    expect(collapsedRowShowsDivider(4, 6, false, false)).toBe(false);
+  });
+
+  it('keeps the divider between two shown collapsed rows', () => {
+    expect(collapsedRowShowsDivider(0, 6, true, true)).toBe(true);
+    expect(collapsedRowShowsDivider(1, 6, true, true)).toBe(true);
+  });
+});
+
+describe('prevShownChronologicalIndex', () => {
+  it('treats the expand control as a break', () => {
+    expect(prevShownChronologicalIndex(0, 6, false)).toBeNull();
+    expect(prevShownChronologicalIndex(4, 6, false)).toBeNull();
+    expect(prevShownChronologicalIndex(5, 6, false)).toBe(4);
+  });
+
+  it('walks consecutive shown messages when the middle is open', () => {
+    expect(prevShownChronologicalIndex(1, 6, true)).toBe(0);
+    expect(prevShownChronologicalIndex(5, 6, true)).toBe(4);
+  });
+});
+
+describe('threadMessageIsExpanded', () => {
+  it('opens the newest message and unread, draft, or manual cards', () => {
+    expect(
+      threadMessageIsExpanded({
+        chronologicalIndex: 2,
+        listLength: 3,
+        isManuallyExpanded: false,
+        isUnread: false,
+        hasDraft: false,
+      })
+    ).toBe(true);
+    expect(
+      threadMessageIsExpanded({
+        chronologicalIndex: 0,
+        listLength: 3,
+        isManuallyExpanded: false,
+        isUnread: true,
+        hasDraft: false,
+      })
+    ).toBe(true);
+    expect(
+      threadMessageIsExpanded({
+        chronologicalIndex: 1,
+        listLength: 3,
+        isManuallyExpanded: false,
+        isUnread: false,
+        hasDraft: false,
+      })
+    ).toBe(false);
+  });
+});
+
+describe('shownOpenCardFlush', () => {
+  it('squares only the edges that touch another open card', () => {
+    const expandedAt = (index: number) => index === 1 || index === 2;
+    expect(shownOpenCardFlush(1, 3, true, expandedAt)).toEqual({
+      top: false,
+      bottom: true,
+    });
+    expect(shownOpenCardFlush(2, 3, true, expandedAt)).toEqual({
+      top: true,
+      bottom: false,
+    });
+  });
+
+  it('does not flush across the expand control', () => {
+    const expandedAt = () => true;
+    expect(shownOpenCardFlush(0, 6, false, expandedAt)).toEqual({
+      top: false,
+      bottom: false,
+    });
+    expect(shownOpenCardFlush(4, 6, false, expandedAt)).toEqual({
+      top: false,
+      bottom: true,
+    });
+  });
+
+  it('keeps full radius next to a collapsed row', () => {
+    expect(shownOpenCardFlush(2, 3, true, (index) => index === 2)).toEqual({
+      top: false,
+      bottom: false,
+    });
+  });
+});
+
+describe('alignmentDelta', () => {
+  it('start-aligns the card to the list top', () => {
+    const container = document.createElement('div');
+    const element = document.createElement('div');
+    box(container, 175, 800);
+    box(element, 175, 400);
+    expect(alignmentDelta(container, element, 'start')).toBe(0);
+    box(element, 200, 400);
+    expect(alignmentDelta(container, element, 'start')).toBe(25);
+  });
+
+  it('end-aligns the card to the list bottom', () => {
+    const container = document.createElement('div');
+    const element = document.createElement('div');
+    box(container, 0, 800);
+    box(element, 600, 800);
+    expect(alignmentDelta(container, element, 'end')).toBe(0);
+  });
+});

--- a/apps/web/src/features/block-email/util/scrollToMessage.test.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest';
 import {
+  adjustScrollAfterPrepend,
   alignmentDelta,
   isTruncatedMiddleMessage,
   nearestDelta,
@@ -208,5 +209,26 @@ describe('pageThenAdvanceDelta', () => {
     box(container, 0, 800);
     box(element, -400, 600);
     expect(pageThenAdvanceDelta(container, element, 'prev')).toBe(-400);
+  });
+});
+
+describe('adjustScrollAfterPrepend', () => {
+  it('keeps the same card on screen when height grows above', () => {
+    const container = document.createElement('div');
+    let scrollHeight = 200;
+    Object.defineProperty(container, 'scrollHeight', {
+      get: () => scrollHeight,
+    });
+    container.scrollTop = 50;
+    scrollHeight = 400;
+    adjustScrollAfterPrepend(container, 200, 50);
+    expect(container.scrollTop).toBe(250);
+  });
+
+  it('leaves the title pinned when you were already at the top', () => {
+    const container = document.createElement('div');
+    container.scrollTop = 0;
+    adjustScrollAfterPrepend(container, 200, 0);
+    expect(container.scrollTop).toBe(0);
   });
 });

--- a/apps/web/src/features/block-email/util/scrollToMessage.test.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.test.ts
@@ -2,31 +2,17 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   alignmentDelta,
-  type OpenTargetMessage,
-  openTargetMessageId,
-  shouldPageForOldestUnread,
   isTruncatedMiddleMessage,
-  nextShownChronologicalIndex,
-  prevShownChronologicalIndex,
   nearestDelta,
+  nextShownChronologicalIndex,
   pageThenAdvanceDelta,
+  prevShownChronologicalIndex,
   revealDelta,
   threadMessageIsExpanded,
   truncatedMiddleCount,
 } from './scrollToMessage';
 
-function msg(id: string, unread = false): OpenTargetMessage {
-  return {
-    db_id: id,
-    labels: unread ? [{ provider_label_id: 'UNREAD' }] : [],
-  };
-}
-
-function box(
-  element: HTMLElement,
-  top: number,
-  bottom: number
-): void {
+function box(element: HTMLElement, top: number, bottom: number): void {
   vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
     top,
     bottom,
@@ -41,46 +27,6 @@ function box(
     },
   });
 }
-
-describe('openTargetMessageId', () => {
-  it('returns newest when every message is unread', () => {
-    expect(openTargetMessageId([msg('a', true), msg('b', true), msg('c', true)])).toBe(
-      'c'
-    );
-  });
-
-  it('skips older read messages to the first unread', () => {
-    expect(openTargetMessageId([msg('a'), msg('b', true), msg('c', true)])).toBe(
-      'b'
-    );
-  });
-
-  it('falls back to newest when nothing is unread', () => {
-    expect(openTargetMessageId([msg('a'), msg('b'), msg('c')])).toBe('c');
-  });
-
-  it('returns undefined for an empty list', () => {
-    expect(openTargetMessageId([])).toBeUndefined();
-  });
-});
-
-describe('shouldPageForOldestUnread', () => {
-  it('pages while the oldest loaded message is unread and more exist', () => {
-    expect(shouldPageForOldestUnread([msg('b', true), msg('c', true)], true)).toBe(
-      true
-    );
-  });
-
-  it('stops when a read message is older than every unread', () => {
-    expect(shouldPageForOldestUnread([msg('a'), msg('b', true)], true)).toBe(
-      false
-    );
-  });
-
-  it('stops at the start of the thread', () => {
-    expect(shouldPageForOldestUnread([msg('a', true)], false)).toBe(false);
-  });
-});
 
 describe('isTruncatedMiddleMessage', () => {
   it('hides only the middle when there are more than three messages', () => {
@@ -221,12 +167,12 @@ describe('nearestDelta', () => {
     expect(nearestDelta(container, element)).toBe(0);
   });
 
-  it('start-aligns a card that sits entirely below the list', () => {
+  it('end-aligns a card that sits entirely below the list', () => {
     const container = document.createElement('div');
     const element = document.createElement('div');
     box(container, 0, 800);
     box(element, 900, 1100);
-    expect(nearestDelta(container, element)).toBe(900);
+    expect(nearestDelta(container, element)).toBe(300);
   });
 });
 

--- a/apps/web/src/features/block-email/util/scrollToMessage.test.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.test.ts
@@ -4,13 +4,9 @@ import {
   adjustScrollAfterPrepend,
   alignmentDelta,
   hiddenMessagesControl,
-  hiddenMessagesFollowsShownIndex,
-  hiddenMessagesPrecedesShownIndex,
   isTruncatedMiddleMessage,
   nearestDelta,
-  nextShownChronologicalIndex,
   pageThenAdvanceDelta,
-  prevShownChronologicalIndex,
   revealDelta,
   scrollToListStartDelta,
   threadMessageIsExpanded,
@@ -45,43 +41,7 @@ describe('isTruncatedMiddleMessage', () => {
   });
 });
 
-describe('nextShownChronologicalIndex', () => {
-  it('treats the expand control as a break', () => {
-    expect(nextShownChronologicalIndex(0, 6, false)).toBeNull();
-    expect(nextShownChronologicalIndex(4, 6, false)).toBe(5);
-  });
-
-  it('steps into the first revealed middle card once open', () => {
-    expect(nextShownChronologicalIndex(0, 6, true)).toBe(1);
-  });
-});
-
-describe('prevShownChronologicalIndex', () => {
-  it('treats the expand control as a break', () => {
-    expect(prevShownChronologicalIndex(0, 6, false)).toBeNull();
-    expect(prevShownChronologicalIndex(4, 6, false)).toBeNull();
-    expect(prevShownChronologicalIndex(5, 6, false)).toBe(4);
-  });
-
-  it('walks consecutive shown messages when the middle is open', () => {
-    expect(prevShownChronologicalIndex(1, 6, true)).toBe(0);
-    expect(prevShownChronologicalIndex(5, 6, true)).toBe(4);
-  });
-});
-
-describe('hiddenMessages chip stops', () => {
-  it('sits after the first shown card when the middle is collapsed', () => {
-    expect(hiddenMessagesFollowsShownIndex(0, 6, false)).toBe(true);
-    expect(hiddenMessagesFollowsShownIndex(0, 6, true)).toBe(false);
-    expect(hiddenMessagesFollowsShownIndex(4, 6, false)).toBe(false);
-  });
-
-  it('sits before the penultimate shown card when the middle is collapsed', () => {
-    expect(hiddenMessagesPrecedesShownIndex(4, 6, false)).toBe(true);
-    expect(hiddenMessagesPrecedesShownIndex(5, 6, false)).toBe(false);
-    expect(hiddenMessagesPrecedesShownIndex(4, 6, true)).toBe(false);
-  });
-
+describe('hiddenMessagesControl', () => {
   it('finds the expand control in the list', () => {
     const list = document.createElement('div');
     const button = document.createElement('button');

--- a/apps/web/src/features/block-email/util/scrollToMessage.test.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   adjustScrollAfterPrepend,
   alignmentDelta,
+  hiddenMessagesControl,
+  hiddenMessagesFollowsShownIndex,
+  hiddenMessagesPrecedesShownIndex,
   isTruncatedMiddleMessage,
   nearestDelta,
   nextShownChronologicalIndex,
@@ -58,6 +61,28 @@ describe('prevShownChronologicalIndex', () => {
   it('walks consecutive shown messages when the middle is open', () => {
     expect(prevShownChronologicalIndex(1, 6, true)).toBe(0);
     expect(prevShownChronologicalIndex(5, 6, true)).toBe(4);
+  });
+});
+
+describe('hiddenMessages chip stops', () => {
+  it('sits after the first shown card when the middle is collapsed', () => {
+    expect(hiddenMessagesFollowsShownIndex(0, 6, false)).toBe(true);
+    expect(hiddenMessagesFollowsShownIndex(0, 6, true)).toBe(false);
+    expect(hiddenMessagesFollowsShownIndex(4, 6, false)).toBe(false);
+  });
+
+  it('sits before the penultimate shown card when the middle is collapsed', () => {
+    expect(hiddenMessagesPrecedesShownIndex(4, 6, false)).toBe(true);
+    expect(hiddenMessagesPrecedesShownIndex(5, 6, false)).toBe(false);
+    expect(hiddenMessagesPrecedesShownIndex(4, 6, true)).toBe(false);
+  });
+
+  it('finds the expand control in the list', () => {
+    const list = document.createElement('div');
+    const button = document.createElement('button');
+    button.setAttribute('data-hidden-messages', '');
+    list.append(button);
+    expect(hiddenMessagesControl(list)).toBe(button);
   });
 });
 

--- a/apps/web/src/features/block-email/util/scrollToMessage.test.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.test.ts
@@ -8,6 +8,7 @@ import {
   isTruncatedMiddleMessage,
   nextShownChronologicalIndex,
   prevShownChronologicalIndex,
+  revealDelta,
   threadMessageIsExpanded,
   truncatedMiddleCount,
 } from './scrollToMessage';
@@ -178,5 +179,31 @@ describe('alignmentDelta', () => {
     box(container, 0, 800);
     box(element, 600, 800);
     expect(alignmentDelta(container, element, 'end')).toBe(0);
+  });
+});
+
+describe('revealDelta', () => {
+  it('does nothing when the card already fits', () => {
+    const container = document.createElement('div');
+    const element = document.createElement('div');
+    box(container, 0, 800);
+    box(element, 200, 400);
+    expect(revealDelta(container, element)).toBe(0);
+  });
+
+  it('scrolls down when the card grows past the bottom', () => {
+    const container = document.createElement('div');
+    const element = document.createElement('div');
+    box(container, 0, 800);
+    box(element, 600, 950);
+    expect(revealDelta(container, element)).toBe(150);
+  });
+
+  it('start-aligns a card taller than the list', () => {
+    const container = document.createElement('div');
+    const element = document.createElement('div');
+    box(container, 0, 800);
+    box(element, 200, 1200);
+    expect(revealDelta(container, element)).toBe(200);
   });
 });

--- a/apps/web/src/features/block-email/util/scrollToMessage.test.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.test.ts
@@ -12,6 +12,7 @@ import {
   pageThenAdvanceDelta,
   prevShownChronologicalIndex,
   revealDelta,
+  scrollToListStartDelta,
   threadMessageIsExpanded,
   truncatedMiddleCount,
 } from './scrollToMessage';
@@ -238,6 +239,20 @@ describe('pageThenAdvanceDelta', () => {
     box(container, 0, 800);
     box(element, -400, 600);
     expect(pageThenAdvanceDelta(container, element, 'prev')).toBe(-400);
+  });
+});
+
+describe('scrollToListStartDelta', () => {
+  it('scrolls the leftover distance to the title', () => {
+    const container = document.createElement('div');
+    container.scrollTop = 80;
+    expect(scrollToListStartDelta(container)).toBe(-80);
+  });
+
+  it('is zero when the list is already at the top', () => {
+    const container = document.createElement('div');
+    container.scrollTop = 0;
+    expect(scrollToListStartDelta(container)).toBe(0);
   });
 });
 

--- a/apps/web/src/features/block-email/util/scrollToMessage.test.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.test.ts
@@ -49,6 +49,10 @@ describe('nextShownChronologicalIndex', () => {
     expect(nextShownChronologicalIndex(0, 6, false)).toBeNull();
     expect(nextShownChronologicalIndex(4, 6, false)).toBe(5);
   });
+
+  it('steps into the first revealed middle card once open', () => {
+    expect(nextShownChronologicalIndex(0, 6, true)).toBe(1);
+  });
 });
 
 describe('prevShownChronologicalIndex', () => {

--- a/apps/web/src/features/block-email/util/scrollToMessage.test.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.test.ts
@@ -4,7 +4,6 @@ import {
   alignmentDelta,
   type OpenTargetMessage,
   openTargetMessageId,
-  reversedChildIndex,
   shouldPageForOldestUnread,
   collapsedRowShowsDivider,
   isTruncatedMiddleMessage,
@@ -41,18 +40,6 @@ function box(
     },
   });
 }
-
-describe('reversedChildIndex', () => {
-  it('maps oldest-first index onto a reversed DOM list', () => {
-    expect(reversedChildIndex(0, 3)).toBe(2);
-    expect(reversedChildIndex(2, 3)).toBe(0);
-    expect(reversedChildIndex(1, 3)).toBe(1);
-  });
-
-  it('returns -1 when the message is missing', () => {
-    expect(reversedChildIndex(-1, 3)).toBe(-1);
-  });
-});
 
 describe('openTargetMessageId', () => {
   it('returns newest when every message is unread', () => {
@@ -142,7 +129,6 @@ describe('threadMessageIsExpanded', () => {
       threadMessageIsExpanded({
         chronologicalIndex: 2,
         listLength: 3,
-        isManuallyExpanded: false,
         isUnread: false,
         hasDraft: false,
       })
@@ -151,7 +137,6 @@ describe('threadMessageIsExpanded', () => {
       threadMessageIsExpanded({
         chronologicalIndex: 0,
         listLength: 3,
-        isManuallyExpanded: false,
         isUnread: true,
         hasDraft: false,
       })
@@ -160,8 +145,28 @@ describe('threadMessageIsExpanded', () => {
       threadMessageIsExpanded({
         chronologicalIndex: 1,
         listLength: 3,
-        isManuallyExpanded: false,
         isUnread: false,
+        hasDraft: false,
+      })
+    ).toBe(false);
+  });
+
+  it('lets an explicit collapse win over newest or unread', () => {
+    expect(
+      threadMessageIsExpanded({
+        chronologicalIndex: 2,
+        listLength: 3,
+        expansionOverride: false,
+        isUnread: false,
+        hasDraft: false,
+      })
+    ).toBe(false);
+    expect(
+      threadMessageIsExpanded({
+        chronologicalIndex: 0,
+        listLength: 3,
+        expansionOverride: false,
+        isUnread: true,
         hasDraft: false,
       })
     ).toBe(false);

--- a/apps/web/src/features/block-email/util/scrollToMessage.test.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.test.ts
@@ -5,11 +5,9 @@ import {
   type OpenTargetMessage,
   openTargetMessageId,
   shouldPageForOldestUnread,
-  collapsedRowShowsDivider,
   isTruncatedMiddleMessage,
   nextShownChronologicalIndex,
   prevShownChronologicalIndex,
-  shownOpenCardFlush,
   threadMessageIsExpanded,
   truncatedMiddleCount,
 } from './scrollToMessage';
@@ -93,20 +91,10 @@ describe('isTruncatedMiddleMessage', () => {
   });
 });
 
-describe('collapsedRowShowsDivider', () => {
-  it('hides the divider when the expand control is next', () => {
+describe('nextShownChronologicalIndex', () => {
+  it('treats the expand control as a break', () => {
     expect(nextShownChronologicalIndex(0, 6, false)).toBeNull();
-    expect(collapsedRowShowsDivider(0, 6, false, true)).toBe(false);
-  });
-
-  it('hides the divider when the next shown message is an opened card', () => {
     expect(nextShownChronologicalIndex(4, 6, false)).toBe(5);
-    expect(collapsedRowShowsDivider(4, 6, false, false)).toBe(false);
-  });
-
-  it('keeps the divider between two shown collapsed rows', () => {
-    expect(collapsedRowShowsDivider(0, 6, true, true)).toBe(true);
-    expect(collapsedRowShowsDivider(1, 6, true, true)).toBe(true);
   });
 });
 
@@ -170,39 +158,6 @@ describe('threadMessageIsExpanded', () => {
         hasDraft: false,
       })
     ).toBe(false);
-  });
-});
-
-describe('shownOpenCardFlush', () => {
-  it('squares only the edges that touch another open card', () => {
-    const expandedAt = (index: number) => index === 1 || index === 2;
-    expect(shownOpenCardFlush(1, 3, true, expandedAt)).toEqual({
-      top: false,
-      bottom: true,
-    });
-    expect(shownOpenCardFlush(2, 3, true, expandedAt)).toEqual({
-      top: true,
-      bottom: false,
-    });
-  });
-
-  it('does not flush across the expand control', () => {
-    const expandedAt = () => true;
-    expect(shownOpenCardFlush(0, 6, false, expandedAt)).toEqual({
-      top: false,
-      bottom: false,
-    });
-    expect(shownOpenCardFlush(4, 6, false, expandedAt)).toEqual({
-      top: false,
-      bottom: true,
-    });
-  });
-
-  it('keeps full radius next to a collapsed row', () => {
-    expect(shownOpenCardFlush(2, 3, true, (index) => index === 2)).toEqual({
-      top: false,
-      bottom: false,
-    });
   });
 });
 

--- a/apps/web/src/features/block-email/util/scrollToMessage.test.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.test.ts
@@ -8,6 +8,8 @@ import {
   isTruncatedMiddleMessage,
   nextShownChronologicalIndex,
   prevShownChronologicalIndex,
+  nearestDelta,
+  pageThenAdvanceDelta,
   revealDelta,
   threadMessageIsExpanded,
   truncatedMiddleCount,
@@ -205,5 +207,60 @@ describe('revealDelta', () => {
     box(container, 0, 800);
     box(element, 200, 1200);
     expect(revealDelta(container, element)).toBe(200);
+  });
+});
+
+describe('nearestDelta', () => {
+  it('does nothing when any part of the card is on screen', () => {
+    const container = document.createElement('div');
+    const element = document.createElement('div');
+    box(container, 0, 800);
+    box(element, 200, 400);
+    expect(nearestDelta(container, element)).toBe(0);
+    box(element, -200, 200);
+    expect(nearestDelta(container, element)).toBe(0);
+  });
+
+  it('start-aligns a card that sits entirely below the list', () => {
+    const container = document.createElement('div');
+    const element = document.createElement('div');
+    box(container, 0, 800);
+    box(element, 900, 1100);
+    expect(nearestDelta(container, element)).toBe(900);
+  });
+});
+
+describe('pageThenAdvanceDelta', () => {
+  it('advances when the card already fits', () => {
+    const container = document.createElement('div');
+    const element = document.createElement('div');
+    box(container, 0, 800);
+    box(element, 200, 400);
+    expect(pageThenAdvanceDelta(container, element, 'next')).toBe(0);
+    expect(pageThenAdvanceDelta(container, element, 'prev')).toBe(0);
+  });
+
+  it('pages down by the remaining overflow when it is less than a viewport', () => {
+    const container = document.createElement('div');
+    const element = document.createElement('div');
+    box(container, 0, 800);
+    box(element, 100, 950);
+    expect(pageThenAdvanceDelta(container, element, 'next')).toBe(150);
+  });
+
+  it('pages down by one viewport when overflow is larger', () => {
+    const container = document.createElement('div');
+    const element = document.createElement('div');
+    box(container, 0, 800);
+    box(element, 0, 2400);
+    expect(pageThenAdvanceDelta(container, element, 'next')).toBe(800);
+  });
+
+  it('pages up when the card top is above the list', () => {
+    const container = document.createElement('div');
+    const element = document.createElement('div');
+    box(container, 0, 800);
+    box(element, -400, 600);
+    expect(pageThenAdvanceDelta(container, element, 'prev')).toBe(-400);
   });
 });

--- a/apps/web/src/features/block-email/util/scrollToMessage.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.ts
@@ -1,4 +1,5 @@
-export type ScrollAlign = 'start' | 'end';
+export type ScrollAlign = 'start' | 'end' | 'nearest';
+export type NavDirection = 'prev' | 'next';
 
 export type OpenTargetMessage = {
   db_id?: string | null;
@@ -96,6 +97,8 @@ export function alignmentDelta(
       return elementBox.bottom - containerBox.bottom;
     case 'start':
       return elementBox.top - containerBox.top;
+    case 'nearest':
+      return nearestDelta(container, element);
     default: {
       const _exhaustive: never = align;
       return _exhaustive;
@@ -129,6 +132,22 @@ export function alignElementInContainer(
   });
 }
 
+/** Scroll only if the card does not intersect the viewport. */
+export function nearestDelta(
+  container: HTMLElement,
+  element: HTMLElement
+): number {
+  const containerBox = container.getBoundingClientRect();
+  const elementBox = element.getBoundingClientRect();
+  if (elementBox.bottom <= containerBox.top + 1) {
+    return alignmentDelta(container, element, 'start');
+  }
+  if (elementBox.top >= containerBox.bottom - 1) {
+    return alignmentDelta(container, element, 'start');
+  }
+  return 0;
+}
+
 /** Keep a card in view after it grows. Prefer scrolling down. */
 export function revealDelta(
   container: HTMLElement,
@@ -146,6 +165,33 @@ export function revealDelta(
     return alignmentDelta(container, element, 'end');
   }
   return 0;
+}
+
+/** Page the focused card if it still overflows. 0 means advance to the next card. */
+export function pageThenAdvanceDelta(
+  container: HTMLElement,
+  element: HTMLElement,
+  dir: NavDirection
+): number {
+  const containerBox = container.getBoundingClientRect();
+  const elementBox = element.getBoundingClientRect();
+  const page = containerBox.height;
+  switch (dir) {
+    case 'next': {
+      const overflow = elementBox.bottom - containerBox.bottom;
+      if (overflow <= 1) return 0;
+      return Math.min(overflow, page);
+    }
+    case 'prev': {
+      const overflow = containerBox.top - elementBox.top;
+      if (overflow <= 1) return 0;
+      return -Math.min(overflow, page);
+    }
+    default: {
+      const _exhaustive: never = dir;
+      return _exhaustive;
+    }
+  }
 }
 
 export function revealMessageInView(

--- a/apps/web/src/features/block-email/util/scrollToMessage.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.ts
@@ -152,7 +152,7 @@ export function revealMessageInView(
   messageId: string,
   messages: Array<{ db_id?: string | null }>,
   container: HTMLElement,
-  behavior: ScrollBehavior = 'auto'
+  behavior: ScrollBehavior = 'smooth'
 ): void {
   const element = messageElement(container, messages, messageId);
   if (!element) return;
@@ -167,7 +167,7 @@ export function revealMessageAfterLayout(
   messageId: string,
   messages: Array<{ db_id?: string | null }>,
   container: HTMLElement | undefined | null,
-  behavior: ScrollBehavior = 'auto'
+  behavior: ScrollBehavior = 'smooth'
 ): void {
   if (!container) return;
   requestAnimationFrame(() => {

--- a/apps/web/src/features/block-email/util/scrollToMessage.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.ts
@@ -84,44 +84,6 @@ export function threadMessageIsExpanded(args: {
   );
 }
 
-/** Square the corners that sit against another open card. */
-export function shownOpenCardFlush(
-  chronologicalIndex: number,
-  length: number,
-  showMiddle: boolean,
-  expandedAt: (index: number) => boolean
-): { top: boolean; bottom: boolean } {
-  if (!expandedAt(chronologicalIndex)) return { top: false, bottom: false };
-  const prev = prevShownChronologicalIndex(
-    chronologicalIndex,
-    length,
-    showMiddle
-  );
-  const next = nextShownChronologicalIndex(
-    chronologicalIndex,
-    length,
-    showMiddle
-  );
-  return {
-    top: prev != null && expandedAt(prev),
-    bottom: next != null && expandedAt(next),
-  };
-}
-
-export function collapsedRowShowsDivider(
-  chronologicalIndex: number,
-  length: number,
-  showMiddle: boolean,
-  nextIsCollapsed: boolean
-): boolean {
-  const next = nextShownChronologicalIndex(
-    chronologicalIndex,
-    length,
-    showMiddle
-  );
-  return next != null && nextIsCollapsed;
-}
-
 export function alignmentDelta(
   container: HTMLElement,
   element: HTMLElement,

--- a/apps/web/src/features/block-email/util/scrollToMessage.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.ts
@@ -10,30 +10,14 @@ export function isUnreadMessage(message: OpenTargetMessage): boolean {
   return message.labels.some((label) => label.provider_label_id === 'UNREAD');
 }
 
-/** `messages` is oldest-first, matching `EmailContext`. */
-export function openTargetMessageId(
-  messages: OpenTargetMessage[]
-): string | undefined {
-  if (messages.length === 0) return undefined;
-  const newestId = messages.at(-1)?.db_id ?? undefined;
-  if (messages.every(isUnreadMessage)) return newestId;
-  return messages.find(isUnreadMessage)?.db_id ?? newestId;
-}
-
-export function shouldPageForOldestUnread(
-  messages: OpenTargetMessage[],
-  hasMore: boolean
-): boolean {
-  const oldest = messages[0];
-  return hasMore && oldest != null && isUnreadMessage(oldest);
-}
-
 /** Oldest, penultimate, and newest stay visible. Hide the rest when length > 3. */
 export function isTruncatedMiddleMessage(
   chronologicalIndex: number,
   length: number
 ): boolean {
-  return length > 3 && chronologicalIndex > 0 && chronologicalIndex < length - 2;
+  return (
+    length > 3 && chronologicalIndex > 0 && chronologicalIndex < length - 2
+  );
 }
 
 export function truncatedMiddleCount(length: number): number {
@@ -111,7 +95,8 @@ export function messageElement(
   messages: Array<{ db_id?: string | null }>,
   messageId: string
 ): HTMLElement | undefined {
-  if (!messages.some((message) => message.db_id === messageId)) return undefined;
+  if (!messages.some((message) => message.db_id === messageId))
+    return undefined;
   const el = container.querySelector(
     `[data-message-body-id="${CSS.escape(messageId)}"]`
   );
@@ -143,7 +128,7 @@ export function nearestDelta(
     return alignmentDelta(container, element, 'start');
   }
   if (elementBox.top >= containerBox.bottom - 1) {
-    return alignmentDelta(container, element, 'start');
+    return alignmentDelta(container, element, 'end');
   }
   return 0;
 }

--- a/apps/web/src/features/block-email/util/scrollToMessage.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.ts
@@ -39,6 +39,37 @@ export function nextShownChronologicalIndex(
   return chronologicalIndex + 1;
 }
 
+export function hiddenMessagesFollowsShownIndex(
+  chronologicalIndex: number,
+  length: number,
+  showMiddle: boolean
+): boolean {
+  return (
+    !showMiddle &&
+    truncatedMiddleCount(length) > 0 &&
+    chronologicalIndex === 0
+  );
+}
+
+export function hiddenMessagesPrecedesShownIndex(
+  chronologicalIndex: number,
+  length: number,
+  showMiddle: boolean
+): boolean {
+  return (
+    !showMiddle &&
+    truncatedMiddleCount(length) > 0 &&
+    chronologicalIndex === length - 2
+  );
+}
+
+export function hiddenMessagesControl(
+  container: HTMLElement
+): HTMLButtonElement | undefined {
+  const el = container.querySelector('[data-hidden-messages]');
+  return el instanceof HTMLButtonElement ? el : undefined;
+}
+
 /** Previous newer-to-older shown index, or null when the expand control or list start precedes. */
 export function prevShownChronologicalIndex(
   chronologicalIndex: number,

--- a/apps/web/src/features/block-email/util/scrollToMessage.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.ts
@@ -210,6 +210,11 @@ export function pageThenAdvanceDelta(
   }
 }
 
+/** Remaining scroll to the thread title. 0 means the list is already at the top. */
+export function scrollToListStartDelta(container: HTMLElement): number {
+  return container.scrollTop > 1 ? -container.scrollTop : 0;
+}
+
 export function revealMessageInView(
   messageId: string,
   messages: Array<{ db_id?: string | null }>,

--- a/apps/web/src/features/block-email/util/scrollToMessage.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.ts
@@ -5,14 +5,6 @@ export type OpenTargetMessage = {
   labels: Array<{ provider_label_id?: string | null }>;
 };
 
-export function reversedChildIndex(
-  chronologicalIndex: number,
-  length: number
-): number {
-  if (chronologicalIndex < 0) return -1;
-  return length - 1 - chronologicalIndex;
-}
-
 export function isUnreadMessage(message: OpenTargetMessage): boolean {
   return message.labels.some((label) => label.provider_label_id === 'UNREAD');
 }
@@ -79,12 +71,13 @@ export function prevShownChronologicalIndex(
 export function threadMessageIsExpanded(args: {
   chronologicalIndex: number;
   listLength: number;
-  isManuallyExpanded: boolean;
+  expansionOverride?: boolean;
   isUnread: boolean;
   hasDraft: boolean;
 }): boolean {
+  if (args.expansionOverride === false) return false;
+  if (args.expansionOverride === true) return true;
   return (
-    args.isManuallyExpanded ||
     args.chronologicalIndex === args.listLength - 1 ||
     args.isUnread ||
     args.hasDraft
@@ -151,8 +144,7 @@ export function alignmentDelta(
 export function messageElement(
   container: HTMLElement,
   messages: Array<{ db_id?: string | null }>,
-  messageId: string,
-  _reversed = true
+  messageId: string
 ): HTMLElement | undefined {
   if (!messages.some((message) => message.db_id === messageId)) return undefined;
   const el = container.querySelector(
@@ -189,20 +181,13 @@ export function scrollToMessage(
   messagesContainer: HTMLElement,
   {
     behavior = 'smooth',
-    reversed = true,
     align = 'start',
   }: {
     behavior?: ScrollBehavior;
-    reversed?: boolean;
     align?: ScrollAlign;
   } = {}
 ): boolean {
-  const targetElement = messageElement(
-    messagesContainer,
-    messages,
-    messageId,
-    reversed
-  );
+  const targetElement = messageElement(messagesContainer, messages, messageId);
   if (!targetElement) return false;
 
   alignElementInContainer(messagesContainer, targetElement, align, behavior);

--- a/apps/web/src/features/block-email/util/scrollToMessage.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.ts
@@ -1,3 +1,5 @@
+import { match } from 'ts-pattern';
+
 export type ScrollAlign = 'start' | 'end' | 'nearest';
 export type NavDirection = 'prev' | 'next';
 
@@ -54,18 +56,11 @@ export function alignmentDelta(
 ): number {
   const containerBox = container.getBoundingClientRect();
   const elementBox = element.getBoundingClientRect();
-  switch (align) {
-    case 'end':
-      return elementBox.bottom - containerBox.bottom;
-    case 'start':
-      return elementBox.top - containerBox.top;
-    case 'nearest':
-      return nearestDelta(container, element);
-    default: {
-      const _exhaustive: never = align;
-      return _exhaustive;
-    }
-  }
+  return match(align)
+    .with('end', () => elementBox.bottom - containerBox.bottom)
+    .with('start', () => elementBox.top - containerBox.top)
+    .with('nearest', () => nearestDelta(container, element))
+    .exhaustive();
 }
 
 export function messageElement(
@@ -139,22 +134,18 @@ export function pageThenAdvanceDelta(
   const containerBox = container.getBoundingClientRect();
   const elementBox = element.getBoundingClientRect();
   const page = containerBox.height;
-  switch (dir) {
-    case 'next': {
+  return match(dir)
+    .with('next', () => {
       const overflow = elementBox.bottom - containerBox.bottom;
       if (overflow <= 1) return 0;
       return Math.min(overflow, page);
-    }
-    case 'prev': {
+    })
+    .with('prev', () => {
       const overflow = containerBox.top - elementBox.top;
       if (overflow <= 1) return 0;
       return -Math.min(overflow, page);
-    }
-    default: {
-      const _exhaustive: never = dir;
-      return _exhaustive;
-    }
-  }
+    })
+    .exhaustive();
 }
 
 /** Remaining scroll to the thread title. 0 means the list is already at the top. */

--- a/apps/web/src/features/block-email/util/scrollToMessage.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.ts
@@ -194,6 +194,17 @@ export function revealMessageInView(
   container.scrollBy({ top, behavior: nativeBehavior });
 }
 
+/** Older pages insert above. Keep the card you were reading on screen. */
+export function adjustScrollAfterPrepend(
+  container: HTMLElement,
+  previousScrollHeight: number,
+  previousScrollTop: number
+): void {
+  if (previousScrollTop <= 0) return;
+  const delta = container.scrollHeight - previousScrollHeight;
+  if (delta > 0) container.scrollTop = previousScrollTop + delta;
+}
+
 export function revealMessageAfterLayout(
   messageId: string,
   messages: Array<{ db_id?: string | null }>,

--- a/apps/web/src/features/block-email/util/scrollToMessage.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.ts
@@ -24,64 +24,11 @@ export function truncatedMiddleCount(length: number): number {
   return length > 3 ? length - 3 : 0;
 }
 
-/** Next older-to-newer shown index, or null when the expand control or list end follows. */
-export function nextShownChronologicalIndex(
-  chronologicalIndex: number,
-  length: number,
-  showMiddle: boolean
-): number | null {
-  if (chronologicalIndex < 0 || chronologicalIndex >= length - 1) return null;
-  if (!showMiddle && truncatedMiddleCount(length) > 0) {
-    if (chronologicalIndex === 0) return null;
-    if (chronologicalIndex === length - 2) return length - 1;
-    return null;
-  }
-  return chronologicalIndex + 1;
-}
-
-export function hiddenMessagesFollowsShownIndex(
-  chronologicalIndex: number,
-  length: number,
-  showMiddle: boolean
-): boolean {
-  return (
-    !showMiddle &&
-    truncatedMiddleCount(length) > 0 &&
-    chronologicalIndex === 0
-  );
-}
-
-export function hiddenMessagesPrecedesShownIndex(
-  chronologicalIndex: number,
-  length: number,
-  showMiddle: boolean
-): boolean {
-  return (
-    !showMiddle &&
-    truncatedMiddleCount(length) > 0 &&
-    chronologicalIndex === length - 2
-  );
-}
-
 export function hiddenMessagesControl(
   container: HTMLElement
 ): HTMLButtonElement | undefined {
   const el = container.querySelector('[data-hidden-messages]');
   return el instanceof HTMLButtonElement ? el : undefined;
-}
-
-/** Previous newer-to-older shown index, or null when the expand control or list start precedes. */
-export function prevShownChronologicalIndex(
-  chronologicalIndex: number,
-  length: number,
-  showMiddle: boolean
-): number | null {
-  if (chronologicalIndex <= 0 || chronologicalIndex >= length) return null;
-  if (!showMiddle && truncatedMiddleCount(length) > 0) {
-    if (chronologicalIndex === length - 1) return length - 2;
-    return null;
-  }
-  return chronologicalIndex - 1;
 }
 
 export function threadMessageIsExpanded(args: {

--- a/apps/web/src/features/block-email/util/scrollToMessage.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.ts
@@ -1,4 +1,179 @@
-import type { ApiMessage } from '@service-email/generated/schemas';
+export type ScrollAlign = 'start' | 'end';
+
+export type OpenTargetMessage = {
+  db_id?: string | null;
+  labels: Array<{ provider_label_id?: string | null }>;
+};
+
+export function reversedChildIndex(
+  chronologicalIndex: number,
+  length: number
+): number {
+  if (chronologicalIndex < 0) return -1;
+  return length - 1 - chronologicalIndex;
+}
+
+export function isUnreadMessage(message: OpenTargetMessage): boolean {
+  return message.labels.some((label) => label.provider_label_id === 'UNREAD');
+}
+
+/** `messages` is oldest-first, matching `EmailContext`. */
+export function openTargetMessageId(
+  messages: OpenTargetMessage[]
+): string | undefined {
+  if (messages.length === 0) return undefined;
+  const newestId = messages.at(-1)?.db_id ?? undefined;
+  if (messages.every(isUnreadMessage)) return newestId;
+  return messages.find(isUnreadMessage)?.db_id ?? newestId;
+}
+
+export function shouldPageForOldestUnread(
+  messages: OpenTargetMessage[],
+  hasMore: boolean
+): boolean {
+  const oldest = messages[0];
+  return hasMore && oldest != null && isUnreadMessage(oldest);
+}
+
+/** Oldest, penultimate, and newest stay visible. Hide the rest when length > 3. */
+export function isTruncatedMiddleMessage(
+  chronologicalIndex: number,
+  length: number
+): boolean {
+  return length > 3 && chronologicalIndex > 0 && chronologicalIndex < length - 2;
+}
+
+export function truncatedMiddleCount(length: number): number {
+  return length > 3 ? length - 3 : 0;
+}
+
+/** Next older-to-newer shown index, or null when the expand control or list end follows. */
+export function nextShownChronologicalIndex(
+  chronologicalIndex: number,
+  length: number,
+  showMiddle: boolean
+): number | null {
+  if (chronologicalIndex < 0 || chronologicalIndex >= length - 1) return null;
+  if (!showMiddle && truncatedMiddleCount(length) > 0) {
+    if (chronologicalIndex === 0) return null;
+    if (chronologicalIndex === length - 2) return length - 1;
+    return null;
+  }
+  return chronologicalIndex + 1;
+}
+
+/** Previous newer-to-older shown index, or null when the expand control or list start precedes. */
+export function prevShownChronologicalIndex(
+  chronologicalIndex: number,
+  length: number,
+  showMiddle: boolean
+): number | null {
+  if (chronologicalIndex <= 0 || chronologicalIndex >= length) return null;
+  if (!showMiddle && truncatedMiddleCount(length) > 0) {
+    if (chronologicalIndex === length - 1) return length - 2;
+    return null;
+  }
+  return chronologicalIndex - 1;
+}
+
+export function threadMessageIsExpanded(args: {
+  chronologicalIndex: number;
+  listLength: number;
+  isManuallyExpanded: boolean;
+  isUnread: boolean;
+  hasDraft: boolean;
+}): boolean {
+  return (
+    args.isManuallyExpanded ||
+    args.chronologicalIndex === args.listLength - 1 ||
+    args.isUnread ||
+    args.hasDraft
+  );
+}
+
+/** Square the corners that sit against another open card. */
+export function shownOpenCardFlush(
+  chronologicalIndex: number,
+  length: number,
+  showMiddle: boolean,
+  expandedAt: (index: number) => boolean
+): { top: boolean; bottom: boolean } {
+  if (!expandedAt(chronologicalIndex)) return { top: false, bottom: false };
+  const prev = prevShownChronologicalIndex(
+    chronologicalIndex,
+    length,
+    showMiddle
+  );
+  const next = nextShownChronologicalIndex(
+    chronologicalIndex,
+    length,
+    showMiddle
+  );
+  return {
+    top: prev != null && expandedAt(prev),
+    bottom: next != null && expandedAt(next),
+  };
+}
+
+export function collapsedRowShowsDivider(
+  chronologicalIndex: number,
+  length: number,
+  showMiddle: boolean,
+  nextIsCollapsed: boolean
+): boolean {
+  const next = nextShownChronologicalIndex(
+    chronologicalIndex,
+    length,
+    showMiddle
+  );
+  return next != null && nextIsCollapsed;
+}
+
+export function alignmentDelta(
+  container: HTMLElement,
+  element: HTMLElement,
+  align: ScrollAlign
+): number {
+  const containerBox = container.getBoundingClientRect();
+  const elementBox = element.getBoundingClientRect();
+  switch (align) {
+    case 'end':
+      return elementBox.bottom - containerBox.bottom;
+    case 'start':
+      return elementBox.top - containerBox.top;
+    default: {
+      const _exhaustive: never = align;
+      return _exhaustive;
+    }
+  }
+}
+
+export function messageElement(
+  container: HTMLElement,
+  messages: Array<{ db_id?: string | null }>,
+  messageId: string,
+  _reversed = true
+): HTMLElement | undefined {
+  if (!messages.some((message) => message.db_id === messageId)) return undefined;
+  const el = container.querySelector(
+    `[data-message-body-id="${CSS.escape(messageId)}"]`
+  );
+  return el instanceof HTMLElement ? el : undefined;
+}
+
+export function alignElementInContainer(
+  container: HTMLElement,
+  element: HTMLElement,
+  align: ScrollAlign,
+  behavior: ScrollBehavior = 'auto'
+): void {
+  const nativeBehavior: ScrollBehavior =
+    behavior === 'instant' ? 'auto' : behavior;
+  container.scrollBy({
+    top: alignmentDelta(container, element, align),
+    behavior: nativeBehavior,
+  });
+}
 
 /**
  * Scrolls to a message by its ID within a messages container
@@ -10,63 +185,26 @@ import type { ApiMessage } from '@service-email/generated/schemas';
  */
 export function scrollToMessage(
   messageId: string,
-  messages: ApiMessage[],
+  messages: Array<{ db_id?: string | null }>,
   messagesContainer: HTMLElement,
   {
     behavior = 'smooth',
-    reversed = false,
-  }: { behavior?: ScrollBehavior; reversed?: boolean }
+    reversed = true,
+    align = 'start',
+  }: {
+    behavior?: ScrollBehavior;
+    reversed?: boolean;
+    align?: ScrollAlign;
+  } = {}
 ): boolean {
-  let messageIndex = messages.findIndex((m) => m.db_id === messageId);
+  const targetElement = messageElement(
+    messagesContainer,
+    messages,
+    messageId,
+    reversed
+  );
+  if (!targetElement) return false;
 
-  if (reversed) {
-    messageIndex = messages.length - 1 - messageIndex;
-  }
-
-  if (messageIndex < 0) {
-    return false;
-  }
-
-  const targetElement = messagesContainer.children[messageIndex];
-
-  if (!targetElement) {
-    return false;
-  }
-
-  targetElement.scrollIntoView({
-    behavior,
-    block: 'start',
-  });
-
+  alignElementInContainer(messagesContainer, targetElement, align, behavior);
   return true;
-}
-
-/**
- * Scrolls to the last message in the thread
- * @param messagesContainer - The DOM container holding the message elements
- * @param behavior - Scroll behavior ('smooth' | 'instant' | 'auto')
- */
-function _scrollToLastMessage(
-  messagesContainer: HTMLDivElement,
-  behavior: ScrollBehavior | 'instant' = 'instant'
-): void {
-  const nativeBehavior: ScrollBehavior =
-    behavior === 'instant' ? 'auto' : behavior;
-  const lastChild = messagesContainer.children[
-    messagesContainer.children.length - 1
-  ] as HTMLElement | undefined;
-
-  if (!lastChild) return;
-  // Align the last child to the bottom of the nearest scrolling container
-  lastChild.scrollIntoView({ behavior: nativeBehavior, block: 'start' });
-}
-
-/**
- * Gets the last message ID from a thread
- * @param messages - Array of messages in the current thread
- * @returns The db_id of the last message, or undefined if no messages
- */
-function _getLastMessageId(messages: ApiMessage[]): string | undefined {
-  const lastMessage = messages[messages.length - 1];
-  return lastMessage?.db_id?.toString();
 }

--- a/apps/web/src/features/block-email/util/scrollToMessage.ts
+++ b/apps/web/src/features/block-email/util/scrollToMessage.ts
@@ -129,6 +129,52 @@ export function alignElementInContainer(
   });
 }
 
+/** Keep a card in view after it grows. Prefer scrolling down. */
+export function revealDelta(
+  container: HTMLElement,
+  element: HTMLElement
+): number {
+  const containerBox = container.getBoundingClientRect();
+  const elementBox = element.getBoundingClientRect();
+  if (elementBox.height >= containerBox.height) {
+    return alignmentDelta(container, element, 'start');
+  }
+  if (elementBox.top < containerBox.top) {
+    return alignmentDelta(container, element, 'start');
+  }
+  if (elementBox.bottom > containerBox.bottom) {
+    return alignmentDelta(container, element, 'end');
+  }
+  return 0;
+}
+
+export function revealMessageInView(
+  messageId: string,
+  messages: Array<{ db_id?: string | null }>,
+  container: HTMLElement,
+  behavior: ScrollBehavior = 'auto'
+): void {
+  const element = messageElement(container, messages, messageId);
+  if (!element) return;
+  const top = revealDelta(container, element);
+  if (top === 0) return;
+  const nativeBehavior: ScrollBehavior =
+    behavior === 'instant' ? 'auto' : behavior;
+  container.scrollBy({ top, behavior: nativeBehavior });
+}
+
+export function revealMessageAfterLayout(
+  messageId: string,
+  messages: Array<{ db_id?: string | null }>,
+  container: HTMLElement | undefined | null,
+  behavior: ScrollBehavior = 'auto'
+): void {
+  if (!container) return;
+  requestAnimationFrame(() => {
+    revealMessageInView(messageId, messages, container, behavior);
+  });
+}
+
 /**
  * Scrolls to a message by its ID within a messages container
  * @param messageId - The db_id of the message to scroll to

--- a/apps/web/src/features/block-email/util/threadStops.test.ts
+++ b/apps/web/src/features/block-email/util/threadStops.test.ts
@@ -11,7 +11,9 @@ const message = (index: number): ThreadStop => ({ kind: 'message', index });
 
 describe('shownStops', () => {
   it('inserts the chip after the first card when the middle is collapsed', () => {
-    expect(shownStops({ length: 6, showMiddle: false, hasComposer: true })).toEqual([
+    expect(
+      shownStops({ length: 6, showMiddle: false, hasComposer: true })
+    ).toEqual([
       { kind: 'title' },
       message(0),
       { kind: 'hidden-chip' },

--- a/apps/web/src/features/block-email/util/threadStops.test.ts
+++ b/apps/web/src/features/block-email/util/threadStops.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import {
+  adjacentStop,
+  enterListStop,
+  shownStops,
+  type ThreadStop,
+} from './threadStops';
+
+const message = (index: number): ThreadStop => ({ kind: 'message', index });
+
+describe('shownStops', () => {
+  it('inserts the chip after the first card when the middle is collapsed', () => {
+    expect(shownStops({ length: 6, showMiddle: false, hasComposer: true })).toEqual([
+      { kind: 'title' },
+      message(0),
+      { kind: 'hidden-chip' },
+      message(4),
+      message(5),
+      { kind: 'composer' },
+    ]);
+  });
+
+  it('lists every card once the middle is open', () => {
+    expect(shownStops({ length: 6, showMiddle: true })).toEqual([
+      { kind: 'title' },
+      message(0),
+      message(1),
+      message(2),
+      message(3),
+      message(4),
+      message(5),
+    ]);
+  });
+});
+
+describe('adjacentStop', () => {
+  const collapsed = shownStops({
+    length: 6,
+    showMiddle: false,
+    hasComposer: true,
+  });
+
+  it('treats the chip as the stop after the first card', () => {
+    expect(adjacentStop(collapsed, message(0), 'next')).toEqual({
+      kind: 'hidden-chip',
+    });
+    expect(adjacentStop(collapsed, { kind: 'hidden-chip' }, 'prev')).toEqual(
+      message(0)
+    );
+  });
+
+  it('treats the chip as the stop before the penultimate card', () => {
+    expect(adjacentStop(collapsed, message(4), 'prev')).toEqual({
+      kind: 'hidden-chip',
+    });
+    expect(adjacentStop(collapsed, { kind: 'hidden-chip' }, 'next')).toEqual(
+      message(4)
+    );
+  });
+
+  it('walks the last shown cards and the composer', () => {
+    expect(adjacentStop(collapsed, message(4), 'next')).toEqual(message(5));
+    expect(adjacentStop(collapsed, message(5), 'next')).toEqual({
+      kind: 'composer',
+    });
+    expect(adjacentStop(collapsed, message(0), 'prev')).toEqual({
+      kind: 'title',
+    });
+  });
+
+  it('steps into the first revealed middle card once open', () => {
+    const opened = shownStops({ length: 6, showMiddle: true });
+    expect(adjacentStop(opened, message(0), 'next')).toEqual(message(1));
+    expect(adjacentStop(opened, message(1), 'prev')).toEqual(message(0));
+    expect(adjacentStop(opened, message(5), 'prev')).toEqual(message(4));
+  });
+});
+
+describe('enterListStop', () => {
+  it('enters at the oldest or newest shown card', () => {
+    const collapsed = shownStops({ length: 6, showMiddle: false });
+    expect(enterListStop(collapsed, 'next')).toEqual(message(0));
+    expect(enterListStop(collapsed, 'prev')).toEqual(message(5));
+  });
+});

--- a/apps/web/src/features/block-email/util/threadStops.ts
+++ b/apps/web/src/features/block-email/util/threadStops.ts
@@ -1,0 +1,55 @@
+import {
+  isTruncatedMiddleMessage,
+  type NavDirection,
+  truncatedMiddleCount,
+} from './scrollToMessage';
+
+export type ThreadStop =
+  | { kind: 'title' }
+  | { kind: 'message'; index: number }
+  | { kind: 'hidden-chip' }
+  | { kind: 'composer' };
+
+function sameStop(left: ThreadStop, right: ThreadStop): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === 'message' && right.kind === 'message') {
+    return left.index === right.index;
+  }
+  return true;
+}
+
+/** Visible reading order: title, shown cards, optional chip, optional composer. */
+export function shownStops(args: {
+  length: number;
+  showMiddle: boolean;
+  hasComposer?: boolean;
+}): ThreadStop[] {
+  const stops: ThreadStop[] = [{ kind: 'title' }];
+  const hideMiddle = !args.showMiddle && truncatedMiddleCount(args.length) > 0;
+  for (let i = 0; i < args.length; i++) {
+    if (hideMiddle && isTruncatedMiddleMessage(i, args.length)) continue;
+    stops.push({ kind: 'message', index: i });
+    if (hideMiddle && i === 0) stops.push({ kind: 'hidden-chip' });
+  }
+  if (args.hasComposer) stops.push({ kind: 'composer' });
+  return stops;
+}
+
+export function adjacentStop(
+  stops: ThreadStop[],
+  current: ThreadStop,
+  dir: NavDirection
+): ThreadStop | undefined {
+  const index = stops.findIndex((stop) => sameStop(stop, current));
+  if (index < 0) return undefined;
+  return dir === 'next' ? stops[index + 1] : stops[index - 1];
+}
+
+/** First Arrow with no cursor: next lands on the oldest card, prev on the newest. */
+export function enterListStop(
+  stops: ThreadStop[],
+  dir: NavDirection
+): ThreadStop | undefined {
+  const messages = stops.filter((stop) => stop.kind === 'message');
+  return dir === 'prev' ? messages.at(-1) : messages[0];
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -966,24 +966,6 @@ a {
     border-bottom-right-radius 150ms ease-out;
 }
 
-@utility macro-thread-card-flush-top {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-  @starting-style {
-    border-top-left-radius: var(--thread-card-radius-used);
-    border-top-right-radius: var(--thread-card-radius-used);
-  }
-}
-
-@utility macro-thread-card-flush-bottom {
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  @starting-style {
-    border-bottom-left-radius: var(--thread-card-radius-used);
-    border-bottom-right-radius: var(--thread-card-radius-used);
-  }
-}
-
 @utility macro-thread-collapsed-row {
   display: grid;
   grid-template-columns: 7rem minmax(0, 1fr) 4.5rem;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -156,6 +156,7 @@ body.tauri-ios {
   --color-surface: var(--theme-surface, var(--layer-surface));
   --color-inset: var(--theme-inset, var(--layer-inset));
   --color-lift: var(--theme-lift, var(--layer-lift));
+  --color-message: var(--color-lift);
 }
 
 [data-layer][data-depth='0'] {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -931,22 +931,6 @@ a {
   @container (width < 936px) { padding-inline: calc(var(--spacing) * 4); }
 }
 
-@utility macro-thread-avatar-axis {
-  --thread-avatar-axis: calc(0.5px + var(--spacing) * 1.5 + var(--spacing) * 2 - var(--spacing) * 3);
-  padding-left: var(--thread-avatar-axis);
-}
-
-@utility macro-thread-card-outdent {
-  --thread-avatar-axis: calc(0.5px + var(--spacing) * 1.5 + var(--spacing) * 2 - var(--spacing) * 3);
-  --thread-card-outdent: calc(var(--spacing) * 4 - var(--thread-avatar-axis) + 0.5px);
-  @container (width < 816px) {
-    --thread-card-outdent: 0px;
-  }
-  margin-inline: calc(-1 * var(--thread-card-outdent));
-  width: calc(100% + 2 * var(--thread-card-outdent));
-  border-radius: var(--radius-lg);
-}
-
 @utility macro-thread-collapsed-row {
   display: grid;
   grid-template-columns: 7rem minmax(0, 1fr) 4.5rem;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -928,7 +928,6 @@ a {
 
 @utility macro-message-padding {
   @container (width < 936px) { padding-inline: calc(var(--spacing) * 4); }
-  @container (width < 640px) { padding-inline: calc(var(--spacing) * 2); }
 }
 
 @utility macro-thread-avatar-axis {
@@ -939,31 +938,12 @@ a {
 @utility macro-thread-card-outdent {
   --thread-avatar-axis: calc(0.5px + var(--spacing) * 1.5 + var(--spacing) * 2 - var(--spacing) * 3);
   --thread-card-outdent: calc(var(--spacing) * 4 - var(--thread-avatar-axis) + 0.5px);
-  @container (width < 640px) {
-    --thread-card-outdent: min(
-      calc(var(--spacing) * 4 - var(--thread-avatar-axis) + 0.5px),
-      calc(var(--spacing) * 2)
-    );
+  @container (width < 816px) {
+    --thread-card-outdent: 0px;
   }
   margin-inline: calc(-1 * var(--thread-card-outdent));
   width: calc(100% + 2 * var(--thread-card-outdent));
-  --thread-card-radius: var(--radius-lg);
-  /* Keep --radius-lg above 40rem. Sharpen to 0 by 20rem. */
-  --thread-card-radius-used: var(--thread-card-radius);
-  --thread-card-radius-used: clamp(
-    0px,
-    (100cqi - 20rem) / 20rem * var(--thread-card-radius),
-    var(--thread-card-radius)
-  );
-  border-top-left-radius: var(--thread-card-radius-used);
-  border-top-right-radius: var(--thread-card-radius-used);
-  border-bottom-left-radius: var(--thread-card-radius-used);
-  border-bottom-right-radius: var(--thread-card-radius-used);
-  transition:
-    border-top-left-radius 150ms ease-out,
-    border-top-right-radius 150ms ease-out,
-    border-bottom-left-radius 150ms ease-out,
-    border-bottom-right-radius 150ms ease-out;
+  border-radius: var(--radius-lg);
 }
 
 @utility macro-thread-collapsed-row {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -931,6 +931,66 @@ a {
   @container (width < 640px) { padding-inline: calc(var(--spacing) * 2); }
 }
 
+@utility macro-thread-avatar-axis {
+  --thread-avatar-axis: calc(0.5px + var(--spacing) * 1.5 + var(--spacing) * 2 - var(--spacing) * 3);
+  padding-left: var(--thread-avatar-axis);
+}
+
+@utility macro-thread-card-outdent {
+  --thread-avatar-axis: calc(0.5px + var(--spacing) * 1.5 + var(--spacing) * 2 - var(--spacing) * 3);
+  --thread-card-outdent: calc(var(--spacing) * 4 - var(--thread-avatar-axis) + 0.5px);
+  @container (width < 640px) {
+    --thread-card-outdent: min(
+      calc(var(--spacing) * 4 - var(--thread-avatar-axis) + 0.5px),
+      calc(var(--spacing) * 2)
+    );
+  }
+  margin-inline: calc(-1 * var(--thread-card-outdent));
+  width: calc(100% + 2 * var(--thread-card-outdent));
+  --thread-card-radius: var(--radius-lg);
+  /* Keep --radius-lg above 40rem. Sharpen to 0 by 20rem. */
+  --thread-card-radius-used: var(--thread-card-radius);
+  --thread-card-radius-used: clamp(
+    0px,
+    (100cqi - 20rem) / 20rem * var(--thread-card-radius),
+    var(--thread-card-radius)
+  );
+  border-top-left-radius: var(--thread-card-radius-used);
+  border-top-right-radius: var(--thread-card-radius-used);
+  border-bottom-left-radius: var(--thread-card-radius-used);
+  border-bottom-right-radius: var(--thread-card-radius-used);
+  transition:
+    border-top-left-radius 150ms ease-out,
+    border-top-right-radius 150ms ease-out,
+    border-bottom-left-radius 150ms ease-out,
+    border-bottom-right-radius 150ms ease-out;
+}
+
+@utility macro-thread-card-flush-top {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  @starting-style {
+    border-top-left-radius: var(--thread-card-radius-used);
+    border-top-right-radius: var(--thread-card-radius-used);
+  }
+}
+
+@utility macro-thread-card-flush-bottom {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  @starting-style {
+    border-bottom-left-radius: var(--thread-card-radius-used);
+    border-bottom-right-radius: var(--thread-card-radius-used);
+  }
+}
+
+@utility macro-thread-collapsed-row {
+  display: grid;
+  grid-template-columns: 7rem minmax(0, 1fr) 4.5rem;
+  align-items: center;
+  column-gap: calc(var(--spacing) * 2);
+}
+
 @utility macro-message-margin {
   @container (width < 936px) { margin-inline: calc(var(--spacing) * 4); }
   @container (width < 640px) { margin-inline: calc(var(--spacing) * 2); }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -937,7 +937,7 @@ a {
   align-items: center;
   column-gap: calc(var(--spacing) * 2);
 
-  & > :nth-child(2) {
+  & > [data-slot='snippet'] {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -947,13 +947,13 @@ a {
     grid-template-columns: minmax(0, 1fr) auto;
     row-gap: calc(var(--spacing) * 2);
 
-    & > :nth-child(1) {
+    & > [data-slot='sender'] {
       grid-column: 1;
       grid-row: 1;
       min-width: 0;
     }
 
-    & > :nth-child(2) {
+    & > [data-slot='snippet'] {
       grid-column: 1 / -1;
       grid-row: 2;
       display: -webkit-box;
@@ -964,7 +964,7 @@ a {
       -webkit-line-clamp: 2;
     }
 
-    & > :nth-child(3) {
+    & > [data-slot='date'] {
       grid-column: 2;
       grid-row: 1;
     }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -936,6 +936,39 @@ a {
   grid-template-columns: 7rem minmax(0, 1fr) 4.5rem;
   align-items: center;
   column-gap: calc(var(--spacing) * 2);
+
+  & > :nth-child(2) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  @container (width < 480px) {
+    grid-template-columns: minmax(0, 1fr) auto;
+    row-gap: calc(var(--spacing) * 2);
+
+    & > :nth-child(1) {
+      grid-column: 1;
+      grid-row: 1;
+      min-width: 0;
+    }
+
+    & > :nth-child(2) {
+      grid-column: 1 / -1;
+      grid-row: 2;
+      display: -webkit-box;
+      overflow: hidden;
+      text-overflow: unset;
+      white-space: normal;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+    }
+
+    & > :nth-child(3) {
+      grid-column: 2;
+      grid-row: 1;
+    }
+  }
 }
 
 @utility macro-message-margin {


### PR DESCRIPTION
## Summary

Simplifying and improving the UI and UX of the email threads experience. Walkthrough at https://video.cpak.me/s/b6fc3qed3kyrkvh

## Test plan

- [x] Open a long thread. You should be at the title.
- [x] Middle messages stay hidden until you click the show control.
- [x] Arrow through cards. Only the selected one has the rail and shadow.
- [x] Enter on a long collapsed message. It grows down. Smooth-scroll only if the card would be clipped.
- [x] Down and Up on that long card page first, then go to the next message.
- [x] Escape once to collapse. Escape again to unselect.
- [x] Two-message thread still looks fine.
- [x] Narrow or mobile width. 16px gutter, corners still rounded.

Made with [Cursor](https://cursor.com)