### PR TITLE
feat(ai-editing-worker): diagnose sync-init timeouts with socket instrumentation

### DIFF
--- a/packages/collaboration/src/sync-service/socket.ts
+++ b/packages/collaboration/src/sync-service/socket.ts
@@ -3,6 +3,7 @@ import {
   BebopSerializer,
   ExponentialBackoff,
   type UrlResolver,
+  type WebSocketFactory,
   type Websocket,
   WebsocketBuilder,
   type WebsocketConnectionState,
@@ -39,11 +40,20 @@ export interface SyncSocket {
  * heartbeat. The `getUrl` resolver is the only environment-specific bit — the
  * browser refreshes a permission token on each (re)connect, the worker returns
  * a static URL.
+ *
+ * `factory` optionally overrides how the underlying native socket is created
+ * (the AI editing worker wraps the default to observe raw frames).
  */
-export function createSyncSocket(getUrl: UrlResolver): SyncWebsocket {
+export function createSyncSocket(
+  getUrl: UrlResolver,
+  factory?: WebSocketFactory
+): SyncWebsocket {
+  let builder = new WebsocketBuilder(getUrl).withSerializer(
+    new BebopSerializer(FromPeer, FromRemote)
+  );
+  if (factory) builder = builder.withFactory(factory);
   return (
-    new WebsocketBuilder(getUrl)
-      .withSerializer(new BebopSerializer(FromPeer, FromRemote))
+    builder
       // Capped exponential backoff. The scheduler calls next() before the first
       // retry, so the delays are 250*2^1 = 500ms doubling to a 250*2^5 = 8s
       // cap; 20 retries ≈ 2 minutes of automatic attempts, after which

--- a/packages/collaboration/src/websocket/core/websocket-builder.ts
+++ b/packages/collaboration/src/websocket/core/websocket-builder.ts
@@ -192,6 +192,7 @@ export class WebsocketBuilder<Send = WebsocketData, Receive = WebsocketData> {
       listeners: this._options?.listeners,
       serializer,
       buffer: this._options?.buffer,
+      factory: this._options?.factory,
     } as unknown as WebsocketOptions<NewSend, NewReceive>;
 
     if (serializer.binaryType !== undefined) {

--- a/packages/collaboration/src/websocket/index.ts
+++ b/packages/collaboration/src/websocket/index.ts
@@ -25,6 +25,11 @@ export {
 export type { WebsocketOptions } from './core/websocket-options';
 export type { WebsocketConnectionRetryOptions } from './core/websocket-retry-options';
 export type { UrlResolver } from './core/websocket-url-resolver';
+export { platformWebSocketFactory } from './platform/factory';
+export type {
+  MinimalWebSocket,
+  WebSocketFactory,
+} from './platform/minimal-websocket';
 export {
   createReconnectEffect,
   createSocketEffect,

--- a/services/ai-editing-worker/src/endpoints/edit.ts
+++ b/services/ai-editing-worker/src/endpoints/edit.ts
@@ -12,6 +12,7 @@ import { type Model, type ResolvedModels, runEditSession } from '../run-edit';
 import { runInSandbox } from '../sandbox';
 import { watchPresenceSpeed } from '../service-clients';
 import { createWorkerSyncSource } from '../sources';
+import { createSyncSocketDiagnostics } from '../sync-diagnostics';
 import { renderTraceMarkdown } from '../trace-log';
 import { insertEditTrace } from '../traces-db';
 
@@ -132,7 +133,13 @@ edit.post('/', zValidator('json', EditBody), async (c) => {
 
   try {
     const wsUrl = `${env.SYNC_WS_BASE}/document/${documentId}/connect?token=${documentToken}`;
-    const source = createWorkerSyncSource(wsUrl, documentId, signal);
+    const syncDiagnostics = createSyncSocketDiagnostics();
+    const source = createWorkerSyncSource(
+      wsUrl,
+      documentId,
+      signal,
+      syncDiagnostics
+    );
 
     // Animations play at 1x while a human is watching and speed up to
     // `unwatchedSpeed` when nobody is, so unseen edits finish faster without
@@ -160,6 +167,7 @@ edit.post('/', zValidator('json', EditBody), async (c) => {
         try {
           const result = await runEditSession({
             source,
+            syncDiagnostics,
             documentId,
             prompt,
             models: buildModels(env, models, () => modelFallbacks++),

--- a/services/ai-editing-worker/src/run-edit.ts
+++ b/services/ai-editing-worker/src/run-edit.ts
@@ -19,6 +19,7 @@ import type { UsageEntry } from './ai-editing/token-tracker';
 import type { CoderRunCode, DispatchEditTrace } from './ai-editing/tools';
 import { serializeWithXml } from './ai-editing/utils';
 import { EditingWorkspace } from './editing-workspace';
+import type { SyncSocketDiagnostics } from './sync-diagnostics';
 import { buildTraceSession, type TraceSession } from './trace-log';
 
 export type Model = {
@@ -41,6 +42,8 @@ export type ResolvedModels = {
 export type RunEditArgs = {
   /** Live sync source, already constructed by the caller (ws in prod). */
   source: SyncServiceSource;
+  /** Diagnostics for the source's socket; reported on the sync-init span. */
+  syncDiagnostics?: SyncSocketDiagnostics;
   documentId: string;
   prompt: string;
   models: ResolvedModels;
@@ -83,10 +86,21 @@ export async function runEditSession(
 
   await Telemetry.span('edit.sync_init', async (span) => {
     const initialResult = await source.doInitialSync();
+    const diagnostics = args.syncDiagnostics;
+    if (diagnostics) {
+      for (const [key, value] of Object.entries(diagnostics.attrs())) {
+        span.setAttr(key, value);
+      }
+    }
     if (initialResult.isErr()) {
       source.cleanup();
       const e = initialResult.error;
-      const err = new Error(`initial sync failed: ${e.type} (${e.duration}ms)`);
+      // The summary rides the error into the HTTP 502 body, so callers see
+      // how far the connection got instead of just "timeout (10000ms)".
+      const detail = diagnostics ? ` [ws ${diagnostics.summary()}]` : '';
+      const err = new Error(
+        `initial sync failed: ${e.type} (${e.duration}ms)${detail}`
+      );
       span.error(err);
       throw err;
     }

--- a/services/ai-editing-worker/src/sources.ts
+++ b/services/ai-editing-worker/src/sources.ts
@@ -6,21 +6,46 @@
  */
 
 import type { Awareness } from '@macro-inc/collaboration/collab/awareness';
+import type { FromRemote } from '@macro-inc/collaboration/sync-service/generated/schema';
 import { createSyncSocket } from '@macro-inc/collaboration/sync-service/socket';
 import { SyncServiceSource } from '@macro-inc/collaboration/sync-service/source';
+import { WebsocketEvent } from '@macro-inc/collaboration/websocket';
 import { EphemeralStore, type PeerID } from 'loro-crdt';
+import type { SyncSocketDiagnostics } from './sync-diagnostics';
+
+function remoteMessageKind(message: FromRemote): string {
+  if (message.isRemoteInitialSync()) return 'initial_sync';
+  if (message.isRemoteUpdate()) return 'update';
+  if (message.isRemoteAwareness()) return 'awareness';
+  if (message.isRemoteSnapshot()) return 'snapshot';
+  if (message.isRemoteUpdateAck()) return 'update_ack';
+  if (message.isRemoteUpdateSince()) return 'update_since';
+  return 'unknown';
+}
 
 /**
  * A {@link SyncServiceSource} bound to a fixed, token-bearing URL. A worker
  * request is short-lived and online for its whole life, so every (re)connect
  * resolves to the same URL. Closes the socket on `signal` abort.
+ *
+ * When `diagnostics` is given, the underlying socket is created through its
+ * observing factory and decoded messages are counted, so a sync timeout can
+ * report how far the connection got.
  */
 export function createWorkerSyncSource(
   wsUrl: string,
   documentId: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  diagnostics?: SyncSocketDiagnostics
 ): SyncServiceSource {
-  const ws = createSyncSocket(() => wsUrl);
+  const ws = createSyncSocket(() => wsUrl, diagnostics?.factory);
+  if (diagnostics) {
+    // The wrapper only dispatches Message after a successful deserialize, so
+    // raw frames (from the factory) minus these are frames that failed decode.
+    ws.addEventListener(WebsocketEvent.Message, (_ws, event) =>
+      diagnostics.recordDecoded(remoteMessageKind(event.data))
+    );
+  }
   const source = new SyncServiceSource(ws, documentId);
   signal?.addEventListener('abort', () => source.cleanup());
   return source;

--- a/services/ai-editing-worker/src/sync-diagnostics.test.ts
+++ b/services/ai-editing-worker/src/sync-diagnostics.test.ts
@@ -1,0 +1,122 @@
+import type { MinimalWebSocket } from '@macro-inc/collaboration/websocket';
+import { describe, expect, it } from 'vitest';
+import { createSyncSocketDiagnostics } from './sync-diagnostics';
+
+type Listener = (event: never) => void;
+
+/** Fake native socket: records listeners so the test can fire raw events. */
+class FakeNativeSocket {
+  binaryType = 'blob';
+  readyState = 0;
+  private readonly listeners = new Map<string, Set<Listener>>();
+
+  addEventListener(type: string, listener: Listener) {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(listener);
+  }
+
+  fire(type: string, event: unknown) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event as never);
+    }
+  }
+}
+
+function createDiagnosticsWithSocket() {
+  const sockets: FakeNativeSocket[] = [];
+  const diagnostics = createSyncSocketDiagnostics(() => {
+    const socket = new FakeNativeSocket();
+    sockets.push(socket);
+    return socket as unknown as MinimalWebSocket;
+  });
+  return { diagnostics, sockets };
+}
+
+describe('createSyncSocketDiagnostics', () => {
+  it('reports a connection that never opened', () => {
+    const { diagnostics, sockets } = createDiagnosticsWithSocket();
+    diagnostics.factory('wss://example', undefined);
+    sockets[0].fire('close', { code: 1006, reason: '', wasClean: false });
+
+    expect(diagnostics.attrs()).toMatchObject({
+      'sync.ws.connect_attempts': 1,
+      'sync.ws.opened': false,
+      'sync.ws.raw_frames': 0,
+      'sync.ws.decoded_frames': 0,
+      'sync.ws.close.code': 1006,
+      'sync.ws.close.clean': false,
+    });
+    expect(diagnostics.summary()).toBe(
+      'attempts=1 opened=false raw_frames=0 decoded=0 close=1006'
+    );
+  });
+
+  it('reports a raw frame that never decoded (Blob delivery)', () => {
+    const { diagnostics, sockets } = createDiagnosticsWithSocket();
+    diagnostics.factory('wss://example', undefined);
+    const socket = sockets[0];
+    socket.binaryType = 'arraybuffer';
+    socket.fire('open', {});
+    socket.fire('message', { data: new Blob([new Uint8Array(16)]) });
+
+    const attrs = diagnostics.attrs();
+    expect(attrs).toMatchObject({
+      'sync.ws.opened': true,
+      'sync.ws.raw_frames': 1,
+      'sync.ws.decoded_frames': 0,
+      'sync.ws.first_frame.type': 'Blob',
+      'sync.ws.first_frame.bytes': 16,
+      'sync.ws.binary_type': 'arraybuffer',
+    });
+    expect(diagnostics.summary()).toBe(
+      'attempts=1 opened=true raw_frames=1 decoded=0 first_frame=Blob'
+    );
+  });
+
+  it('keeps first-frame details while counting later frames and decodes', () => {
+    const { diagnostics, sockets } = createDiagnosticsWithSocket();
+    diagnostics.factory('wss://example', undefined);
+    const socket = sockets[0];
+    socket.binaryType = 'arraybuffer';
+    socket.fire('open', {});
+    socket.fire('message', { data: new ArrayBuffer(30770) });
+    socket.fire('message', { data: new ArrayBuffer(4) });
+    diagnostics.recordDecoded('initial_sync');
+    diagnostics.recordDecoded('update_ack');
+
+    expect(diagnostics.attrs()).toMatchObject({
+      'sync.ws.raw_frames': 2,
+      'sync.ws.decoded_frames': 2,
+      'sync.ws.first_frame.type': 'ArrayBuffer',
+      'sync.ws.first_frame.bytes': 30770,
+      'sync.ws.decoded_kinds': 'initial_sync,update_ack',
+    });
+  });
+
+  it('counts retries as separate connect attempts and errors', () => {
+    const { diagnostics, sockets } = createDiagnosticsWithSocket();
+    diagnostics.factory('wss://example', undefined);
+    sockets[0].fire('error', {});
+    sockets[0].fire('close', {
+      code: 1002,
+      reason: 'protocol',
+      wasClean: false,
+    });
+    diagnostics.factory('wss://example', undefined);
+    sockets[1].fire('error', {});
+
+    expect(diagnostics.attrs()).toMatchObject({
+      'sync.ws.connect_attempts': 2,
+      'sync.ws.error_events': 2,
+      'sync.ws.close.code': 1002,
+      'sync.ws.close.reason': 'protocol',
+    });
+    expect(diagnostics.summary()).toBe(
+      'attempts=2 opened=false raw_frames=0 decoded=0 close=1002 errors=2'
+    );
+  });
+});

--- a/services/ai-editing-worker/src/sync-diagnostics.ts
+++ b/services/ai-editing-worker/src/sync-diagnostics.ts
@@ -1,0 +1,150 @@
+/**
+ * Passive diagnostics for the worker's sync WebSocket, built to explain
+ * `edit.sync_init` timeouts. Every prod timeout so far surfaced as an opaque
+ * "initial sync failed: timeout (10000ms)"; these counters distinguish the
+ * three failure modes: the socket never opened, a raw frame arrived but never
+ * decoded (e.g. Blob delivered where the Bebop serializer expects an
+ * ArrayBuffer), or frames decoded fine but no RemoteInitialSync was sent.
+ *
+ * Observation only: the factory wraps the platform default and merely attaches
+ * extra listeners to the native socket, so transport behavior is unchanged.
+ */
+
+import {
+  platformWebSocketFactory,
+  type WebSocketFactory,
+} from '@macro-inc/collaboration/websocket';
+import type { Attribute } from '@macro-inc/observability';
+
+const MAX_DECODED_KINDS = 10;
+
+export type SyncSocketDiagnostics = {
+  /** Hand to {@link createSyncSocket} so raw socket events are observed. */
+  factory: WebSocketFactory;
+  /** Record a message that made it through deserialization. */
+  recordDecoded(kind: string): void;
+  /** Flat span attributes describing everything observed so far. */
+  attrs(): Record<string, Attribute>;
+  /** One-line summary for error messages, e.g. "opened=false raw_frames=0". */
+  summary(): string;
+};
+
+/** Raw `MessageEvent.data` type without reading the bytes. */
+function frameType(data: unknown): string {
+  if (typeof data === 'string') return 'string';
+  if (data instanceof ArrayBuffer) return 'ArrayBuffer';
+  if (typeof Blob !== 'undefined' && data instanceof Blob) return 'Blob';
+  if (ArrayBuffer.isView(data)) return data.constructor.name;
+  if (data === null || data === undefined) return String(data);
+  return (
+    (data as { constructor?: { name?: string } }).constructor?.name ??
+    typeof data
+  );
+}
+
+function frameBytes(data: unknown): number | undefined {
+  if (typeof data === 'string') return data.length;
+  if (data instanceof ArrayBuffer) return data.byteLength;
+  if (typeof Blob !== 'undefined' && data instanceof Blob) return data.size;
+  if (ArrayBuffer.isView(data)) return data.byteLength;
+  return undefined;
+}
+
+export function createSyncSocketDiagnostics(
+  create: WebSocketFactory = platformWebSocketFactory
+): SyncSocketDiagnostics {
+  let connectAttempts = 0;
+  let opened = false;
+  let errorEvents = 0;
+  let rawFrames = 0;
+  let firstFrame:
+    | { type: string; bytes?: number; binaryType: string }
+    | undefined;
+  let lastClose:
+    | { code: number; reason: string; wasClean: boolean }
+    | undefined;
+  let decodedFrames = 0;
+  const decodedKinds: string[] = [];
+
+  const factory: WebSocketFactory = (url, protocols) => {
+    const socket = create(url, protocols);
+    connectAttempts += 1;
+    socket.addEventListener('open', () => {
+      opened = true;
+    });
+    socket.addEventListener('error', () => {
+      errorEvents += 1;
+    });
+    socket.addEventListener('close', (event) => {
+      lastClose = {
+        code: event.code,
+        reason: event.reason,
+        wasClean: event.wasClean,
+      };
+    });
+    socket.addEventListener('message', (event) => {
+      rawFrames += 1;
+      firstFrame ??= {
+        type: frameType(event.data),
+        bytes: frameBytes(event.data),
+        // As seen when the frame arrived — the wrapper sets 'arraybuffer',
+        // so anything else here means the runtime ignored the setter.
+        binaryType: socket.binaryType,
+      };
+    });
+    return socket;
+  };
+
+  return {
+    factory,
+    recordDecoded(kind: string): void {
+      decodedFrames += 1;
+      if (decodedKinds.length < MAX_DECODED_KINDS) decodedKinds.push(kind);
+    },
+    attrs(): Record<string, Attribute> {
+      const attrs: Record<string, Attribute> = {
+        'sync.ws.connect_attempts': connectAttempts,
+        'sync.ws.opened': opened,
+        'sync.ws.error_events': errorEvents,
+        'sync.ws.raw_frames': rawFrames,
+        'sync.ws.decoded_frames': decodedFrames,
+      };
+      if (firstFrame) {
+        attrs['sync.ws.first_frame.type'] = firstFrame.type;
+        attrs['sync.ws.binary_type'] = firstFrame.binaryType;
+        if (firstFrame.bytes !== undefined) {
+          attrs['sync.ws.first_frame.bytes'] = firstFrame.bytes;
+        }
+      }
+      if (decodedKinds.length > 0) {
+        attrs['sync.ws.decoded_kinds'] = decodedKinds.join(',');
+      }
+      if (lastClose) {
+        attrs['sync.ws.close.code'] = lastClose.code;
+        attrs['sync.ws.close.clean'] = lastClose.wasClean;
+        if (lastClose.reason) {
+          attrs['sync.ws.close.reason'] = lastClose.reason.slice(0, 256);
+        }
+      }
+      return attrs;
+    },
+    summary(): string {
+      const parts = [
+        `attempts=${connectAttempts}`,
+        `opened=${opened}`,
+        `raw_frames=${rawFrames}`,
+        `decoded=${decodedFrames}`,
+      ];
+      if (firstFrame) {
+        parts.push(`first_frame=${firstFrame.type}`);
+      }
+      if (lastClose) {
+        parts.push(`close=${lastClose.code}`);
+      }
+      if (errorEvents > 0) {
+        parts.push(`errors=${errorEvents}`);
+      }
+      return parts.join(' ');
+    },
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Every production `EditDocument` (MCP and in-app AI edit) has failed since 2026-08-26 14:02 UTC with an opaque 502: `initial sync failed: timeout (10000ms)` (e.g. trace [`10177c9d32f83ade1a1de82b0e01976c`](https://us5.datadoghq.com/apm/trace/10177c9d32f83ade1a1de82b0e01976c)). The worker waits 10s for `RemoteInitialSync` from `sync-service-prod2` and cannot currently distinguish:

1. the outbound WebSocket never opened,
2. a raw frame arrived but never decoded (e.g. Blob delivered where the Bebop serializer expects an ArrayBuffer), or
3. frames decoded fine but the server never sent `RemoteInitialSync`.

This PR adds passive instrumentation so the next timeout answers that directly.

## Changes

**`services/ai-editing-worker` (all diagnostic logic lives here):**
- New `sync-diagnostics.ts`: a recorder whose factory wraps the platform WebSocket factory and attaches extra listeners to the raw native socket — connect attempts, open, error count, raw frame count, first-frame type/bytes/`binaryType`, last close code/reason. Observation only; transport behavior is unchanged.
- `createWorkerSyncSource` counts decoded messages (and their kinds) via the wrapper's public `Message` event, which only fires after a successful deserialize — so `raw_frames > decoded_frames` pinpoints a decode failure.
- `run-edit.ts` sets `sync.ws.*` attributes on the existing `edit.sync_init` span (success and failure) and appends a compact summary to the timeout error, so the 502 body reads e.g. `initial sync failed: timeout (10000ms) [ws attempts=1 opened=false raw_frames=0 decoded=0 close=1006]`.

**`packages/collaboration` (additive only, no behavior change):**
- `createSyncSocket` accepts an optional `WebSocketFactory` pass-through.
- `websocket/index.ts` exports `platformWebSocketFactory` and the `WebSocketFactory` / `MinimalWebSocket` types.
- Fix: `WebsocketBuilder.withSerializer` silently dropped a `factory` set before it when copying options into the new builder.

## Testing

- New `sync-diagnostics.test.ts`: 4 tests covering never-opened, Blob-first-frame (decode-failure signature), multi-frame decode tracking, and retry/error counting — all pass.
- `tsc --noEmit` clean for both `ai-editing-worker` and `collaboration`.
- Collaboration transport suite: 195/197 pass; the 2 failures (`websocket.test.ts` retry-timing) fail identically on clean `main` in this environment (pre-existing flakes).
- Biome clean on all touched files.

## Reading the new signals

| Signal on `edit.sync_init` | Meaning |
| --- | --- |
| `sync.ws.opened=false`, `close.code` set | handshake/connect failure to sync-service |
| `raw_frames>0`, `decoded_frames=0`, `first_frame.type=Blob` | runtime delivered Blob despite `binaryType='arraybuffer'` (Workers compat-flag hypothesis) |
| `decoded_frames>0`, no `initial_sync` in `decoded_kinds` | sync DO accepted the socket but withheld the snapshot |

Prod deploy of the worker ships via the `Deploy Production Release` workflow (`deploy-ai-editing-worker`); main pushes deploy dev only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-466958f0-b6aa-4cdf-87f8-e086880a7d1d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-466958f0-b6aa-4cdf-87f8-e086880a7d1d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

