### PR TITLE
feat(agent_session): batch streamed log frames instead of one pg transaction per frame

### DIFF
--- a/.sqlx/query-939c842bb426263a2caf45c5d47d66f740dc345ac3bae40487e839a5a23f2f9a.json
+++ b/.sqlx/query-939c842bb426263a2caf45c5d47d66f740dc345ac3bae40487e839a5a23f2f9a.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO agent_session_log (id, agent_session_id, user_id, direction, content, created_at)\n            SELECT * FROM UNNEST(\n                $1::uuid[], $2::uuid[], $3::text[], $4::text[], $5::jsonb[], $6::timestamptz[]\n            )\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "UuidArray",
+        "TextArray",
+        "TextArray",
+        "JsonbArray",
+        "TimestamptzArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "939c842bb426263a2caf45c5d47d66f740dc345ac3bae40487e839a5a23f2f9a"
+}

--- a/crates/agent_session/src/bin/seed_jsonl.rs
+++ b/crates/agent_session/src/bin/seed_jsonl.rs
@@ -254,9 +254,10 @@ async fn seed(args: &Args) -> Result<(), SeedError> {
     .await
     .map_err(SeedError::CreateSession)?;
 
-    // Frames go in one at a time and in order: `agent_session_log` stamps
-    // `created_at` itself and the log is read back `ORDER BY created_at, id`,
-    // so append order is what makes the recording replay as recorded.
+    // Frames go in one at a time and in order: the writer stamps `created_at`
+    // as each frame is appended and the log is read back
+    // `ORDER BY created_at, id`, so append order is what makes the recording
+    // replay as recorded.
     //
     // One writer for the whole recording, so its fold is built once and
     // advanced a frame at a time. Rebuilding it per frame is what made long
@@ -285,6 +286,15 @@ async fn seed(args: &Args) -> Result<(), SeedError> {
             );
         }
     }
+    // The writer batches streamed frames; nothing may stay buffered once the
+    // replay ends.
+    AgentSessionLogWriter::flush(&mut logs)
+        .await
+        .map_err(|source| SeedError::WriteLog {
+            entry: total,
+            total,
+            source,
+        })?;
 
     println!("session:  {}", session.id);
     println!("entries:  {total}");

--- a/crates/agent_session/src/domain/ports.rs
+++ b/crates/agent_session/src/domain/ports.rs
@@ -258,6 +258,19 @@ pub trait AgentSessionLogRepo: Send + Sync + 'static {
         log: AgentSessionLog,
     ) -> impl Future<Output = Result<StoredAgentSessionLog>> + Send;
 
+    /// Append a run of already-stamped entries in order, as one write.
+    ///
+    /// Entries arrive stamped because the writer holding them back is what
+    /// knows when each frame was appended; stamping at flush time would give
+    /// a whole batch the flush's timestamp and lose the order `created_at`
+    /// exists to preserve. Only the last system event in the batch needs
+    /// projecting onto the session status - statuses overwrite, so the
+    /// intermediates were never observable.
+    fn create_batch(
+        &self,
+        entries: Vec<StoredAgentSessionLog>,
+    ) -> impl Future<Output = Result<()>> + Send;
+
     /// List all log entries for a session, in chronological order.
     ///
     /// Entries come back stamped with when the log recorded them: the frame
@@ -270,9 +283,27 @@ pub trait AgentSessionLogRepo: Send + Sync + 'static {
 }
 
 /// Sequential live log writer owned by one session actor.
+///
+/// A writer may hold streamed frames back and write them in batches: `append`
+/// returning `Ok` means the frame is either durable or buffered, and
+/// [`flush_deadline`](Self::flush_deadline) tells the owning actor when the
+/// buffer must next be forced out with [`flush`](Self::flush).
 pub trait AgentSessionLogWriter: Send + 'static {
-    /// Persist and fold one frame into this connection's live projection.
+    /// Persist (or buffer) and fold one frame into this connection's live
+    /// projection.
     fn append(&mut self, log: AgentSessionLog) -> impl Future<Output = Result<()>> + Send;
+
+    /// Durably write any frames still held back. A writer that buffers
+    /// nothing has nothing to do.
+    fn flush(&mut self) -> impl Future<Output = Result<()>> + Send {
+        async { Ok(()) }
+    }
+
+    /// When buffered frames must be flushed by - `None` while nothing is
+    /// buffered, so an idle writer never wakes its owner.
+    fn flush_deadline(&self) -> Option<tokio::time::Instant> {
+        None
+    }
 }
 
 /// Pushing a live session's frames to whoever is watching it.

--- a/crates/agent_session/src/domain/service.rs
+++ b/crates/agent_session/src/domain/service.rs
@@ -722,8 +722,29 @@ fn validate_agent_session_name(raw: &str) -> Result<&str> {
     Ok(name)
 }
 
