### PR TITLE
feat(agent_session): fenced session-management lease

### DIFF
--- a/.sqlx/query-18fd730ea7a2734ac0d674edec980025a77971dac52498a2adb9470e6dc73787.json
+++ b/.sqlx/query-18fd730ea7a2734ac0d674edec980025a77971dac52498a2adb9470e6dc73787.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO agent_session_log (id, agent_session_id, user_id, direction, content)\n            SELECT $1, $2, $3, $4, $5\n            WHERE EXISTS (\n                SELECT 1 FROM agent_session\n                WHERE id = $2 AND manager_replica_id = $6 AND manager_fence = $7\n            )\n            RETURNING created_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Text",
+        "Jsonb",
+        "Uuid",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "18fd730ea7a2734ac0d674edec980025a77971dac52498a2adb9470e6dc73787"
+}

--- a/.sqlx/query-1a2b568193d4d16c9aa62cb7d8dfee75bdce4824f21561f2cf4b7c3390e422dd.json
+++ b/.sqlx/query-1a2b568193d4d16c9aa62cb7d8dfee75bdce4824f21561f2cf4b7c3390e422dd.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH replica AS (\n                INSERT INTO harness_replica (id, last_heartbeat_at)\n                VALUES ($2, now())\n                ON CONFLICT (id) DO UPDATE SET last_heartbeat_at = now()\n            )\n            UPDATE agent_session\n            SET manager_replica_id = $2,\n                manager_fence = manager_fence + 1,\n                modified_at = now()\n            WHERE id = $1\n              AND (\n                manager_replica_id IS NULL\n                OR manager_replica_id = $2\n                OR NOT EXISTS (\n                    SELECT 1 FROM harness_replica live\n                    WHERE live.id = agent_session.manager_replica_id\n                      AND live.last_heartbeat_at > now() - make_interval(secs => $3)\n                )\n              )\n            RETURNING manager_fence\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "manager_fence",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Float8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "1a2b568193d4d16c9aa62cb7d8dfee75bdce4824f21561f2cf4b7c3390e422dd"
+}

--- a/.sqlx/query-521b591873e9fdbaa3310380723aafad9da0742692aec0122c5c922804c5f795.json
+++ b/.sqlx/query-521b591873e9fdbaa3310380723aafad9da0742692aec0122c5c922804c5f795.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE agent_session\n            SET manager_replica_id = NULL,\n                modified_at = now()\n            WHERE id = $1 AND manager_replica_id = $2 AND manager_fence = $3\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "521b591873e9fdbaa3310380723aafad9da0742692aec0122c5c922804c5f795"
+}

--- a/.sqlx/query-8b9476b82011c40253d7dd36078e92e9fc4e0e295c9031b76879a8b472bb2aa5.json
+++ b/.sqlx/query-8b9476b82011c40253d7dd36078e92e9fc4e0e295c9031b76879a8b472bb2aa5.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM harness_replica WHERE last_heartbeat_at < now() - interval '7 days'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "8b9476b82011c40253d7dd36078e92e9fc4e0e295c9031b76879a8b472bb2aa5"
+}

--- a/.sqlx/query-a6d600a2285024d53f613e78fac8e24c64a44430b34b3f2f82edd6426ec26751.json
+++ b/.sqlx/query-a6d600a2285024d53f613e78fac8e24c64a44430b34b3f2f82edd6426ec26751.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT manager_replica_id FROM agent_session WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "manager_replica_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "a6d600a2285024d53f613e78fac8e24c64a44430b34b3f2f82edd6426ec26751"
+}

--- a/.sqlx/query-b8fe8b8e678d0fe39b5f7f815541c9eab62094768a9a0284d1341838b2db88d3.json
+++ b/.sqlx/query-b8fe8b8e678d0fe39b5f7f815541c9eab62094768a9a0284d1341838b2db88d3.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO harness_replica (id, last_heartbeat_at)\n            VALUES ($1, now())\n            ON CONFLICT (id) DO UPDATE SET last_heartbeat_at = now()\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b8fe8b8e678d0fe39b5f7f815541c9eab62094768a9a0284d1341838b2db88d3"
+}

--- a/crates/agent_session/src/domain/error.rs
+++ b/crates/agent_session/src/domain/error.rs
@@ -8,6 +8,10 @@ pub type Result<T, E = AgentSessionError> = std::result::Result<T, E>;
 pub enum AgentSessionError {
     #[error("agent session {0} already has an active transport")]
     AlreadyConnected(AgentSessionId),
+    #[error("agent session {0} is managed by another live replica")]
+    ManagedElsewhere(AgentSessionId),
+    #[error("agent session {0} write was fenced out: another replica claimed the session")]
+    FencedOut(AgentSessionId),
     #[error("acp handshake failed: {0}")]
     Handshake(String),
     #[error("agent session {0} is no longer connected")]

--- a/crates/agent_session/src/domain/model.rs
+++ b/crates/agent_session/src/domain/model.rs
@@ -15,6 +15,73 @@ pub use agent_fold::domain::model::{
     Author, AuthorKind, FoldEvent, MessageId, OwnedFoldEvent, TurnId,
 };
 
+/// Identity of one harness participant, minted fresh at construction.
+///
+/// A restarted process is a new replica: whatever the old identity claimed is
+/// released by its heartbeat going stale, never inherited.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ReplicaId(Uuid);
+
+impl ReplicaId {
+    /// Mint a fresh replica identity.
+    #[must_use]
+    pub fn mint() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    /// The raw uuid, for persistence.
+    #[must_use]
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+
+    /// Rebuild an identity from its persisted uuid.
+    #[must_use]
+    pub fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+}
+
+impl std::fmt::Display for ReplicaId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// A session's takeover counter, bumped by every successful claim.
+///
+/// Carried by the claim holder into each live-actor write; the store rejects
+/// writes whose fence has been superseded, so a stale holder is neutralized
+/// by the same statement that would have written (a fencing token).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ManagerFence(pub i64);
+
+/// Proof that this replica claimed a session's live management.
+///
+/// Obtained only from [`SessionOwnership::claim`](super::ports::SessionOwnership::claim);
+/// holding one is what entitles an actor to attach and write the session's
+/// log under its fence.
+#[derive(Debug, Clone, Copy)]
+pub struct SessionClaim {
+    /// The claimed session.
+    pub session: AgentSessionId,
+    /// The replica holding the claim.
+    pub replica: ReplicaId,
+    /// The fence this claim writes under.
+    pub fence: ManagerFence,
+}
+
+/// What claiming a session yielded.
+#[derive(Debug, Clone, Copy)]
+pub enum ClaimOutcome {
+    /// This replica now manages the session.
+    Claimed(SessionClaim),
+    /// A replica with a fresh heartbeat already manages it. Until command
+    /// forwarding exists this surfaces as an error; with it, commands are
+    /// routed to the named replica instead.
+    ManagedElsewhere(ReplicaId),
+}
+
 /// Display name assigned to a newly created agent session.
 pub const DEFAULT_AGENT_SESSION_NAME: &str = "Agent Session";
 

--- a/crates/agent_session/src/domain/ports.rs
+++ b/crates/agent_session/src/domain/ports.rs
@@ -267,12 +267,69 @@ pub trait ExternalSessionRepo: Send + Sync + 'static {
     fn delete(&self, id: AgentSessionId) -> impl Future<Output = Result<()>> + Send;
 }
 
