### PR TITLE
fix(block-agent): poll for a Cursor session's external url

### DIFF
--- a/apps/web/src/features/block-agent/context/create-agent-session-feed.ts
+++ b/apps/web/src/features/block-agent/context/create-agent-session-feed.ts
@@ -27,6 +27,7 @@ import {
   type Accessor,
   batch,
   createEffect,
+  createMemo,
   createResource,
   createSignal,
   onCleanup,
@@ -49,6 +50,14 @@ export type AgentSessionFeed = {
   /** The newest turn has no stop reason yet — the agent is working. */
   working: Accessor<boolean>;
 };
+
+/**
+ * How often, and how many times, to re-read a Cursor session's snapshot
+ * while its cursor.com url is still missing. Together they span ~30s, which
+ * comfortably covers Cursor's agent creation inside the first prompt.
+ */
+export const EXTERNAL_URL_POLL_INTERVAL_MS = 2_000;
+export const EXTERNAL_URL_POLL_ATTEMPTS = 15;
 
 /** Prompt sorts before reply within a turn. */
 function authorRank(message: FoldedMessage): number {
@@ -196,28 +205,50 @@ export function createAgentSessionFeed(
   };
 
   // The external identity — the Cursor agent's id, name, and the link out to
-  // it — is minted inside the session's *first prompt*, so the snapshot
-  // fetched at load never carries it: `create` returns those columns NULL by
-  // construction. Nothing announces it on the wire either, so re-read the
-  // snapshot once a turn has settled, and keep the whole payload this time.
+  // it — is minted by Cursor's API inside the session's *first prompt*, so
+  // the snapshot fetched at load never carries it: `create` returns those
+  // columns NULL by construction. Nothing announces it on the wire either,
+  // so a session opened before the mint must poll the snapshot for it.
   //
-  // Bounded by construction: the only session kind that gets one is Cursor's,
-  // and the moment it lands this stops matching. A turn that settles without
-  // minting one (a prompt that failed outright) is retried on the next.
-  createEffect(() => {
+  // The url specifically, not the row: the harness writes the row the moment
+  // the agent exists, but fills the url from a best-effort follow-up fetch
+  // that can fail, and a url-less row is exactly as unopenable as no row.
+  // The budget covers a slow mint; a session still url-less past it is that
+  // failed follow-up, which no amount of polling can repair.
+  // The memo gate keeps the interval from restarting — and the attempts
+  // budget from resetting — when the snapshot changes for unrelated reasons
+  // (a rename refresh replaces the whole value).
+  const sessionAwaitingExternalUrl = createMemo(() => {
     const id = sessionId();
     const session = resource.latest;
-    if (!id || !session || session.external) return;
-    if (!isCursorBotId(session.botId) || working() || messages().length === 0) {
-      return;
-    }
-    const run = generation;
-    void agentHarnessServiceClient.get(id).then((refreshed) => {
-      // A superseded run has already replaced the value this would land on.
-      if (refreshed.isErr() || closed || generation !== run) return;
-      if (sessionId() !== id || !refreshed.value.external) return;
-      mutate(refreshed.value);
-    });
+    if (!id || !session || session.external?.url) return undefined;
+    return isCursorBotId(session.botId) ? id : undefined;
+  });
+  createEffect(() => {
+    const id = sessionAwaitingExternalUrl();
+    if (!id) return;
+    let attempts = EXTERNAL_URL_POLL_ATTEMPTS;
+    let inFlight = false;
+    const read = () => {
+      if (inFlight) return;
+      if (attempts <= 0) {
+        clearInterval(timer);
+        return;
+      }
+      attempts -= 1;
+      inFlight = true;
+      void agentHarnessServiceClient.get(id).then((refreshed) => {
+        inFlight = false;
+        if (refreshed.isErr() || closed || sessionId() !== id) return;
+        if (!refreshed.value.external?.url) return;
+        // Landing the url flips the gate, so the interval is cleaned up
+        // rather than polling on.
+        mutate(refreshed.value);
+      });
+    };
+    const timer = setInterval(read, EXTERNAL_URL_POLL_INTERVAL_MS);
+    onCleanup(() => clearInterval(timer));
+    read();
   });
 
   return {


### PR DESCRIPTION
## Problem

The **Open in Cursor** button in the agent block header only renders once the session snapshot carries `external.url` — but Cursor's API mints that url inside the session's *first prompt* (`create_agent` requires a prompt), so a block opened from the magic chip mid-run loads a snapshot without it, and nothing announces the url on the wire.

The existing compensation in `create-agent-session-feed.ts` refetched the snapshot only **once a turn settled**, which has two failure modes users hit:

1. **Minutes of missing button.** The url exists in Postgres seconds after the prompt starts, but a Cursor cloud run takes minutes — no button until it finishes (a reload "fixes" it because the fresh GET picks the row up immediately).
2. **Permanently missing button.** The harness fills the url from a best-effort follow-up `get_agent`; when that fails the row is written url-less, and the old guard (`session.external` truthy) latched the refetch off forever.

## Fix

Replace the settle-gated refetch with a short bounded poll (2s × 15, ~30s of coverage), following the same `createEffect` + `setInterval` + `onCleanup` pattern as `incoming-calls.ts`:

- starts as soon as the snapshot shows a Cursor session with no `external.url` — the button appears within seconds of the agent being minted, mid-run
- keyed on the **url**, not the row, so a url-less row keeps polling instead of latching off
- memo-gated on the session id so unrelated snapshot refreshes (renames) don't restart the interval or reset the budget

All 7 existing tests in `create-agent-session-feed.test.ts` pass unchanged.

## Not in scope

A url-less row in Postgres (failed `get_agent` follow-up) can't be repaired from the client — that needs a backend backfill (retry on `resume` or lazily in the GET handler). The principled long-term fix is announcing the external identity over the session's realtime log so no polling is needed at all.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only polling in the agent session feed with a fixed budget; no auth, persistence, or API contract changes beyond repeated GETs.
> 
> **Overview**
> **Replaces the one-shot “refetch after turn settles” logic** for Cursor sessions missing an **Open in Cursor** link with a **bounded snapshot poll** (every 2s, up to 15 attempts ≈ 30s).
> 
> Polling starts as soon as the loaded snapshot is a Cursor bot session **without `external.url`**—including mid-run—so the header button can appear shortly after the harness writes the url, instead of waiting for a long cloud run to finish. The gate keys on **`external.url`**, not a truthy `external` row, so a url-less external record keeps polling instead of stopping refetches forever.
> 
> A **`createMemo`** on session id + “awaiting url” keeps unrelated snapshot updates (e.g. renames) from restarting the interval or resetting the attempt budget. Exported **`EXTERNAL_URL_POLL_INTERVAL_MS`** and **`EXTERNAL_URL_POLL_ATTEMPTS`** document the timing; cleanup uses **`onCleanup`** on the interval like other feed effects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8721d41544d3ef15e64086d8f5d2d763f9501c60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->