### PR TITLE
fix(block-agent): cap and scroll the agent model selector

### DIFF
--- a/apps/web/src/features/block-agent/ui/AgentModelSelector.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentModelSelector.tsx
@@ -5,13 +5,35 @@
  * ACP `configOptions` and the current model is the fold's rejection-safe
  * projection of them, so this component never needs a model registry of its
  * own. Renders nothing until the harness has advertised its models.
+ *
+ * Harnesses advertise as many models as they like, so the list scrolls rather
+ * than growing without bound: it shows at most `MAX_VISIBLE_ROWS` (or fewer,
+ * when the popper has less room than that), leaving the next row half-cut
+ * under a gradient so the overflow is visible rather than merely scrollable.
  */
 
+import { ScrollIndicators } from '@core/component/VerticalScrollIndicators';
 import CaretDown from '@phosphor-icons/core/regular/caret-down.svg?component-solid';
 import type { ModelOption } from '@service-agent-fold/generated/types';
 import { cn, Dropdown } from '@ui';
-import { For, Show } from 'solid-js';
+import { createSignal, For, Show } from 'solid-js';
 import { TextShimmer } from './TextShimmer';
+
+/** Height of one model row — `h-7` on the item, so the cap is exact. */
+const ROW_HEIGHT_PX = 28;
+/** Rows shown in full before the list starts scrolling. */
+const MAX_VISIBLE_ROWS = 10;
+/** The scroll container's own top padding, inside the capped window. */
+const LIST_PADDING_PX = 6;
+
+/**
+ * Ten whole rows plus half of the eleventh, clamped to the room the popper
+ * actually has (Kobalte's size middleware publishes that on the content
+ * element, so a short screen caps the list before the row count does).
+ */
+const LIST_MAX_HEIGHT = `min(${
+  LIST_PADDING_PX + MAX_VISIBLE_ROWS * ROW_HEIGHT_PX + ROW_HEIGHT_PX / 2
+}px, calc(var(--kb-popper-content-available-height, 100vh) - 4px))`;
 
 export interface AgentModelSelectorProps {
   /** Current model id, when the fold has learned it. */
@@ -30,6 +52,7 @@ export interface AgentModelSelectorProps {
 }
 
 export function AgentModelSelector(props: AgentModelSelectorProps) {
+  const [listRef, setListRef] = createSignal<HTMLElement>();
   const shown = () => props.changingTo ?? props.model;
   const label = () =>
     props.options.find((option) => option.id === shown())?.name ??
@@ -48,25 +71,37 @@ export function AgentModelSelector(props: AgentModelSelectorProps) {
           <TextShimmer text={label()} active={props.changingTo !== undefined} />
           <CaretDown />
         </Dropdown.Trigger>
-        <Dropdown.Content>
-          <Dropdown.Group>
-            <For each={props.options}>
-              {(option) => (
-                <Dropdown.Item
-                  class={cn(
-                    'gap-2',
-                    option.id === shown() && 'text-ink font-medium'
+        <Dropdown.Content class="overflow-hidden">
+          {/* The gradients anchor here, outside the scrolling box, and read
+              the menu background through `--color-surface`. */}
+          <div class="relative [--color-surface:var(--color-menu)]">
+            <Dropdown.Group
+              ref={setListRef}
+              class="overflow-y-auto overscroll-contain p-0"
+              style={{ 'max-height': LIST_MAX_HEIGHT }}
+            >
+              <div class="flex flex-col p-1.5">
+                <For each={props.options}>
+                  {(option) => (
+                    <Dropdown.Item
+                      class={cn(
+                        'h-7 shrink-0 gap-2',
+                        option.id === shown() && 'text-ink font-medium'
+                      )}
+                      title={option.description ?? undefined}
+                      onSelect={() => {
+                        if (option.id !== props.model)
+                          props.onSelect(option.id);
+                      }}
+                    >
+                      <span class="flex-1 truncate text-xs">{option.name}</span>
+                    </Dropdown.Item>
                   )}
-                  title={option.description ?? undefined}
-                  onSelect={() => {
-                    if (option.id !== props.model) props.onSelect(option.id);
-                  }}
-                >
-                  <span class="flex-1 truncate text-xs">{option.name}</span>
-                </Dropdown.Item>
-              )}
-            </For>
-          </Dropdown.Group>
+                </For>
+              </div>
+            </Dropdown.Group>
+            <ScrollIndicators scrollRef={listRef} appearance="gradient" />
+          </div>
         </Dropdown.Content>
       </Dropdown>
     </Show>


### PR DESCRIPTION
Caps the agent session model list at 10 rows (or the room the popper has) and scrolls the rest, with the next row half-shown under a gradient so the overflow is visible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only dropdown layout and scrolling; no changes to model selection logic beyond existing `onSelect` guards.
> 
> **Overview**
> The agent model dropdown no longer grows with every harness-reported model. **It caps height** at ten full rows plus a half-visible eleventh row, and **respects Kobalte popper space** via `--kb-popper-content-available-height` so short viewports shrink the list first.
> 
> The menu content is a **scrollable** `Dropdown.Group` with fixed `h-7` rows, `overflow-hidden` on the panel, and **`ScrollIndicators`** gradient overlays so overflow is obvious. Selection behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08e5f3f120b08cae4e47209df16c57a8cd7f9db8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->