### PR TITLE
fix(agent-trigger): keep rdkafka out of the self-hosted daemon

### DIFF
--- a/crates/agent_trigger/Cargo.toml
+++ b/crates/agent_trigger/Cargo.toml
@@ -4,13 +4,20 @@ name = "agent_trigger"
 publish = false
 version = "0.1.0"
 
+[features]
+# Lexical / fast-model adapters. Off by default: `lexical_client` pulls
+# models_search → models_soup → notification → rdkafka, and the self-hosted
+# daemon only needs domain events from this crate. Services that construct
+# the adapters enable this; do not add it to coding_agent_worker.
+outbound = ["dep:agent", "dep:ai_usage", "dep:lexical_client"]
+
 [dependencies]
-agent = { path = "../agent" }
+agent = { path = "../agent", optional = true }
 agent_session = { path = "../agent_session" }
-ai_usage = { path = "../ai_usage" }
+ai_usage = { path = "../ai_usage", optional = true }
 anyhow = { workspace = true }
 bot_id = { path = "../bot_id" }
-lexical_client = { path = "../lexical_client" }
+lexical_client = { path = "../lexical_client", optional = true }
 channels = { path = "../channels", features = ["ports"] }
 chrono = { workspace = true }
 # Only the domain vocabulary (`Event`, `MacroEvent`, `TopicEvent`). Asking for

--- a/crates/agent_trigger/src/lib.rs
+++ b/crates/agent_trigger/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod domain;
+#[cfg(feature = "outbound")]
 pub mod outbound;

--- a/services/agent_harness_service/Cargo.toml
+++ b/services/agent_harness_service/Cargo.toml
@@ -20,7 +20,7 @@ agent_inmem = { path = "../../crates/agent_inmem" }
 ai_tools = { path = "../../crates/ai_tools" }
 agent_runtime_protocol = { path = "../../crates/agent_runtime_protocol", features = ["utoipa"] }
 agent_session = { path = "../../crates/agent_session" }
-agent_trigger = { path = "../../crates/agent_trigger" }
+agent_trigger = { path = "../../crates/agent_trigger", features = ["outbound"] }
 ai_usage = { path = "../../crates/ai_usage" }
 aws-sdk-sqs = { workspace = true }
 bot_id = { path = "../../crates/bot_id" }

--- a/services/agent_trigger_service/Cargo.toml
+++ b/services/agent_trigger_service/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 agent_session = { path = "../../crates/agent_session" }
-agent_trigger = { path = "../../crates/agent_trigger" }
+agent_trigger = { path = "../../crates/agent_trigger", features = ["outbound"] }
 ai_usage = { path = "../../crates/ai_usage" }
 anyhow = { workspace = true }
 bots = { path = "../../crates/bots", default-features = false, features = ["outbound", "ports"] }


### PR DESCRIPTION
Implicit quote-reply detection added lexical_client to agent_trigger as a required dep. That pulls models_search → notification → rdkafka into coding_agent_worker, so the musl zigbuild dies on librdkafka 2.12's unconditional curl/curl.h include.

Gate the outbound adapters behind a feature. The trigger and harness services enable it; the daemon only needs domain events.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cargo feature and dependency wiring only; services that need outbound explicitly opt in, so runtime behavior for those binaries should be unchanged.
> 
> **Overview**
> **`agent_trigger` no longer pulls `lexical_client` (and the transitive `rdkafka` chain) by default.** Lexical/fast-model outbound code is behind a new **`outbound`** Cargo feature that optionally enables `agent`, `ai_usage`, and `lexical_client`; the `outbound` module is only compiled when that feature is on.
> 
> **`agent_trigger_service` and `agent_harness_service` now depend on `agent_trigger` with `features = ["outbound"]`**, so they keep building the adapters. Consumers that only need domain events (e.g. the self-hosted **`coding_agent_worker`** daemon) can stay on the default feature set and avoid linking Kafka/openssl for static musl builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b18fbc8feeb121b46bce031698b072ba3f427360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->