### PR TITLE
fix(crm): show retired stage names in list cells

### DIFF
--- a/apps/web/src/features/entity/extractors-property/property-helpers.test.ts
+++ b/apps/web/src/features/entity/extractors-property/property-helpers.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { PROPERTY_OPTION_IDS, SYSTEM_PROPERTY_IDS } from '@property/constants';
+import { formatPropertyValue } from '@property/utils/formatting';
+import type { SoupProperty } from '@service-storage/generated/schemas/soupProperty';
+import { describe, expect, it } from 'vitest';
+import { soupPropertyToProperty } from './property-helpers';
+
+const EPOCH_ZERO = new Date(0).toISOString();
+
+const stageSoupProperty = (optionId: string): SoupProperty => ({
+  id: SYSTEM_PROPERTY_IDS.STAGE,
+  definition: {
+    id: SYSTEM_PROPERTY_IDS.STAGE,
+    display_name: 'Stage',
+    data_type: 'SELECT_STRING',
+    is_metadata: false,
+    is_multi_select: false,
+    is_system: true,
+    owner: { scope: 'system' },
+    created_at: EPOCH_ZERO,
+    updated_at: EPOCH_ZERO,
+  },
+  value: { type: 'SelectOption', value: [optionId] },
+});
+
+describe('soupPropertyToProperty stage labels', () => {
+  it.each([
+    ['Lead', PROPERTY_OPTION_IDS.STAGE.LEAD],
+    ['Demo', PROPERTY_OPTION_IDS.STAGE.DEMO],
+    ['Customer', PROPERTY_OPTION_IDS.STAGE.CUSTOMER],
+    ['Churned', PROPERTY_OPTION_IDS.STAGE.CHURNED],
+    ['Qualified', PROPERTY_OPTION_IDS.STAGE.QUALIFIED],
+    ['Trial', PROPERTY_OPTION_IDS.STAGE.TRIAL],
+    ['Negotiation', PROPERTY_OPTION_IDS.STAGE.NEGOTIATION],
+  ] as const)('formats %s from its option id', (label, optionId) => {
+    const property = soupPropertyToProperty(stageSoupProperty(optionId));
+    expect(formatPropertyValue(property, optionId)).toBe(label);
+  });
+});

--- a/apps/web/src/features/property/utils/formatting.ts
+++ b/apps/web/src/features/property/utils/formatting.ts
@@ -1,3 +1,4 @@
+import { getPropertyOptionLabel } from '@entity/utils/task-properties';
 import { NUMBER_DECIMAL_PLACES } from '../constants';
 import type { Property, PropertyOptionValue } from '../types';
 
@@ -107,12 +108,9 @@ const formatOptionValueById = (
   optionId: string,
   options: Array<{ id: string; value: PropertyOptionValue }> | undefined
 ): string => {
-  if (!options) return optionId;
-
-  const option = options.find((opt) => opt.id === optionId);
-  if (!option) return optionId; // Fallback to showing the ID if option not found
-
-  return formatOptionValue(option);
+  const option = options?.find((opt) => opt.id === optionId);
+  if (option) return formatOptionValue(option);
+  return getPropertyOptionLabel(optionId) ?? optionId;
 };
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PR #4822 trimmed Qualified, Trial, and Negotiation out of the default stage picker. Group headers still resolve those ids through `getPropertyOptionLabel`, so a Negotiation group still says Negotiation. List cells go through `soupPropertyToProperty` → `formatPropertyValue` → `formatOptionValueById`, and that last step used only `property.options`. After the trim, `SYSTEM_PROPERTY_OPTIONS` for Stage is `COMPANY_STAGE_OPTIONS` (Lead, Demo, Customer, Churned). A stored Negotiation id therefore printed as `00000001-0000-0000-0010-000000000005`.

The picker should stay trimmed. The Set-stage modal reads `property.options`. Putting `ALL_COMPANY_STAGE_OPTIONS` back on `SYSTEM_PROPERTY_OPTIONS` would offer retired stages again.

## Scope

`formatOptionValueById` in `apps/web/src/features/property/utils/formatting.ts` still prefers a match in `property.options`. If that list has no match, it asks `getPropertyOptionLabel` before it falls back to the raw id.

`apps/web/src/features/entity/extractors-property/property-helpers.test.ts` formats Lead, Demo, Customer, Churned, Qualified, Trial, and Negotiation through `soupPropertyToProperty` + `formatPropertyValue`.

Out of scope: the Set-stage modal, backend option lists, and group-header labeling.

## Tradeoffs

Display labels and picker options stay on two catalogs. `ALL_COMPANY_STAGE_OPTIONS` is the label table. `COMPANY_STAGE_OPTIONS` is the picker set. A one-list change would be smaller and would put retired stages back in the modal.

The import is `@entity/utils/task-properties`, not the `@entity` barrel, so the extractors → `@property/utils` cycle does not close.

## Blast Radius

Any select cell that formats through `formatPropertyValue` now can show a catalog label for an id missing from `property.options`. Unknown ids still print as ids. Current picker stages are unchanged.

CRM users who still have Negotiation, Qualified, or Trial on a company see the name in the list cell, matching the group header.

## Verification

Isolated vitest on `property-helpers.test.ts`: 7 passed, including the three retired stage ids.

Customers list on the local stack, List mode, Group by Stage. gloxco Stage cell shows Negotiation, not the option id. OSC still shows Customer. Qualco and Trialco show Qualified and Trial.

[gloxco Stage cell shows Negotiation](https://cursor.com/agents/bc-4396d190-e94c-4acf-b559-1c112500d71e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgloxco_stage_cell_shows_negotiation.webp)
[customers_list_retired_stage_cells_show_names.mp4](https://cursor.com/agents/bc-4396d190-e94c-4acf-b559-1c112500d71e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcustomers_list_retired_stage_cells_show_names.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4396d190-e94c-4acf-b559-1c112500d71e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4396d190-e94c-4acf-b559-1c112500d71e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