+/// How long an appended frame may sit buffered before it must be durably
+/// flushed. The crash window: a process dying loses at most this much of the
+/// *tail* of a session's streamed output - flushes happen in append order, so
+/// a lost suffix never punches a hole in the middle of the log.
+const LOG_FLUSH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+/// How many frames may accumulate before a flush happens regardless of age,
+/// bounding both memory and the size of the batch a crash could lose.
+const MAX_BUFFERED_LOG_FRAMES: usize = 32;
+
 /// The [`AgentSessionLogRepo`] a session's actor writes through: the durable
 /// append, then the push to whoever is watching the session right now.
+///
+/// Writes are batched. Streamed output chunks - the overwhelming bulk of a
+/// live session's frames - are buffered and written [`MAX_BUFFERED_LOG_FRAMES`]
+/// at a time or every [`LOG_FLUSH_INTERVAL`], whichever comes first, instead
+/// of costing a Postgres transaction each. Frames the rest of the system
+/// reacts to keep the old durable-before-anything contract: anything headed
+/// to the runtime (a prompt the agent will act on must never be missing from
+/// history) and system events (they project onto the session's status) flush
+/// the buffer through with themselves before this writer does anything else
+/// with them. Streaming to viewers stays per-frame either way - a buffered
+/// frame is published immediately, durability deferred, which is the whole
+/// point.
 ///
 /// This is also where a writer's fold lives, and the fold is what makes
 /// re-attaching correct: [`TurnId`](agent_fold::domain::model::TurnId)s are a
@@ -739,6 +760,14 @@ pub struct LiveSessionLogWriter<R, Rt> {
     repo: R,
     realtime: Rt,
     fold: Option<FoldMachineImpl>,
+    /// Frames appended but not yet durably written, stamped when they arrived.
+    buffer: Vec<StoredAgentSessionLog>,
+    /// When the oldest buffered frame must be flushed by; `None` while the
+    /// buffer is empty.
+    flush_due: Option<tokio::time::Instant>,
+    /// The model last projected onto the session row, so a thousand streamed
+    /// frames under one model cost one `UPDATE`, not a thousand.
+    projected_model: Option<String>,
 }
 
 impl<R, Rt> LiveSessionLogWriter<R, Rt> {
@@ -753,6 +782,9 @@ impl<R, Rt> LiveSessionLogWriter<R, Rt> {
             repo,
             realtime,
             fold: None,
+            buffer: Vec::new(),
+            flush_due: None,
+            projected_model: None,
         }
     }
 }
@@ -780,12 +812,31 @@ where
             );
         }
 
-        // Durable first: projections are rebuildable, but a frame omitted from
-        // session history is not.
-        let stored = AgentSessionLogRepo::create(&self.repo, log.clone()).await?;
+        // A frame the rest of the system reacts to must be durable before it
+        // is acted on: anything headed to the runtime (session history must
+        // never lack a message its agent received) and system events (they
+        // project onto the session's status). Streamed output chunks are the
+        // volume, and only ever get read back, so they can wait for the batch.
+        let flush_through = matches!(
+            &log.content,
+            Message::ToRuntime(_) | Message::ToServer(ToServerMessage::Event { .. })
+        );
+
+        // Stamped now rather than at flush: `created_at` records when the log
+        // accepted the frame, and it is all a reader has to order by.
+        let stored = StoredAgentSessionLog {
+            created_at: chrono::Utc::now(),
+            entry: log.clone(),
+        };
+        self.buffer.push(stored.clone());
+        self.flush_due
+            .get_or_insert_with(|| tokio::time::Instant::now() + LOG_FLUSH_INTERVAL);
+        if flush_through || self.buffer.len() >= MAX_BUFFERED_LOG_FRAMES {
+            AgentSessionLogWriter::flush(self).await?;
+        }
 
         if let Some(fold) = &mut self.fold {
-            let _ = fold.push(log.clone());
+            let _ = fold.push(log);
         } else {
             match self.catch_up(session).await {
                 Ok(fold) => self.fold = Some(fold),
@@ -799,25 +850,33 @@ where
             }
         }
 
-        // Projected on every frame - idempotent, rebuildable from the log,
+        // Projected when it changes - idempotent, rebuildable from the log,
         // and best-effort like the stream below, so a failed write must not
-        // fail the append. Batch if the write rate ever matters.
+        // fail the append.
         if let Some(model) = self
             .fold
             .as_ref()
             .and_then(|fold| fold.metadata().model.clone())
-            && let Err(error) = self.repo.set_model(session, &model).await
+            && self.projected_model.as_ref() != Some(&model)
         {
-            tracing::error!(
-                error = ?error,
-                %session,
-                "failed to project agent session model"
-            );
+            match self.repo.set_model(session, &model).await {
+                Ok(()) => self.projected_model = Some(model),
+                Err(error) => {
+                    tracing::error!(
+                        error = ?error,
+                        %session,
+                        "failed to project agent session model"
+                    );
+                }
+            }
         }
 
