### PR TITLE
fix(web): clear channel soup notifications on open

### DIFF
--- a/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
@@ -2,6 +2,7 @@ import { isListViewID, LIST_VIEW_ID } from '@app/constants/list-views';
 import { useSoup } from '@app/features/next-soup/soup-context';
 import { openEntityInSplitFromUnifiedList } from '@app/features/next-soup/utils';
 import { CALENDAR_BLOCK_ID } from '@block-calendar/types';
+import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
 import { useSidebarCollapse } from '@components/app/sidebarVisibility';
 import type { BlockName } from '@core/block';
 import {
@@ -224,6 +225,7 @@ function SplitCloseButton() {
 function SoupNavigationButtons() {
   const context = useContext(SplitPanelContext);
   const soup = useSoup();
+  const notificationSource = useGlobalNotificationSource();
   if (!context) return null;
 
   const rows = createMemo(() => soup.rows());
@@ -266,6 +268,7 @@ function SoupNavigationButtons() {
       splitHandle: context.handle,
       mergeHistory: true,
       referredFrom: navigationReferredFrom(),
+      notificationSource,
     });
   };
 
@@ -461,6 +464,7 @@ export function SplitHeader(props: {
   collapseController: PriorityCollapseController;
 }) {
   const panel = useContext(SplitPanelContext);
+  const notificationSource = useGlobalNotificationSource();
   if (!panel) {
     throw new Error('<SplitHeader> must be used within a <SplitLayout>');
   }
@@ -497,6 +501,7 @@ export function SplitHeader(props: {
     void openEntityInSplitFromUnifiedList(data, {
       splitHandle: panel.handle,
       allowDuplicate: true,
+      notificationSource,
     });
   });
 

--- a/apps/web/src/features/dynamic-ui/widgets/List.tsx
+++ b/apps/web/src/features/dynamic-ui/widgets/List.tsx
@@ -7,6 +7,7 @@ import {
 import type { FieldFilters } from '@app/features/next-soup/filters/filter-store/types';
 import { soupItemMatchesQuery } from '@app/features/next-soup/filters/query-filters';
 import { openEntityInSplitFromUnifiedList } from '@app/features/next-soup/utils';
+import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
 import { ListEntityMetadataQueryProvider } from '@entity';
 import { CollapsibleList } from '@entity/components/CollapsibleList';
 import { ListEntity, ListLayoutProvider } from '@entity/composed/ListEntity';
@@ -118,11 +119,16 @@ const GROUP_BY_BY_NAME: Record<
  * `email` included.
  */
 function Row(props: { entity: EntityData }) {
+  const notificationSource = useGlobalNotificationSource();
   return (
     <ListEntity
       entity={props.entity as WithNotification<EntityData>}
       hideCheckbox
-      onClick={() => openEntityInSplitFromUnifiedList(props.entity, {})}
+      onClick={() =>
+        openEntityInSplitFromUnifiedList(props.entity, {
+          notificationSource,
+        })
+      }
     />
   );
 }

--- a/apps/web/src/features/next-soup/actions/make-mark-done-action.test.ts
+++ b/apps/web/src/features/next-soup/actions/make-mark-done-action.test.ts
@@ -77,6 +77,7 @@ const nextEntity = {
   type: 'email',
   id: 'next',
 } as EntityData;
+const notificationSource = {} as NotificationSource;
 
 function createSoup() {
   const focusSet = vi.fn();
@@ -107,7 +108,7 @@ function createSoup() {
 function createAction() {
   return createRoot((dispose) => ({
     action: makeMarkDoneAction({
-      notificationSource: () => ({}) as NotificationSource,
+      notificationSource: () => notificationSource,
     }),
     dispose,
   }));
@@ -145,6 +146,7 @@ describe('makeMarkDoneAction', () => {
       {
         splitHandle: mocks.controller as unknown as SplitHandle,
         mergeHistory: true,
+        notificationSource,
       }
     );
     dispose();

--- a/apps/web/src/features/next-soup/actions/make-mark-done-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-mark-done-action.ts
@@ -362,6 +362,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
         void openEntityInSplitFromUnifiedList(nextRow.original, {
           splitHandle: controller,
           mergeHistory: true,
+          notificationSource: options.notificationSource(),
         });
       }
       onNavigate?.(nextRow.original);

--- a/apps/web/src/features/next-soup/actions/use-block-entity-commands.ts
+++ b/apps/web/src/features/next-soup/actions/use-block-entity-commands.ts
@@ -131,6 +131,7 @@ export const useBlockEntityCommands = (
       splitHandle,
       mergeHistory: true,
       referredFrom: splitHandle.referredFrom(),
+      notificationSource,
     });
   };
 

--- a/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
+++ b/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
@@ -130,6 +130,7 @@ export const useEntityActionHotkeys = (
       splitHandle,
       mergeHistory: true,
       referredFrom: splitHandle.referredFrom(),
+      notificationSource,
     });
   };
 

--- a/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
+++ b/apps/web/src/features/next-soup/soup-view/create-soup-entity-actions.ts
@@ -277,6 +277,7 @@ export function createSoupEntityActions(): {
           ...options,
           splitHandle,
           referredFrom: 'entity-actions-menu',
+          notificationSource,
         });
       };
 

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -294,6 +294,7 @@ interface SoupViewProps {
 export const SoupView = (props: SoupViewProps) => {
   const soup = useSoup();
   const panel = useSplitPanelOrThrow();
+  const notificationSource = useGlobalNotificationSource();
   const soupView = useSoupView();
   const isInboxView = useIsInboxView();
   const openFocusedEntityInPreview = () => {
@@ -307,6 +308,7 @@ export const SoupView = (props: SoupViewProps) => {
     }
     void openEntityInSplitFromUnifiedList(focusedRow.original, {
       splitHandle: panel.handle,
+      notificationSource,
     });
   };
   const hasPreviewItems = useSoupPreviewAvailability({
@@ -1000,7 +1002,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
       // Join button (or, in preview, the Viewer's Join prompt) is the only
       // affordance.
       if (!isNonMemberChannelEntity(entity)) {
-        markChannelNotificationsSeenOnOpen(entity);
+        markChannelNotificationsSeenOnOpen(entity, notificationSource);
         openEntityInNewTab({ entity, location });
       }
       return;
@@ -1035,6 +1037,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
         splitHandle: panel.handle,
         replacePreview: event.altKey,
         referredFrom: currentView(),
+        notificationSource,
       });
       return;
     }
@@ -1047,6 +1050,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
         location,
         splitHandle: panel.handle,
         referredFrom: currentView(),
+        notificationSource,
       });
     } finally {
       finishTouchHighlight?.();

--- a/apps/web/src/features/next-soup/soup-view/soup-view.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view.tsx
@@ -52,7 +52,7 @@ import { TaskListEntity } from '@app/features/next-soup/soup-view/views/tasks/Ta
 import { ResponsiveTaskListHeader } from '@app/features/next-soup/soup-view/views/tasks/TaskListHeader';
 import { TaskGroupHeader } from '@app/features/next-soup/soup-view/views/tasks/task-group-header';
 import {
-  markChannelTargetSeenOnOpen,
+  markChannelNotificationsSeenOnOpen,
   markReminderSeenOnOpen,
   openEntityInNewTab,
   openEntityInSplitFromUnifiedList,
@@ -1000,7 +1000,7 @@ const SoupViewListContent = (props: SoupViewListProps) => {
       // Join button (or, in preview, the Viewer's Join prompt) is the only
       // affordance.
       if (!isNonMemberChannelEntity(entity)) {
-        markChannelTargetSeenOnOpen(entity, notificationSource);
+        markChannelNotificationsSeenOnOpen(entity);
         openEntityInNewTab({ entity, location });
       }
       return;
@@ -1027,9 +1027,6 @@ const SoupViewListContent = (props: SoupViewListProps) => {
       // Single click: focus the row AND open it in the Preview Pair's Viewer.
       // The openWithSplit redirect keeps the Viewer unfocused so keyboard
       // navigation stays in this list.
-      if (!isNonMemberChannelEntity(entity)) {
-        markChannelTargetSeenOnOpen(entity, notificationSource);
-      }
       if (args.rowIndex !== undefined) soup.focus.setIndex(args.rowIndex);
       else soup.focus.set(entity.id);
 
@@ -1043,10 +1040,6 @@ const SoupViewListContent = (props: SoupViewListProps) => {
     }
 
     const finishTouchHighlight = persistSoupNavigationTouchHighlight(event);
-
-    if (!isNonMemberChannelEntity(entity)) {
-      markChannelTargetSeenOnOpen(entity, notificationSource);
-    }
 
     try {
       await openEntityInSplitFromUnifiedList(entity, {

--- a/apps/web/src/features/next-soup/soup-view/use-soup-navigation-hotkeys.test.ts
+++ b/apps/web/src/features/next-soup/soup-view/use-soup-navigation-hotkeys.test.ts
@@ -29,6 +29,10 @@ vi.mock('@app/signal/splitLayout', () => ({
   globalSplitManager: () => undefined,
 }));
 
+vi.mock('@components/app/GlobalAppState', () => ({
+  useGlobalNotificationSource: () => ({ bulkMarkAsRead: vi.fn() }),
+}));
+
 vi.mock('@core/hotkey/hotkeys', () => {
   const registration = {
     dispose: vi.fn(),

--- a/apps/web/src/features/next-soup/soup-view/use-soup-navigation-hotkeys.ts
+++ b/apps/web/src/features/next-soup/soup-view/use-soup-navigation-hotkeys.ts
@@ -5,6 +5,7 @@ import {
   openEntityInSplitFromUnifiedList,
 } from '@app/features/next-soup/utils';
 import { globalSplitManager } from '@app/signal/splitLayout';
+import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
 import type {
   SplitContent,
   SplitEvent,
@@ -36,6 +37,7 @@ export const useSoupNavigationHotkeys = (
   options: UseSoupNavigationHotkeysOptions
 ) => {
   const { scopeId, soup, splitHandle, virtualizerHandle } = options;
+  const notificationSource = useGlobalNotificationSource();
 
   const scrollTo = (index: number) => {
     const handle = virtualizerHandle();
@@ -66,6 +68,7 @@ export const useSoupNavigationHotkeys = (
       splitHandle,
       mergeHistory: true,
       referredFrom: navigationReferredFrom(),
+      notificationSource,
     });
   }, 150);
   onCleanup(() => openInViewerDebounced.clear());
@@ -84,6 +87,7 @@ export const useSoupNavigationHotkeys = (
       splitHandle,
       mergeHistory: true,
       referredFrom: navigationReferredFrom(),
+      notificationSource,
     });
   };
 

--- a/apps/web/src/features/next-soup/soup-view/use-soup-view-hotkeys.ts
+++ b/apps/web/src/features/next-soup/soup-view/use-soup-view-hotkeys.ts
@@ -3,6 +3,7 @@ import { isListViewID, type ListView } from '@app/constants/list-views';
 import { CommandState } from '@app/features/command/state';
 import { VIEW_TAB_PRESETS } from '@app/features/next-soup/sidebar/soup-filter-presets';
 import {
+  markChannelNotificationsSeenOnOpen,
   markReminderSeenOnOpen,
   openEntityInSplitFromUnifiedList,
 } from '@app/features/next-soup/utils';
@@ -131,15 +132,18 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
       filterValidNotifications(entity.notifications?.() ?? [])
     );
     const splitManager = globalSplitManager();
-    return (
+    const didOpen =
       !!splitManager &&
       openSingleStackNotification(
         validNotifs,
         splitManager,
         newSplit,
         splitHandle
-      )
-    );
+      );
+    if (didOpen) {
+      markChannelNotificationsSeenOnOpen(entity);
+    }
+    return didOpen;
   };
 
   // enter - Open entity in split, toggle group, or load more

--- a/apps/web/src/features/next-soup/soup-view/use-soup-view-hotkeys.ts
+++ b/apps/web/src/features/next-soup/soup-view/use-soup-view-hotkeys.ts
@@ -141,7 +141,7 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
         splitHandle
       );
     if (didOpen) {
-      markChannelNotificationsSeenOnOpen(entity);
+      markChannelNotificationsSeenOnOpen(entity, notificationSource);
     }
     return didOpen;
   };
@@ -192,6 +192,7 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
         splitHandle,
         location,
         referredFrom: currentView(),
+        notificationSource,
       });
       return true;
     },
