### PR TITLE
fix(agent_harness): source egress URL from Doppler

### DIFF
--- a/crates/cursor_cloud_agents/src/api.rs
+++ b/crates/cursor_cloud_agents/src/api.rs
@@ -289,7 +289,7 @@ impl CursorClient {
 }
 
 impl CursorAgents for CursorClient {
-    #[tracing::instrument(skip(self, prompt), err)]
+    #[tracing::instrument(skip_all, err, fields(mcp_servers = mcp_servers.len()))]
     async fn create_agent(
         &self,
         prompt: &str,

--- a/infra/stacks/agent-harness-service/agent_harness_service.ts
+++ b/infra/stacks/agent-harness-service/agent_harness_service.ts
@@ -347,13 +347,6 @@ export class AgentHarnessService extends pulumi.ComponentResource {
                   name: 'BASE_URL',
                   value: this.domain,
                 },
-                // Where sandboxes dial the egress proxy - through the ALB,
-                // not the container port, so it is set here where the
-                // hostname is defined rather than in Doppler.
-                {
-                  name: 'EGRESS_BASE_URL',
-                  value: this.egressDomain,
-                },
               ],
               secrets: [...dopplerEcsEnvironment.containerSecrets],
               logConfiguration: {

--- a/services/agent_harness_service/src/config.rs
+++ b/services/agent_harness_service/src/config.rs
@@ -145,7 +145,6 @@ pub struct Config {
     ///
     /// Not derivable from `egress_port`: the sandbox reaches this through
     /// whatever ingress fronts the deployment, not on the container's own port.
-    #[macro_config_default(String::from("http://localhost:8102"))]
     pub egress_base_url: String,
     /// OAuth client ID for the Pipedream API.
     pub pipedream_client_id: PipedreamClientId,


### PR DESCRIPTION
## Summary
- use Doppler `APP_SECRETS_JSON` as the single runtime source for `EGRESS_BASE_URL`
- remove the ineffective duplicate Pulumi process environment entry
- require the egress URL at startup instead of silently falling back to localhost
- stop Cursor agent-creation spans from recording MCP headers and session bearers

## Root cause
`macro_config` treats `APP_SECRETS_JSON` as the authoritative configuration object. When it did not contain `EGRESS_BASE_URL`, it did not fall back to the process environment entry injected by Pulumi, so the service silently used `http://localhost:8102`. Cursor cloud agents then attempted Macro, Linear, and other proxied MCP discovery against their own localhost.

The Doppler configs now contain:
- dev: `https://agent-harness-egress-dev.macro.com`
- prd: `https://agent-harness-egress.macro.com`

The synced dev Secrets Manager value was verified and the dev ECS service was restarted successfully. Production was not restarted. Existing Cursor agents retain creation-time MCP configuration and need to be recreated.

The Datadog trace used to diagnose this also showed that `CursorClient::create_agent` recorded the full MCP server value, including its bearer. The span now records only the server count.

## Verification
- `cargo test -p cursor_cloud_agents`
- `cargo test -p agent_harness_service`
- `cargo fmt --check`
- `bun run check` in `infra`
- `bunx biome check stacks/agent-harness-service/agent_harness_service.ts`
- `git diff --check`
- dev ECS service returned to one healthy running task
- no new `agent-harness-service` error logs after restart

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Misconfigured egress URL would break sandbox MCP/proxy traffic at startup (now explicit) rather than silently; deployed envs must have Doppler values set before restart.
> 
> **Overview**
> **Egress URL configuration** is fixed so sandboxes dial the real egress ingress instead of `http://localhost:8102`. The service no longer defaults `egress_base_url` to localhost; it must be present in Doppler-driven `APP_SECRETS_JSON` (via `macro_config`), and startup fails if it is missing. Pulumi no longer injects a duplicate `EGRESS_BASE_URL` on the ECS task—that value was ignored when absent from the secrets JSON, which is why Cursor cloud agents were discovering Macro/Linear MCP against their own localhost.
> 
> Separately, **`create_agent` tracing** in `cursor_cloud_agents` uses `skip_all` and logs only `mcp_servers` count instead of skipping just `self` and `prompt`, reducing risk of logging large prompts while keeping useful fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 150f9b3c086fe7dc50b216a914e32d064195851c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->