### PR TITLE
infra(agent-harness): roll deploys instead of stop-then-start

### DIFF
--- a/infra/stacks/agent-harness-service/agent_harness_service.ts
+++ b/infra/stacks/agent-harness-service/agent_harness_service.ts
@@ -60,11 +60,18 @@ type Args = {
 
 /**
  * The agent harness service. Like agent-proxy before it, this component pins
- * `desiredCount` to 1 and forces a stop-then-start deployment (min healthy
- * 0%, max 100%) with no autoscaling: the harness owns the live agent-session
- * actors in process memory with no cross-instance sync, and its Kafka consumer
- * groups must not split partitions across two momentarily-coexisting tasks
- * (see the consumer groups in `services/agent_harness_service`).
+ * `desiredCount` to 1 with no autoscaling: the harness owns the live
+ * agent-session actors in process memory with no cross-instance sync (see the
+ * consumer groups in `services/agent_harness_service`).
+ *
+ * Deploys roll (min healthy 100%, max 200%): the outgoing task keeps serving
+ * until the replacement passes health checks, so the control API and egress
+ * proxy stay up instead of blacking out for the old task's sandbox cleanup.
+ * The two tasks coexist briefly, during which the Kafka consumer group splits
+ * partitions between them; a command routed to the new task for a session
+ * whose live actor is still on the old one self-heals through resume. Live
+ * sessions already restart across every deploy (`shutdown_all` stops each
+ * sandbox), so the overlap narrows the blast radius rather than widening it.
  */
 export class AgentHarnessService extends pulumi.ComponentResource {
   public role: aws.iam.Role;
@@ -310,18 +317,16 @@ export class AgentHarnessService extends pulumi.ComponentResource {
           enable: true,
           rollback: true,
         },
-        // Never run 2 tasks at once, even transiently during a deploy: stop
-        // the old one before the new one starts (see the class doc comment).
-        // This blackout covers the egress proxy too - sandbox git and MCP
-        // calls fail for the whole window, they are not more available than
-        // the control API.
-        deploymentMinimumHealthyPercent: 0,
-        deploymentMaximumPercent: 100,
+        // Rolling replace: the old task serves until the new one is healthy
+        // (see the class doc comment for the overlap semantics). A failed
+        // deploy rolls back with the old task still up rather than at zero.
+        deploymentMinimumHealthyPercent: 100,
+        deploymentMaximumPercent: 200,
         desiredCount: 1,
         // ALB checks /health every 10s and fails the target after two
         // misses (~20s). HTTP does not listen until after DB, AWS config,
         // and JWT secrets, so a 0s grace period trips the circuit breaker
-        // on this stop-then-start replace. Ignore those checks until bind.
+        // before the replacement binds. Ignore those checks until then.
         healthCheckGracePeriodSeconds: 120,
         taskDefinitionArgs: {
           taskRole: {


### PR DESCRIPTION
## Why

Every agent-harness deploy blacks out the control API and the sandbox egress proxy for ~2 minutes. The service deployed stop-then-start (min healthy 0%, max 100%), so the sequence was fully serial: drain the old target (15s) → SIGTERM → up to 120s `stopTimeout` while `shutdown_all` makes its two 30-second Daytona stop attempts → Fargate pull/boot of the replacement → ~20s of ALB health checks. The old task's sandbox cleanup sat inside the outage.

## What

Switch the ECS deployment to rolling: `deploymentMinimumHealthyPercent: 100`, `deploymentMaximumPercent: 200` (still `desiredCount: 1`, no autoscaling). The old task keeps serving until the replacement passes health checks, so the slow teardown happens in parallel and HTTP/egress downtime drops to roughly zero. A failed deploy now rolls back with the old task still up instead of sitting at zero tasks while the circuit breaker retries.

## Tradeoff

The two tasks coexist for ~35-60s and split the Kafka consumer group during that window. A command handled by the new task for a session whose live actor is still on the old one self-heals through the existing resume path; the worst case is a double-attach interleaving log frames for a session actively prompted mid-deploy, or the old task's shutdown stopping a sandbox the new task just resumed (heals on the next prompt). Live sessions already restart on every deploy — `shutdown_all` stops every sandbox — so this narrows the deploy blast radius rather than widening it.

Follow-up: a Postgres session-attach lease to make the overlap window race-free rather than merely rare.

## Testing

- `biome check` clean on the file; `tsc --noEmit` in `infra/` fails only on pre-existing errors in unrelated files (`kafka-cluster.ts`, `doppler-projects`).
- Not deployed. On the first deploy after merge, confirm the account tolerates the transient second task (same size, briefly doubled).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rolling deploys introduce a short dual-task window with split Kafka consumption and possible session routing races; mitigated by existing resume behavior but not eliminated until a follow-up lease.
> 
> **Overview**
> **Agent-harness ECS deploys** switch from stop-then-start (`deploymentMinimumHealthyPercent: 0`, `deploymentMaximumPercent: 100`) to a rolling replace (`100` / `200`) while keeping `desiredCount: 1`.
> 
> The replacement task must pass health checks before the old task is drained, so the control API and sandbox egress proxy should stay reachable during deploys instead of sitting in a multi-minute blackout while `shutdown_all` and Daytona teardown run. Failed deploys roll back with the previous task still serving rather than dropping to zero tasks.
> 
> Class-level and inline comments are updated to document the brief two-task overlap, Kafka consumer group partition splitting during that window, and reliance on session **resume** for mis-routed commands—framed as narrowing blast radius because live sessions already restart on every deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 106b89b22892f8e7da0f3c087feb7db15b0e5e7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->