-        // Best-effort once the durable append has succeeded: the port drops
-        // frames by contract, and the log this was derived from is already
-        // durable, so the worst a failure costs is a viewer who has to reload.
+        // Best-effort, and for a buffered frame it deliberately runs ahead of
+        // durability: viewers watch streamed output live, so it cannot wait
+        // for the batch. The port drops frames by contract, and a reader who
+        // reloads folds the stored log - so the worst a dropped publish costs
+        // is a viewer who has to reload, and the worst a crash costs is a
+        // viewer who briefly saw frames the log lost with the buffer.
         if let Err(error) = self.stream(session, stored).await {
             tracing::error!(
                 error = ?error,
@@ -826,6 +885,26 @@ where
             );
         }
         Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<()> {
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+        let result = AgentSessionLogRepo::create_batch(&self.repo, self.buffer.clone()).await;
+        // Cleared on failure too: retrying a batch whose commit may have
+        // landed would duplicate frames, so a failed flush loses its frames
+        // the same way a failed per-frame write used to lose its one - and
+        // the caller tears the session down over the error either way. Only
+        // cancellation (this future dropped mid-write) keeps the buffer, for
+        // the shutdown path to retry.
+        self.buffer.clear();
+        self.flush_due = None;
+        result
+    }
+
+    fn flush_deadline(&self) -> Option<tokio::time::Instant> {
+        self.flush_due
     }
 }
 
@@ -930,12 +1009,13 @@ where
             .await
     }
 
-    /// Walk this connection's fold through the session's stored log, so it
-    /// starts from where the session actually is rather than from nothing.
+    /// Walk this connection's fold through the session's stored log and then
+    /// through anything still buffered, so it starts from where the session
+    /// actually is rather than from nothing.
     ///
     /// Runs once per connection, on its first frame - by which point that
-    /// frame is already in the log, so replaying the log folds it too and the
-    /// caller must not push it again.
+    /// frame is in the log or in the buffer, so replaying both folds it too
+    /// and the caller must not push it again.
     ///
     /// This is what makes re-attaching correct.
     /// [`TurnId`](agent_fold::domain::model::TurnId)s are a counter over the
@@ -954,6 +1034,9 @@ where
         let mut fold = FoldMachineImpl::new();
         for stored in log {
             let _ = fold.push(stored.entry);
+        }
+        for stored in &self.buffer {
+            let _ = fold.push(stored.entry.clone());
         }
         Ok(fold)
     }

--- a/crates/agent_session/src/domain/service/test.rs
+++ b/crates/agent_session/src/domain/service/test.rs
@@ -408,6 +408,22 @@ impl AgentSessionLogRepo for BlockingPromptLogs {
         AgentSessionLogRepo::create(&self.repo, log).await
     }
 
