### PR TITLE
fix(calendar): open event guest list on the first click

### DIFF
--- a/apps/web/src/components/app/split-layout/components/PopoverSplitRenderer.tsx
+++ b/apps/web/src/components/app/split-layout/components/PopoverSplitRenderer.tsx
@@ -165,8 +165,7 @@ function PopoverSplitModal(props: {
         <SplitPanelContext.Provider value={stubPanelContext}>
           <SoupContextProvider>
             <Show when={props.popover.mount}>
-              {/* Escape Panel.Body's default overflow-hidden so flipped menus are not clipped. */}
-              <Panel.Body class="overflow-visible">
+              <Panel.Body>
                 <Dynamic component={props.popover.mount.element} />
               </Panel.Body>
             </Show>

--- a/apps/web/src/components/app/split-layout/components/PopoverSplitRenderer.tsx
+++ b/apps/web/src/components/app/split-layout/components/PopoverSplitRenderer.tsx
@@ -165,7 +165,8 @@ function PopoverSplitModal(props: {
         <SplitPanelContext.Provider value={stubPanelContext}>
           <SoupContextProvider>
             <Show when={props.popover.mount}>
-              <Panel.Body>
+              {/* Escape Panel.Body's default overflow-hidden so flipped menus are not clipped. */}
+              <Panel.Body class="overflow-visible">
                 <Dynamic component={props.popover.mount.element} />
               </Panel.Body>
             </Show>

--- a/apps/web/src/features/calendar/components/composer/EventPropertyPills.test.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventPropertyPills.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { recipientEntityMapper } from '@core/user';
+import { cleanup, render, screen } from '@solidjs/testing-library';
+import { Dialog } from '@ui';
+import userEvent from '@testing-library/user-event';
+import { createSignal } from 'solid-js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  EventEditorGuestOption,
+  SelectedEventEditorGuest,
+} from './event-form-model';
+import { EventComposerGuestsPill } from './EventPropertyPills';
+
+vi.mock('@core/component/UserIcon', () => ({
+  UserIcon: () => <div data-testid="user-avatar" />,
+}));
+
+function guest(email: string, name: string): EventEditorGuestOption {
+  return recipientEntityMapper('user')({
+    id: `macro|${email}`,
+    email,
+    name,
+  });
+}
+
+const OPTIONS = [
+  guest('ada@example.com', 'Ada Lovelace'),
+  guest('grace@example.com', 'Grace Hopper'),
+];
+
+function renderInComposerDialog() {
+  const [selected, setSelected] = createSignal<SelectedEventEditorGuest[]>([]);
+
+  render(() => (
+    <Dialog open>
+      <input aria-label="Title" />
+      <EventComposerGuestsPill
+        options={() => OPTIONS}
+        selected={selected()}
+        onChange={setSelected}
+      />
+    </Dialog>
+  ));
+}
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+  vi.stubGlobal('scrollTo', vi.fn() as unknown as typeof window.scrollTo);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('EventComposerGuestsPill', () => {
+  it('opens the guest list on the first click from the title field', async () => {
+    const user = userEvent.setup();
+    renderInComposerDialog();
+
+    screen.getByLabelText('Title').focus();
+    const trigger = screen.getByRole('button', { name: 'Guests' });
+    await user.click(trigger);
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('listbox')).toBeTruthy();
+    expect(
+      screen.getByRole('combobox', { name: 'Search for guests' })
+    ).toBeTruthy();
+  });
+
+  it('closes the guest list when focus moves to the title', async () => {
+    const user = userEvent.setup();
+    renderInComposerDialog();
+
+    const trigger = screen.getByRole('button', { name: 'Guests' });
+    await user.click(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    await user.click(screen.getByLabelText('Title'));
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+});

--- a/apps/web/src/features/calendar/components/composer/EventPropertyPills.test.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventPropertyPills.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { recipientEntityMapper } from '@core/user';
-import { cleanup, render, screen, within } from '@solidjs/testing-library';
+import { cleanup, render, screen } from '@solidjs/testing-library';
 import userEvent from '@testing-library/user-event';
 import { Dialog } from '@ui';
 import { createSignal } from 'solid-js';
@@ -26,11 +26,6 @@ function guest(email: string, name: string): EventEditorGuestOption {
   });
 }
 
-const OPTIONS = [
-  guest('ada@example.com', 'Ada Lovelace'),
-  guest('grace@example.com', 'Grace Hopper'),
-];
-
 function renderInComposerDialog() {
   const [selected, setSelected] = createSignal<SelectedEventEditorGuest[]>([]);
 
@@ -38,7 +33,7 @@ function renderInComposerDialog() {
     <Dialog open>
       <input aria-label="Title" />
       <EventComposerGuestsPill
-        options={() => OPTIONS}
+        options={() => [guest('ada@example.com', 'Ada Lovelace')]}
         selected={selected()}
         onChange={setSelected}
       />
@@ -72,41 +67,5 @@ describe('EventComposerGuestsPill', () => {
     await user.click(trigger);
 
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
-    expect(
-      within(screen.getByRole('dialog')).getByRole('listbox')
-    ).toBeTruthy();
-    const search = screen.getByRole('combobox', { name: 'Search for guests' });
-    expect(document.activeElement).toBe(search);
-
-    await user.click(search);
-    expect(document.activeElement).toBe(search);
-    expect(trigger.getAttribute('aria-expanded')).toBe('true');
-  });
-
-  it('restores search focus when the dialog steals focus', async () => {
-    const user = userEvent.setup();
-    renderInComposerDialog();
-
-    const trigger = screen.getByRole('button', { name: 'Guests' });
-    await user.click(trigger);
-
-    screen.getByRole('dialog').focus();
-
-    expect(trigger.getAttribute('aria-expanded')).toBe('true');
-    expect(document.activeElement).toBe(
-      screen.getByRole('combobox', { name: 'Search for guests' })
-    );
-  });
-
-  it('closes the guest list when focus moves to the title', async () => {
-    const user = userEvent.setup();
-    renderInComposerDialog();
-
-    const trigger = screen.getByRole('button', { name: 'Guests' });
-    await user.click(trigger);
-    expect(trigger.getAttribute('aria-expanded')).toBe('true');
-
-    await user.click(screen.getByLabelText('Title'));
-    expect(trigger.getAttribute('aria-expanded')).toBe('false');
   });
 });

--- a/apps/web/src/features/calendar/components/composer/EventPropertyPills.test.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventPropertyPills.test.tsx
@@ -15,7 +15,20 @@ import type {
 } from './event-form-model';
 
 vi.mock('@core/component/UserIcon', () => ({
-  UserIcon: () => <div data-testid="user-avatar" />,
+  UserIcon: () => {
+    const el = document.createElement('div');
+    el.setAttribute('data-testid', 'user-avatar');
+    return el;
+  },
+}));
+
+vi.mock('@property/editors/selectors/PropertyEntitySelector', () => ({
+  PropertyEntitySelector: () => {
+    const input = document.createElement('input');
+    input.setAttribute('aria-label', 'Search for guests');
+    input.setAttribute('placeholder', 'Add guests...');
+    return input;
+  },
 }));
 
 function guest(email: string, name: string): EventEditorGuestOption {
@@ -47,8 +60,17 @@ class ResizeObserverStub {
   disconnect() {}
 }
 
+class WebSocketStub {
+  close() {}
+  send() {}
+  addEventListener() {}
+  removeEventListener() {}
+}
+
 beforeEach(() => {
   vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+  vi.stubGlobal('IntersectionObserver', ResizeObserverStub);
+  vi.stubGlobal('WebSocket', WebSocketStub);
   vi.stubGlobal('scrollTo', vi.fn() as unknown as typeof window.scrollTo);
 });
 
@@ -63,9 +85,12 @@ describe('EventComposerGuestsPill', () => {
     renderInComposerDialog();
 
     screen.getByLabelText('Title').focus();
-    const trigger = screen.getByRole('button', { name: 'Guests' });
-    await user.click(trigger);
+    const guests = screen.getByRole('button', { name: 'Guests' });
+    await user.click(guests);
 
-    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    // The property dropdown is modal, so the composer dialog (and this
+    // trigger) is aria-hidden while the list is open.
+    expect(guests.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByPlaceholderText('Add guests...')).toBeTruthy();
   });
 });

--- a/apps/web/src/features/calendar/components/composer/EventPropertyPills.test.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventPropertyPills.test.tsx
@@ -4,15 +4,15 @@
 
 import { recipientEntityMapper } from '@core/user';
 import { cleanup, render, screen } from '@solidjs/testing-library';
-import { Dialog } from '@ui';
 import userEvent from '@testing-library/user-event';
+import { Dialog } from '@ui';
 import { createSignal } from 'solid-js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventComposerGuestsPill } from './EventPropertyPills';
 import type {
   EventEditorGuestOption,
   SelectedEventEditorGuest,
 } from './event-form-model';
-import { EventComposerGuestsPill } from './EventPropertyPills';
 
 vi.mock('@core/component/UserIcon', () => ({
   UserIcon: () => <div data-testid="user-avatar" />,

--- a/apps/web/src/features/calendar/components/composer/EventPropertyPills.test.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventPropertyPills.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { recipientEntityMapper } from '@core/user';
-import { cleanup, render, screen } from '@solidjs/testing-library';
+import { cleanup, render, screen, within } from '@solidjs/testing-library';
 import userEvent from '@testing-library/user-event';
 import { Dialog } from '@ui';
 import { createSignal } from 'solid-js';
@@ -72,7 +72,9 @@ describe('EventComposerGuestsPill', () => {
     await user.click(trigger);
 
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
-    expect(screen.getByRole('listbox')).toBeTruthy();
+    expect(
+      within(screen.getByRole('dialog')).getByRole('listbox')
+    ).toBeTruthy();
     expect(
       screen.getByRole('combobox', { name: 'Search for guests' })
     ).toBeTruthy();

--- a/apps/web/src/features/calendar/components/composer/EventPropertyPills.test.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventPropertyPills.test.tsx
@@ -75,9 +75,27 @@ describe('EventComposerGuestsPill', () => {
     expect(
       within(screen.getByRole('dialog')).getByRole('listbox')
     ).toBeTruthy();
-    expect(
+    const search = screen.getByRole('combobox', { name: 'Search for guests' });
+    expect(document.activeElement).toBe(search);
+
+    await user.click(search);
+    expect(document.activeElement).toBe(search);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('restores search focus when the dialog steals focus', async () => {
+    const user = userEvent.setup();
+    renderInComposerDialog();
+
+    const trigger = screen.getByRole('button', { name: 'Guests' });
+    await user.click(trigger);
+
+    screen.getByRole('dialog').focus();
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(document.activeElement).toBe(
       screen.getByRole('combobox', { name: 'Search for guests' })
-    ).toBeTruthy();
+    );
   });
 
   it('closes the guest list when focus moves to the title', async () => {

--- a/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
@@ -168,8 +168,14 @@ function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
   const [search, setSearch] = createSignal('');
   const [comboboxDisabled, setComboboxDisabled] = createSignal(false);
   const [scrollToItem, setScrollToItem] = createSignal<(key: string) => void>();
+  const [portalSearchRef, setPortalSearchRef] = createSignal<HTMLDivElement>();
 
   let input: HTMLInputElement | undefined;
+  let control: HTMLDivElement | undefined;
+  let content: HTMLElement | undefined;
+
+  const portalMount = () =>
+    portalSearchRef()?.closest<HTMLElement>('.portal-scope') ?? undefined;
 
   const propertyLabel = () => guestPropertyLabel(props.selected);
 
@@ -252,13 +258,29 @@ function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
 
   const changeOpen = (next: boolean) => {
     setOpen(next);
-    if (!next) setSearch('');
+    if (!next) {
+      setSearch('');
+      return;
+    }
+    queueMicrotask(() => input?.focus());
+  };
+
+  const keepListOpenOnControlPress = (event: {
+    detail: { originalEvent: Event };
+    preventDefault: () => void;
+  }) => {
+    const target = event.detail.originalEvent.target;
+    if (target instanceof Node && control?.contains(target)) {
+      event.preventDefault();
+    }
   };
 
   return (
     <Combobox<GuestPickerItem>
       multiple
       virtualized
+      triggerMode="manual"
+      selectionBehavior="toggle"
       open={open() && !props.disabled}
       onOpenChange={changeOpen}
       onInputChange={setSearch}
@@ -276,14 +298,26 @@ function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
       }
       placeholder="Add guests..."
       closeOnSelection={false}
+      removeOnBackspace={false}
       allowsEmptyCollection
       placement="bottom-start"
       disabled={props.disabled || comboboxDisabled()}
     >
-      <Combobox.Control<GuestPickerItem> class="inline-flex min-w-0 max-w-48 shrink-0">
-        <Tooltip label="Add guests to this event" placement="bottom">
+      <div class="hidden" ref={setPortalSearchRef} />
+      <Combobox.Control<GuestPickerItem>
+        ref={(element) => {
+          control = element;
+        }}
+        class="inline-flex min-w-0 max-w-48 shrink-0"
+      >
+        <Tooltip
+          label="Add guests to this event"
+          placement="bottom"
+          disabled={open() || props.disabled}
+        >
           <Combobox.Trigger
             tabIndex={0}
+            aria-label="Guests"
             aria-readonly={props.readOnly || undefined}
             class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
             onKeyDown={(event) => {
@@ -312,10 +346,30 @@ function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
         </Tooltip>
       </Combobox.Control>
 
-      <Combobox.Portal>
+      <Combobox.Portal mount={portalMount()}>
         <Layer depth={3}>
           <Combobox.Content
+            ref={(element) => {
+              content = element;
+            }}
             class="z-action-menu flex w-96 max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-edge bg-menu p-0 text-sm shadow-menu menu-open-animation"
+            onPointerDown={(event) => event.preventDefault()}
+            onFocusOutside={(event) => {
+              // Modal dialogs steal focus back onto an ancestor; don't treat
+              // that as dismiss. Clicks on other fields still close the list.
+              const focused = event.detail.originalEvent.target;
+              if (!(focused instanceof Node)) return;
+              if (control?.contains(focused)) {
+                event.preventDefault();
+                return;
+              }
+              if (content && focused.contains(content)) {
+                event.preventDefault();
+                input?.focus();
+              }
+            }}
+            onPointerDownOutside={keepListOpenOnControlPress}
+            onInteractOutside={keepListOpenOnControlPress}
             on:keydown={(event: KeyboardEvent) => {
               if (event.key !== 'Escape') return;
               event.preventDefault();

--- a/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
@@ -1,27 +1,23 @@
 import { UserIcon } from '@core/component/UserIcon';
-import { emailToId, recipientEntityMapper } from '@core/user';
-import { Combobox } from '@kobalte/core/combobox';
+import { type IUser, idToEmail, recipientEntityMapper } from '@core/user';
 import { Popover } from '@kobalte/core/popover';
 import BellSimpleIcon from '@phosphor/bell-simple.svg';
 import CalendarDotsIcon from '@phosphor/calendar-dots.svg';
 import CaretDownIcon from '@phosphor/caret-down.svg';
-import MagnifyingGlassIcon from '@phosphor/magnifying-glass.svg';
 import MapPinIcon from '@phosphor/map-pin.svg';
 import RepeatIcon from '@phosphor/repeat.svg';
 import UsersIcon from '@phosphor/users.svg';
 import VideoCameraIcon from '@phosphor/video-camera.svg';
+import { useProperty } from '@property/core/context';
+import { Root as PropertyRoot } from '@property/core/Root';
+import { EditorPopover } from '@property/editors/popover/EditorPopover';
 import { OptionCheckBox } from '@property/editors/selectors/OptionCheckBox';
+import { PropertyEntitySelector } from '@property/editors/selectors/PropertyEntitySelector';
+import { PropertyCaret } from '@property/extractors/PropertyCaret';
+import { PropertyPill } from '@property/extractors/PropertyPill';
+import type { EntityProperty } from '@property/types';
 import { cn, Layer, Select, Tooltip } from '@ui';
-import * as EmailValidator from 'email-validator';
-import {
-  type Accessor,
-  createMemo,
-  createSignal,
-  createUniqueId,
-  For,
-  Show,
-} from 'solid-js';
-import { type VirtualizerHandle, VList } from 'virtua/solid';
+import { type Accessor, createMemo, createSignal, For, Show } from 'solid-js';
 import {
   formatReminderOffset,
   REMINDER_OVERRIDES_MAX,
@@ -35,11 +31,6 @@ import {
   type SelectedEventEditorGuest,
 } from './event-form-model';
 
-const GUEST_NAME_COLLATOR = new Intl.Collator(undefined, {
-  sensitivity: 'base',
-});
-const GUEST_OPTION_HEIGHT_PX = 36;
-const GUEST_OPTION_MAX_VISIBLE_COUNT = 5;
 const PROPERTY_TRIGGER_CLASS =
   'group flex h-7 items-center justify-between gap-1.5 rounded-full border border-edge-muted bg-surface px-2 py-1 text-left text-xs leading-tight text-ink-muted hover:bg-hover hover:text-ink focus-visible:bg-active focus-visible:text-ink focus-visible:ring-accent/10 data-expanded:bg-hover data-expanded:text-ink';
 const PROPERTY_VALUE_CLASS =
@@ -50,16 +41,50 @@ export type EventComposerSelectOption = {
   label: string;
 };
 
-type GuestPickerItem =
-  | { kind: 'guest'; guest: SelectedEventEditorGuest }
-  | { kind: 'custom'; email: string };
+const GUESTS_PROPERTY_ID = 'event-composer-guests';
 
-function guestPickerItemEmail(item: GuestPickerItem) {
-  return item.kind === 'guest' ? guestEmail(item.guest) : item.email;
+function guestToUser(guest: SelectedEventEditorGuest): IUser {
+  return {
+    id: guest.id,
+    email: guestEmail(guest),
+    name: guestDisplayName(guest),
+  };
 }
 
-function guestPickerItemValue(item: GuestPickerItem) {
-  return guestPickerItemEmail(item).toLowerCase();
+function guestFromId(
+  id: string,
+  options: EventEditorGuestOption[],
+  selected: SelectedEventEditorGuest[]
+): SelectedEventEditorGuest {
+  const option = options.find((guest) => guest.id === id);
+  if (option) return option;
+  const prior = selected.find((guest) => guest.id === id);
+  if (prior) return prior;
+  return recipientEntityMapper('custom')({
+    id,
+    email: idToEmail(id),
+    invalid: false,
+  });
+}
+
+function guestsAsProperty(
+  selected: SelectedEventEditorGuest[]
+): EntityProperty {
+  return {
+    propertyId: GUESTS_PROPERTY_ID,
+    propertyDefinitionId: GUESTS_PROPERTY_ID,
+    displayName: 'Guests',
+    isMultiSelect: true,
+    owner: { scope: 'system' },
+    specificEntityType: 'USER',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    valueType: 'ENTITY',
+    value: selected.map((guest) => ({
+      entity_id: guest.id,
+      entity_type: 'USER',
+    })),
+  };
 }
 
 export interface EventComposerGuestsPillProps {
@@ -162,370 +187,97 @@ function ReadOnlyEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
 }
 
 function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
-  const inputId = `event-composer-guests-${createUniqueId()}`;
-
-  const [open, setOpen] = createSignal(false);
-  const [search, setSearch] = createSignal('');
-  const [comboboxDisabled, setComboboxDisabled] = createSignal(false);
-  const [scrollToItem, setScrollToItem] = createSignal<(key: string) => void>();
-  const [portalSearchRef, setPortalSearchRef] = createSignal<HTMLDivElement>();
-
-  let input: HTMLInputElement | undefined;
-  let control: HTMLDivElement | undefined;
-  let content: HTMLElement | undefined;
-
-  // Mount on the dialog, not the inner composer `.portal-scope`. The composer
-  // sits in a Panel.Body with overflow-hidden, which clips a flipped list —
-  // the same class of bug the create menu avoids by leaving its overflow
-  // container (it portals to body). Stay inside the dialog so the modal
-  // focus trap and a11y tree still own the list.
-  const portalMount = () => {
-    const start = portalSearchRef();
-    if (!start) return undefined;
-    return (
-      start.closest<HTMLElement>('[role="dialog"]') ??
-      start.closest<HTMLElement>('.portal-scope') ??
-      undefined
-    );
-  };
-
-  const propertyLabel = () => guestPropertyLabel(props.selected);
-
-  const pickerOptions = createMemo(() => {
-    const byEmail = new Map<string, SelectedEventEditorGuest>();
+  const users = createMemo((): IUser[] => {
+    const byId = new Map<string, IUser>();
     for (const guest of props.options()) {
-      byEmail.set(guestEmail(guest).toLowerCase(), guest);
+      byId.set(guest.id, guestToUser(guest));
     }
     for (const guest of props.selected) {
-      byEmail.set(guestEmail(guest).toLowerCase(), guest);
+      byId.set(guest.id, guestToUser(guest));
     }
-    return [...byEmail.values()].sort((left, right) =>
-      GUEST_NAME_COLLATOR.compare(
-        guestDisplayName(left),
-        guestDisplayName(right)
-      )
-    );
+    return [...byId.values()];
   });
-
-  const customEmail = () => {
-    const email = search().trim();
-    if (!EmailValidator.validate(email)) return undefined;
-    if (
-      pickerOptions().some(
-        (guest) => guestEmail(guest).toLowerCase() === email.toLowerCase()
-      )
-    ) {
-      return undefined;
-    }
-    return email;
-  };
-
-  const visibleItems = createMemo<GuestPickerItem[]>(() => {
-    const items: GuestPickerItem[] = pickerOptions().map((guest) => ({
-      kind: 'guest',
-      guest,
-    }));
-    const email = customEmail();
-    if (email) items.push({ kind: 'custom', email });
-    return items;
-  });
-
-  const selectedItems = () =>
-    props.selected.map((guest): GuestPickerItem => ({ kind: 'guest', guest }));
-
-  const comboboxOptions = createMemo(() => {
-    const items = new Map<string, GuestPickerItem>();
-    for (const item of selectedItems()) {
-      items.set(guestPickerItemValue(item), item);
-    }
-    for (const item of visibleItems()) {
-      items.set(guestPickerItemValue(item), item);
-    }
-    return [...items.values()];
-  });
-
-  const isSelected = (guest: SelectedEventEditorGuest) =>
-    props.selected.some(
-      (selected) =>
-        guestEmail(selected).toLowerCase() === guestEmail(guest).toLowerCase()
-    );
-
-  const changeSelection = (items: GuestPickerItem[]) => {
-    const guests = new Map<string, SelectedEventEditorGuest>();
-    for (const item of items) {
-      const guest =
-        item.kind === 'guest'
-          ? item.guest
-          : recipientEntityMapper('custom')({
-              id: emailToId(item.email),
-              email: item.email,
-              invalid: false,
-            });
-      guests.set(guestEmail(guest).toLowerCase(), guest);
-    }
-    props.onChange([...guests.values()]);
-    setSearch('');
-    queueMicrotask(() => input?.focus());
-  };
-
-  const changeOpen = (next: boolean) => {
-    setOpen(next);
-    if (!next) {
-      setSearch('');
-      return;
-    }
-    queueMicrotask(() => input?.focus());
-  };
-
-  const keepListOpenOnControlPress = (event: {
-    detail: { originalEvent: Event };
-    preventDefault: () => void;
-  }) => {
-    const target = event.detail.originalEvent.target;
-    if (target instanceof Node && control?.contains(target)) {
-      event.preventDefault();
-    }
-  };
 
   return (
-    <Combobox<GuestPickerItem>
-      multiple
-      virtualized
-      triggerMode="manual"
-      selectionBehavior="toggle"
-      open={open() && !props.disabled}
-      onOpenChange={changeOpen}
-      onInputChange={setSearch}
-      options={comboboxOptions()}
-      value={selectedItems()}
-      onChange={changeSelection}
-      optionValue={guestPickerItemValue}
-      optionLabel={(item) =>
-        item.kind === 'guest' ? guestDisplayName(item.guest) : item.email
-      }
-      optionTextValue={(item) =>
-        item.kind === 'guest'
-          ? `${guestDisplayName(item.guest)} ${guestEmail(item.guest)}`
-          : item.email
-      }
-      placeholder="Add guests..."
-      closeOnSelection={false}
-      removeOnBackspace={false}
-      allowsEmptyCollection
-      placement="bottom-start"
-      disabled={props.disabled || comboboxDisabled()}
+    <PropertyRoot
+      property={guestsAsProperty(props.selected)}
+      canEdit={!props.disabled}
     >
-      <div class="hidden" ref={setPortalSearchRef} />
-      <Combobox.Control<GuestPickerItem>
-        ref={(element) => {
-          control = element;
-        }}
-        class="inline-flex min-w-0 max-w-48 shrink-0"
+      <GuestsPillTrigger {...props} />
+      <GuestsPopoverEditor
+        users={users}
+        selected={props.selected}
+        options={props.options}
+        onChange={props.onChange}
+      />
+    </PropertyRoot>
+  );
+}
+
+function GuestsPillTrigger(props: EventComposerGuestsPillProps) {
+  const ctx = useProperty();
+  return (
+    <Tooltip
+      label="Add guests to this event"
+      placement="bottom"
+      disabled={ctx.editorOpen() || props.disabled}
+    >
+      <PropertyPill
+        aria-label="Guests"
+        aria-expanded={ctx.editorOpen()}
+        data-expanded={ctx.editorOpen() ? '' : undefined}
+        class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
       >
-        <Tooltip
-          label="Add guests to this event"
-          placement="bottom"
-          disabled={open() || props.disabled}
+        <Show when={!props.hideIcon}>
+          <UsersIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
+        </Show>
+        <span
+          class={cn(
+            'min-w-0 truncate',
+            PROPERTY_VALUE_CLASS,
+            props.selected.length > 0 ? 'text-current' : 'text-ink-extra-muted'
+          )}
         >
-          <Combobox.Trigger
-            tabIndex={0}
-            aria-label="Guests"
-            aria-readonly={props.readOnly || undefined}
-            class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
-            onKeyDown={(event) => {
-              if (event.key !== 'Enter' && event.key !== ' ') return;
-              event.preventDefault();
-              setOpen((current) => !current);
-              queueMicrotask(() => input?.focus());
-            }}
-          >
-            <Show when={!props.hideIcon}>
-              <UsersIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
-            </Show>
-            <span
-              class={cn(
-                'min-w-0 truncate',
-                PROPERTY_VALUE_CLASS,
-                props.selected.length > 0
-                  ? 'text-current'
-                  : 'text-ink-extra-muted'
-              )}
-            >
-              {propertyLabel()}
-            </span>
-            <CaretDownIcon class="size-3 shrink-0 text-ink-extra-muted" />
-          </Combobox.Trigger>
-        </Tooltip>
-      </Combobox.Control>
+          {guestPropertyLabel(props.selected)}
+        </span>
+        <PropertyCaret class="text-ink-extra-muted" />
+      </PropertyPill>
+    </Tooltip>
+  );
+}
 
-      <Combobox.Portal mount={portalMount()}>
-        <Layer depth={3}>
-          <Combobox.Content
-            ref={(element) => {
-              content = element;
-            }}
-            class="z-action-menu flex w-96 max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-edge bg-menu p-0 text-sm shadow-menu menu-open-animation"
-            onPointerDown={(event) => {
-              const target = event.target;
-              // Keep row clicks from stealing input focus, but allow the
-              // search field itself to take focus if the dialog stole it.
-              if (target instanceof Node && input?.contains(target)) return;
-              event.preventDefault();
-            }}
-            onFocusOutside={(event) => {
-              // Dialog trap focuses the dialog (an ancestor of this list).
-              // Veto that dismiss and put caret back in search. Focus that
-              // lands on another field (title, description) still dismisses.
-              const focused = event.detail.originalEvent.target;
-              if (
-                content &&
-                focused instanceof Node &&
-                focused.contains(content)
-              ) {
-                event.preventDefault();
-                input?.focus({ preventScroll: true });
-              }
-            }}
-            onPointerDownOutside={keepListOpenOnControlPress}
-            onInteractOutside={keepListOpenOnControlPress}
-            on:keydown={(event: KeyboardEvent) => {
-              if (event.key !== 'Escape') return;
-              event.preventDefault();
-              event.stopPropagation();
-              setOpen(false);
-            }}
-          >
-            <div class="flex w-full items-center gap-2 border-b border-edge-muted px-2 py-2">
-              <MagnifyingGlassIcon class="size-4 shrink-0 text-ink-muted" />
-              <label for={inputId} class="sr-only">
-                Search for guests
-              </label>
-              <Combobox.Input
-                ref={input}
-                id={inputId}
-                class="w-full bg-transparent text-ink caret-accent outline-none placeholder:text-ink-placeholder"
-                onKeyDown={(event) => {
-                  if (
-                    (event.key === 'a' && event.ctrlKey) ||
-                    (event.key === 'a' && event.metaKey)
-                  ) {
-                    setComboboxDisabled(true);
-                    queueMicrotask(() => setComboboxDisabled(false));
-                  }
-                }}
-                on:keydown={(event: KeyboardEvent) => {
-                  if (event.key === 'Escape' && open()) {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    setOpen(false);
-                  }
-                }}
-              />
-            </div>
-
-            <div class="p-1.5">
-              <Combobox.Listbox<GuestPickerItem> scrollToItem={scrollToItem()}>
-                {(items) => {
-                  const nodes = Array.from(items());
-                  const visibleCount = Math.min(
-                    nodes.length,
-                    GUEST_OPTION_MAX_VISIBLE_COUNT
-                  );
-                  const [virtualizer, setVirtualizer] =
-                    createSignal<VirtualizerHandle | null>(null);
-
-                  setScrollToItem(() => (key: string) => {
-                    const index = nodes.findIndex((node) => node.key === key);
-                    if (index >= 0) {
-                      virtualizer()?.scrollToIndex(index, {
-                        align: 'nearest',
-                      });
-                    }
-                  });
-
-                  return (
-                    <Show
-                      when={nodes.length > 0}
-                      fallback={
-                        <p class="py-4 text-center text-sm text-ink-muted">
-                          No users found
-                        </p>
-                      }
-                    >
-                      <VList
-                        data={nodes}
-                        itemSize={GUEST_OPTION_HEIGHT_PX}
-                        style={{
-                          height: `${visibleCount * GUEST_OPTION_HEIGHT_PX}px`,
-                        }}
-                        ref={setVirtualizer}
-                      >
-                        {(node) => {
-                          const item = node.rawValue;
-                          return (
-                            <Combobox.Item
-                              item={node}
-                              class="group flex h-9 w-full min-w-0 cursor-default items-center justify-between gap-1.5 rounded-lg px-2 text-left font-normal text-ink outline-none hover:bg-hover data-highlighted:bg-hover"
-                            >
-                              {item.kind === 'guest' ? (
-                                <>
-                                  <OptionCheckBox
-                                    checked={isSelected(item.guest)}
-                                    multiselect
-                                  />
-                                  <div class="flex min-w-0 flex-1 items-center gap-2">
-                                    <div class="flex size-4 shrink-0 items-center">
-                                      <UserIcon
-                                        id={item.guest.id}
-                                        size="sm"
-                                        isDeleted={false}
-                                        suppressClick
-                                      />
-                                    </div>
-                                    <Combobox.ItemLabel class="min-w-0 max-w-full truncate">
-                                      {guestDisplayName(item.guest)}
-                                      <Show
-                                        when={
-                                          guestDisplayName(item.guest) !==
-                                          guestEmail(item.guest)
-                                        }
-                                      >
-                                        <span class="ml-[0.5em] opacity-50">
-                                          {guestEmail(item.guest)}
-                                        </span>
-                                      </Show>
-                                    </Combobox.ItemLabel>
-                                  </div>
-                                </>
-                              ) : (
-                                <>
-                                  <div class="size-3.5 shrink-0" />
-                                  <div class="flex size-4 shrink-0 items-center">
-                                    <UserIcon
-                                      id={item.email}
-                                      size="sm"
-                                      isDeleted={false}
-                                      suppressClick
-                                    />
-                                  </div>
-                                  <Combobox.ItemLabel class="truncate">
-                                    Add {item.email}
-                                  </Combobox.ItemLabel>
-                                </>
-                              )}
-                            </Combobox.Item>
-                          );
-                        }}
-                      </VList>
-                    </Show>
-                  );
-                }}
-              </Combobox.Listbox>
-            </div>
-          </Combobox.Content>
-        </Layer>
-      </Combobox.Portal>
-    </Combobox>
+function GuestsPopoverEditor(props: {
+  users: Accessor<IUser[]>;
+  selected: SelectedEventEditorGuest[];
+  options: Accessor<EventEditorGuestOption[]>;
+  onChange: (selected: SelectedEventEditorGuest[]) => void;
+}) {
+  const ctx = useProperty();
+  return (
+    <Show when={ctx.editorOpen()}>
+      <EditorPopover>
+        <PropertyEntitySelector
+          config={{
+            isMultiSelect: true,
+            placeholder: 'Add guests...',
+            specificEntityType: 'USER',
+            users: props.users,
+            allowCustomEmail: true,
+          }}
+          selectedOptions={() =>
+            new Set(props.selected.map((guest) => guest.id))
+          }
+          setSelectedOptions={(ids) => {
+            props.onChange(
+              [...ids].map((id) =>
+                guestFromId(id, props.options(), props.selected)
+              )
+            );
+          }}
+          onClose={() => ctx.closeEditor()}
+        />
+      </EditorPopover>
+    </Show>
   );
 }
 

--- a/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
@@ -168,9 +168,25 @@ function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
   const [search, setSearch] = createSignal('');
   const [comboboxDisabled, setComboboxDisabled] = createSignal(false);
   const [scrollToItem, setScrollToItem] = createSignal<(key: string) => void>();
+  const [portalSearchRef, setPortalSearchRef] = createSignal<HTMLDivElement>();
 
   let input: HTMLInputElement | undefined;
   let control: HTMLDivElement | undefined;
+
+  // Mount on the dialog, not the inner composer `.portal-scope`. The composer
+  // sits in a Panel.Body with overflow-hidden, which clips a flipped list —
+  // the same class of bug the create menu avoids by leaving its overflow
+  // container (it portals to body). Stay inside the dialog so the modal
+  // focus trap and a11y tree still own the list.
+  const portalMount = () => {
+    const start = portalSearchRef();
+    if (!start) return undefined;
+    return (
+      start.closest<HTMLElement>('[role="dialog"]') ??
+      start.closest<HTMLElement>('.portal-scope') ??
+      undefined
+    );
+  };
 
   const propertyLabel = () => guestPropertyLabel(props.selected);
 
@@ -298,6 +314,7 @@ function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
       placement="bottom-start"
       disabled={props.disabled || comboboxDisabled()}
     >
+      <div class="hidden" ref={setPortalSearchRef} />
       <Combobox.Control<GuestPickerItem>
         ref={(element) => {
           control = element;
@@ -340,15 +357,14 @@ function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
         </Tooltip>
       </Combobox.Control>
 
-      <Combobox.Portal>
+      <Combobox.Portal mount={portalMount()}>
         <Layer depth={3}>
           <Combobox.Content
-            class="z-action-menu flex w-96 max-h-[var(--kb-popper-content-available-height)] max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-edge bg-menu p-0 text-sm shadow-menu menu-open-animation"
+            class="z-action-menu flex w-96 max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-edge bg-menu p-0 text-sm shadow-menu menu-open-animation"
             onPointerDown={(event) => event.preventDefault()}
             onFocusOutside={(event) => {
-              // Portal to body so flip/dropup is not clipped by the dialog.
-              // The modal focus trap then moves focus onto the title/dialog;
-              // ignore that steal. Pointer/interact-outside still closes.
+              // Dialog focus trap can land on the title; don't treat that as
+              // dismiss. Clicks on other fields still close via interact-outside.
               event.preventDefault();
             }}
             onPointerDownOutside={keepListOpenOnControlPress}

--- a/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
@@ -168,14 +168,9 @@ function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
   const [search, setSearch] = createSignal('');
   const [comboboxDisabled, setComboboxDisabled] = createSignal(false);
   const [scrollToItem, setScrollToItem] = createSignal<(key: string) => void>();
-  const [portalSearchRef, setPortalSearchRef] = createSignal<HTMLDivElement>();
 
   let input: HTMLInputElement | undefined;
   let control: HTMLDivElement | undefined;
-  let content: HTMLElement | undefined;
-
-  const portalMount = () =>
-    portalSearchRef()?.closest<HTMLElement>('.portal-scope') ?? undefined;
 
   const propertyLabel = () => guestPropertyLabel(props.selected);
 
@@ -303,7 +298,6 @@ function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
       placement="bottom-start"
       disabled={props.disabled || comboboxDisabled()}
     >
-      <div class="hidden" ref={setPortalSearchRef} />
       <Combobox.Control<GuestPickerItem>
         ref={(element) => {
           control = element;
@@ -346,27 +340,16 @@ function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
         </Tooltip>
       </Combobox.Control>
 
-      <Combobox.Portal mount={portalMount()}>
+      <Combobox.Portal>
         <Layer depth={3}>
           <Combobox.Content
-            ref={(element) => {
-              content = element;
-            }}
-            class="z-action-menu flex w-96 max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-edge bg-menu p-0 text-sm shadow-menu menu-open-animation"
+            class="z-action-menu flex w-96 max-h-[var(--kb-popper-content-available-height)] max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-edge bg-menu p-0 text-sm shadow-menu menu-open-animation"
             onPointerDown={(event) => event.preventDefault()}
             onFocusOutside={(event) => {
-              // Modal dialogs steal focus back onto an ancestor; don't treat
-              // that as dismiss. Clicks on other fields still close the list.
-              const focused = event.detail.originalEvent.target;
-              if (!(focused instanceof Node)) return;
-              if (control?.contains(focused)) {
-                event.preventDefault();
-                return;
-              }
-              if (content && focused.contains(content)) {
-                event.preventDefault();
-                input?.focus();
-              }
+              // Portal to body so flip/dropup is not clipped by the dialog.
+              // The modal focus trap then moves focus onto the title/dialog;
+              // ignore that steal. Pointer/interact-outside still closes.
+              event.preventDefault();
             }}
             onPointerDownOutside={keepListOpenOnControlPress}
             onInteractOutside={keepListOpenOnControlPress}

--- a/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
@@ -172,6 +172,7 @@ function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
 
   let input: HTMLInputElement | undefined;
   let control: HTMLDivElement | undefined;
+  let content: HTMLElement | undefined;
 
   // Mount on the dialog, not the inner composer `.portal-scope`. The composer
   // sits in a Panel.Body with overflow-hidden, which clips a flipped list —
@@ -360,12 +361,30 @@ function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
       <Combobox.Portal mount={portalMount()}>
         <Layer depth={3}>
           <Combobox.Content
+            ref={(element) => {
+              content = element;
+            }}
             class="z-action-menu flex w-96 max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-edge bg-menu p-0 text-sm shadow-menu menu-open-animation"
-            onPointerDown={(event) => event.preventDefault()}
-            onFocusOutside={(event) => {
-              // Dialog focus trap can land on the title; don't treat that as
-              // dismiss. Clicks on other fields still close via interact-outside.
+            onPointerDown={(event) => {
+              const target = event.target;
+              // Keep row clicks from stealing input focus, but allow the
+              // search field itself to take focus if the dialog stole it.
+              if (target instanceof Node && input?.contains(target)) return;
               event.preventDefault();
+            }}
+            onFocusOutside={(event) => {
+              // Dialog trap focuses the dialog (an ancestor of this list).
+              // Veto that dismiss and put caret back in search. Focus that
+              // lands on another field (title, description) still dismisses.
+              const focused = event.detail.originalEvent.target;
+              if (
+                content &&
+                focused instanceof Node &&
+                focused.contains(content)
+              ) {
+                event.preventDefault();
+                input?.focus({ preventScroll: true });
+              }
             }}
             onPointerDownOutside={keepListOpenOnControlPress}
             onInteractOutside={keepListOpenOnControlPress}

--- a/apps/web/src/features/property/editors/selectors/PropertyEntitySelector.tsx
+++ b/apps/web/src/features/property/editors/selectors/PropertyEntitySelector.tsx
@@ -1,6 +1,6 @@
 import { UserIcon } from '@core/component/UserIcon';
 import { useEmail, useUserId } from '@core/context/user';
-import { useAugmentUserWithDmActivity } from '@core/user';
+import { emailToId, useAugmentUserWithDmActivity } from '@core/user';
 import { createFreshSearch } from '@core/util/freshSort';
 import { useKeyPressed } from '@core/util/useKeyPressed';
 import { useSelectedFirst } from '@core/util/useSelectedFirst';
@@ -16,6 +16,7 @@ import { useSearchInputFocus } from '@property/utils';
 import { useSearchSoupQuery } from '@queries/soup/search';
 import type { EntityType } from '@service-properties/generated/schemas/entityType';
 import { debounce } from '@solid-primitives/scheduled';
+import * as EmailValidator from 'email-validator';
 import {
   createEffect,
   createMemo,
@@ -249,6 +250,25 @@ export function PropertyEntitySelector(props: EntityInputProps) {
     return converted;
   });
 
+  const customEmail = createMemo(() => {
+    if (!props.config.allowCustomEmail) return undefined;
+    const raw = inputValue().trim();
+    if (!EmailValidator.validate(raw)) return undefined;
+    const lower = raw.toLowerCase();
+    const alreadyListed = entities().some(
+      (entity) =>
+        entity.kind === 'user' && entity.data.email.toLowerCase() === lower
+    );
+    if (alreadyListed) return undefined;
+    return raw;
+  });
+
+  const customEmailEntity = (): CombinedEntity | undefined => {
+    const email = customEmail();
+    if (!email) return undefined;
+    return userToEntity({ id: emailToId(email), email, name: email });
+  };
+
   const entitySearch = createFreshSearch<CombinedEntity>({
     config: createEntitySearchConfig(currentUserDomain, currentUserId),
     getName: getEntitySearchText,
@@ -369,7 +389,8 @@ export function PropertyEntitySelector(props: EntityInputProps) {
     }
   };
 
-  const totalCount = () => pinnedCount() + sortedEntities().length;
+  const totalCount = () =>
+    pinnedCount() + sortedEntities().length + (customEmail() ? 1 : 0);
 
   // Reset selected index to top when search term or list changes
   createEffect(() => {
@@ -405,8 +426,11 @@ export function PropertyEntitySelector(props: EntityInputProps) {
       const pCount = pinnedCount();
       if (idx < pCount) {
         togglePinnedOption(visiblePinnedOptions()[idx]);
-      } else {
+      } else if (idx < pCount + sortedEntities().length) {
         const entity = sortedEntities()[idx - pCount];
+        if (entity) toggleEntity(entity);
+      } else {
+        const entity = customEmailEntity();
         if (entity) toggleEntity(entity);
       }
     }
@@ -582,6 +606,44 @@ export function PropertyEntitySelector(props: EntityInputProps) {
                 }}
               </For>
             </div>
+          </Show>
+          <Show when={customEmail()}>
+            {(email) => {
+              const rowIndex = () => pinnedCount() + sortedEntities().length;
+              const entity = () => customEmailEntity();
+              return (
+                <div
+                  class="group rounded-lg w-full flex items-center justify-between gap-1.5 p-1.5 px-2 text-left text-ink font-normal cursor-default min-w-0"
+                  classList={{
+                    'bg-hover': rowIndex() === selectedIndex(),
+                  }}
+                  onClick={() => {
+                    const next = entity();
+                    if (next) toggleEntity(next);
+                  }}
+                  onMouseEnter={() => {
+                    if (!keyboardMode()) setSelectedIndex(rowIndex());
+                  }}
+                >
+                  <Show when={props.config.isMultiSelect}>
+                    <div class="shrink-0">
+                      <OptionCheckBox checked={false} multiselect />
+                    </div>
+                  </Show>
+                  <div class="flex items-center gap-2 flex-1 min-w-0">
+                    <div class="size-4 shrink-0 flex items-center">
+                      <UserIcon
+                        id={emailToId(email())}
+                        size="sm"
+                        isDeleted={false}
+                        suppressClick={true}
+                      />
+                    </div>
+                    <span class="truncate min-w-0">Add {email()}</span>
+                  </div>
+                </div>
+              );
+            }}
           </Show>
         </div>
       </Show>

--- a/apps/web/src/features/property/editors/selectors/types.ts
+++ b/apps/web/src/features/property/editors/selectors/types.ts
@@ -21,4 +21,7 @@ export type EntitySelectorConfig = {
   /** Explicit pool for USER pickers (e.g. company owner → team members);
    * replaces the default quick-access people list. */
   users?: Accessor<IUser[]>;
+  /** When the query is a valid email that is not already in the pool,
+   * offer it as an "Add {email}" row (calendar guests, share sheets). */
+  allowCustomEmail?: boolean;
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Creating a new calendar event (and adding another guest after selecting one) often took two clicks to open the guest list. Combobox-specific focus and portal workarounds then clipped the dropup or left search unfocusable.

The composer is a modal dialog. The old guests control was a Kobalte Combobox whose search lived in a portaled list. The first click opened the list and focused search outside the dialog; the dialog focus trap pulled focus back; Combobox treated that as focus-outside and closed.

## Fix

Use the same stack as create-task assignees:

- `Property.Root` (controlled Kobalte dropdown + virtual anchor)
- `EditorPopover` (body portal, `fitViewport`)
- `PropertyEntitySelector` (plain search input + list, not Combobox)

A modal dropdown on a body portal owns focus the way the create-task menu already does, so the dialog trap no longer closes the list. The body portal plus `fitViewport` also keeps a flipped list visible instead of clipping it inside `Panel.Body`.

Custom invite emails use a new `allowCustomEmail` flag on `PropertyEntitySelector` (`Add {email}`).

`Panel.Body` stays `overflow-hidden`.

## Test

`EventPropertyPills.test.tsx` renders the guests pill inside an open `Dialog` and asserts one click from the title field opens the list.

Browser (local stack, `guest-click-test@example.com`): New event → one click on Guests opens the list. The menu extends past the dialog edge and stays fully visible. Search accepts typing. Selecting a guest leaves the list open and the pill updates (`guest-click-test` → `2 guests` → `3 guests`). Custom email shows `Add invitee@example.com`. Clicking the title closes the list; one click on the pill reopens it.

[Guest list opens on the first click](https://cursor.com/agents/bc-926f1119-cfd2-463b-8d3b-71bcdba07587/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fguests_property_dropdown_first_open.webp)
[Two guests selected, list still open and unclipped](https://cursor.com/agents/bc-926f1119-cfd2-463b-8d3b-71bcdba07587/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fguests_property_dropdown_two_selected.webp)
[Custom email added, pill shows 3 guests](https://cursor.com/agents/bc-926f1119-cfd2-463b-8d3b-71bcdba07587/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fguests_property_dropdown_custom_email.webp)

[new_event_guest_list_first_click.mp4](https://cursor.com/agents/bc-926f1119-cfd2-463b-8d3b-71bcdba07587/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnew_event_guest_list_first_click.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-926f1119-cfd2-463b-8d3b-71bcdba07587?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-926f1119-cfd2-463b-8d3b-71bcdba07587&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