+/// How often a replica refreshes its heartbeat row.
+pub const REPLICA_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// How stale a replica's heartbeat may be before its claims are up for
+/// grabs. Three missed heartbeats: long enough that one slow write does not
+/// get a live replica's sessions stolen, short enough that a crashed
+/// replica's sessions resume on the next prompt rather than minutes later.
+pub const REPLICA_STALE_AFTER: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// The session-management lease: which replica holds a session's live actor.
+///
+/// Implemented by the same store that persists the session log, never
+/// separately - the fence a claim carries is checked by that store's fenced
+/// appends, and minting fences in one place while checking them in another
+/// is the mis-wiring this coupling forbids.
+///
+/// Claiming is a single conditional update (compare-and-swap): it succeeds
+/// when the session is unmanaged, already ours, or held by a replica whose
+/// heartbeat has gone stale, and every success increments the session's
+/// fence. There are deliberately no explicit locks anywhere in the contract -
+/// see [`ManagerFence`](super::model::ManagerFence) for why a fence, not a
+/// lock, is what neutralizes a stale holder.
+pub trait SessionOwnership: Send + Sync + 'static {
+    /// Claim live management of a session for `replica`, registering the
+    /// replica's heartbeat as a side effect so a claim can never dangle on a
+    /// replica the store has not seen.
+    fn claim(
+        &self,
+        session: AgentSessionId,
+        replica: ReplicaId,
+    ) -> impl Future<Output = Result<ClaimOutcome>> + Send;
+
+    /// Release a claim this replica holds. Conditional on the claim's fence
+    /// still being current: releasing after having been superseded is a
+    /// no-op, never a theft of the successor's claim. A session already
+    /// released (or deleted) is in the asked-for state, so this succeeds.
+    fn release(&self, claim: &SessionClaim) -> impl Future<Output = Result<()>> + Send;
+
+    /// Refresh this replica's heartbeat, upserting its row.
+    fn heartbeat(&self, replica: ReplicaId) -> impl Future<Output = Result<()>> + Send;
+}
+
 #[cfg_attr(feature = "test-utils", mockall::automock)]
 pub trait AgentSessionLogRepo: Send + Sync + 'static {
     /// Append a log entry and project any system event onto the session status.
     fn create(
         &self,
         log: AgentSessionLog,
+    ) -> impl Future<Output = Result<StoredAgentSessionLog>> + Send;
+
+    /// [`create`](Self::create), conditioned on `claim` still holding the
+    /// session's current fence.
+    ///
+    /// This is the write half of the fencing contract: the check and the
+    /// append are one atomic statement, so a replica that stalled past its
+    /// heartbeat and was superseded cannot interleave frames no matter when
+    /// it wakes - its append matches nothing and fails with
+    /// [`FencedOut`](super::error::AgentSessionError::FencedOut), which the
+    /// actor treats as its cue to tear down.
+    fn create_fenced(
+        &self,
+        log: AgentSessionLog,
+        claim: &SessionClaim,
     ) -> impl Future<Output = Result<StoredAgentSessionLog>> + Send;
 
     /// List all log entries for a session, in chronological order.

--- a/crates/agent_session/src/domain/service.rs
+++ b/crates/agent_session/src/domain/service.rs
@@ -47,12 +47,12 @@ use super::connection::RuntimeAttachment;
 use super::error::{AgentSessionError, Result};
 use super::model::{
     AgentSession, AgentSessionId, AgentSessionLog, AgentSessionRenamed, AuthorKind, ChannelSession,
-    CreateAgentSessionParams, LogAppended, MAX_AGENT_SESSION_NAME_CHARS, Message, MessageId,
-    SandboxSize, SessionLog, StoredAgentSessionLog,
+    ClaimOutcome, CreateAgentSessionParams, LogAppended, MAX_AGENT_SESSION_NAME_CHARS, Message,
+    MessageId, ReplicaId, SandboxSize, SessionClaim, SessionLog, StoredAgentSessionLog,
 };
 use super::ports::{
     AgentConnector, AgentSessionLogRepo, AgentSessionLogWriter, AgentSessionNameGenerator,
-    AgentSessionRealtime, AgentSessionRepo, NoOpAgentSessionNameGenerator,
+    AgentSessionRealtime, AgentSessionRepo, NoOpAgentSessionNameGenerator, SessionOwnership,
 };
 use super::session::actors::{SessionActor, SessionCommand, Stepped};
 use super::session::{CloseReason, Input};
@@ -230,6 +230,10 @@ pub struct AgentSessionServiceImpl<R, Folds, Rt, Namer = NoOpAgentSessionNameGen
     realtime: Rt,
     name_generator: Namer,
     active: Arc<ActiveSessions>,
+    /// This service's identity in the session-management lease. Minted at
+    /// construction: a restarted process is a new replica, and its claims
+    /// are recovered by heartbeat staleness, never inherited.
+    replica: ReplicaId,
     tasks: TaskTracker,
     cancellation: CancellationToken,
     lifecycle: Arc<Mutex<()>>,
@@ -249,6 +253,7 @@ impl<R, Folds, Rt> AgentSessionServiceImpl<R, Folds, Rt> {
             realtime,
             name_generator: NoOpAgentSessionNameGenerator,
             active: Arc::new(DashMap::new()),
+            replica: ReplicaId::mint(),
             tasks: TaskTracker::new(),
             cancellation: CancellationToken::new(),
             lifecycle: Arc::new(Mutex::new(())),
@@ -269,10 +274,18 @@ impl<R, Folds, Rt, Namer> AgentSessionServiceImpl<R, Folds, Rt, Namer> {
             realtime: self.realtime,
             name_generator,
             active: self.active,
+            replica: self.replica,
             tasks: self.tasks,
             cancellation: self.cancellation,
             lifecycle: self.lifecycle,
         }
+    }
+
+    /// This service's identity in the session-management lease, for the
+    /// composition root to heartbeat while the process lives.
+    #[must_use]
+    pub fn replica_id(&self) -> ReplicaId {
+        self.replica
     }
 
     /// Stop active actors and wait for their tasks to release their transports.
@@ -322,9 +335,10 @@ impl<R, Folds, Rt, Namer> AgentSessionServiceImpl<R, Folds, Rt, Namer> {
         session: AgentSession,
         attachment: RuntimeAttachment<Connector>,
         reservation: AttachReservation,
+        claim: SessionClaim,
     ) -> Result<()>
     where