+    async fn create_batch(&self, entries: Vec<StoredAgentSessionLog>) -> Result<()> {
+        if self.hang_disconnect
+            && entries.iter().any(|stored| {
+                matches!(
+                    &stored.entry.content,
+                    Message::ToServer(ToServerMessage::Event {
+                        event: SystemEvent::Disconnected
+                    })
+                )
+            })
+        {
+            return std::future::pending().await;
+        }
+        AgentSessionLogRepo::create_batch(&self.repo, entries).await
+    }
+
     async fn list_by_session(
         &self,
         agent_session_id: AgentSessionId,
@@ -760,6 +776,9 @@ async fn live_inbound_logs_do_not_reuse_the_expired_handshake_deadline() {
 
     let mut persisted = false;
     for _ in 0..20 {
+        // A streamed update sits in the writer's buffer until its flush
+        // interval elapses; time is paused, so elapse it by hand.
+        tokio::time::advance(LOG_FLUSH_INTERVAL).await;
         tokio::task::yield_now().await;
         persisted = AgentSessionLogRepo::list_by_session(&repo, session)
             .await
@@ -835,6 +854,159 @@ async fn appending_persists_the_event() {
         .await
         .expect("in-memory repo cannot fail");
     assert_eq!(log.len(), 2);
+}
+
+/// A streamed output chunk, the frame shape that makes up the bulk of a live
+/// session's log - the kind the writer holds back for a batch.
+fn streamed_chunk(session: AgentSessionId) -> AgentSessionLog {
+    AgentSessionLog {
+        agent_session_id: session,
+        user_id: None,
+        content: Message::ToServer(ToServerMessage::Acp(AcpMessage(
+            agent_client_protocol::RawJsonRpcMessage::notification(
+                "session/update".to_owned(),
+                serde_json::json!({ "sessionId": "acp-1", "update": {} }),
+            )
+            .expect("a notification builds"),
+        ))),
+    }
+}
+
+/// A frame headed to the runtime - the kind that must be durable before the
+/// agent can have acted on it.
+fn runtime_bound(session: AgentSessionId) -> AgentSessionLog {
+    AgentSessionLog {
+        agent_session_id: session,
+        user_id: None,
+        content: Message::ToRuntime(ToRuntimeMessage::Acp(AcpMessage(
+            agent_client_protocol::RawJsonRpcMessage::notification(
+                "session/cancel".to_owned(),
+                serde_json::json!({ "sessionId": "acp-1" }),
+            )
+            .expect("a notification builds"),
+        ))),
+    }
+}
+
+/// Streamed chunks wait for the batch: they are published to viewers at once,
+/// but only reach the store when the writer flushes.
+#[tokio::test]
+async fn streamed_frames_are_buffered_until_flushed() {
+    let fx = fixture();
+    let realtime = RecordingRealtime::new();
+    let mut logs = streaming_connection(fx.repo.clone(), realtime.clone());
+
+    AgentSessionLogWriter::append(&mut logs, streamed_chunk(fx.session))
+        .await
+        .expect("append succeeds");
+    AgentSessionLogWriter::append(&mut logs, streamed_chunk(fx.session))
+        .await
+        .expect("append succeeds");
+
+    assert_eq!(realtime.published().len(), 2, "viewers see frames live");
+    assert!(
+        AgentSessionLogRepo::list_by_session(&fx.repo, fx.session)
+            .await
+            .expect("in-memory repo cannot fail")
+            .is_empty(),
+        "streamed chunks wait for the batch"
+    );
+    assert!(
+        logs.flush_deadline().is_some(),
+        "a buffering writer names its deadline so the actor can wake for it"
+    );
+
+    AgentSessionLogWriter::flush(&mut logs)
+        .await
+        .expect("flush succeeds");
+
+    let stored = AgentSessionLogRepo::list_by_session(&fx.repo, fx.session)
+        .await
+        .expect("in-memory repo cannot fail");
+    assert_eq!(stored.len(), 2, "the flush wrote the whole buffer");
+    assert_eq!(
+        stored
+            .iter()
+            .map(|entry| entry.created_at)
+            .collect::<Vec<_>>(),
+        realtime
+            .published()
+            .iter()
+            .map(|event| event.entry.created_at)
+            .collect::<Vec<_>>(),
+        "stored frames keep the stamps they were published with"
+    );
+    assert!(
+        logs.flush_deadline().is_none(),
+        "an empty buffer must not wake the actor"
+    );
+}
+
+/// A frame the rest of the system reacts to cannot wait: it flushes whatever
+/// is buffered through with itself, in append order.
+#[tokio::test]
+async fn runtime_bound_frames_flush_the_buffer_through() {
+    let fx = fixture();
+    let mut logs = connection(fx.repo.clone());
+
+    AgentSessionLogWriter::append(&mut logs, streamed_chunk(fx.session))
+        .await
+        .expect("append succeeds");
+    AgentSessionLogWriter::append(&mut logs, runtime_bound(fx.session))
+        .await
+        .expect("append succeeds");
+
+    let stored = AgentSessionLogRepo::list_by_session(&fx.repo, fx.session)
+        .await
+        .expect("in-memory repo cannot fail");
+    assert!(
+        matches!(
+            &stored[..],
+            [
+                StoredAgentSessionLog {
+                    entry: AgentSessionLog {
+                        content: Message::ToServer(_),
+                        ..
+                    },
+                    ..
+                },
+                StoredAgentSessionLog {
+                    entry: AgentSessionLog {
+                        content: Message::ToRuntime(_),
+                        ..
+                    },
+                    ..
+                },
+            ]
+        ),
+        "both frames are durable before the append returns, in append order"
+    );
+}
+
+/// The buffer is bounded: filling it flushes without waiting for the interval.
+#[tokio::test]
+async fn a_full_buffer_flushes_without_waiting() {
+    let fx = fixture();
+    let mut logs = connection(fx.repo.clone());
+
+    for _ in 0..MAX_BUFFERED_LOG_FRAMES {
+        AgentSessionLogWriter::append(&mut logs, streamed_chunk(fx.session))
+            .await
+            .expect("append succeeds");
+    }
+
+    let stored = AgentSessionLogRepo::list_by_session(&fx.repo, fx.session)
+        .await
+        .expect("in-memory repo cannot fail");
+    assert_eq!(
+        stored.len(),
+        MAX_BUFFERED_LOG_FRAMES,
+        "filling the buffer is a flush trigger of its own"
+    );
+    assert!(
+        logs.flush_deadline().is_none(),
+        "nothing is left buffered after the size-triggered flush"
+    );
 }
 
 #[tokio::test]
@@ -943,6 +1115,11 @@ async fn a_connections_frames_are_published_to_its_channel() {
             .await
             .expect("append succeeds");
     }
+    // Streamed chunks may still be buffered; the durable log is only complete
+    // once the writer has flushed.
+    AgentSessionLogWriter::flush(&mut logs)
+        .await
+        .expect("flush succeeds");
 
     let published = realtime.published();
     assert_eq!(published.len(), log.len(), "one event per frame, no more");
@@ -1036,6 +1213,9 @@ async fn a_failed_publish_does_not_fail_the_append() {
             .await
             .expect("a refused publish does not fail the append");
     }
+    AgentSessionLogWriter::flush(&mut logs)
+        .await
+        .expect("flush succeeds");
 
     let stored = AgentSessionLogRepo::list_by_session(&repo, test_session())
         .await

--- a/crates/agent_session/src/domain/session/actors.rs
+++ b/crates/agent_session/src/domain/session/actors.rs
@@ -154,8 +154,29 @@ where
                     std::future::pending::<()>().await;
                 }
             };
+            let log_flush_deadline = self.logs.flush_deadline();
+            let log_flush_due = async {
+                match log_flush_deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => std::future::pending().await,
+                }
+            };
             let input = tokio::select! {
             () = handshake_timeout => Input::Closed(CloseReason::HandshakeTimedOut),
+            // Buffered log frames have waited long enough; write them out. A
+            // failed flush is a failed log write, and the machine decides
+            // what that means, same as a failed append.
+            () = log_flush_due => match self.logs.flush().await {
+                Ok(()) => continue,
+                Err(error) => {
+                    tracing::error!(
+                        error = ?error,
+                        id = %self.machine.id(),
+                        "agent session failed to flush buffered log frames"
+                    );
+                    Input::Closed(CloseReason::LogFailed)
+                }
+            },
             command = self.commands.recv() => match command {
                 Some(SessionCommand { user_id, action, action_id, completed, span, enqueued_at }) => {
                     span.record(

--- a/crates/agent_session/src/outbound/postgres.rs
+++ b/crates/agent_session/src/outbound/postgres.rs
@@ -722,6 +722,95 @@ impl AgentSessionLogRepo for PgAgentSessionRepo {
         })
     }
 
+    async fn create_batch(&self, entries: Vec<StoredAgentSessionLog>) -> Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        let mut ids = Vec::with_capacity(entries.len());
+        let mut session_ids = Vec::with_capacity(entries.len());
+        let mut user_ids: Vec<Option<String>> = Vec::with_capacity(entries.len());
+        let mut directions: Vec<String> = Vec::with_capacity(entries.len());
+        let mut contents = Vec::with_capacity(entries.len());
+        let mut created_ats = Vec::with_capacity(entries.len());
+        for stored in &entries {
+            let (direction, content) = message_columns(&stored.entry.content)?;
+            ids.push(macro_uuid::generate_uuid_v7());
+            session_ids.push(stored.entry.agent_session_id.as_uuid());
+            user_ids.push(
+                stored
+                    .entry
+                    .user_id
+                    .as_ref()
+                    .map(|user_id| user_id.as_ref().to_owned()),
+            );
+            directions.push(direction.to_owned());
+            contents.push(content);
+            created_ats.push(stored.created_at);
+        }
+
+        // Only the last event needs projecting: statuses overwrite, so the
+        // intermediates were never observable.
+        let event_status = entries
+            .iter()
+            .rev()
+            .find_map(|stored| match &stored.entry.content {
+                Message::ToServer(ToServerMessage::Event { event }) => Some((
+                    stored.entry.agent_session_id,
+                    SessionStatus::Event(event.clone()),
+                )),
+                _ => None,
+            });
+
+        let mut transaction = self
+            .pool
+            .begin()
+            .await
+            .context("begin agent session log batch create")?;
+        sqlx::query!(
+            r#"
+            INSERT INTO agent_session_log (id, agent_session_id, user_id, direction, content, created_at)
+            SELECT * FROM UNNEST(
+                $1::uuid[], $2::uuid[], $3::text[], $4::text[], $5::jsonb[], $6::timestamptz[]
+            )
+            "#,
+            &ids,
+            &session_ids,
+            &user_ids as &[Option<String>],
+            &directions,
+            &contents,
+            &created_ats,
+        )
+        .execute(&mut *transaction)
+        .await
+        .context("failed to create agent session log batch")?;
+
+        if let Some((session_id, status)) = event_status {
+            let (status, status_event_name) = status_columns(&status);
+            sqlx::query!(
+                r#"
+                UPDATE agent_session
+                SET status = $2,
+                    status_event_name = $3,
+                    modified_at = now()
+                WHERE id = $1
+                "#,
+                session_id.as_uuid(),
+                status,
+                status_event_name,
+            )
+            .execute(&mut *transaction)
+            .await
+            .context("failed to update agent session status from log batch")?;
+        }
+
+        transaction
+            .commit()
+            .await
+            .context("commit agent session log batch create")?;
+        Ok(())
+    }
+
     async fn list_by_session(
         &self,
         agent_session_id: AgentSessionId,

--- a/crates/agent_session/src/outbound/postgres/test.rs
+++ b/crates/agent_session/src/outbound/postgres/test.rs
@@ -463,6 +463,86 @@ async fn log_create_and_list_by_session_orders_chronologically(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn log_create_batch_stores_stamps_and_projects_the_last_event(pool: PgPool) {
+    let repo = PgAgentSessionRepo::new(pool.clone());
+    let bot_id = create_test_bot(&pool).await;
+    let session_id = create_session(&repo, new_session(bot_id, None, None))
+        .await
+        .id;
+
+    let user = user_id("macro|agent-session-log-batch-test@example.com");
+    let stamp = |offset_ms: i64| {
+        chrono::Utc::now() - chrono::Duration::milliseconds(1_000)
+            + chrono::Duration::milliseconds(offset_ms)
+    };
+    let entries = vec![
+        StoredAgentSessionLog {
+            created_at: stamp(0),
+            entry: AgentSessionLog {
+                agent_session_id: session_id,
+                user_id: Some(user.clone()),
+                content: Message::ToRuntime(ToRuntimeMessage::Acp(acp_notification())),
+            },
+        },
+        StoredAgentSessionLog {
+            created_at: stamp(1),
+            entry: AgentSessionLog {
+                agent_session_id: session_id,
+                user_id: None,
+                content: Message::ToServer(ToServerMessage::Event {
+                    event: SystemEvent::AcpReady,
+                }),
+            },
+        },
+        StoredAgentSessionLog {
+            created_at: stamp(2),
+            entry: AgentSessionLog {
+                agent_session_id: session_id,
+                user_id: None,
+                content: Message::ToServer(ToServerMessage::Event {
+                    event: SystemEvent::Disconnected,
+                }),
+            },
+        },
+    ];
+
+    AgentSessionLogRepo::create_batch(&repo, entries.clone())
+        .await
+        .expect("create log batch");
+
+    let logs = repo
+        .list_by_session(session_id)
+        .await
+        .expect("list agent session log entries");
+    assert_eq!(logs.len(), 3, "every entry in the batch is durable");
+    // The writer's stamps survive the batch (to Postgres's microsecond
+    // resolution), so ordering reflects when frames were appended, not when
+    // the flush landed.
+    for (stored, given) in logs.iter().zip(&entries) {
+        assert_eq!(stored.entry.user_id, given.entry.user_id);
+        assert!((stored.created_at - given.created_at).abs() < chrono::Duration::milliseconds(1));
+    }
+    assert!(matches!(
+        logs[0].entry.content,
+        Message::ToRuntime(ToRuntimeMessage::Acp(_))
+    ));
+
+    // Only the last event projects onto the session status.
+    let session = AgentSessionRepo::get(&repo, session_id)
+        .await
+        .expect("get session after batch");
+    assert!(matches!(
+        session.status,
+        SessionStatus::Event(SystemEvent::Disconnected)
+    ));
+
+    // An empty batch is a no-op, not an invalid statement.
+    AgentSessionLogRepo::create_batch(&repo, Vec::new())
+        .await
+        .expect("empty batch is fine");
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
 async fn find_for_channel_matches_the_originating_thread_and_bot(pool: PgPool) {
     let repo = PgAgentSessionRepo::new(pool.clone());
     let bot_a = create_test_bot(&pool).await;

--- a/crates/agent_session/src/testing.rs
+++ b/crates/agent_session/src/testing.rs
@@ -70,6 +70,51 @@ impl InMemoryAgentSessionRepo {
         self.session_reads.load(Ordering::Relaxed)
     }
 
+    /// Record one already-stamped log entry and apply the same projections
+    /// [`AgentSessionLogRepo::create`] does, so the batch path cannot drift.
+    fn persist_stored(&self, stored: StoredAgentSessionLog) {
+        let model_change = match &stored.entry.content {
+            crate::domain::model::Message::ToRuntime(message) => {
+                agent_runtime_protocol::domain::action::AgentSetModelAction::from_runtime(message)
+            }
+            _ => None,
+        };
+        let event = match &stored.entry.content {
+            crate::domain::model::Message::ToServer(ToServerMessage::Event { event }) => {
+                Some(event.clone())
+            }
+            _ => None,
+        };
+        let session_id = stored.entry.agent_session_id;
+        self.logs
+            .lock()
+            .expect("in-memory log store is not poisoned")
+            .entry(session_id)
+            .or_default()
+            .push(stored);
+        if let Some(event) = event
+            && let Some(session) = self
+                .sessions
+                .lock()
+                .expect("in-memory session store is not poisoned")
+                .get_mut(&session_id)
+        {
+            session.status = SessionStatus::Event(event);
+            session.modified_at = chrono::Utc::now();
+        }
+        if let Some((acp_session_id, change)) = model_change
+            && let Some(session) = self
+                .sessions
+                .lock()
+                .expect("in-memory session store is not poisoned")
+                .get_mut(&session_id)
+            && session.acp_session_id.as_ref() == Some(&acp_session_id)
+        {
+            session.model = change.model;
+            session.modified_at = chrono::Utc::now();
+        }
+    }
+
     /// Seed log entries, in the order they should be read back.
     ///
     /// Each is stamped as it lands, the way the real table's `created_at`
@@ -291,88 +336,19 @@ impl AgentSessionRepo for InMemoryAgentSessionRepo {
 
 impl AgentSessionLogRepo for InMemoryAgentSessionRepo {
     async fn create(&self, log: AgentSessionLog) -> Result<StoredAgentSessionLog> {
-        let model_change = match &log.content {
-            crate::domain::model::Message::ToRuntime(message) => {
-                agent_runtime_protocol::domain::action::AgentSetModelAction::from_runtime(message)
-            }
-            _ => None,
-        };
-        let event = match &log.content {
-            crate::domain::model::Message::ToServer(ToServerMessage::Event { event }) => {
-                Some(event.clone())
-            }
-            _ => None,
-        };
-        let session_id = log.agent_session_id;
         let stored = StoredAgentSessionLog {
             created_at: chrono::Utc::now(),
             entry: log,
         };
-        self.logs
-            .lock()
-            .expect("in-memory log store is not poisoned")
-            .entry(session_id)
-            .or_default()
-            .push(stored.clone());
-        if let Some(event) = event
-            && let Some(session) = self
-                .sessions
-                .lock()
-                .expect("in-memory session store is not poisoned")
-                .get_mut(&session_id)
-        {
-            session.status = SessionStatus::Event(event);
-            session.modified_at = chrono::Utc::now();
-        }
-        if let Some((acp_session_id, change)) = model_change
-            && let Some(session) = self
-                .sessions
-                .lock()
-                .expect("in-memory session store is not poisoned")
-                .get_mut(&session_id)
-            && session.acp_session_id.as_ref() == Some(&acp_session_id)
-        {
-            session.model = change.model;
-            session.modified_at = chrono::Utc::now();
-        }
+        self.persist_stored(stored.clone());
         Ok(stored)
     }
 
     async fn create_batch(&self, entries: Vec<StoredAgentSessionLog>) -> Result<()> {
-        // The last event wins the status projection, same as the Postgres
-        // adapter - statuses overwrite, so intermediates were never
-        // observable.
-        let event = entries
-            .iter()
-            .rev()
-            .find_map(|stored| match &stored.entry.content {
-                crate::domain::model::Message::ToServer(ToServerMessage::Event { event }) => {
-                    Some((stored.entry.agent_session_id, event.clone()))
-                }
-                _ => None,
-            });
-        {
-            let mut logs = self
-                .logs
-                .lock()
-                .expect("in-memory log store is not poisoned");
-            for stored in entries {
-                // Entries keep the writer's stamp: they carry the time they
-                // were appended, not the time the flush landed.
-                logs.entry(stored.entry.agent_session_id)
-                    .or_default()
-                    .push(stored);
-            }
-        }
-        if let Some((session_id, event)) = event
-            && let Some(session) = self
-                .sessions
-                .lock()
-                .expect("in-memory session store is not poisoned")
-                .get_mut(&session_id)
-        {
-            session.status = SessionStatus::Event(event);
-            session.modified_at = chrono::Utc::now();
+        for stored in entries {
+            // Entries keep the writer's stamp: they carry the time they
+            // were appended, not the time the flush landed.
+            self.persist_stored(stored);
         }
         Ok(())
     }
@@ -487,3 +463,6 @@ impl AgentSessionRealtime for RecordingRealtime {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/crates/agent_session/src/testing.rs
+++ b/crates/agent_session/src/testing.rs
@@ -338,6 +338,45 @@ impl AgentSessionLogRepo for InMemoryAgentSessionRepo {
         Ok(stored)
     }
 
+    async fn create_batch(&self, entries: Vec<StoredAgentSessionLog>) -> Result<()> {
+        // The last event wins the status projection, same as the Postgres
+        // adapter - statuses overwrite, so intermediates were never
+        // observable.
+        let event = entries
+            .iter()
+            .rev()
+            .find_map(|stored| match &stored.entry.content {
+                crate::domain::model::Message::ToServer(ToServerMessage::Event { event }) => {
+                    Some((stored.entry.agent_session_id, event.clone()))
+                }
+                _ => None,
+            });
+        {
+            let mut logs = self
+                .logs
+                .lock()
+                .expect("in-memory log store is not poisoned");
+            for stored in entries {
+                // Entries keep the writer's stamp: they carry the time they
+                // were appended, not the time the flush landed.
+                logs.entry(stored.entry.agent_session_id)
+                    .or_default()
+                    .push(stored);
+            }
+        }
+        if let Some((session_id, event)) = event
+            && let Some(session) = self
+                .sessions
+                .lock()
+                .expect("in-memory session store is not poisoned")
+                .get_mut(&session_id)
+        {
+            session.status = SessionStatus::Event(event);
+            session.modified_at = chrono::Utc::now();
+        }
+        Ok(())
+    }
+
     async fn list_by_session(
         &self,
         agent_session_id: AgentSessionId,

--- a/crates/agent_session/src/testing/test.rs
+++ b/crates/agent_session/src/testing/test.rs
@@ -1,0 +1,76 @@
+use super::*;
+use crate::domain::model::Message;
+use agent_client_protocol::schema::v1::RequestId;
+use agent_runtime_protocol::domain::action::AgentAction;
+
+fn set_model_log(
+    session_id: AgentSessionId,
+    acp: &SessionId,
+    model: &str,
+) -> StoredAgentSessionLog {
+    let message = AgentAction::set_model(model)
+        .to_runtime(acp, RequestId::Str("c".to_owned()))
+        .expect("set-model is a runtime frame");
+    StoredAgentSessionLog {
+        created_at: chrono::Utc::now(),
+        entry: AgentSessionLog {
+            agent_session_id: session_id,
+            user_id: None,
+            content: Message::ToRuntime(message),
+        },
+    }
+}
+
+fn session_with_acp(id: AgentSessionId, acp: SessionId) -> AgentSession {
+    let mut session = test_agent_session(id);
+    session.model = "claude".to_owned();
+    session.acp_session_id = Some(acp);
+    session
+}
+
+#[tokio::test]
+async fn create_batch_projects_a_set_model_request_onto_the_session() {
+    let repo = InMemoryAgentSessionRepo::new();
+    let id = AgentSessionId::new();
+    let acp = SessionId::new("s1");
+    repo.insert_session(session_with_acp(id, acp.clone()));
+
+    AgentSessionLogRepo::create_batch(&repo, vec![set_model_log(id, &acp, "opus")])
+        .await
+        .expect("batch write");
+
+    assert_eq!(
+        AgentSessionRepo::get(&repo, id)
+            .await
+            .expect("exists")
+            .model,
+        "opus",
+        "create_batch must project models the same way create does"
+    );
+}
+
+#[tokio::test]
+async fn create_batch_projects_the_last_set_model_in_the_batch() {
+    let repo = InMemoryAgentSessionRepo::new();
+    let id = AgentSessionId::new();
+    let acp = SessionId::new("s1");
+    repo.insert_session(session_with_acp(id, acp.clone()));
+
+    AgentSessionLogRepo::create_batch(
+        &repo,
+        vec![
+            set_model_log(id, &acp, "sonnet"),
+            set_model_log(id, &acp, "opus"),
+        ],
+    )
+    .await
+    .expect("batch write");
+
+    assert_eq!(
+        AgentSessionRepo::get(&repo, id)
+            .await
+            .expect("exists")
+            .model,
+        "opus"
+    );
+}


### PR DESCRIPTION
## Why

Every ACP frame crossing `LiveSessionLogWriter::append` cost its own Postgres transaction (`BEGIN` + `INSERT` + optional status `UPDATE` + `COMMIT`) — several round trips per frame, many frames per second per token-streaming session. The code even had a comment anticipating this: *"Batch if the write rate ever matters."*

## What

**Buffered writes for streamed chunks.** `LiveSessionLogWriter` now buffers streamed output frames and lands them in one multi-row `INSERT ... UNNEST` via a new `AgentSessionLogRepo::create_batch`. Flush triggers:

- 1 second since the first buffered frame (`LOG_FLUSH_INTERVAL`, driven by a new arm in the session actor's `next_input` select loop),
- 32 buffered frames (`MAX_BUFFERED_LOG_FRAMES`),
- any flush-through frame (below) arriving.

**Durability contract kept where it matters.** Frames the rest of the system reacts to flush the buffer through with themselves *before* the append returns: anything headed to the runtime (history must never lack a message the agent received) and system events (they project onto session status). Only streamed `ToServer` output — the volume — waits for the batch, so a crash loses at most ~1s of the *tail* of streamed output, never a hole in the middle (flushes are in append order).

**Streaming stays live.** Viewers get every frame published immediately; for buffered frames durability is deferred behind the publish, which is the point.

**Timestamps stay truthful.** Frames are stamped by the writer when appended, not when the flush lands, and the batch insert writes those stamps — so `ORDER BY created_at, id` read-back still reflects append order, and streamed timestamps match stored ones exactly.

**Write coalescing on projections.** Only the last system event in a batch projects onto `agent_session.status` (statuses overwrite; intermediates were never observable), and the model projection now writes only when the model changes rather than an `UPDATE` per frame.

## Notes

- `append` returning `Ok` now means durable *or* buffered; a failed flush drops its batch (same loss semantics as the old failed per-frame write, never a duplicate) and tears the session down through the existing `LogFailed` path.
- `seed_jsonl` flushes after its replay loop.
- New coverage: writer buffering/flush-through/size-trigger tests, and a live-Postgres `create_batch` test (stamps survive, last event projects, empty batch is a no-op).

## Testing

- `cargo test -p agent_session` — 115 passed (live local Postgres).
- `cargo check` of dependent crates (`agent_harness`, `agent_trigger`, `agent_inmem`, `coding_agent_worker`, `webhook`) against the live DB.
- `just prepare_db` — one new cached query, checked in.
- Offline clippy (CI shape) clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent session log persistence semantics (brief tail loss on crash for buffered stream chunks) and adds timed flush in the actor loop, though runtime-bound and status frames keep the prior durable-before-act contract.
> 
> **Overview**
> **Live session log writes are batched** so high-volume streamed ACP output no longer triggers a Postgres transaction per frame. `LiveSessionLogWriter` buffers frames and persists them via new `AgentSessionLogRepo::create_batch` (multi-row `INSERT … UNNEST`), flushing on a **1s timer**, when **32 frames** accumulate, or when a **flush-through** frame arrives.
> 
> **Durability rules are split by frame kind.** `ToRuntime` messages and system events still force a flush before `append` returns; streamed `ToServer` chunks can stay buffered. **Viewers still get realtime publishes immediately**; only durability is deferred for those chunks. Frames are **`created_at`-stamped at append**, and batch inserts preserve those stamps for ordering.
> 
> The **session actor** now wakes on `flush_deadline` to flush buffered logs (failures close via `LogFailed`). **Postgres batch writes** project only the **last** system event in a batch onto session status; the writer also **coalesces model `UPDATE`s** when the model unchanged. `seed_jsonl` and tests call **`flush`** where a complete durable log is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 200e62399e01d0869bdcdd6a10509532984f66d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->