### PR TITLE
feat(email): send APNS for new_email

### DIFF
--- a/crates/model_notifications/src/metadata.rs
+++ b/crates/model_notifications/src/metadata.rs
@@ -724,6 +724,27 @@ impl NotificationTitle for NewEmailMetadata {
     }
 }
 
+impl NotificationExtIos for NewEmailMetadata {
+    type NotifData = PushNotificationData;
+
+    fn collapse_key(&self, _entity: &Entity<'_>) -> NotifCollapseKey {
+        // Collapse on the thread so a new message replaces the unread
+        // lock-screen alert for that conversation.
+        NotifCollapseKey::new(Self::TYPE_NAME).append(&self.thread_id)
+    }
+
+    fn as_apns<'a>(
+        &self,
+        sender_id: Option<MacroUserIdStr<'a>>,
+        _entity: &Entity<'_>,
+        notification_id: Uuid,
+    ) -> Option<APNSPushNotification<Self::NotifData>> {
+        let mut apns = alert_apns(self, sender_id, notification_id, None).ok()?;
+        apns.aps.thread_id = Some(self.thread_id.clone());
+        Some(apns)
+    }
+}
+
 impl notification::domain::models::Notification for AiResponseMetadata {
     const TYPE_NAME: &'static str = "ai_response";
 }

--- a/crates/model_notifications/src/metadata/test.rs
+++ b/crates/model_notifications/src/metadata/test.rs
@@ -752,6 +752,57 @@ fn reminder_body_is_bounded_for_the_push_payload() {
     assert!(body.len() < 4_096, "must fit inside the APNS payload limit");
 }
 
