### PR TITLE
chore: port maxxing for mobile dev

### DIFF
--- a/apps/web/justfile
+++ b/apps/web/justfile
@@ -1,6 +1,14 @@
-# iOS: dev-facing, for testing in Simulator
+# iOS: dev-facing, for testing in Simulator. Honors PORT like the web dev
+# server (`PORT=3001 just ios-dev`): the vite server picks PORT up through
+# beforeDevCommand's environment, and the --config merge points the webview's
+# devUrl at the same port.
 ios-dev: ios-prepare
-    cd tauri/src-tauri && cargo tauri ios dev --open -- --no-default-features
+    #!/usr/bin/env bash
+    set -euo pipefail
+    PORT="${PORT:-3000}"
+    cd tauri/src-tauri && cargo tauri ios dev --open \
+      --config "{\"build\":{\"devUrl\":\"http://localhost:${PORT}\"}}" \
+      -- --no-default-features
 
 # iOS: prod-facing build, with bundle auto-update turned off, for testing locally on actual iPhone
 ios-build-no-update: ios-prepare


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dev-only justfile change for iOS Simulator workflow; no production build or runtime behavior.
> 
> **Overview**
> **`just ios-dev`** now respects **`PORT`** (default **3000**), matching the web dev server so the Simulator webview and Vite stay on the same host/port.
> 
> The recipe runs as a small bash script and passes a merged Tauri **`--config`** that sets **`build.devUrl`** to `http://localhost:${PORT}`, instead of relying only on the fixed **`devUrl`** in `tauri.conf.json`. Comments document the intended flow: e.g. `PORT=3001 just ios-dev` when Vite picks up **`PORT`** via **`beforeDevCommand`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 209e63a4283ad41103807e4f27dfcc13c03cd584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->