### PR TITLE
fix(mobile): override the native iOS long-press menu on images

### DIFF
--- a/apps/web/src/features/channel/Message/ChannelMessage.tsx
+++ b/apps/web/src/features/channel/Message/ChannelMessage.tsx
@@ -197,8 +197,6 @@ export function ChannelMessage(props: ChannelMessageProps) {
         ref={(el) =>
           touchHandler(el, () => ({
             touchClassName: 'channel-message-long-press-highlight',
-            // Yield to the native image callout when long-pressing an image.
-            skipSelectors: ['img'],
             onLongPress: () =>
               drawerManager?.open(props.message, props.actions),
           }))

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -539,6 +539,15 @@ html[data-theme-light='false'] {
     user-select: text;
   }
 
+  /* iOS answers a long-press on an image with its own callout ("Share", "Save
+     to Photos", "Copy"), which preempts the app's own long-press affordances
+     (e.g. the channel message action drawer). Suppress it everywhere; the
+     zero-specificity selector lets a component opt back in if it ever needs
+     the native menu. */
+  :where(img) {
+    -webkit-touch-callout: none;
+  }
+
   :where(*) {
     scrollbar-width: none;
   }

--- a/apps/web/src/lib/core/directive/touchHandler.ts
+++ b/apps/web/src/lib/core/directive/touchHandler.ts
@@ -14,13 +14,6 @@ interface TouchHandlerOptions {
   delay?: number;
   moveThreshold?: number;
   stopTouchStartPropagation?: boolean;
-  /**
-   * Selectors for which our touch handling should be skipped entirely when the
-   * touch originates on a matching element (or one of its ancestors). Useful to
-   * avoid competing with native behavior, e.g. `['img']` so a long-press on an
-   * image yields to the native image callout.
-   */
-  skipSelectors?: string[];
   /** CSS class added while the touch highlight is active. */
   touchClassName?: string;
   touchClassEnterDelay?: number;
@@ -143,21 +136,6 @@ export function touchHandler(
 
   function handleTouchStart(e: TouchEvent) {
     if (e.touches.length > 1) {
-      clearState();
-      cancelTouchClassEnter();
-      endTouchClass();
-      setValidShortTouch(false);
-      return;
-    }
-
-    // Skip our touch handling when the touch originates on an opted-out element
-    // so it doesn't compete with native behavior (e.g. `['img']` yields to the
-    // native image callout).
-    const skipSelectors = options().skipSelectors;
-    if (
-      skipSelectors?.length &&
-      (e.target as Element)?.closest(skipSelectors.join(','))
-    ) {
       clearState();
       cancelTouchClassEnter();
       endTouchClass();


### PR DESCRIPTION
Long-pressing an image in the iOS app popped WebKit's own callout ("Share", "Save to Photos", "Copy") instead of the app's own affordances.

- `index.css`: a base rule suppresses `-webkit-touch-callout` on every `img`. Only a few components (`ImagePreview`, `ImageGalleryPreview`, `Lightbox`) set this inline, so images elsewhere — chat media tiles, markdown images, inbox cards, avatars — still got the native menu. The zero-specificity `:where(img)` selector leaves any component free to opt back in.
- `ChannelMessage.tsx`: drops the `skipSelectors: ['img']` opt-out that deliberately yielded long-presses on images to that native menu. Long-pressing an image in a message now opens the message action drawer, same as long-pressing anywhere else on the row. Image-specific actions (copy, download) remain in the lightbox on tap.
- `touchHandler.ts`: `skipSelectors` existed solely for that opt-out, so it goes with it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WF8hjoNoAWvu9Jb4GoUqUM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile UX and CSS touch-callout behavior only; no auth, data, or API changes.
> 
> **Overview**
> On iOS, long-pressing images showed WebKit’s native callout instead of app gestures like the channel message action drawer.
> 
> **Global CSS** adds `:where(img) { -webkit-touch-callout: none; }` so all images suppress that menu by default; zero-specificity keeps room for components to opt back in.
> 
> **Channel messages** no longer pass `skipSelectors: ['img']` on `touchHandler`, so long-press on inline message images opens the same action drawer as the rest of the row.
> 
> **`touchHandler`** drops the `skipSelectors` option and the touch-start early return that existed only for the image opt-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5872cedba7a72d73589789b7f5eeb5ce03485d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->