### PR TITLE
fix(channel_bots): restore @macro in-channel replies; agent sessions move to @macro-new

### DIFF
--- a/.github/workspace-dep-closures.json
+++ b/.github/workspace-dep-closures.json
@@ -2656,6 +2656,7 @@
       "crates/cal",
       "crates/calendar_events",
       "crates/call",
+      "crates/channel_bots",
       "crates/channel_sender",
       "crates/channels",
       "crates/chat",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5061,6 +5061,7 @@ dependencies = [
  "cal",
  "calendar_events",
  "call",
+ "channel_bots",
  "channels",
  "chat",
  "chrono",

--- a/apps/web/src/features/channel/Input/ChannelInput.tsx
+++ b/apps/web/src/features/channel/Input/ChannelInput.tsx
@@ -41,8 +41,10 @@ import {
   cursorMentionUser,
   isMacroAiId,
   isMacroCoderId,
+  isMacroNewId,
   macroAiMentionUser,
   macroCoderMentionUser,
+  macroNewMentionUser,
 } from '../macroAi';
 import { CHANNEL_FILE_PICKER_ACCEPT } from './accepted-file-types';
 import { createInputAttachmentTracker } from './attachment-tracker';
@@ -275,6 +277,12 @@ export function ChannelInput(props: ChannelInputProps) {
       !base.some((user) => isMacroCoderId(user.id))
     ) {
       base.unshift(macroCoderMentionUser());
+    }
+    if (
+      ENABLE_CHAT_V3_AGENTS() &&
+      !base.some((user) => isMacroNewId(user.id))
+    ) {
+      base.unshift(macroNewMentionUser());
     }
     if (
       cursorEnabled &&

--- a/apps/web/src/features/channel/macroAi.ts
+++ b/apps/web/src/features/channel/macroAi.ts
@@ -10,6 +10,10 @@ import {
   MACRO_CODER_NAME,
   MACRO_CODER_PRINCIPAL_ID,
 } from '@core/constant/macroCoder';
+import {
+  MACRO_NEW_NAME,
+  MACRO_NEW_PRINCIPAL_ID,
+} from '@core/constant/macroNew';
 import type { IUser } from '@core/user/types';
 
 // Re-export the shared Macro identity under the names used in this package.
@@ -21,6 +25,7 @@ export {
   MACRO_AGENT_PRINCIPAL_ID as MACRO_AI_PRINCIPAL_ID,
 } from '@core/constant/macroAgent';
 export { isMacroCoderId } from '@core/constant/macroCoder';
+export { isMacroNewId } from '@core/constant/macroNew';
 
 /**
  * A synthetic [`IUser`] entry so Macro appears in the channel `@`-mention
@@ -48,6 +53,19 @@ export function macroCoderMentionUser(): IUser {
     id: MACRO_CODER_PRINCIPAL_ID,
     name: MACRO_CODER_NAME,
     email: MACRO_CODER_NAME,
+  };
+}
+
+/**
+ * A synthetic [`IUser`] entry so macro(new) appears in the channel
+ * `@`-mention typeahead, exactly like [`macroAiMentionUser`]. Mentioning it
+ * opens an agent session on the in-process runtime rather than a chat reply.
+ */
+export function macroNewMentionUser(): IUser {
+  return {
+    id: MACRO_NEW_PRINCIPAL_ID,
+    name: MACRO_NEW_NAME,
+    email: MACRO_NEW_NAME,
   };
 }
 

--- a/apps/web/src/lib/core/component/UserIcon.tsx
+++ b/apps/web/src/lib/core/component/UserIcon.tsx
@@ -2,6 +2,7 @@ import { useSplitLayout } from '@components/app/split-layout/layout';
 import { ENABLE_PROFILE_PICTURES } from '@core/constant/featureFlags';
 import { isBotPrincipalId, isMacroAgentId } from '@core/constant/macroAgent';
 import { isMacroCoderId } from '@core/constant/macroCoder';
+import { isMacroNewId } from '@core/constant/macroNew';
 import { staticFileSizedUrl } from '@core/constant/servers';
 import { internalDrag } from '@core/directive/internalDragState';
 import { useProfilePictureUrl } from '@core/signal/profilePicture';
@@ -173,7 +174,13 @@ export function UserIcon(props: UserIconProps) {
 
   return (
     <Switch>
-      <Match when={isMacroAgentId(props.id) || isMacroCoderId(props.id)}>
+      <Match
+        when={
+          isMacroAgentId(props.id) ||
+          isMacroCoderId(props.id) ||
+          isMacroNewId(props.id)
+        }
+      >
         <Avatar
           size={size()}
           class={cn('bg-surface text-accent ring ring-edge-muted', props.class)}

--- a/apps/web/src/lib/core/constant/macroNew.ts
+++ b/apps/web/src/lib/core/constant/macroNew.ts
@@ -1,0 +1,29 @@
+/**
+ * Identity for the first-party "macro(new)" system bot. Mirrors
+ * `bot_id::MACRO_NEW_BOT_ID` on the backend. Deliberately a distinct bot from
+ * Macro (see `macroAgent.ts`): mentioning Macro answers in chat, while
+ * mentioning macro(new) opens an agent session on the in-process runtime.
+ */
+export const MACRO_NEW_BOT_ID = '00000000-0000-0000-0000-00000000a2a2';
+
+/**
+ * Canonical principal id for macro(new), matching the `bot|<uuid>` form used
+ * for bot senders and participants everywhere else.
+ */
+export const MACRO_NEW_PRINCIPAL_ID = `bot|${MACRO_NEW_BOT_ID}`;
+
+/** Display name for macro(new). */
+export const MACRO_NEW_NAME = 'macro(new)';
+
+/** Handle used to find macro(new) in the mention typeahead (`@macro-new`). */
+export const MACRO_NEW_HANDLE = 'macro-new';
+
+/**
+ * Whether an id refers to the macro(new) bot. Accepts both the bare UUID and
+ * the `bot|<uuid>` participant/sender form.
+ */
+export function isMacroNewId(id: string | undefined): boolean {
+  if (!id) return false;
+  const bare = id.startsWith('bot|') ? id.slice('bot|'.length) : id;
+  return bare === MACRO_NEW_BOT_ID;
+}

--- a/crates/agent_harness/src/domain/model.rs
+++ b/crates/agent_harness/src/domain/model.rs
@@ -65,7 +65,7 @@ pub enum AgentKind {
     SandboxedCoder,
     /// A Cursor cloud agent, served over an in-process ACP pipe.
     Cursor,
-    /// The in-process (in-memory) Macro bot, served by `agent_inmem`.
+    /// The in-process (in-memory) "macro(new)" bot, served by `agent_inmem`.
     InMemory,
     /// The bot's operator hosts the runtime and dials the gateway; no
     /// deployment here provisions anything for it.
@@ -80,7 +80,7 @@ impl AgentKind {
             Self::SandboxedCoder
         } else if bot == bot_id::CURSOR_BOT_ID {
             Self::Cursor
-        } else if bot == bot_id::MACRO_AI_BOT_ID {
+        } else if bot == bot_id::MACRO_NEW_BOT_ID {
             Self::InMemory
         } else {
             Self::External

--- a/crates/bot_id/src/lib.rs
+++ b/crates/bot_id/src/lib.rs
@@ -52,8 +52,9 @@ fn bot_id_str(input: &str) -> IResult<&str, BotIdStorage<ArcCowStr<'_>>> {
 
 /// Stable [`BotId`] for the first-party "Macro AI" system bot.
 ///
-/// Mentioning it opens an agent session served by the in-process (in-memory)
-/// agent harness, which answers with the Macro product toolset.
+/// Mentioning it answers with the classic in-channel chat reply (the
+/// `channel_bots` agent loop in `document_storage_service`). Agent sessions
+/// belong to [`MACRO_NEW_BOT_ID`] instead.
 pub const MACRO_AI_BOT_ID: BotId =
     BotId::new_from_uuid(Uuid::from_u128(0x0000_0000_0000_0000_0000_0000_0000_a1a1));
 
@@ -62,6 +63,22 @@ pub const MACRO_AI_HANDLE: &str = "macro";
 
 /// Display name for the "Macro" system bot.
 pub const MACRO_AI_NAME: &str = "Macro";
+
+/// Stable [`BotId`] for the "macro(new)" system bot.
+///
+/// The next-generation Macro bot: mentioning it opens an agent session served
+/// by the in-process (in-memory) agent harness, which answers with the Macro
+/// product toolset. A separate bot from [`MACRO_AI_BOT_ID`] on purpose - the
+/// classic in-channel reply stays on `@macro` for everyone while this one
+/// rolls out, and one id cannot mean both.
+pub const MACRO_NEW_BOT_ID: BotId =
+    BotId::new_from_uuid(Uuid::from_u128(0x0000_0000_0000_0000_0000_0000_0000_a2a2));
+
+/// Stable handle for the "macro(new)" system bot (used for `@` mentions).
+pub const MACRO_NEW_HANDLE: &str = "macro-new";
+
+/// Display name for the "macro(new)" system bot.
+pub const MACRO_NEW_NAME: &str = "macro(new)";
 
 /// Stable [`BotId`] for autonomous Macro platform operations.
 pub const MACRO_SYSTEM_BOT_ID: BotId =
@@ -122,10 +139,19 @@ pub struct SystemBot {
 
 /// Every first-party bot.
 pub const SYSTEM_BOTS: &[SystemBot] = &[
+    // Answers in channel via the classic `channel_bots` reply loop, which
+    // needs no agent session; its next-generation replacement below is the
+    // one whose mentions open sessions.
     SystemBot {
         id: MACRO_AI_BOT_ID,
         name: MACRO_AI_NAME,
         handle: MACRO_AI_HANDLE,
+        has_agent: false,
+    },
+    SystemBot {
+        id: MACRO_NEW_BOT_ID,
+        name: MACRO_NEW_NAME,
+        handle: MACRO_NEW_HANDLE,
         has_agent: true,
     },
     SystemBot {

--- a/crates/bot_id/src/test.rs
+++ b/crates/bot_id/src/test.rs
@@ -47,6 +47,18 @@ fn system_bot_id_is_stable_and_distinct_from_ai_personas() {
 }
 
 #[test]
+fn macro_new_id_is_stable_and_distinct_from_macro() {
+    assert_eq!(
+        MACRO_NEW_BOT_ID.into_storage_id().as_ref(),
+        "bot|00000000-0000-0000-0000-00000000a2a2"
+    );
+    assert_ne!(MACRO_NEW_BOT_ID, MACRO_AI_BOT_ID);
+    // The classic bot answers in channel; only its replacement opens sessions.
+    assert!(!system_bot(MACRO_AI_BOT_ID).unwrap().has_agent);
+    assert!(system_bot(MACRO_NEW_BOT_ID).unwrap().has_agent);
+}
+
+#[test]
 fn rejects_non_bot_storage_string() {
     assert!(BotIdStr::parse_from_str("macro|teo@macro.com").is_err());
 }

--- a/services/agent_harness_service/justfile
+++ b/services/agent_harness_service/justfile
@@ -13,8 +13,8 @@ check:
 # Run against host-exposed local Postgres, Kafka, and connection gateway.
 # Needs DAYTONA_API_KEY, DAYTONA_SNAPSHOT, and GITHUB_TOKEN in the environment.
 #
-# Two managed bots: @coder (HARNESS_BOT_ID) runs in a Daytona sandbox, @macro
-# (INMEM_BOT_ID) runs on the in-process ACP runtime.
+# Two managed bots: @coder (HARNESS_BOT_ID) runs in a Daytona sandbox,
+# @macro-new (INMEM_BOT_ID) runs on the in-process ACP runtime.
 run-local:
   ENVIRONMENT=local \
     DATABASE_URL=postgres://user:password@localhost:5432/macrodb \
@@ -22,7 +22,7 @@ run-local:
     OVERRIDE_CONNECTION_GATEWAY_URL=http://localhost:8082 \
     INTERNAL_API_KEY=local \
     HARNESS_BOT_ID=00000000-0000-0000-0000-00000000a9e7 \
-    INMEM_BOT_ID=00000000-0000-0000-0000-00000000a1a1 \
+    INMEM_BOT_ID=00000000-0000-0000-0000-00000000a2a2 \
     cargo run -p agent_harness_service
 
 # Print the full agent-session protocol log for a dedicated channel, oldest

--- a/services/agent_harness_service/src/containers/test.rs
+++ b/services/agent_harness_service/src/containers/test.rs
@@ -28,12 +28,12 @@ fn sessions_with(bot: BotId) -> (AgentSessionId, impl AgentSessionService + use<
     (id, service)
 }
 
-/// The whole point of the refusal: `@macro`'s sessions have no repository to
+/// The whole point of the refusal: `@macro-new`'s sessions have no repository to
 /// clone, so a deployment that cannot run them in-process must not quietly
 /// bill a sandbox for one.
 #[tokio::test]
 async fn refuses_the_in_process_bot_when_no_in_memory_runtime_is_configured() {
-    let (id, sessions) = sessions_with(bot_id::MACRO_AI_BOT_ID);
+    let (id, sessions) = sessions_with(bot_id::MACRO_NEW_BOT_ID);
     let containers = RoutedContainers::new(unreachable_sandbox(), None, sessions);
 
     let error = containers

--- a/services/agent_harness_service/src/main.rs
+++ b/services/agent_harness_service/src/main.rs
@@ -144,13 +144,15 @@ async fn run() -> anyhow::Result<()> {
         .await
         .context("failed to resolve agent harness service secrets")?;
     let bot_id = BotId::new_from_uuid(config.harness_bot_id);
-    // The in-process Macro bot is a compile-time identity, not configuration:
-    // it is always `bot_id::MACRO_AI_BOT_ID`, so the only real question is
-    // whether this environment serves it. Production stays off until its AI
-    // tool config lands - `build_tool_service_context_from_env` below is
-    // fatal, so turning it on without that config would refuse to boot.
+    // The in-process "macro(new)" bot is a compile-time identity, not
+    // configuration: it is always `bot_id::MACRO_NEW_BOT_ID`, so the only real
+    // question is whether this environment serves it. Production stays off
+    // until its AI tool config lands - `build_tool_service_context_from_env`
+    // below is fatal, so turning it on without that config would refuse to
+    // boot. (`@macro` itself is not served here at all: its mentions get the
+    // classic in-channel reply from `document_storage_service`.)
     let inmem_bot = match config.environment {
-        Environment::Local | Environment::Develop => Some(bot_id::MACRO_AI_BOT_ID),
+        Environment::Local | Environment::Develop => Some(bot_id::MACRO_NEW_BOT_ID),
         Environment::Production => None,
     };
 
@@ -293,7 +295,8 @@ async fn run() -> anyhow::Result<()> {
         .collect();
     // Logged because the failure mode this replaced was silent: a harness that
     // resolved no in-process bot booted healthy, passed its health check, and
-    // dropped every `@macro` mention as ForeignBot with nothing to show for it.
+    // dropped every in-process-bot mention as ForeignBot with nothing to show
+    // for it.
     tracing::info!(
         bots = ?our_bots.iter().map(|bot| bot.as_uuid()).collect::<Vec<_>>(),
         in_process_bot = ?inmem_bot.map(BotId::as_uuid),

--- a/services/document_storage_service/Cargo.toml
+++ b/services/document_storage_service/Cargo.toml
@@ -56,6 +56,7 @@ bzip2 = { workspace = true, default-features = false, features = [
 ] }
 cal = { path = "../../crates/cal", features = ["axum", "outbound"] }
 call = { path = "../../crates/call" }
+channel_bots = { path = "../../crates/channel_bots" }
 channels = { path = "../../crates/channels", features = [
   "entity_mutation",
   "inbound",

--- a/services/document_storage_service/src/main.rs
+++ b/services/document_storage_service/src/main.rs
@@ -892,6 +892,7 @@ async fn run() -> anyhow::Result<()> {
         Arc::new(PgTaskMatchRepo::new(db.clone())),
     ));
     let channels_repo = PgChannelsRepo::new(db.clone());
+    let (bot_trigger_sender, bot_trigger_receiver) = tokio::sync::mpsc::unbounded_channel();
 
     let channel_side_effects = ChannelSideEffectService::new(
         PgChannelSideEffectContext::new(db.clone()),
@@ -899,12 +900,13 @@ async fn run() -> anyhow::Result<()> {
         NotificationChannelSender::new(notification_ingress_service.clone()),
         ContactsChannelDispatcher::new(contacts_ingress.clone()),
     )
+    .with_bot_trigger_sender(bot_trigger_sender)
     .with_macro_event_broker(macro_event_broker.clone());
 
     let channels_service = Arc::new(
         ChannelServiceImpl::with_dependencies(
             channels_repo,
-            SpawnedChannelEventDispatcher::new(channel_side_effects),
+            SpawnedChannelEventDispatcher::new(channel_side_effects.clone()),
             PgChannelReferenceSharePermissions::new(db.clone(), entity_access_service.clone()),
         )
         .with_mention_extractor(lexical_mention_extractor::LexicalMentionExtractor::new(
@@ -953,9 +955,43 @@ async fn run() -> anyhow::Result<()> {
         }
     });
 
-    // Mentioning @macro no longer answers with an in-process chat reply: the
-    // mention rides the channel event to the agent trigger service, which
-    // opens an agent session on the harness's in-memory runtime instead.
+    // Wire Macro AI to react to mentions with the classic in-channel chat
+    // reply. The router posts replies through the channel service we just
+    // built and runs the agent loop in-process with the same pre-configured
+    // toolset used by other AI hosts. Agent sessions belong to a different
+    // bot entirely (`bot_id::MACRO_NEW_BOT_ID`, served by the harness), so
+    // the two paths can never answer the same mention.
+    let mut macro_agent_tool_context =
+        ai_tools::build_tool_service_context_from_env(db.clone(), event_broker_tracker.clone())
+            .await
+            .context("failed to build Macro agent tool context")?;
+    // Wire the agent's SendChannelMessage tool to this service's own
+    // side-effect pipeline so agent-posted messages share the exact instance
+    // used by the HTTP API, including the in-process bot trigger sender (the
+    // env builder wires an equivalent pipeline, but without bot triggers).
+    macro_agent_tool_context.channel_tool_context =
+        ai_tools::build_channel_tool_context_with_dispatcher(
+            db.clone(),
+            std::sync::Arc::new(SpawnedChannelEventDispatcher::new(channel_side_effects)),
+            lexical_client.clone(),
+        );
+    let macro_agent_tools = ai_tools::all_tools();
+    let bot_trigger_router = channel_bots::inbound::BotTriggerRouter::new(
+        channels_service.clone(),
+        Arc::new(channel_bots::outbound::AgentLoopResponder::new(
+            macro_agent_tool_context,
+            macro_agent_tools,
+        )),
+        Arc::new(
+            channel_bots::domain::trigger_detector::MentionOrInferredDetector::new(
+                channels_service.clone(),
+                Arc::new(channel_bots::outbound::FastModelTriggerClassifier::new(
+                    ai_usage::pg_recorder(db.clone()),
+                )),
+            ),
+        ),
+    );
+    bot_trigger_router.spawn(bot_trigger_receiver);
 
     let channel_bot_webhook_state =
         bots::inbound::channel_webhook_router::ChannelBotWebhookRouterState::new(


### PR DESCRIPTION
Restores the classic @macro in-channel reply pipeline that #5834 removed (prod has been silently dropping every @macro mention since, because the in-memory harness is unarmed there), and moves agent sessions to a new first-party "macro(new)" bot (@macro-new) offered in the mention typeahead behind the existing ENABLE_CHAT_V3_AGENTS flag — two bots, two paths, no rollout env var.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which bot opens harness sessions vs in-channel AI replies and wires new startup paths in document_storage_service; misconfiguration could drop mentions or route users to the wrong experience.
> 
> **Overview**
> **Splits Macro into two first-party bots** so `@macro` and agent sessions no longer share one identity. **`@macro`** is wired back to the classic **in-channel** reply path via the new `channel_bots` integration in `document_storage_service` (bot trigger channel → `BotTriggerRouter` + in-process agent loop). **`macro(new)` / `@macro-new`** takes the stable in-memory harness bot id (`MACRO_NEW_BOT_ID`); `agent_harness_service` and `AgentKind::of` now treat that bot as `InMemory`, not `MACRO_AI_BOT_ID`.
> 
> **Backend metadata** updates `SYSTEM_BOTS`: Macro AI has `has_agent: false`; macro(new) has `has_agent: true`. **Web** adds `macroNew` constants, mention typeahead entry (when chat v3 agents are enabled), and Macro-logo rendering for the new principal id.
> 
> Local harness dev config (`INMEM_BOT_ID`, justfile comments) points at the new uuid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a7ec67db4d4141debd53c531b8d36a96cc85588. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->