-        R: AgentSessionRepo + AgentSessionLogRepo + Clone,
+        R: AgentSessionRepo + AgentSessionLogRepo + SessionOwnership + Clone,
         Rt: AgentSessionRealtime + Clone + Send + Sync + 'static,
         Connector: AgentConnector,
     {
@@ -348,8 +362,10 @@ impl<R, Folds, Rt, Namer> AgentSessionServiceImpl<R, Folds, Rt, Namer> {
         // rather than the bare repository - see module docs. Its fold starts
         // empty and catches itself up on the stored log on the first frame,
         // which costs an attach nothing until the session actually says
-        // something.
-        let logs = LiveSessionLogWriter::new(self.repo.clone(), self.realtime.clone());
+        // something. Fenced under the claim taken above: if another replica
+        // supersedes this one, the store rejects the next append and the
+        // actor tears down through its ordinary log-failure path.
+        let logs = LiveSessionLogWriter::fenced(self.repo.clone(), self.realtime.clone(), claim);
         let actor = SessionActor::new(
             id,
             session.acp_session_id,
@@ -367,6 +383,8 @@ impl<R, Folds, Rt, Namer> AgentSessionServiceImpl<R, Folds, Rt, Namer> {
                 marker,
                 stopped_tx,
                 self.cancellation.clone(),
+                self.repo.clone(),
+                claim,
             )
             .with_current_subscriber(),
         );
@@ -476,7 +494,7 @@ impl<R, Folds, Rt, Namer> AgentSessionServiceImpl<R, Folds, Rt, Namer> {
 
 impl<R, Folds, Rt, Namer> AgentSessionService for AgentSessionServiceImpl<R, Folds, Rt, Namer>
 where
-    R: AgentSessionRepo + AgentSessionLogRepo + Clone,
+    R: AgentSessionRepo + AgentSessionLogRepo + SessionOwnership + Clone,
     Folds: FoldedMessageRepo + Clone + Send + Sync + 'static,
     Rt: AgentSessionRealtime + Clone + Send + Sync + 'static,
     Namer: AgentSessionNameGenerator + Clone,
@@ -571,10 +589,42 @@ where
     where
         Connector: AgentConnector,
     {
+        // Reservation first: it is the in-process exclusion, so no sibling
+        // attach of this instance can race us to the claim below - which
+        // matters because every successful claim bumps the fence, and bumping
+        // it under a live actor of our own would fence that actor out.
         let reservation = self.reserve_attach(id).await?;
-        let session = self.repo.get(id).await?;
-        self.activate_reserved(session, attachment, reservation)
-            .await
+        let claim = match self.repo.claim(id, self.replica).await? {
+            ClaimOutcome::Claimed(claim) => claim,
+            ClaimOutcome::ManagedElsewhere(holder) => {
+                tracing::info!(%id, %holder, "agent session is managed by another live replica");
+                return Err(AgentSessionError::ManagedElsewhere(id));
+            }
+        };
+        let activated = async {
+            let session = self.repo.get(id).await?;
+            self.activate_reserved(session, attachment, reservation, claim)
+                .await
+        }
+        .await;
+        if let Err(error) = activated {
+            // The actor that would have released this claim never started;
+            // free it here so another replica is not left waiting out our
+            // heartbeat to resume the session.
+            self.repo
+                .release(&claim)
+                .await
+                .inspect_err(|release_error| {
+                    tracing::error!(
+                        error = ?release_error,
+                        %id,
+                        "failed to release an agent session claim after a failed attach"
+                    );
+                })
+                .ok();
+            return Err(error);
+        }
+        Ok(())
     }
 
     async fn send_action(
@@ -740,6 +790,12 @@ pub struct LiveSessionLogWriter<R, Rt> {
     repo: R,
     realtime: Rt,
     fold: Option<FoldMachineImpl>,
+    /// The management claim this writer appends under, when it has one. A
+    /// session actor always writes fenced; the unfenced constructor exists
+    /// for writers outside any live-management contest - `seed_jsonl`
+    /// replaying a recording, and `mark_disconnected` recording that a
+    /// runtime dropped before anything attached.
+    claim: Option<SessionClaim>,
 }
 
 impl<R, Rt> LiveSessionLogWriter<R, Rt> {
@@ -754,6 +810,18 @@ impl<R, Rt> LiveSessionLogWriter<R, Rt> {
             repo,
             realtime,
             fold: None,
+            claim: None,
+        }
+    }
+
+    /// [`new`](Self::new), with every append conditioned on `claim` still
+    /// holding the session's current fence. What a live actor writes with.
+    pub fn fenced(repo: R, realtime: Rt, claim: SessionClaim) -> Self {
+        Self {
+            repo,
+            realtime,
+            fold: None,
+            claim: Some(claim),
         }
     }
 }
@@ -783,7 +851,10 @@ where
 
         // Durable first: projections are rebuildable, but a frame omitted from
         // session history is not.
-        let stored = AgentSessionLogRepo::create(&self.repo, log.clone()).await?;
+        let stored = match &self.claim {
+            Some(claim) => self.repo.create_fenced(log.clone(), claim).await?,
+            None => AgentSessionLogRepo::create(&self.repo, log.clone()).await?,
+        };
 
         if let Some(fold) = &mut self.fold {
             let _ = fold.push(log.clone());
@@ -967,16 +1038,20 @@ where
     }
 }
 
-/// Step the actor until its machine stops, then release the registry entry.
-async fn run_session<Connector, Logs>(
+/// Step the actor until its machine stops, then release the registry entry
+/// and the session's management claim.
+async fn run_session<Connector, Logs, Ownership>(
     mut actor: SessionActor<Connector, Logs>,
     active: std::sync::Weak<ActiveSessions>,
     marker: Arc<()>,
     stopped: watch::Sender<bool>,
     cancellation: CancellationToken,
+    ownership: Ownership,
+    claim: SessionClaim,
 ) where
     Connector: AgentConnector,
     Logs: AgentSessionLogWriter + AgentSessionRepo,
+    Ownership: SessionOwnership,
 {
     loop {
         let input = tokio::select! {
@@ -997,6 +1072,13 @@ async fn run_session<Connector, Logs>(
 
     // Tear down the old transport before allowing another actor to attach.
     drop(actor);
+    // Give the claim back before announcing the stop: fence-conditioned, so
+    // if a successor already took over this quietly does nothing. Releasing
+    // here rather than waiting for heartbeat staleness is what lets another
+    // replica resume this session immediately after a graceful stop.
+    if let Err(error) = ownership.release(&claim).await {
+        tracing::error!(error = ?error, %id, "failed to release an agent session claim");
+    }
     let _ = stopped.send(true);
     if let Some(active) = active.upgrade() {
         active.remove_if(&id, |_, current| {

--- a/crates/agent_session/src/domain/service/test.rs
+++ b/crates/agent_session/src/domain/service/test.rs
@@ -162,6 +162,21 @@ impl AgentSessionLogWriter for BlockingPromptLogs {
     }
 }
 
+/// Claim a session's management for a freshly minted replica, as
+/// `attach_session` does before activating.
+async fn claim_for_test(repo: &InMemoryAgentSessionRepo, session: AgentSessionId) -> SessionClaim {
+    match repo
+        .claim(session, ReplicaId::mint())
+        .await
+        .expect("claim for test")
+    {
+        ClaimOutcome::Claimed(claim) => claim,
+        ClaimOutcome::ManagedElsewhere(holder) => {
+            panic!("test session is unexpectedly managed by {holder}")
+        }
+    }
+}
+
 fn owner_access(session: AgentSessionId) -> EntityAccessReceipt<OwnerAccessLevel> {
     EntityAccessReceipt::dangerously_assert_internal_user(
         &session.as_uuid().to_string(),
@@ -400,7 +415,31 @@ impl AgentSessionRepo for BlockingPromptLogs {
     }
 }
 
+/// Pure delegation: the lease semantics under test live in the shared
+/// in-memory store, and this wrapper only intercepts log writes.
+impl SessionOwnership for BlockingPromptLogs {
+    async fn claim(&self, session: AgentSessionId, replica: ReplicaId) -> Result<ClaimOutcome> {
+        self.repo.claim(session, replica).await
+    }
+
+    async fn release(&self, claim: &SessionClaim) -> Result<()> {
+        self.repo.release(claim).await
+    }
+
+    async fn heartbeat(&self, replica: ReplicaId) -> Result<()> {
+        self.repo.heartbeat(replica).await
+    }
+}
+
 impl AgentSessionLogRepo for BlockingPromptLogs {
+    async fn create_fenced(
+        &self,
+        log: AgentSessionLog,
+        claim: &SessionClaim,
+    ) -> Result<StoredAgentSessionLog> {
+        self.repo.create_fenced(log, claim).await
+    }
+
     async fn create(&self, log: AgentSessionLog) -> Result<StoredAgentSessionLog> {
         if self.hang_disconnect
             && matches!(
@@ -512,6 +551,7 @@ async fn close_claiming_an_attach_reservation_prevents_actor_start() {
         .await
         .expect("attach reserves before reading");
     let session = fx.repo.get(fx.session).await.expect("session exists");
+    let claim = claim_for_test(&fx.repo, fx.session).await;
     let (stopped, marker) = fx.service.begin_stop(fx.session, false);
 
     let result = fx
@@ -520,6 +560,7 @@ async fn close_claiming_an_attach_reservation_prevents_actor_start() {
             session,
             RuntimeAttachment::solo(PendingTransport),
             reservation,
+            claim,
         )
         .await;
     AgentSessionServiceImpl::<
@@ -552,6 +593,7 @@ async fn shutdown_prevents_a_reserved_attach_from_spawning() {
         .await
         .expect("attach reserves before reading");
     let session = fx.repo.get(fx.session).await.expect("session exists");
+    let claim = claim_for_test(&fx.repo, fx.session).await;
 
     fx.service.shutdown().await;
     let result = fx
@@ -560,6 +602,7 @@ async fn shutdown_prevents_a_reserved_attach_from_spawning() {
             session,
             RuntimeAttachment::solo(PendingTransport),
             reservation,
+            claim,
         )
         .await;
 
@@ -581,6 +624,30 @@ async fn close_does_not_remove_a_concurrent_delete_guard() {
     fx.service.active.remove_if(&fx.session, |_, active| {
         Arc::ptr_eq(&active.marker, &marker)
     });
+}
+
+/// The cross-replica half of what `AlreadyConnected` guards in-process: a
+/// second service instance over the same store - two replicas, in production
+/// - cannot attach a session whose managing replica is live. Its claim comes
+/// back `ManagedElsewhere` and the attach refuses before touching the actor.
+#[tokio::test]
+async fn a_second_replica_cannot_attach_a_session_with_a_live_manager() {
+    let fx = fixture();
+    fx.service
+        .attach_session(fx.session, RuntimeAttachment::solo(PendingTransport))
+        .await
+        .expect("first replica attaches");
+
+    let second_replica = AgentSessionServiceImpl::new(
+        fx.repo.clone(),
+        FoldedMessageService::new(fx.repo.clone()),
+        NoOpRealtime,
+    );
+    let result = second_replica
+        .attach_session(fx.session, RuntimeAttachment::solo(PendingTransport))
+        .await;
+
+    assert!(matches!(result, Err(AgentSessionError::ManagedElsewhere(id)) if id == fx.session));
 }
 
 /// A command sent while the handshake never completes cannot hang its caller
@@ -653,12 +720,15 @@ async fn cancellation_does_not_drop_an_effect_batch_after_machine_mutation() {
     let cancellation = CancellationToken::new();
     let marker = Arc::new(());
     let (stopped_tx, _) = watch::channel(false);
+    let claim = claim_for_test(&repo, session).await;
     let task = tokio::spawn(run_session(
         actor,
         Arc::downgrade(&active),
         marker,
         stopped_tx,
         cancellation.clone(),
+        repo.clone(),
+        claim,
     ));
 
     open_test_session(&inbound_tx, &mut outbound_rx, session).await;
@@ -726,6 +796,7 @@ async fn live_inbound_logs_do_not_reuse_the_expired_handshake_deadline() {
     let active = Arc::new(ActiveSessions::new());
     let cancellation = CancellationToken::new();
     let (stopped_tx, _) = watch::channel(false);
+    let claim = claim_for_test(&repo, session).await;
     let task = tokio::spawn(
         run_session(
             actor,
@@ -733,6 +804,8 @@ async fn live_inbound_logs_do_not_reuse_the_expired_handshake_deadline() {
             Arc::new(()),
             stopped_tx,
             cancellation.clone(),
+            repo.clone(),
+            claim,
         )
         .with_current_subscriber(),
     );

--- a/crates/agent_session/src/outbound/postgres.rs
+++ b/crates/agent_session/src/outbound/postgres.rs
@@ -7,10 +7,14 @@ mod test;
 
 use crate::domain::error::{AgentSessionError, Result};
 use crate::domain::model::{
-    AgentSession, AgentSessionId, AgentSessionLog, ChannelSession, CreateAgentSessionParams,
-    ExternalSession, Message, SandboxSize, SessionBot, SessionStatus, StoredAgentSessionLog,
+    AgentSession, AgentSessionId, AgentSessionLog, ChannelSession, ClaimOutcome,
+    CreateAgentSessionParams, ExternalSession, ManagerFence, Message, ReplicaId, SandboxSize,
+    SessionBot, SessionClaim, SessionStatus, StoredAgentSessionLog,
 };
-use crate::domain::ports::{AgentSessionLogRepo, AgentSessionRepo, ExternalSessionRepo};
+use crate::domain::ports::{
+    AgentSessionLogRepo, AgentSessionRepo, ExternalSessionRepo, REPLICA_STALE_AFTER,
+    SessionOwnership,
+};
 use crate::outbound::connection_gateway_realtime::SessionAudience;
 use agent_client_protocol::schema::v1::SessionId;
 use agent_runtime_protocol::domain::schema::v0::{SystemEvent, ToRuntimeMessage, ToServerMessage};
@@ -758,6 +762,81 @@ impl AgentSessionLogRepo for PgAgentSessionRepo {
         })
     }
 
+    async fn create_fenced(
+        &self,
+        log: AgentSessionLog,
+        claim: &SessionClaim,
+    ) -> Result<StoredAgentSessionLog> {
+        let event_status = match &log.content {
+            Message::ToServer(ToServerMessage::Event { event }) => {
+                Some(SessionStatus::Event(event.clone()))
+            }
+            _ => None,
+        };
+        let (direction, content) = message_columns(&log.content)?;
+        let mut transaction = self
+            .pool
+            .begin()
+            .await
+            .context("begin fenced agent session log create")?;
+        // The fencing contract: the guard and the append are one statement,
+        // so there is no instant between "checked we still hold the lease"
+        // and "wrote" for a takeover to slip into.
+        let created_at = sqlx::query_scalar!(
+            r#"
+            INSERT INTO agent_session_log (id, agent_session_id, user_id, direction, content)
+            SELECT $1, $2, $3, $4, $5
+            WHERE EXISTS (
+                SELECT 1 FROM agent_session
+                WHERE id = $2 AND manager_replica_id = $6 AND manager_fence = $7
+            )
+            RETURNING created_at
+            "#,
+            macro_uuid::generate_uuid_v7(),
+            log.agent_session_id.as_uuid(),
+            log.user_id.as_ref().map(|user_id| user_id.as_ref()),
+            direction,
+            content,
+            claim.replica.as_uuid(),
+            claim.fence.0,
+        )
+        .fetch_optional(&mut *transaction)
+        .await
+        .context("failed to create fenced agent session log entry")?;
+        let Some(created_at) = created_at else {
+            return Err(AgentSessionError::FencedOut(log.agent_session_id));
+        };
+
+        if let Some(status) = event_status {
+            let (status, status_event_name) = status_columns(&status);
+            sqlx::query!(
+                r#"
+                UPDATE agent_session
+                SET status = $2,
+                    status_event_name = $3,
+                    modified_at = now()
+                WHERE id = $1
+                "#,
+                log.agent_session_id.as_uuid(),
+                status,
+                status_event_name,
+            )
+            .execute(&mut *transaction)
+            .await
+            .context("failed to update agent session status from fenced log entry")?;
+        }
+
+        transaction
+            .commit()
+            .await
+            .context("commit fenced agent session log create")?;
+
+        Ok(StoredAgentSessionLog {
+            created_at,
+            entry: log,
+        })
+    }
+
     async fn list_by_session(
         &self,
         agent_session_id: AgentSessionId,
@@ -785,6 +864,117 @@ impl AgentSessionLogRepo for PgAgentSessionRepo {
             .into_iter()
             .map(TryInto::try_into)
             .collect::<anyhow::Result<Vec<_>>>()?)
+    }
+}
+
+impl SessionOwnership for PgAgentSessionRepo {
+    async fn claim(&self, session: AgentSessionId, replica: ReplicaId) -> Result<ClaimOutcome> {
+        // One statement: the replica's heartbeat row is upserted in the CTE
+        // (a claim can never reference a replica the store has not seen),
+        // then the lease itself is a compare-and-swap - taken only from
+        // nobody, ourselves, or a stale holder, and every take bumps the
+        // fence so a superseded holder's fenced writes stop matching.
+        let fence = sqlx::query_scalar!(
+            r#"
+            WITH replica AS (
+                INSERT INTO harness_replica (id, last_heartbeat_at)
+                VALUES ($2, now())
+                ON CONFLICT (id) DO UPDATE SET last_heartbeat_at = now()
+            )
+            UPDATE agent_session
+            SET manager_replica_id = $2,
+                manager_fence = manager_fence + 1,
+                modified_at = now()
+            WHERE id = $1
+              AND (
+                manager_replica_id IS NULL
+                OR manager_replica_id = $2
+                OR NOT EXISTS (
+                    SELECT 1 FROM harness_replica live
+                    WHERE live.id = agent_session.manager_replica_id
+                      AND live.last_heartbeat_at > now() - make_interval(secs => $3)
+                )
+              )
+            RETURNING manager_fence
+            "#,
+            session.as_uuid(),
+            replica.as_uuid(),
+            REPLICA_STALE_AFTER.as_secs_f64(),
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .context("failed to claim agent session management")?;
+
+        if let Some(fence) = fence {
+            return Ok(ClaimOutcome::Claimed(SessionClaim {
+                session,
+                replica,
+                fence: ManagerFence(fence),
+            }));
+        }
+
+        // The swap matched nothing: either a live replica holds the lease, or
+        // the session row is gone. A deleted session reads as Unknown so the
+        // caller does not forward commands toward a row that no longer exists.
+        let holder = sqlx::query_scalar!(
+            r#"SELECT manager_replica_id FROM agent_session WHERE id = $1"#,
+            session.as_uuid(),
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .context("failed to read the agent session manager")?;
+        match holder {
+            Some(Some(holder)) => Ok(ClaimOutcome::ManagedElsewhere(ReplicaId::from_uuid(holder))),
+            Some(None) | None => Err(AgentSessionError::Unknown(anyhow::anyhow!(
+                "agent session {session} claim matched nothing yet no live replica holds it"
+            ))),
+        }
+    }
+
+    async fn release(&self, claim: &SessionClaim) -> Result<()> {
+        // Conditional on both holder and fence: a release arriving after a
+        // successor claimed must not free the successor's lease, and a
+        // deleted session matches nothing, which is the asked-for state.
+        sqlx::query!(
+            r#"
+            UPDATE agent_session
+            SET manager_replica_id = NULL,
+                modified_at = now()
+            WHERE id = $1 AND manager_replica_id = $2 AND manager_fence = $3
+            "#,
+            claim.session.as_uuid(),
+            claim.replica.as_uuid(),
+            claim.fence.0,
+        )
+        .execute(&self.pool)
+        .await
+        .context("failed to release agent session management")?;
+        Ok(())
+    }
+
+    async fn heartbeat(&self, replica: ReplicaId) -> Result<()> {
+        sqlx::query!(
+            r#"
+            INSERT INTO harness_replica (id, last_heartbeat_at)
+            VALUES ($1, now())
+            ON CONFLICT (id) DO UPDATE SET last_heartbeat_at = now()
+            "#,
+            replica.as_uuid(),
+        )
+        .execute(&self.pool)
+        .await
+        .context("failed to heartbeat harness replica")?;
+        // Housekeeping on the writer that is already here: rows a week past
+        // their last heartbeat are boots nothing can still reference usefully
+        // (their claims were stealable within seconds); the FK sets any
+        // stragglers' claims to NULL.
+        sqlx::query!(
+            r#"DELETE FROM harness_replica WHERE last_heartbeat_at < now() - interval '7 days'"#,
+        )
+        .execute(&self.pool)
+        .await
+        .context("failed to prune stale harness replicas")?;
+        Ok(())
     }
 }
 

--- a/crates/agent_session/src/outbound/postgres/test.rs
+++ b/crates/agent_session/src/outbound/postgres/test.rs
@@ -842,3 +842,138 @@ async fn deleting_a_session_cascades_its_external_row(pool: PgPool) {
         None
     );
 }
+
+/// Backdate a replica's heartbeat far past `REPLICA_STALE_AFTER`, so its
+/// claims read as up for grabs.
+async fn let_heartbeat_go_stale(pool: &PgPool, replica: ReplicaId) {
+    sqlx::query!(
+        r#"UPDATE harness_replica SET last_heartbeat_at = now() - interval '10 minutes' WHERE id = $1"#,
+        replica.as_uuid(),
+    )
+    .execute(pool)
+    .await
+    .expect("backdate replica heartbeat");
+}
+
+fn claimed(outcome: ClaimOutcome) -> SessionClaim {
+    match outcome {
+        ClaimOutcome::Claimed(claim) => claim,
+        ClaimOutcome::ManagedElsewhere(holder) => {
+            panic!("expected to claim, but {holder} manages the session")
+        }
+    }
+}
+
+fn fenced_log(id: AgentSessionId) -> AgentSessionLog {
+    AgentSessionLog {
+        agent_session_id: id,
+        user_id: None,
+        content: Message::ToRuntime(ToRuntimeMessage::Acp(acp_notification())),
+    }
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn claiming_is_reentrant_and_every_claim_bumps_the_fence(pool: PgPool) {
+    let repo = PgAgentSessionRepo::new(pool.clone());
+    let bot_id = create_test_bot(&pool).await;
+    let session = create_session(&repo, new_session(bot_id, None, None)).await;
+    let replica = ReplicaId::mint();
+
+    let first = claimed(repo.claim(session.id, replica).await.expect("first claim"));
+    let second = claimed(repo.claim(session.id, replica).await.expect("second claim"));
+
+    assert_eq!(first.fence, ManagerFence(1));
+    assert_eq!(second.fence, ManagerFence(2));
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn a_live_holder_blocks_a_second_replica(pool: PgPool) {
+    let repo = PgAgentSessionRepo::new(pool.clone());
+    let bot_id = create_test_bot(&pool).await;
+    let session = create_session(&repo, new_session(bot_id, None, None)).await;
+    let holder = ReplicaId::mint();
+    let contender = ReplicaId::mint();
+
+    claimed(repo.claim(session.id, holder).await.expect("claim"));
+    match repo.claim(session.id, contender).await.expect("contend") {
+        ClaimOutcome::ManagedElsewhere(seen) => assert_eq!(seen, holder),
+        ClaimOutcome::Claimed(_) => panic!("a live holder's claim was stolen"),
+    }
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn a_stale_holder_is_superseded(pool: PgPool) {
+    let repo = PgAgentSessionRepo::new(pool.clone());
+    let bot_id = create_test_bot(&pool).await;
+    let session = create_session(&repo, new_session(bot_id, None, None)).await;
+    let crashed = ReplicaId::mint();
+    let successor = ReplicaId::mint();
+
+    claimed(repo.claim(session.id, crashed).await.expect("claim"));
+    let_heartbeat_go_stale(&pool, crashed).await;
+
+    let takeover = claimed(repo.claim(session.id, successor).await.expect("takeover"));
+    assert_eq!(takeover.fence, ManagerFence(2));
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn release_frees_the_lease_but_never_a_successors(pool: PgPool) {
+    let repo = PgAgentSessionRepo::new(pool.clone());
+    let bot_id = create_test_bot(&pool).await;
+    let session = create_session(&repo, new_session(bot_id, None, None)).await;
+    let crashed = ReplicaId::mint();
+    let successor = ReplicaId::mint();
+    let third = ReplicaId::mint();
+
+    let superseded = claimed(repo.claim(session.id, crashed).await.expect("claim"));
+    let_heartbeat_go_stale(&pool, crashed).await;
+    let current = claimed(repo.claim(session.id, successor).await.expect("takeover"));
+
+    // The superseded holder's release is a no-op: the successor still holds.
+    repo.release(&superseded).await.expect("stale release");
+    match repo.claim(session.id, third).await.expect("contend") {
+        ClaimOutcome::ManagedElsewhere(seen) => assert_eq!(seen, successor),
+        ClaimOutcome::Claimed(_) => panic!("a stale release freed the successor's lease"),
+    }
+
+    // The current holder's release frees it for anyone.
+    repo.release(&current).await.expect("current release");
+    claimed(repo.claim(session.id, third).await.expect("reclaim"));
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn a_fenced_append_rejects_a_superseded_writer(pool: PgPool) {
+    let repo = PgAgentSessionRepo::new(pool.clone());
+    let bot_id = create_test_bot(&pool).await;
+    let session = create_session(&repo, new_session(bot_id, None, None)).await;
+    let zombie = ReplicaId::mint();
+    let successor = ReplicaId::mint();
+
+    let old_claim = claimed(repo.claim(session.id, zombie).await.expect("claim"));
+    repo.create_fenced(fenced_log(session.id), &old_claim)
+        .await
+        .expect("the live holder's fenced append lands");
+
+    let_heartbeat_go_stale(&pool, zombie).await;
+    let new_claim = claimed(repo.claim(session.id, successor).await.expect("takeover"));
+
+    // The zombie wakes and writes under its superseded fence: rejected by the
+    // same statement that would have written, no matter how it got confused.
+    match repo.create_fenced(fenced_log(session.id), &old_claim).await {
+        Err(AgentSessionError::FencedOut(id)) => assert_eq!(id, session.id),
+        other => panic!("a superseded fence wrote anyway: {other:?}"),
+    }
+
+    repo.create_fenced(fenced_log(session.id), &new_claim)
+        .await
+        .expect("the successor's fenced append lands");
+
+    let log = AgentSessionLogRepo::list_by_session(&repo, session.id)
+        .await
+        .expect("list log");
+    assert_eq!(
+        log.len(),
+        2,
+        "exactly the two live-holder appends are in the log"
+    );
+}

--- a/crates/agent_session/src/testing.rs
+++ b/crates/agent_session/src/testing.rs
@@ -6,11 +6,14 @@
 
 use crate::domain::error::{AgentSessionError, Result};
 use crate::domain::model::{
-    AgentSession, AgentSessionId, AgentSessionLog, ChannelSession, CreateAgentSessionParams,
-    DEFAULT_AGENT_SESSION_NAME, LogAppended, SandboxSize, SessionBot, SessionStatus,
-    StoredAgentSessionLog,
+    AgentSession, AgentSessionId, AgentSessionLog, ChannelSession, ClaimOutcome,
+    CreateAgentSessionParams, DEFAULT_AGENT_SESSION_NAME, LogAppended, ManagerFence, ReplicaId,
+    SandboxSize, SessionBot, SessionClaim, SessionStatus, StoredAgentSessionLog,
 };
-use crate::domain::ports::{AgentSessionLogRepo, AgentSessionRealtime, AgentSessionRepo};
+use crate::domain::ports::{
+    AgentSessionLogRepo, AgentSessionRealtime, AgentSessionRepo, REPLICA_STALE_AFTER,
+    SessionOwnership,
+};
 use agent_client_protocol::schema::v1::SessionId;
 use agent_runtime_protocol::domain::schema::v0::ToServerMessage;
 use bots::domain::models::BotId;
@@ -19,6 +22,10 @@ use macro_uuid::Uuid;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+
+/// One session's lease state: the holding replica (if any) and the fence,
+/// which outlives the holder as in the real schema.
+type Lease = (Option<ReplicaId>, i64);
 
 /// An in-memory [`AgentSessionRepo`] and [`AgentSessionLogRepo`].
 ///
@@ -36,6 +43,11 @@ pub struct InMemoryAgentSessionRepo {
     user_sizes: Arc<Mutex<HashMap<String, SandboxSize>>>,
     log_reads: Arc<AtomicUsize>,
     session_reads: Arc<AtomicUsize>,
+    /// Replica heartbeats, mirroring `harness_replica`.
+    replicas: Arc<Mutex<HashMap<ReplicaId, std::time::Instant>>>,
+    /// Session -> lease, mirroring the lease columns: release clears the
+    /// holder and leaves the counter.
+    leases: Arc<Mutex<HashMap<AgentSessionId, Lease>>>,
 }
 
 impl InMemoryAgentSessionRepo {
@@ -317,6 +329,69 @@ impl AgentSessionRepo for InMemoryAgentSessionRepo {
     }
 }
 
+impl SessionOwnership for InMemoryAgentSessionRepo {
+    async fn claim(&self, session: AgentSessionId, replica: ReplicaId) -> Result<ClaimOutcome> {
+        if !self
+            .sessions
+            .lock()
+            .expect("in-memory session store is not poisoned")
+            .contains_key(&session)
+        {
+            return Err(AgentSessionError::Unknown(anyhow::anyhow!(
+                "agent session {session} does not exist to claim"
+            )));
+        }
+        let now = std::time::Instant::now();
+        let mut replicas = self
+            .replicas
+            .lock()
+            .expect("in-memory replica store is not poisoned");
+        replicas.insert(replica, now);
+        let mut leases = self
+            .leases
+            .lock()
+            .expect("in-memory lease store is not poisoned");
+        let (holder, fence) = leases.entry(session).or_insert((None, 0));
+        let holder_is_live = holder.filter(|holder| *holder != replica).filter(|holder| {
+            replicas
+                .get(holder)
+                .is_some_and(|beat| now.duration_since(*beat) < REPLICA_STALE_AFTER)
+        });
+        if let Some(holder) = holder_is_live {
+            return Ok(ClaimOutcome::ManagedElsewhere(holder));
+        }
+        *holder = Some(replica);
+        *fence += 1;
+        Ok(ClaimOutcome::Claimed(SessionClaim {
+            session,
+            replica,
+            fence: ManagerFence(*fence),
+        }))
+    }
+
+    async fn release(&self, claim: &SessionClaim) -> Result<()> {
+        let mut leases = self
+            .leases
+            .lock()
+            .expect("in-memory lease store is not poisoned");
+        if let Some((holder, fence)) = leases.get_mut(&claim.session)
+            && *holder == Some(claim.replica)
+            && *fence == claim.fence.0
+        {
+            *holder = None;
+        }
+        Ok(())
+    }
+
+    async fn heartbeat(&self, replica: ReplicaId) -> Result<()> {
+        self.replicas
+            .lock()
+            .expect("in-memory replica store is not poisoned")
+            .insert(replica, std::time::Instant::now());
+        Ok(())
+    }
+}
+
 impl AgentSessionLogRepo for InMemoryAgentSessionRepo {
     async fn create(&self, log: AgentSessionLog) -> Result<StoredAgentSessionLog> {
         let model_change = match &log.content {
@@ -364,6 +439,28 @@ impl AgentSessionLogRepo for InMemoryAgentSessionRepo {
             session.modified_at = chrono::Utc::now();
         }
         Ok(stored)
+    }
+
+    async fn create_fenced(
+        &self,
+        log: AgentSessionLog,
+        claim: &SessionClaim,
+    ) -> Result<StoredAgentSessionLog> {
+        let fenced_out = {
+            let leases = self
+                .leases
+                .lock()
+                .expect("in-memory lease store is not poisoned");
+            !matches!(
+                leases.get(&log.agent_session_id),
+                Some((holder, fence))
+                    if *holder == Some(claim.replica) && *fence == claim.fence.0
+            )
+        };
+        if fenced_out {
+            return Err(AgentSessionError::FencedOut(log.agent_session_id));
+        }
+        AgentSessionLogRepo::create(self, log).await
     }
 
     async fn list_by_session(

--- a/crates/macro_db_client/migrations/20260828161717_agent_session_manager_lease.sql
+++ b/crates/macro_db_client/migrations/20260828161717_agent_session_manager_lease.sql
@@ -1,0 +1,22 @@
+-- Which harness replica holds a session's live actor, as a lease.
+--
+-- One row per booted harness participant, heartbeated while it lives. A
+-- replica that stops heartbeating is dead by definition: its claims become
+-- claimable by anyone, so a crashed process releases everything at once
+-- without per-session cleanup.
+CREATE TABLE harness_replica (
+    id                UUID        PRIMARY KEY,
+    started_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_heartbeat_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The lease itself lives on the session so claiming and deleting are
+-- transactional with the row they protect. manager_fence is a takeover
+-- counter: every successful claim increments it, and live-actor log appends
+-- are conditioned on the fence they were attached under, so a replica that
+-- stalls past its heartbeat and gets superseded has its writes rejected by
+-- the store rather than interleaved (fencing tokens). The fence never
+-- resets - ON DELETE SET NULL frees the claim but keeps the counter.
+ALTER TABLE agent_session
+    ADD COLUMN manager_replica_id UUID REFERENCES harness_replica(id) ON DELETE SET NULL,
+    ADD COLUMN manager_fence BIGINT NOT NULL DEFAULT 0;

--- a/infra/stacks/agent-harness-service/agent_harness_service.ts
+++ b/infra/stacks/agent-harness-service/agent_harness_service.ts
@@ -60,11 +60,18 @@ type Args = {
 
 /**
  * The agent harness service. Like agent-proxy before it, this component pins
- * `desiredCount` to 1 and forces a stop-then-start deployment (min healthy
- * 0%, max 100%) with no autoscaling: the harness owns the live agent-session
- * actors in process memory with no cross-instance sync, and its Kafka consumer
- * groups must not split partitions across two momentarily-coexisting tasks
- * (see the consumer groups in `services/agent_harness_service`).
+ * `desiredCount` to 1 with no autoscaling: the harness owns the live
+ * agent-session actors in process memory with no cross-instance sync (see the
+ * consumer groups in `services/agent_harness_service`).
+ *
+ * Deploys roll (min healthy 100%, max 200%): the outgoing task keeps serving
+ * until the replacement passes health checks, so the control API and egress
+ * proxy stay up instead of blacking out for the old task's sandbox cleanup.
+ * The two tasks coexist briefly, during which the Kafka consumer group splits
+ * partitions between them; a command routed to the new task for a session
+ * whose live actor is still on the old one self-heals through resume. Live
+ * sessions already restart across every deploy (`shutdown_all` stops each
+ * sandbox), so the overlap narrows the blast radius rather than widening it.
  */
 export class AgentHarnessService extends pulumi.ComponentResource {
   public role: aws.iam.Role;
@@ -310,18 +317,16 @@ export class AgentHarnessService extends pulumi.ComponentResource {
           enable: true,
           rollback: true,
         },
-        // Never run 2 tasks at once, even transiently during a deploy: stop
-        // the old one before the new one starts (see the class doc comment).
-        // This blackout covers the egress proxy too - sandbox git and MCP
-        // calls fail for the whole window, they are not more available than
-        // the control API.
-        deploymentMinimumHealthyPercent: 0,
-        deploymentMaximumPercent: 100,
+        // Rolling replace: the old task serves until the new one is healthy
+        // (see the class doc comment for the overlap semantics). A failed
+        // deploy rolls back with the old task still up rather than at zero.
+        deploymentMinimumHealthyPercent: 100,
+        deploymentMaximumPercent: 200,
         desiredCount: 1,
         // ALB checks /health every 10s and fails the target after two
         // misses (~20s). HTTP does not listen until after DB, AWS config,
         // and JWT secrets, so a 0s grace period trips the circuit breaker
-        // on this stop-then-start replace. Ignore those checks until bind.
+        // before the replacement binds. Ignore those checks until then.
         healthCheckGracePeriodSeconds: 120,
         taskDefinitionArgs: {
           taskRole: {

--- a/services/agent_harness_service/src/main.rs
+++ b/services/agent_harness_service/src/main.rs
@@ -42,7 +42,7 @@ use agent_harness::outbound::runtime_registry::RuntimeRegistry;
 use agent_inmem::outbound::log_frames::LogFrameSource;
 use agent_inmem::outbound::manager::InMemAgentManager;
 use agent_inmem::outbound::rig_engine::RigTurnEngine;
-use agent_session::domain::ports::NoOpRealtime;
+use agent_session::domain::ports::{NoOpRealtime, SessionOwnership as _};
 use agent_session::domain::service::AgentSessionServiceImpl;
 use agent_session::inbound::axum_router::{
     AgentSessionControlState, AgentSessionRouterState, CreateSessionState,
@@ -257,15 +257,17 @@ async fn run() -> anyhow::Result<()> {
     };
     // The sandbox provider serves every bot but the in-memory one, which the
     // router pulls out by bot id before the provider ever sees it.
-    let sandbox_and_inmem = RoutedContainers::new(
-        sandbox,
-        inmem,
-        AgentSessionServiceImpl::new(
-            session_repo.clone(),
-            FoldedMessageService::new(session_repo.clone()),
-            NoOpRealtime,
-        ),
+    let inmem_sessions = AgentSessionServiceImpl::new(
+        session_repo.clone(),
+        FoldedMessageService::new(session_repo.clone()),
+        NoOpRealtime,
     );
+    // Both attach-capable service instances participate in the session
+    // lease; heartbeat their replica identities while this process lives so
+    // their claims read as held. Read here because both instances are moved
+    // into their owners below.
+    let lease_replicas = [sessions.replica_id(), inmem_sessions.replica_id()];
+    let sandbox_and_inmem = RoutedContainers::new(sandbox, inmem, inmem_sessions);
 
     // Cursor sessions run on their owner's own Cursor account, so there is no
     // deployment-wide key to arm this with: the manager reads each session
@@ -456,6 +458,25 @@ async fn run() -> anyhow::Result<()> {
         .await
         {
             tracing::error!(error = ?error, "agent harness service http stopped");
+        }
+    });
+
+    // The session lease's liveness signal: while this beats, this process's
+    // claims are held; when it stops - crash or shutdown - they go stale
+    // within REPLICA_STALE_AFTER and any successor can claim. Graceful stops
+    // release each claim eagerly in the actor teardown path; this loop is
+    // what covers the ungraceful ones.
+    let heartbeat_repo = session_repo.clone();
+    let heartbeat = tokio::spawn(async move {
+        let mut ticker =
+            tokio::time::interval(agent_session::domain::ports::REPLICA_HEARTBEAT_INTERVAL);
+        loop {
+            ticker.tick().await;
+            for replica in lease_replicas {
+                if let Err(error) = heartbeat_repo.heartbeat(replica).await {
+                    tracing::warn!(error = ?error, %replica, "failed to heartbeat harness replica");
+                }
+            }
         }
     });
 
@@ -674,6 +695,7 @@ async fn run() -> anyhow::Result<()> {
     http.abort();
     trigger.abort();
     egress_http.abort();
+    heartbeat.abort();
     let stop_failures = container_shutdown.shutdown_all().await;
     if stop_failures > 0 {
         tracing::error!(stop_failures, "some sandboxes failed to stop");


### PR DESCRIPTION
First increment of horizontalizing the agent harness (follow-up to #6022): make "which process owns this session's live actor" a durable, fenced fact in Postgres instead of an implicit property of being the only replica.

## What

- **`harness_replica` table**: one heartbeated row per booted service instance (10s interval). A replica that stops heartbeating is dead by definition — its claims become stealable after 30s, so a crashed process releases everything at once with no per-session cleanup.
- **Lease columns on `agent_session`**: `manager_replica_id` + `manager_fence`, transactional with the row they protect. Claiming is a single conditional `UPDATE` (compare-and-swap): succeeds when the session is unmanaged, already ours, or held by a stale replica; every success bumps the fence. No explicit locks anywhere — the statement's own atomicity serializes racing claimers.
- **`SessionOwnership` port** in `agent_session`'s domain, implemented by `PgAgentSessionRepo` — deliberately the same store that persists the log, so fences are minted and checked in one place and cannot be mis-wired apart.
- **Claim-on-attach**: `attach_session` claims before activating and refuses with `ManagedElsewhere` when a live replica holds the session. The actor's teardown releases the claim eagerly (fence-conditioned, so a superseded release can never free a successor's lease).
- **Fenced appends**: a live actor's log writes go through `create_fenced`, where the ownership guard and the insert are one atomic statement. A replica that stalls past its heartbeat and gets superseded has its next append match zero rows → `FencedOut` → the actor tears down through the existing log-failure path. Two replicas can never interleave frames in one session log, no matter how a zombie got confused (fencing tokens — the check-then-write race has no gap to slip into).
- **Heartbeat loop** in the harness composition root for both attach-capable service instances.

Behavior at `desiredCount: 1` is unchanged except for the eager release. What it buys today: the rolling-deploy overlap window from #6022 is now provably race-free instead of merely rare — the old task's actors get fenced out the moment the new task legitimately claims.

## How routing works with this (and where it's going)

The design principle: **the ALB never needs to route to a session's owner.** Any replica accepts any request; the lease tells whoever caught it whether to execute or hand off. Session affinity lives in Postgres, not the load balancer.

- **Mention path**: user's message → comms API → `macro.channels` → trigger consumer (stateless, any replica) → `macro.agent_sessions` → consumer-group assignment hands it to an arbitrary replica → that replica reads the lease: unclaimed/stale → claim (CAS) + dial the sandbox; held by a live peer → *forward to the peer's address* (next PR).
- **Control path**: browser → `agent-harness.` ALB → any replica → same claim-or-forward at the handler. The control routes stop being "only mountable in the owning process."
- **Frames back to the user**: never touch this ALB. The owner appends to Postgres (fenced), then POSTs to connection_gateway, which holds the browser sockets and is already multi-replica (DynamoDB membership + Redis pub/sub between its replicas).
- **Daytona sandboxes**: no inbound routing — the owner dials *out* to the sidecar by label; ownership migration is a re-dial + ACP resume. Sandbox egress (git/MCP) hits `agent-harness-egress.` on the same ALB and is stateless per-request (token hash → Postgres), so any replica serves it.
- **User-hosted runtimes**: they dial in to `/runtime/ws`, the ALB pins the socket to one replica, so for external bots the rule inverts — the socket's replica becomes the owner and commands forward to it.

Next PR adds the `address` column on `harness_replica` plus replica-to-replica command forwarding, which is what actually lets `desiredCount` exceed 1.

## Testing

- 5 new `#[sqlx::test]` cases: reentrant claim bumps fence, live holder blocks a contender, stale holder is superseded, release is fence-conditional (a zombie's release can't free a successor's lease), and a superseded writer's fenced append is rejected while the successor's lands.
- Service-level test: a second `AgentSessionServiceImpl` over the same store cannot attach a session with a live manager.
- `cargo test -p agent_session` (117 passed), `-p agent_inmem -p agent_harness -p agent_harness_service` (all green), CI-style clippy (`-Dwarnings`) clean, `just prepare_db` run from the root.

Hexagonal boundary: the port, claim types, and refusal policy live in `domain/`; all SQL in `outbound/postgres.rs`; the composition root only mints the replica identity and heartbeats.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core session attach, log persistence, and multi-replica behavior during deploys; incorrect lease or fencing logic could drop writes, block attaches, or allow split-brain log interleaving.
> 
> **Overview**
> Introduces a **durable Postgres lease** for which harness replica owns a session’s live actor, replacing the implicit “only one task” assumption and making rolling deploy overlap safe.
> 
> **Schema:** `harness_replica` (heartbeated rows, 10s interval / 30s stale) plus `agent_session.manager_replica_id` and `manager_fence`. Claiming is a single CAS `UPDATE` that bumps the fence; log appends from live actors use **`create_fenced`** so the fence check and insert are one atomic statement (`FencedOut` when superseded).
> 
> **Domain/service:** New `SessionOwnership` port (`claim` / `release` / `heartbeat`), `ReplicaId` per `AgentSessionServiceImpl`, claim-on-**`attach_session`** with **`ManagedElsewhere`** when a live peer holds the lease, fenced **`LiveSessionLogWriter`** for actors, and eager **`release`** on actor teardown (failed attach releases too).
> 
> **Runtime/infra:** Harness heartbeats both sandbox and in-mem session service replicas; ECS moves from stop-then-start (**0%/100%**) to **rolling replace (100%/200%)** now that cross-replica races are fenced rather than “hope we never overlap.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b746a1931ce553002a7464857df4301c101bce1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->