+fn new_email_metadata() -> NewEmailMetadata {
+    NewEmailMetadata {
+        sender: Some("Ada Lovelace".to_string()),
+        to_email: "teo@macro.com".to_string(),
+        thread_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa".to_string(),
+        subject: "Quarterly plan".to_string(),
+        snippet: "Here is the draft".to_string(),
+    }
+}
+
+#[test]
+fn new_email_apns_uses_subject_and_snippet() {
+    let metadata = new_email_metadata();
+    let entity = EntityType::EmailThread.with_entity_str(&metadata.thread_id);
+    let notification_id = Uuid::parse_str("55555555-5555-4555-8555-555555555555").unwrap();
+
+    let apns = metadata
+        .as_apns(None, &entity, notification_id)
+        .expect("new_email should build an APNS alert");
+
+    match apns.aps.alert {
+        Some(notification::domain::models::apple::Alert::Dictionary(alert)) => {
+            assert_eq!(alert.title.as_deref(), Some("Quarterly plan"));
+            assert_eq!(alert.body.as_deref(), Some("Here is the draft"));
+        }
+        other => panic!("expected dictionary alert, got {other:?}"),
+    }
+    assert_eq!(
+        apns.aps.thread_id.as_deref(),
+        Some(metadata.thread_id.as_str())
+    );
+    assert_eq!(apns.push_notification_data.notification_id, notification_id);
+}
+
+#[test]
+fn new_email_collapse_key_is_per_thread() {
+    let entity = EntityType::EmailThread.with_entity_str("ignored");
+    let first = new_email_metadata();
+    let mut second = first.clone();
+    second.thread_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb".to_string();
+
+    assert_ne!(
+        first.collapse_key(&entity).into_hashed().into_inner(),
+        second.collapse_key(&entity).into_hashed().into_inner()
+    );
+    assert_eq!(
+        first.collapse_key(&entity).into_hashed().into_inner(),
+        first.collapse_key(&entity).into_hashed().into_inner()
+    );
+}
+
 /// A reminder metadata collapse key, hashed for comparison.
 fn reminder_key(id: &str, scheduled_for: Option<DateTime<Utc>>) -> String {
     let entity = EntityType::Document.with_entity_str("doc-1");

--- a/services/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
+++ b/services/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
@@ -36,7 +36,7 @@ use models_email::service::attachment::{
 use models_email::service::message::{Message, is_inbound, is_outbound, is_spam_or_trash};
 use models_email::service::pubsub::{DetailedError, FailureReason, ProcessingError};
 use models_email::service::thread::Thread;
-use notification::domain::models::SendNotificationRequestBuilder;
+use notification::domain::models::{SendNotificationRequest, SendNotificationRequestBuilder};
 use notification::domain::service::NotificationIngress;
 use std::collections::HashSet;
 use std::result;
@@ -732,18 +732,49 @@ async fn send_notifications(
     })?;
 
     let recipient_ids = build_notification_recipients(&link.macro_id, primaries);
+    let (staff_recipients, customer_recipients) = partition_email_push_recipients(recipient_ids);
 
-    let request = SendNotificationRequestBuilder {
-        notification_entity: EntityType::EmailThread
-            .with_entity_string(message.thread_db_id.to_string()),
-        secondary_notification_entity: None,
-        notification,
-        sender_id,
-        recipient_ids,
+    let notification_entity =
+        EntityType::EmailThread.with_entity_string(message.thread_db_id.to_string());
+
+    // Staff get APNS as well as the inbox / websocket row. Customers stay
+    // websocket-only so this dogfood does not turn on email lock-screen
+    // push for everyone. Split the send so a mixed owner/delegate set
+    // still creates one inbox row per recipient.
+    if !staff_recipients.is_empty() {
+        let request = SendNotificationRequestBuilder {
+            notification_entity: notification_entity.clone(),
+            secondary_notification_entity: None,
+            notification: notification.clone(),
+            sender_id: sender_id.clone(),
+            recipient_ids: staff_recipients,
+        }
+        .into_request()
+        .with_conn_gateway()
+        .with_apns();
+        publish_new_email_notification(ctx, request).await;
     }
-    .into_request()
-    .with_conn_gateway();
 
+    if !customer_recipients.is_empty() {
+        let request = SendNotificationRequestBuilder {
+            notification_entity,
+            secondary_notification_entity: None,
+            notification,
+            sender_id,
+            recipient_ids: customer_recipients,
+        }
+        .into_request()
+        .with_conn_gateway();
+        publish_new_email_notification(ctx, request).await;
+    }
+
+    Ok(())
+}
+
+async fn publish_new_email_notification<U: serde::Serialize + Send + Sync + 'static>(
+    ctx: &PubSubContext,
+    request: SendNotificationRequest<'_, NewEmailMetadata, U>,
+) {
     if let Err(e) = ctx
         .notification_ingress_service
         .send_notification(request)
@@ -751,12 +782,23 @@ async fn send_notifications(
     {
         tracing::error!(error=?e, "unable to send notification");
     }
-
-    Ok(())
 }
 
-/// Who should get an in-app / push `new_email` notification for a synced inbox
-/// message.
+/// Split recipients so only `@macro.com` users are on the APNS path.
+fn partition_email_push_recipients(
+    recipient_ids: HashSet<MacroUserIdStr<'static>>,
+) -> (
+    HashSet<MacroUserIdStr<'static>>,
+    HashSet<MacroUserIdStr<'static>>,
+) {
+    recipient_ids
+        .into_iter()
+        .partition(|id| id.is_macro_staff())
+}
+
+/// Who should get a `new_email` inbox / websocket notification for a synced
+/// inbox message. Lock-screen APNS is attached separately, and only for
+/// `@macro.com` recipients.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NewEmailNotifyPolicy {
     /// Every non-sent, non-draft inbox message. Used for `@macro.com` dogfood.

--- a/services/email_service/src/pubsub/inbox_sync/operations/upsert_message/test.rs
+++ b/services/email_service/src/pubsub/inbox_sync/operations/upsert_message/test.rs
@@ -219,6 +219,30 @@ fn customer_gets_signal_only_new_email_policy() {
 }
 
 #[test]
+fn staff_recipients_are_split_onto_the_apns_path() {
+    let (staff, customers) = partition_email_push_recipients(HashSet::from([
+        id("macro|teo@macro.com"),
+        id("macro|teo+notify@macro.com"),
+        id("macro|user@example.com"),
+    ]));
+
+    assert_eq!(
+        staff,
+        HashSet::from([id("macro|teo@macro.com"), id("macro|teo+notify@macro.com"),])
+    );
+    assert_eq!(customers, HashSet::from([id("macro|user@example.com")]));
+}
+
+#[test]
+fn customer_only_recipients_do_not_take_the_apns_path() {
+    let (staff, customers) =
+        partition_email_push_recipients(HashSet::from([id("macro|user@example.com")]));
+
+    assert!(staff.is_empty());
+    assert_eq!(customers, HashSet::from([id("macro|user@example.com")]));
+}
+
+#[test]
 fn all_inbox_preview_filter_is_thread_only() {
     let thread_id = Uuid::nil();
     match new_email_preview_filter(thread_id, NewEmailNotifyPolicy::AllInbox) {


### PR DESCRIPTION
Enable APNS push notifications for `new_email`. Flagged on only for @macro.com emails.

## Change

- Implement `NotificationExtIos` for `NewEmailMetadata` (subject / snippet alert, collapse by thread).
- In email sync, split recipients with `is_macro_staff()`. Staff get `.with_conn_gateway().with_apns()`. Customers stay websocket-only.
- Mixed owner/delegate sets still produce one inbox row per recipient.

This is still staff dogfood. It does not enable email APNS for customers, and it does not add Android FCM send (that path is still unused). Delivery still requires the iOS app, OS permission, and a successful `/device/register`.

## Test plan

- [x] `cargo test -p model_notifications -- new_email`
- [x] `cargo test -p email_service -- staff_recipients_are_split customer_only_recipients_do_not_take_the_apns_path`
- [ ] On a registered iOS device as `@macro.com`, receive a new inbox message and confirm a lock-screen alert (subject / snippet).

[Unit test log](https://cursor.com/agents/bc-8c444047-c254-48b2-b6da-b5497d78fd54/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstaff_email_apns_tests.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c444047-c254-48b2-b6da-b5497d78fd54?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c444047-c254-48b2-b6da-b5497d78fd54&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