@@ -232,6 +233,7 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
         splitHandle,
         replacePreview: true,
         referredFrom: currentView(),
+        notificationSource,
       });
       return true;
     },
@@ -350,6 +352,7 @@ export const useSoupViewHotkeys = (options: UseSoupViewHotkeysOptions) => {
         splitHandle,
         openInNewSplit: true,
         referredFrom: currentView(),
+        notificationSource,
       });
       return true;
     },

--- a/apps/web/src/features/next-soup/utils.test.ts
+++ b/apps/web/src/features/next-soup/utils.test.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const { toastAlert, ...operationMocks } = vi.hoisted(() => ({
   toastAlert: vi.fn(),
   bulkMarkNotificationsAsDone: vi.fn(async () => {}),
-  bulkMarkNotificationsAsSeen: vi.fn(async () => {}),
   bulkMarkNotificationsAsUndone: vi.fn(async () => {}),
   cancelQueries: vi.fn(async () => {}),
   flagArchived: vi.fn(async () => ({ isErr: () => false, value: undefined })),
@@ -43,7 +42,6 @@ vi.mock('@queries/notification/entity-mutations', () => ({
 }));
 vi.mock('@queries/notification/user-notifications', () => ({
   bulkMarkNotificationsAsDone: operationMocks.bulkMarkNotificationsAsDone,
-  bulkMarkNotificationsAsSeen: operationMocks.bulkMarkNotificationsAsSeen,
   bulkMarkNotificationsAsUndone: operationMocks.bulkMarkNotificationsAsUndone,
   restoreUserNotifications: vi.fn(),
   snapshotUserNotifications: vi.fn(() => []),
@@ -125,6 +123,10 @@ const asRead = (notification: UnifiedNotification): UnifiedNotification =>
     ...notification,
     viewed_at: '2026-07-14T00:00:00.000Z',
   }) as unknown as UnifiedNotification;
+
+const notificationSourceWithBulkMarkAsRead = (
+  bulkMarkAsRead = vi.fn(async () => {})
+) => ({ bulkMarkAsRead }) as unknown as NotificationSource;
 
 const channelMessageRow = (opts?: {
   target?: ChannelEntityTarget;
@@ -412,16 +414,18 @@ describe('getChannelEntityTarget', () => {
     const olderNotification = sendNotification('older-notification', 'older');
     const readNotification = asRead(sendNotification('read', 'read-msg'));
 
+    const bulkMarkAsRead = vi.fn(async () => {});
     markChannelNotificationsSeenOnOpen(
       channelRow({
         notifications: [agentNotification, olderNotification, readNotification],
-      })
+      }),
+      notificationSourceWithBulkMarkAsRead(bulkMarkAsRead)
     );
 
-    expect(operationMocks.bulkMarkNotificationsAsSeen).toHaveBeenCalledOnce();
-    expect(operationMocks.bulkMarkNotificationsAsSeen).toHaveBeenCalledWith([
-      agentNotification.id,
-      olderNotification.id,
+    expect(bulkMarkAsRead).toHaveBeenCalledOnce();
+    expect(bulkMarkAsRead).toHaveBeenCalledWith([
+      agentNotification,
+      olderNotification,
     ]);
   });
 
@@ -437,9 +441,13 @@ describe('getChannelEntityTarget', () => {
       openWithSplit,
     } as unknown as SplitManager);
 
+    const bulkMarkAsRead = vi.fn(async () => {});
     await openEntityInSplitFromUnifiedList(
       channelRow({ notifications: [notification] }),
-      {}
+      {
+        notificationSource:
+          notificationSourceWithBulkMarkAsRead(bulkMarkAsRead),
+      }
     );
 
     expect(openWithSplit).toHaveBeenCalledWith(
@@ -448,9 +456,7 @@ describe('getChannelEntityTarget', () => {
       }),
       expect.any(Object)
     );
-    expect(operationMocks.bulkMarkNotificationsAsSeen).toHaveBeenCalledWith([
-      notification.id,
-    ]);
+    expect(bulkMarkAsRead).toHaveBeenCalledWith([notification]);
   });
 
   it('does not mark a thread-stack notification when opening its parent channel row', async () => {
@@ -469,18 +475,20 @@ describe('getChannelEntityTarget', () => {
       openWithSplit: vi.fn(),
     } as unknown as SplitManager);
 
+    const bulkMarkAsRead = vi.fn(async () => {});
     await openEntityInSplitFromUnifiedList(
       channelRow({
         notifications: [parentNotification, threadNotification],
       }),
-      {}
+      {
+        notificationSource:
+          notificationSourceWithBulkMarkAsRead(bulkMarkAsRead),
+      }
     );
 
-    expect(operationMocks.bulkMarkNotificationsAsSeen).toHaveBeenCalledWith([
-      parentNotification.id,
-    ]);
-    expect(operationMocks.bulkMarkNotificationsAsSeen).not.toHaveBeenCalledWith(
-      expect.arrayContaining([threadNotification.id])
+    expect(bulkMarkAsRead).toHaveBeenCalledWith([parentNotification]);
+    expect(bulkMarkAsRead).not.toHaveBeenCalledWith(
+      expect.arrayContaining([threadNotification])
     );
   });
 
@@ -490,11 +498,14 @@ describe('getChannelEntityTarget', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => {});
     const notification = sendNotification('notification', 'message');
-    operationMocks.bulkMarkNotificationsAsSeen.mockRejectedValueOnce(error);
+    const bulkMarkAsRead = vi.fn(async () => {
+      throw error;
+    });
 
     try {
       markChannelNotificationsSeenOnOpen(
-        channelRow({ notifications: [notification] })
+        channelRow({ notifications: [notification] }),
+        notificationSourceWithBulkMarkAsRead(bulkMarkAsRead)
       );
       await Promise.resolve();
 

--- a/apps/web/src/features/next-soup/utils.test.ts
+++ b/apps/web/src/features/next-soup/utils.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const { toastAlert, ...operationMocks } = vi.hoisted(() => ({
   toastAlert: vi.fn(),
   bulkMarkNotificationsAsDone: vi.fn(async () => {}),
+  bulkMarkNotificationsAsSeen: vi.fn(async () => {}),
   bulkMarkNotificationsAsUndone: vi.fn(async () => {}),
   cancelQueries: vi.fn(async () => {}),
   flagArchived: vi.fn(async () => ({ isErr: () => false, value: undefined })),
@@ -42,6 +43,7 @@ vi.mock('@queries/notification/entity-mutations', () => ({
 }));
 vi.mock('@queries/notification/user-notifications', () => ({
   bulkMarkNotificationsAsDone: operationMocks.bulkMarkNotificationsAsDone,
+  bulkMarkNotificationsAsSeen: operationMocks.bulkMarkNotificationsAsSeen,
   bulkMarkNotificationsAsUndone: operationMocks.bulkMarkNotificationsAsUndone,
   restoreUserNotifications: vi.fn(),
   snapshotUserNotifications: vi.fn(() => []),
@@ -79,7 +81,7 @@ import {
   executeMarkEntitiesDone,
   getChannelEntityTarget,
   getRowClickFallbackLocation,
-  markChannelTargetSeenOnOpen,
+  markChannelNotificationsSeenOnOpen,
   openEntityInSplitFromUnifiedList,
   preventDuplicatePreviewEntityOpen,
   resolveMarkEntitiesDoneVariables,
@@ -394,9 +396,12 @@ describe('getChannelEntityTarget', () => {
     });
   });
 
-  it('marks an attached agent notification read even when the global source does not contain it', () => {
-    const notification = sendNotification('agent-notification', 'agent-msg');
-    notification.notification_metadata = {
+  it('marks every unread notification attached to a channel row', () => {
+    const agentNotification = sendNotification(
+      'agent-notification',
+      'agent-msg'
+    );
+    agentNotification.notification_metadata = {
       tag: 'channel_message_send',
       content: {
         messageId: 'agent-msg',
@@ -404,19 +409,79 @@ describe('getChannelEntityTarget', () => {
         senderDisplayName: 'Macro Agent',
       },
     } as UnifiedNotification['notification_metadata'];
-    const bulkMarkAsRead = vi.fn(async () => {});
-    const notificationSource = {
-      notificationsByEntity: () => ({}),
-      bulkMarkAsRead,
-    } as unknown as NotificationSource;
+    const olderNotification = sendNotification('older-notification', 'older');
+    const readNotification = asRead(sendNotification('read', 'read-msg'));
 
-    markChannelTargetSeenOnOpen(
-      channelRow({ notifications: [notification] }),
-      notificationSource
+    markChannelNotificationsSeenOnOpen(
+      channelRow({
+        notifications: [agentNotification, olderNotification, readNotification],
+      })
     );
 
-    expect(bulkMarkAsRead).toHaveBeenCalledOnce();
-    expect(bulkMarkAsRead).toHaveBeenCalledWith([notification]);
+    expect(operationMocks.bulkMarkNotificationsAsSeen).toHaveBeenCalledOnce();
+    expect(operationMocks.bulkMarkNotificationsAsSeen).toHaveBeenCalledWith([
+      agentNotification.id,
+      olderNotification.id,
+    ]);
+  });
+
+  it('marks attached channel notifications through the shared split-open path', async () => {
+    const notification = sendNotification('shared-open', 'message');
+    const openWithSplit = vi.fn();
+    setGlobalSplitManager({
+      activeSplit: vi.fn(),
+      getOrchestrator: vi.fn(() => ({
+        getBlockHandle: vi.fn(async () => undefined),
+      })),
+      getSplitByContent: vi.fn(),
+      openWithSplit,
+    } as unknown as SplitManager);
+
+    await openEntityInSplitFromUnifiedList(
+      channelRow({ notifications: [notification] }),
+      {}
+    );
+
+    expect(openWithSplit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ channel_message_id: 'message' }),
+      }),
+      expect.any(Object)
+    );
+    expect(operationMocks.bulkMarkNotificationsAsSeen).toHaveBeenCalledWith([
+      notification.id,
+    ]);
+  });
+
+  it('does not mark a thread-stack notification when opening its parent channel row', async () => {
+    const parentNotification = sendNotification('parent-send', 'message');
+    const threadNotification = replyNotification(
+      'thread-reply',
+      'reply',
+      'thread-root'
+    );
+    setGlobalSplitManager({
+      activeSplit: vi.fn(),
+      getOrchestrator: vi.fn(() => ({
+        getBlockHandle: vi.fn(async () => undefined),
+      })),
+      getSplitByContent: vi.fn(),
+      openWithSplit: vi.fn(),
+    } as unknown as SplitManager);
+
+    await openEntityInSplitFromUnifiedList(
+      channelRow({
+        notifications: [parentNotification, threadNotification],
+      }),
+      {}
+    );
+
+    expect(operationMocks.bulkMarkNotificationsAsSeen).toHaveBeenCalledWith([
+      parentNotification.id,
+    ]);
+    expect(operationMocks.bulkMarkNotificationsAsSeen).not.toHaveBeenCalledWith(
+      expect.arrayContaining([threadNotification.id])
+    );
   });
 
   it('reports failures to mark an attached channel notification read', async () => {
@@ -425,21 +490,16 @@ describe('getChannelEntityTarget', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => {});
     const notification = sendNotification('notification', 'message');
-    const notificationSource = {
-      bulkMarkAsRead: vi.fn(async () => {
-        throw error;
-      }),
-    } as unknown as NotificationSource;
+    operationMocks.bulkMarkNotificationsAsSeen.mockRejectedValueOnce(error);
 
     try {
-      markChannelTargetSeenOnOpen(
-        channelRow({ notifications: [notification] }),
-        notificationSource
+      markChannelNotificationsSeenOnOpen(
+        channelRow({ notifications: [notification] })
       );
       await Promise.resolve();
 
       expect(consoleError).toHaveBeenCalledWith(
-        'Failed to mark message notifications as read',
+        'Failed to mark channel notifications as read',
         error
       );
     } finally {

--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -72,7 +72,6 @@ import {
 import { notificationKeys } from '@queries/notification/keys';
 import {
   bulkMarkNotificationsAsDone,
-  bulkMarkNotificationsAsSeen,
   bulkMarkNotificationsAsUndone,
   restoreUserNotifications,
   snapshotUserNotifications,
@@ -374,6 +373,11 @@ interface OpenEntityOptions {
   mergeHistory?: boolean;
   allowDuplicate?: boolean;
   referredFrom?: ReferredFrom;
+  /**
+   * Notification source used to keep REST-backed unread state optimistic when
+   * opening a channel row. Callers that can open channels must provide it.
+   */
+  notificationSource?: NotificationSource;
 }
 
 const DUPLICATE_CONTENT_MESSAGE = 'Content already open.';
@@ -670,7 +674,9 @@ export const openEntityInSplitFromUnifiedList = async (
     channelTarget?.kind === 'message' ? channelTarget : undefined;
   const openChannelAtLatest = channelTarget?.kind === 'latest';
 
-  markChannelNotificationsSeenOnOpen(entity);
+  if (options.notificationSource) {
+    markChannelNotificationsSeenOnOpen(entity, options.notificationSource);
+  }
 
   let params: Record<string, string> | undefined;
   if (entity.type === 'channel' && location?.type === 'channel') {
@@ -741,10 +747,14 @@ export const openEntityInSplitFromUnifiedList = async (
  *
  * The row's attached Soup edge is authoritative. The channel block's message
  * marker discovers notifications through the separately paginated global
- * source, so it cannot reliably clear older notifications. ID-scoped writes
- * update normalized Soup edges optimistically; the uncached fallback refetches.
+ * source, so it cannot reliably clear older notifications. Passing the row's
+ * attached notifications through the source keeps its REST cache and durable
+ * seen overrides in sync while the configured mutation updates GraphQL edges.
  */
-export function markChannelNotificationsSeenOnOpen(entity: EntityData) {
+export function markChannelNotificationsSeenOnOpen(
+  entity: EntityData,
+  notificationSource: NotificationSource
+) {
   if (
     (entity.type !== 'channel' &&
       entity.type !== 'channel_message' &&
@@ -760,9 +770,7 @@ export function markChannelNotificationsSeenOnOpen(entity: EntityData) {
   ).filter((notification) => !notificationIsRead(notification));
   if (notifications.length === 0) return;
 
-  void bulkMarkNotificationsAsSeen(
-    notifications.map((notification) => notification.id)
-  ).catch((error) => {
+  void notificationSource.bulkMarkAsRead(notifications).catch((error) => {
     console.error('Failed to mark channel notifications as read', error);
   });
 }

--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -72,6 +72,7 @@ import {
 import { notificationKeys } from '@queries/notification/keys';
 import {
   bulkMarkNotificationsAsDone,
+  bulkMarkNotificationsAsSeen,
   bulkMarkNotificationsAsUndone,
   restoreUserNotifications,
   snapshotUserNotifications,
@@ -669,6 +670,8 @@ export const openEntityInSplitFromUnifiedList = async (
     channelTarget?.kind === 'message' ? channelTarget : undefined;
   const openChannelAtLatest = channelTarget?.kind === 'latest';
 
+  markChannelNotificationsSeenOnOpen(entity);
+
   let params: Record<string, string> | undefined;
   if (entity.type === 'channel' && location?.type === 'channel') {
     params = getChannelParams(location.messageId, location.threadId);
@@ -734,32 +737,33 @@ export const openEntityInSplitFromUnifiedList = async (
 };
 
 /**
- * Mark the attached notification that caused a channel row to target a message.
+ * Mark every unread notification represented by an opened channel Soup row.
  *
- * The row's Soup edge is authoritative here. The channel block's message marker
- * discovers notifications through the separately paginated global source, so
- * an older notification can drive navigation without being present there.
+ * The row's attached Soup edge is authoritative. The channel block's message
+ * marker discovers notifications through the separately paginated global
+ * source, so it cannot reliably clear older notifications. ID-scoped writes
+ * update normalized Soup edges optimistically; the uncached fallback refetches.
  */
-export function markChannelTargetSeenOnOpen(
-  entity: EntityData,
-  notificationSource: NotificationSource
-) {
-  const target = getChannelEntityTarget(entity);
-  if (target?.kind !== 'message' || !isWithNotification(entity)) return;
+export function markChannelNotificationsSeenOnOpen(entity: EntityData) {
+  if (
+    (entity.type !== 'channel' &&
+      entity.type !== 'channel_message' &&
+      entity.type !== 'channel_thread') ||
+    !isWithNotification(entity)
+  ) {
+    return;
+  }
 
   const notifications = scopeChannelNotificationsForEntity(
     entity,
     entity.notifications?.() ?? []
-  ).filter((notification) => {
-    if (notificationIsRead(notification)) return false;
-    return (
-      getChannelNotificationParams(notification).messageId === target.messageId
-    );
-  });
+  ).filter((notification) => !notificationIsRead(notification));
   if (notifications.length === 0) return;
 
-  void notificationSource.bulkMarkAsRead(notifications).catch((error) => {
-    console.error('Failed to mark message notifications as read', error);
+  void bulkMarkNotificationsAsSeen(
+    notifications.map((notification) => notification.id)
+  ).catch((error) => {
+    console.error('Failed to mark channel notifications as read', error);
   });
 }
 

--- a/apps/web/src/lib/queries/notification/entity-mutations.ts
+++ b/apps/web/src/lib/queries/notification/entity-mutations.ts
@@ -1,11 +1,15 @@
 import type { UnifiedNotification } from '@notifications/types';
+import { refreshActiveGraphqlSoupQueries } from '@queries/soup/graphql/active-queries';
 import type {
   GraphqlEntityType,
   NotificationEntityInput,
   NotificationUpdateOperation,
 } from '@service-storage/graphql/generated/graphql';
 import { updateNotificationsForEntities as updateGraphqlNotificationsForEntities } from '@service-storage/graphql-notifications';
-import { mapGraphqlNotification } from '@service-storage/graphql-soup';
+import {
+  graphqlCacheEnabled,
+  mapGraphqlNotification,
+} from '@service-storage/graphql-soup';
 
 type SimpleNotificationEntityType =
   | 'calendar_event'
@@ -122,5 +126,8 @@ export async function updateNotificationsForEntities(args: {
     entities: args.entities.map(toNotificationEntityInput),
     operation: args.operation,
   });
+  if (!graphqlCacheEnabled()) {
+    await refreshActiveGraphqlSoupQueries();
+  }
   return rows.map((row) => mapGraphqlNotification(row));
 }

--- a/apps/web/src/lib/queries/notification/tests/entity-mutations.test.ts
+++ b/apps/web/src/lib/queries/notification/tests/entity-mutations.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  cacheEnabled: true,
+  refreshActiveGraphqlSoupQueries: vi.fn(async () => undefined),
+  updateGraphqlNotificationsForEntities: vi.fn(async () => []),
+}));
+
+vi.mock('@queries/soup/graphql/active-queries', () => ({
+  refreshActiveGraphqlSoupQueries: mocks.refreshActiveGraphqlSoupQueries,
+}));
+
+vi.mock('@service-storage/graphql-notifications', () => ({
+  updateNotificationsForEntities: mocks.updateGraphqlNotificationsForEntities,
+}));
+
+vi.mock('@service-storage/graphql-soup', () => ({
+  graphqlCacheEnabled: () => mocks.cacheEnabled,
+  mapGraphqlNotification: vi.fn((notification) => notification),
+}));
+
+import { updateNotificationsForEntities } from '../entity-mutations';
+
+describe('updateNotificationsForEntities', () => {
+  beforeEach(() => {
+    mocks.cacheEnabled = true;
+    vi.clearAllMocks();
+  });
+
+  it('relies on normalized cache updates when the cache is active', async () => {
+    await updateNotificationsForEntities({
+      entities: [{ type: 'channel', id: 'channel-1' }],
+      operation: 'MARK_SEEN',
+    });
+
+    expect(mocks.refreshActiveGraphqlSoupQueries).not.toHaveBeenCalled();
+  });
+
+  it('refreshes active Soup queries after an uncached write', async () => {
+    mocks.cacheEnabled = false;
+
+    await updateNotificationsForEntities({
+      entities: [{ type: 'channel', id: 'channel-1' }],
+      operation: 'MARK_SEEN',
+    });
+
+    expect(mocks.refreshActiveGraphqlSoupQueries).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/lib/queries/notification/tests/user-notifications.test.tsx
+++ b/apps/web/src/lib/queries/notification/tests/user-notifications.test.tsx
@@ -13,7 +13,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { notificationKeys } from '../keys';
 import {
   applyNotificationStatusUpdate,
-  bulkMarkNotificationsAsSeen,
   optimisticInsertNotification,
   type UserNotificationsQuery,
   useMarkNotificationsAsDoneMutation,
@@ -32,7 +31,6 @@ const {
   restMarkSeenMock,
   restUserNotificationsMock,
   restMarkUndoneMock,
-  updateNotificationsMock,
 } = vi.hoisted(() => ({
   createGraphqlMutationMock: vi.fn(),
   createGraphqlQueryMock: vi.fn(),
@@ -44,7 +42,6 @@ const {
   restMarkSeenMock: vi.fn(),
   restUserNotificationsMock: vi.fn(),
   restMarkUndoneMock: vi.fn(),
-  updateNotificationsMock: vi.fn(async () => []),
 }));
 
 vi.mock('@core/constant/featureFlags', () => ({
@@ -69,7 +66,7 @@ vi.mock('../graphql/user-notifications', () => ({
 }));
 
 vi.mock('@service-storage/graphql-notifications', () => ({
-  updateNotifications: updateNotificationsMock,
+  updateNotifications: vi.fn(),
 }));
 
 vi.mock('@queries/soup/graphql/active-queries', () => ({
@@ -418,26 +415,6 @@ describe('notification mutations', () => {
 
   afterEach(() => {
     testQueryClient.clear();
-  });
-
-  describe('bulkMarkNotificationsAsSeen', () => {
-    it('writes notification IDs without refreshing the normalized cache', async () => {
-      await bulkMarkNotificationsAsSeen(['notification-1']);
-
-      expect(updateNotificationsMock).toHaveBeenCalledWith({
-        notificationIds: ['notification-1'],
-        operation: 'MARK_SEEN',
-      });
-      expect(refreshActiveSoupQueriesMock).not.toHaveBeenCalled();
-    });
-
-    it('refreshes active Soup queries for the uncached fallback', async () => {
-      graphqlCacheEnabledMock.mockReturnValue(false);
-
-      await bulkMarkNotificationsAsSeen(['notification-1']);
-
-      expect(refreshActiveSoupQueriesMock).toHaveBeenCalledOnce();
-    });
   });
 
   describe('useMarkNotificationsAsSeenMutation', () => {

--- a/apps/web/src/lib/queries/notification/tests/user-notifications.test.tsx
+++ b/apps/web/src/lib/queries/notification/tests/user-notifications.test.tsx
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { notificationKeys } from '../keys';
 import {
   applyNotificationStatusUpdate,
+  bulkMarkNotificationsAsSeen,
   optimisticInsertNotification,
   type UserNotificationsQuery,
   useMarkNotificationsAsDoneMutation,
@@ -24,20 +25,26 @@ const {
   createGraphqlMutationMock,
   createGraphqlQueryMock,
   executeGraphqlMutationMock,
+  graphqlCacheEnabledMock,
   graphqlSoupEnabledMock,
+  refreshActiveSoupQueriesMock,
   restMarkDoneMock,
   restMarkSeenMock,
   restUserNotificationsMock,
   restMarkUndoneMock,
+  updateNotificationsMock,
 } = vi.hoisted(() => ({
   createGraphqlMutationMock: vi.fn(),
   createGraphqlQueryMock: vi.fn(),
   executeGraphqlMutationMock: vi.fn(),
+  graphqlCacheEnabledMock: vi.fn(() => true),
   graphqlSoupEnabledMock: vi.fn(() => true),
+  refreshActiveSoupQueriesMock: vi.fn(async () => undefined),
   restMarkDoneMock: vi.fn(),
   restMarkSeenMock: vi.fn(),
   restUserNotificationsMock: vi.fn(),
   restMarkUndoneMock: vi.fn(),
+  updateNotificationsMock: vi.fn(async () => []),
 }));
 
 vi.mock('@core/constant/featureFlags', () => ({
@@ -62,13 +69,21 @@ vi.mock('../graphql/user-notifications', () => ({
 }));
 
 vi.mock('@service-storage/graphql-notifications', () => ({
-  updateNotifications: vi.fn(),
+  updateNotifications: updateNotificationsMock,
+}));
+
+vi.mock('@queries/soup/graphql/active-queries', () => ({
+  refreshActiveGraphqlSoupQueries: refreshActiveSoupQueriesMock,
 }));
 
 vi.mock('@queries/soup/normalized-cache', () => ({
   optimisticUpdateSoupItemUpdatedAt: vi.fn(),
   hasSoupEntity: vi.fn(() => false),
   refetchSoupEntity: vi.fn(),
+}));
+
+vi.mock('@service-storage/graphql-soup', () => ({
+  graphqlCacheEnabled: graphqlCacheEnabledMock,
 }));
 
 import {
@@ -108,6 +123,7 @@ type GraphqlMutationOptions = {
 };
 
 beforeEach(() => {
+  graphqlCacheEnabledMock.mockReturnValue(true);
   graphqlSoupEnabledMock.mockReturnValue(true);
   restUserNotificationsMock.mockResolvedValue(
     ok({ items: [], next_cursor: null })
@@ -404,6 +420,26 @@ describe('notification mutations', () => {
     testQueryClient.clear();
   });
 
+  describe('bulkMarkNotificationsAsSeen', () => {
+    it('writes notification IDs without refreshing the normalized cache', async () => {
+      await bulkMarkNotificationsAsSeen(['notification-1']);
+
+      expect(updateNotificationsMock).toHaveBeenCalledWith({
+        notificationIds: ['notification-1'],
+        operation: 'MARK_SEEN',
+      });
+      expect(refreshActiveSoupQueriesMock).not.toHaveBeenCalled();
+    });
+
+    it('refreshes active Soup queries for the uncached fallback', async () => {
+      graphqlCacheEnabledMock.mockReturnValue(false);
+
+      await bulkMarkNotificationsAsSeen(['notification-1']);
+
+      expect(refreshActiveSoupQueriesMock).toHaveBeenCalledOnce();
+    });
+  });
+
   describe('useMarkNotificationsAsSeenMutation', () => {
     it('should optimistically update viewed_at when marking as seen', async () => {
       const n1 = createMockNotification({ id: 'n1', viewed_at: null });
@@ -431,7 +467,26 @@ describe('notification mutations', () => {
       const notifications = getNotificationsFromCache();
       expect(typeof notifications[0].viewed_at).toBe('string');
       expect(notifications[1].viewed_at).toBe(null);
+      expect(refreshActiveSoupQueriesMock).not.toHaveBeenCalled();
 
+      cleanup();
+    });
+
+    it('refreshes active Soup queries when the GraphQL cache is unavailable', async () => {
+      graphqlCacheEnabledMock.mockReturnValue(false);
+      executeGraphqlMutationMock.mockResolvedValue([]);
+
+      let mutatePromise: Promise<unknown> | undefined;
+      const TestComponent = () => {
+        const mutation = useMarkNotificationsAsSeenMutation();
+        mutatePromise = mutation.mutateAsync({ notificationIds: ['n1'] });
+        return null;
+      };
+      const cleanup = renderWithClient(TestComponent);
+
+      await mutatePromise;
+
+      expect(refreshActiveSoupQueriesMock).toHaveBeenCalledOnce();
       cleanup();
     });
 

--- a/apps/web/src/lib/queries/notification/user-notifications.ts
+++ b/apps/web/src/lib/queries/notification/user-notifications.ts
@@ -2,6 +2,7 @@ import { ENABLE_GRAPHQL_SOUP } from '@core/constant/featureFlags';
 import type { Maybe } from '@core/types';
 import { throwOnErr } from '@core/util/result';
 import type { UnifiedNotification } from '@notifications/types';
+import { refreshActiveGraphqlSoupQueries } from '@queries/soup/graphql/active-queries';
 import {
   hasSoupEntity,
   optimisticUpdateSoupItemUpdatedAt,
@@ -14,6 +15,7 @@ import type { ApiUserNotification } from '@service-notification/generated/schema
 import type { GetAllUserNotificationsResponse } from '@service-notification/generated/schemas/getAllUserNotificationsResponse';
 import type { NotificationUpdateOperation } from '@service-storage/graphql/generated/graphql';
 import { updateNotifications } from '@service-storage/graphql-notifications';
+import { graphqlCacheEnabled } from '@service-storage/graphql-soup';
 import {
   type InfiniteData,
   useInfiniteQuery,
@@ -386,6 +388,21 @@ export function invalidateUserNotifications() {
   });
 }
 
+async function refreshSoupAfterUncachedGraphqlWrite(): Promise<void> {
+  if (ENABLE_GRAPHQL_SOUP() && !graphqlCacheEnabled()) {
+    await refreshActiveGraphqlSoupQueries();
+  }
+}
+
+/** Mark notifications seen through the configured transport. Throws on failure. */
+export async function bulkMarkNotificationsAsSeen(
+  notificationIds: string[]
+): Promise<void> {
+  if (notificationIds.length === 0) return;
+  await updateNotifications({ notificationIds, operation: 'MARK_SEEN' });
+  await refreshSoupAfterUncachedGraphqlWrite();
+}
+
 /** Mark notifications done through the shared GraphQL mutation. Throws on failure. */
 export async function bulkMarkNotificationsAsDone(
   notificationIds: string[]
@@ -594,6 +611,10 @@ function createNotificationsMutation(
             context as NotificationsMutationContext,
             undefined as never
           );
+          // The normalized client propagates the optimistic notification row
+          // into active Soup edges. Its uncached fallback cannot, so refetch
+          // mounted Soup queries after the authoritative mutation succeeds.
+          await refreshSoupAfterUncachedGraphqlWrite();
         },
         onError: async (error, variables, context) => {
           await lifecycle.onError?.(

--- a/apps/web/src/lib/queries/notification/user-notifications.ts
+++ b/apps/web/src/lib/queries/notification/user-notifications.ts
@@ -394,15 +394,6 @@ async function refreshSoupAfterUncachedGraphqlWrite(): Promise<void> {
   }
 }
 
-/** Mark notifications seen through the configured transport. Throws on failure. */
-export async function bulkMarkNotificationsAsSeen(
-  notificationIds: string[]
-): Promise<void> {
-  if (notificationIds.length === 0) return;
-  await updateNotifications({ notificationIds, operation: 'MARK_SEEN' });
-  await refreshSoupAfterUncachedGraphqlWrite();
-}
-
 /** Mark notifications done through the shared GraphQL mutation. Throws on failure. */
 export async function bulkMarkNotificationsAsDone(
   notificationIds: string[]


### PR DESCRIPTION
fixes an issue on gql where channel notifications were not being marked as read

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches notification read state across many list/split open paths and adds mutation follow-up refetches; incorrect scoping could clear wrong notifications or leave stale unread UI.
> 
> **Overview**
> Fixes channel rows staying unread in GraphQL Soup when opening a channel from the unified list.
> 
> **Mark-read on open** is centralized in `openEntityInSplitFromUnifiedList`: when callers pass `notificationSource`, it runs `markChannelNotificationsSeenOnOpen` (renamed from `markChannelTargetSeenOnOpen`). That helper now bulk-marks **all unread notifications on the row’s Soup edge** (not only the message that drives navigation), while still scoping thread vs parent channel rows. List clicks, split header nav/drag, hotkeys, mark-done advance, dynamic UI lists, and related paths now thread `useGlobalNotificationSource()` into that open helper; redundant per-click marking in `soup-view` is removed. Channel notification hotkeys still mark seen when opening a stacked notification directly.
> 
> **GraphQL without normalized cache**: after entity-level and user notification “mark seen” mutations succeed, the app **refetches active Soup queries** so list unread dots update when optimistic cache propagation is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8891084a3161164d9d25179df22ceeb43e0bfe14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->