### PR TITLE
fix(calendar): polish in-calendar search

### DIFF
--- a/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
+++ b/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
@@ -5,6 +5,7 @@ import { parseLocalDate } from '@app/features/calendar/utils/calendar-date';
 import { formatCalendarTime } from '@app/features/calendar/utils/time-format';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { EntityIcon } from '@core/component/EntityIcon';
+import { IS_MAC } from '@core/constant/isMac';
 import { registerHotkey } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
 import { debouncedDependent } from '@core/util/debounce';
@@ -189,8 +190,11 @@ function CalendarSearchControl() {
   // The portal content lives outside the split hotkey scope, so a second Cmd+F
   // never reaches the split-scoped opener above — handle it here so it
   // re-selects the query instead of falling through to the browser find dialog.
+  // Match the app's `cmd+f` semantics: the platform modifier (Cmd on Mac, not
+  // Ctrl) and a case-insensitive key so Caps Lock still hits.
   const handleContentKeyDown = (event: KeyboardEvent) => {
-    if ((event.metaKey || event.ctrlKey) && event.key === 'f') {
+    const cmdPressed = IS_MAC ? event.metaKey : event.ctrlKey;
+    if (cmdPressed && event.key.toLowerCase() === 'f') {
       event.preventDefault();
       focusInput();
     }

--- a/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
+++ b/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
@@ -15,10 +15,7 @@ import SearchIcon from '@icon/macro-magnifying-glass.svg';
 import { Popover } from '@kobalte/core/popover';
 import CaretLeftIcon from '@phosphor/caret-left.svg';
 import RepeatIcon from '@phosphor/repeat.svg';
-import {
-  type CalendarMentionPreviewInput,
-  useCalendarMentionPreviewQuery,
-} from '@queries/calendar/mention-preview';
+import { useCalendarMentionPreviewQuery } from '@queries/calendar/mention-preview';
 import { useSearchSoupQuery } from '@queries/soup/search';
 import type { EntityFilters } from '@service-search/generated/models';
 import { Button, cn, Layer } from '@ui';
@@ -26,10 +23,9 @@ import {
   createMemo,
   createSignal,
   For,
-  Match,
   onCleanup,
+  onMount,
   Show,
-  Switch,
 } from 'solid-js';
 import { createCalendarBlockRange } from '../calendar-range';
 import {
@@ -99,49 +95,48 @@ function formatEventWhen(
 /**
  * Read-only card for a result the calendar cannot navigate to: occurrences
  * older than the backend's rolling materialized window aren't fetchable, so
- * there is nothing to focus and no editable event to open. Shows the viewer's
- * own preview of the meeting — the same projection a calendar mention uses —
- * with a way back to the results.
+ * there is nothing to focus and no editable event to open. The card's identity
+ * — title, when, organizer, recurrence — comes from the selected row so it
+ * always describes the instance the user picked; the mention preview only
+ * supplements the meeting-level location and guest count the row lacks.
  */
 function CalendarEventPreviewContent(props: {
-  target: CalendarMentionPreviewInput;
+  event: CalendarSearchResult;
   timeFormat: CalendarTimeFormat;
   onBack: () => void;
 }) {
-  const previewQuery = useCalendarMentionPreviewQuery(() => props.target);
+  let backRef: HTMLButtonElement | undefined;
+  // Pull focus into the card as it replaces the search body. A non-modal
+  // Kobalte popover dismisses on focus-outside, and the vacated input would
+  // otherwise drop focus to <body> and close the popover before it shows.
+  onMount(() => backRef?.focus());
 
-  const when = () => {
-    const event = previewQuery.data;
-    if (!event) return '';
-    const time: EventTime =
-      event.time.kind === 'timed'
-        ? {
-            kind: 'timed',
-            startsAt: event.time.startsAt,
-            endsAt: event.time.endsAt,
-          }
-        : {
-            kind: 'allDay',
-            startDate: event.time.startDate,
-            endDate: event.time.endDate,
-          };
-    return formatEventWhen(time, props.timeFormat);
-  };
+  // Supplemental meeting-level detail only. The preview's own `time` is
+  // deliberately unused: for an out-of-range hit the requested occurrence
+  // isn't materialized, so the endpoint resolves a DIFFERENT instance — the
+  // row already carries the occurrence the user selected.
+  const previewQuery = useCalendarMentionPreviewQuery(() => ({
+    eventId: props.event.id,
+    occurrenceKey: props.event.occurrenceKey,
+  }));
+
+  const when = () => formatEventWhen(props.event.time, props.timeFormat);
   const organizer = () =>
-    previewQuery.data?.organizerName || previewQuery.data?.organizerEmail || '';
+    props.event.organizer?.name || props.event.organizer?.email || '';
   const detail = () => {
-    const event = previewQuery.data;
-    if (!event) return '';
+    const preview = previewQuery.data;
+    if (!preview) return '';
     const guests =
-      event.attendeeCount > 0
-        ? `${event.attendeeCount} guest${event.attendeeCount === 1 ? '' : 's'}`
+      preview.attendeeCount > 0
+        ? `${preview.attendeeCount} guest${preview.attendeeCount === 1 ? '' : 's'}`
         : '';
-    return [event.location, guests].filter(Boolean).join(' · ');
+    return [preview.location, guests].filter(Boolean).join(' · ');
   };
 
   return (
     <div class="p-1">
       <button
+        ref={backRef}
         type="button"
         onClick={props.onBack}
         class="flex items-center gap-0.5 rounded-md px-2 py-1 text-xs text-ink-muted outline-none hover:text-ink"
@@ -149,60 +144,40 @@ function CalendarEventPreviewContent(props: {
         <CaretLeftIcon class="size-3" />
         Back to search
       </button>
-      <Switch>
-        <Match when={previewQuery.isLoading}>
-          <div class="px-3 py-4 text-center text-xs text-ink-muted">
-            Loading…
-          </div>
-        </Match>
-        <Match when={previewQuery.data}>
-          {(event) => (
-            <div class="flex flex-col gap-1 px-2 pb-2">
-              <div class="flex items-center gap-2">
-                <span class="flex size-4 shrink-0 items-center justify-center">
-                  <EntityIcon
-                    targetType="calendar"
-                    size="xs"
-                    theme="monochrome"
-                  />
-                </span>
-                <span class="min-w-0 flex-1 truncate text-sm font-medium text-ink">
-                  {event().title || 'Untitled event'}
-                </span>
-                <Show when={event().isRecurring}>
-                  <RepeatIcon
-                    class="size-3 shrink-0 text-ink-muted"
-                    aria-label="Repeats"
-                  />
-                </Show>
-              </div>
-              <Show when={when()}>
-                {(label) => (
-                  <span class="truncate text-xs text-ink-muted">{label()}</span>
-                )}
-              </Show>
-              <Show when={organizer()}>
-                {(name) => (
-                  <span class="truncate text-xs text-ink-muted">{name()}</span>
-                )}
-              </Show>
-              <Show when={detail()}>
-                {(text) => (
-                  <span class="truncate text-xs text-ink-muted">{text()}</span>
-                )}
-              </Show>
-              <span class="mt-1 border-t border-edge-muted pt-1.5 text-[11px] text-ink-extra-muted">
-                Outside the calendar's navigable range
-              </span>
-            </div>
+      <div class="flex flex-col gap-1 px-2 pb-2">
+        <div class="flex items-center gap-2">
+          <span class="flex size-4 shrink-0 items-center justify-center">
+            <EntityIcon targetType="calendar" size="xs" theme="monochrome" />
+          </span>
+          <span class="min-w-0 flex-1 truncate text-sm font-medium text-ink">
+            {props.event.name || 'Untitled event'}
+          </span>
+          <Show when={props.event.isRecurring}>
+            <RepeatIcon
+              class="size-3 shrink-0 text-ink-muted"
+              aria-label="Repeats"
+            />
+          </Show>
+        </div>
+        <Show when={when()}>
+          {(label) => (
+            <span class="truncate text-xs text-ink-muted">{label()}</span>
           )}
-        </Match>
-        <Match when={!previewQuery.isLoading}>
-          <div class="px-3 py-4 text-center text-xs text-ink-muted">
-            Couldn't load this event
-          </div>
-        </Match>
-      </Switch>
+        </Show>
+        <Show when={organizer()}>
+          {(name) => (
+            <span class="truncate text-xs text-ink-muted">{name()}</span>
+          )}
+        </Show>
+        <Show when={detail()}>
+          {(text) => (
+            <span class="truncate text-xs text-ink-muted">{text()}</span>
+          )}
+        </Show>
+        <span class="mt-1 border-t border-edge-muted pt-1.5 text-[11px] text-ink-extra-muted">
+          Outside the calendar's navigable range
+        </span>
+      </div>
     </div>
   );
 }
@@ -229,10 +204,10 @@ function CalendarSearchControl() {
   let inputRef: HTMLInputElement | undefined;
   let listRef: HTMLDivElement | undefined;
   const [activeRow, setActiveRow] = createSignal(0);
-  // Set when a chosen result falls outside the navigable range: the popover
-  // then floats a read-only preview in place of the search body.
+  // Set to the chosen result when it falls outside the navigable range: the
+  // popover then floats a read-only preview of it in place of the search body.
   const [previewTarget, setPreviewTarget] =
-    createSignal<CalendarMentionPreviewInput | null>(null);
+    createSignal<CalendarSearchResult | null>(null);
 
   const query = createMemo(() => rawQuery().trim());
   const debouncedQuery = debouncedDependent(query, 250);
@@ -306,10 +281,7 @@ function CalendarSearchControl() {
 
     // Older than the backend's rolling window: the calendar can't navigate to
     // this occurrence, so float a read-only preview instead of a dead click.
-    setPreviewTarget({
-      eventId: event.id,
-      occurrenceKey: event.occurrenceKey,
-    });
+    setPreviewTarget(event);
   };
 
   const closePreview = () => {
@@ -352,7 +324,9 @@ function CalendarSearchControl() {
     const cmdPressed = IS_MAC ? event.metaKey : event.ctrlKey;
     if (cmdPressed && event.key.toLowerCase() === 'f') {
       event.preventDefault();
-      focusInput();
+      // The input is unmounted while the preview shows, so go back to it first.
+      if (previewTarget()) closePreview();
+      else focusInput();
     }
   };
 
@@ -490,9 +464,9 @@ function CalendarSearchControl() {
                   </>
                 }
               >
-                {(target) => (
+                {(event) => (
                   <CalendarEventPreviewContent
-                    target={target()}
+                    event={event()}
                     timeFormat={calendarView.displaySettings.timeFormat}
                     onBack={closePreview}
                   />

--- a/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
+++ b/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
@@ -3,7 +3,10 @@ import { useCalendarSearchUiFlag } from '@app/features/calendar/hooks/use-calend
 import type { CalendarTimeFormat } from '@app/features/calendar/types';
 import { parseLocalDate } from '@app/features/calendar/utils/calendar-date';
 import { formatCalendarTime } from '@app/features/calendar/utils/time-format';
+import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { EntityIcon } from '@core/component/EntityIcon';
+import { registerHotkey } from '@core/hotkey/hotkeys';
+import { TOKENS } from '@core/hotkey/tokens';
 import { debouncedDependent } from '@core/util/debounce';
 import type { EntityData, WithSearch } from '@entity';
 import SearchIcon from '@icon/macro-magnifying-glass.svg';
@@ -11,7 +14,7 @@ import { Popover } from '@kobalte/core/popover';
 import { useSearchSoupQuery } from '@queries/soup/search';
 import type { EntityFilters } from '@service-search/generated/models';
 import { Button, Layer } from '@ui';
-import { createMemo, createSignal, For, Show } from 'solid-js';
+import { createMemo, createSignal, For, onCleanup, Show } from 'solid-js';
 import { openCalendarEventSplit } from '../open-calendar-event';
 
 type CalendarSearchResult = WithSearch<
@@ -79,8 +82,17 @@ function formatEventWhen(
  * occurrence, the same navigation an event mention or soup row performs.
  */
 export function CalendarSearch() {
-  const calendarView = useCalendarView();
   const searchEnabled = useCalendarSearchUiFlag();
+  return (
+    <Show when={searchEnabled()}>
+      <CalendarSearchControl />
+    </Show>
+  );
+}
+
+function CalendarSearchControl() {
+  const calendarView = useCalendarView();
+  const panel = useSplitPanelOrThrow();
   const [open, setOpen] = createSignal(false);
   const [rawQuery, setRawQuery] = createSignal('');
   let inputRef: HTMLInputElement | undefined;
@@ -133,124 +145,135 @@ export function CalendarSearch() {
     });
   };
 
+  // Cmd+F opens the search, matching the channel block's find-bar. Registered
+  // only while this control is mounted, which the calendar-search flag gates.
+  const searchHotkey = registerHotkey({
+    hotkey: 'cmd+f',
+    scopeId: panel.splitHotkeyScope,
+    hotkeyToken: TOKENS.calendar.search,
+    description: 'Search events',
+    runWithInputFocused: true,
+    keyDownHandler: () => {
+      if (open()) {
+        inputRef?.focus();
+        inputRef?.select();
+      } else {
+        setOpen(true);
+      }
+      return true;
+    },
+  });
+  onCleanup(searchHotkey.dispose);
+
   return (
-    <Show when={searchEnabled()}>
-      <Popover
-        open={open()}
-        onOpenChange={(next) => {
-          setOpen(next);
-          if (!next) setRawQuery('');
-        }}
-        placement="bottom-end"
-        gutter={6}
-        flip
+    <Popover
+      open={open()}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setRawQuery('');
+      }}
+      placement="bottom-end"
+      gutter={6}
+      flip
+    >
+      <Popover.Trigger
+        as={Button}
+        variant="ghost"
+        size="icon-sm"
+        class="rounded-lg"
+        aria-label="Search events"
       >
-        <Popover.Trigger
-          as={Button}
-          variant="ghost"
-          size="icon-sm"
-          class="rounded-lg"
-          aria-label="Search events"
-        >
-          <SearchIcon class="size-4" />
-        </Popover.Trigger>
+        <SearchIcon class="size-4" />
+      </Popover.Trigger>
 
-        <Popover.Portal>
-          <Layer depth={3}>
-            <Popover.Content
-              class="portal-scope z-modal outline-none"
-              onOpenAutoFocus={(event) => {
-                event.preventDefault();
-                inputRef?.focus();
-              }}
-            >
-              <div class="w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl bg-surface text-ink shadow-menu ring ring-edge-muted">
-                <div class="flex items-center gap-2 border-b border-edge-muted px-3 py-2">
-                  <SearchIcon class="size-4 shrink-0 text-ink-muted" />
-                  <input
-                    ref={inputRef}
-                    type="text"
-                    value={rawQuery()}
-                    onInput={(event) => setRawQuery(event.currentTarget.value)}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Enter') {
-                        const first = results()[0];
-                        if (first) openResult(first);
-                      }
-                    }}
-                    placeholder="Search events"
-                    class="min-w-0 flex-1 rounded-sm bg-transparent text-sm caret-accent outline-none placeholder:text-ink-placeholder focus-visible:ring-1 focus-visible:ring-accent"
-                  />
-                </div>
+      <Popover.Portal>
+        <Layer depth={3}>
+          <Popover.Content
+            class="portal-scope z-modal outline-none"
+            onOpenAutoFocus={(event) => {
+              event.preventDefault();
+              inputRef?.focus();
+            }}
+          >
+            <div class="w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl bg-surface text-ink shadow-menu ring ring-edge-muted">
+              <div class="flex items-center gap-2 px-3 py-2">
+                <SearchIcon class="size-4 shrink-0 text-ink-muted" />
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={rawQuery()}
+                  onInput={(event) => setRawQuery(event.currentTarget.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      const first = results()[0];
+                      if (first) openResult(first);
+                    }
+                  }}
+                  placeholder="Search by event name"
+                  class="min-w-0 flex-1 bg-transparent text-sm caret-accent outline-none placeholder:text-ink-placeholder"
+                />
+              </div>
 
-                <div class="max-h-80 overflow-y-auto p-1">
+              <Show when={query().length >= MIN_QUERY_LENGTH}>
+                <div class="max-h-80 overflow-y-auto border-t border-edge-muted p-1">
                   <Show
-                    when={query().length >= MIN_QUERY_LENGTH}
+                    when={!isLoading()}
                     fallback={
                       <div class="px-2 py-3 text-center text-xs text-ink-muted">
-                        Type at least {MIN_QUERY_LENGTH} characters to search
+                        Searching…
                       </div>
                     }
                   >
                     <Show
-                      when={!isLoading()}
+                      when={results().length > 0}
                       fallback={
                         <div class="px-2 py-3 text-center text-xs text-ink-muted">
-                          Searching…
+                          No events found
                         </div>
                       }
                     >
-                      <Show
-                        when={results().length > 0}
-                        fallback={
-                          <div class="px-2 py-3 text-center text-xs text-ink-muted">
-                            No events found
-                          </div>
-                        }
-                      >
-                        <For each={results()}>
-                          {(event) => (
-                            <button
-                              type="button"
-                              class="flex w-full items-center gap-2 rounded-lg p-1.5 px-2 text-left outline-none hover:bg-ink/5 focus-visible:bg-ink/5 focus-visible:ring-1 focus-visible:ring-accent"
-                              onClick={() => openResult(event)}
-                            >
-                              <span class="flex size-4 shrink-0 items-center justify-center">
-                                <EntityIcon
-                                  targetType="calendar"
-                                  size="xs"
-                                  theme="monochrome"
-                                />
+                      <For each={results()}>
+                        {(event) => (
+                          <button
+                            type="button"
+                            class="flex w-full items-center gap-2 rounded-lg p-1.5 px-2 text-left outline-none hover:bg-ink/5 focus-visible:bg-ink/5"
+                            onClick={() => openResult(event)}
+                          >
+                            <span class="flex size-4 shrink-0 items-center justify-center">
+                              <EntityIcon
+                                targetType="calendar"
+                                size="xs"
+                                theme="monochrome"
+                              />
+                            </span>
+                            <span class="min-w-0 flex-1">
+                              <span class="block truncate text-sm text-ink">
+                                {event.name || 'Untitled event'}
                               </span>
-                              <span class="min-w-0 flex-1">
-                                <span class="block truncate text-sm text-ink">
-                                  {event.name || 'Untitled event'}
-                                </span>
-                                <Show
-                                  when={formatEventWhen(
-                                    event.time,
-                                    calendarView.displaySettings.timeFormat
-                                  )}
-                                >
-                                  {(label) => (
-                                    <span class="block truncate text-xs text-ink-muted">
-                                      {label()}
-                                    </span>
-                                  )}
-                                </Show>
-                              </span>
-                            </button>
-                          )}
-                        </For>
-                      </Show>
+                              <Show
+                                when={formatEventWhen(
+                                  event.time,
+                                  calendarView.displaySettings.timeFormat
+                                )}
+                              >
+                                {(label) => (
+                                  <span class="block truncate text-xs text-ink-muted">
+                                    {label()}
+                                  </span>
+                                )}
+                              </Show>
+                            </span>
+                          </button>
+                        )}
+                      </For>
                     </Show>
                   </Show>
                 </div>
-              </div>
-            </Popover.Content>
-          </Layer>
-        </Popover.Portal>
-      </Popover>
-    </Show>
+              </Show>
+            </div>
+          </Popover.Content>
+        </Layer>
+      </Popover.Portal>
+    </Popover>
   );
 }

--- a/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
+++ b/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
@@ -162,8 +162,16 @@ function CalendarSearchControl() {
     });
   };
 
+  const focusInput = () => {
+    inputRef?.focus();
+    inputRef?.select();
+  };
+
   // Cmd+F opens the search, matching the channel block's find-bar. Registered
   // only while this control is mounted, which the calendar-search flag gates.
+  // Once the popover is open its portal holds focus outside the split scope, so
+  // this split-scoped handler only fires to open it — the re-select-while-open
+  // case is handled by `handleContentKeyDown` on the portal content instead.
   const searchHotkey = registerHotkey({
     hotkey: 'cmd+f',
     scopeId: panel.splitHotkeyScope,
@@ -171,16 +179,22 @@ function CalendarSearchControl() {
     description: 'Search events',
     runWithInputFocused: true,
     keyDownHandler: () => {
-      if (open()) {
-        inputRef?.focus();
-        inputRef?.select();
-      } else {
-        setOpen(true);
-      }
+      if (open()) focusInput();
+      else setOpen(true);
       return true;
     },
   });
   onCleanup(searchHotkey.dispose);
+
+  // The portal content lives outside the split hotkey scope, so a second Cmd+F
+  // never reaches the split-scoped opener above — handle it here so it
+  // re-selects the query instead of falling through to the browser find dialog.
+  const handleContentKeyDown = (event: KeyboardEvent) => {
+    if ((event.metaKey || event.ctrlKey) && event.key === 'f') {
+      event.preventDefault();
+      focusInput();
+    }
+  };
 
   return (
     <Popover
@@ -214,6 +228,7 @@ function CalendarSearchControl() {
               event.preventDefault();
               inputRef?.focus();
             }}
+            onKeyDown={handleContentKeyDown}
           >
             <div class="w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl bg-surface text-ink shadow-menu ring ring-edge-muted">
               <div class="flex items-center gap-2 px-3 py-2">
@@ -273,7 +288,7 @@ function CalendarSearchControl() {
                               'flex w-full items-center gap-2 rounded-lg p-1.5 px-2 text-left outline-none',
                               index() === activeIndex() && 'bg-ink/5'
                             )}
-                            onMouseEnter={() => setActiveRow(index())}
+                            onMouseMove={() => setActiveRow(index())}
                             onClick={() => openResult(event)}
                           >
                             <span class="flex size-4 shrink-0 items-center justify-center">

--- a/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
+++ b/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
@@ -2,6 +2,7 @@ import { useCalendarView } from '@app/features/calendar/components/CalendarViewC
 import { useCalendarSearchUiFlag } from '@app/features/calendar/hooks/use-calendar-ui-flag';
 import type { CalendarTimeFormat } from '@app/features/calendar/types';
 import { parseLocalDate } from '@app/features/calendar/utils/calendar-date';
+import { isCalendarRangeSupported } from '@app/features/calendar/utils/calendar-supported-range';
 import { formatCalendarTime } from '@app/features/calendar/utils/time-format';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { EntityIcon } from '@core/component/EntityIcon';
@@ -12,11 +13,29 @@ import { debouncedDependent } from '@core/util/debounce';
 import type { EntityData, WithSearch } from '@entity';
 import SearchIcon from '@icon/macro-magnifying-glass.svg';
 import { Popover } from '@kobalte/core/popover';
+import CaretLeftIcon from '@phosphor/caret-left.svg';
+import RepeatIcon from '@phosphor/repeat.svg';
+import {
+  type CalendarMentionPreviewInput,
+  useCalendarMentionPreviewQuery,
+} from '@queries/calendar/mention-preview';
 import { useSearchSoupQuery } from '@queries/soup/search';
 import type { EntityFilters } from '@service-search/generated/models';
 import { Button, cn, Layer } from '@ui';
-import { createMemo, createSignal, For, onCleanup, Show } from 'solid-js';
-import { openCalendarEventSplit } from '../open-calendar-event';
+import {
+  createMemo,
+  createSignal,
+  For,
+  Match,
+  onCleanup,
+  Show,
+  Switch,
+} from 'solid-js';
+import { createCalendarBlockRange } from '../calendar-range';
+import {
+  eventTimeFromOccurrenceKey,
+  openCalendarEventSplit,
+} from '../open-calendar-event';
 
 type CalendarSearchResult = WithSearch<
   Extract<EntityData, { type: 'calendar_event' }>
@@ -78,6 +97,117 @@ function formatEventWhen(
 }
 
 /**
+ * Read-only card for a result the calendar cannot navigate to: occurrences
+ * older than the backend's rolling materialized window aren't fetchable, so
+ * there is nothing to focus and no editable event to open. Shows the viewer's
+ * own preview of the meeting — the same projection a calendar mention uses —
+ * with a way back to the results.
+ */
+function CalendarEventPreviewContent(props: {
+  target: CalendarMentionPreviewInput;
+  timeFormat: CalendarTimeFormat;
+  onBack: () => void;
+}) {
+  const previewQuery = useCalendarMentionPreviewQuery(() => props.target);
+
+  const when = () => {
+    const event = previewQuery.data;
+    if (!event) return '';
+    const time: EventTime =
+      event.time.kind === 'timed'
+        ? {
+            kind: 'timed',
+            startsAt: event.time.startsAt,
+            endsAt: event.time.endsAt,
+          }
+        : {
+            kind: 'allDay',
+            startDate: event.time.startDate,
+            endDate: event.time.endDate,
+          };
+    return formatEventWhen(time, props.timeFormat);
+  };
+  const organizer = () =>
+    previewQuery.data?.organizerName || previewQuery.data?.organizerEmail || '';
+  const detail = () => {
+    const event = previewQuery.data;
+    if (!event) return '';
+    const guests =
+      event.attendeeCount > 0
+        ? `${event.attendeeCount} guest${event.attendeeCount === 1 ? '' : 's'}`
+        : '';
+    return [event.location, guests].filter(Boolean).join(' · ');
+  };
+
+  return (
+    <div class="p-1">
+      <button
+        type="button"
+        onClick={props.onBack}
+        class="flex items-center gap-0.5 rounded-md px-2 py-1 text-xs text-ink-muted outline-none hover:text-ink"
+      >
+        <CaretLeftIcon class="size-3" />
+        Back to search
+      </button>
+      <Switch>
+        <Match when={previewQuery.isLoading}>
+          <div class="px-3 py-4 text-center text-xs text-ink-muted">
+            Loading…
+          </div>
+        </Match>
+        <Match when={previewQuery.data}>
+          {(event) => (
+            <div class="flex flex-col gap-1 px-2 pb-2">
+              <div class="flex items-center gap-2">
+                <span class="flex size-4 shrink-0 items-center justify-center">
+                  <EntityIcon
+                    targetType="calendar"
+                    size="xs"
+                    theme="monochrome"
+                  />
+                </span>
+                <span class="min-w-0 flex-1 truncate text-sm font-medium text-ink">
+                  {event().title || 'Untitled event'}
+                </span>
+                <Show when={event().isRecurring}>
+                  <RepeatIcon
+                    class="size-3 shrink-0 text-ink-muted"
+                    aria-label="Repeats"
+                  />
+                </Show>
+              </div>
+              <Show when={when()}>
+                {(label) => (
+                  <span class="truncate text-xs text-ink-muted">{label()}</span>
+                )}
+              </Show>
+              <Show when={organizer()}>
+                {(name) => (
+                  <span class="truncate text-xs text-ink-muted">{name()}</span>
+                )}
+              </Show>
+              <Show when={detail()}>
+                {(text) => (
+                  <span class="truncate text-xs text-ink-muted">{text()}</span>
+                )}
+              </Show>
+              <span class="mt-1 border-t border-edge-muted pt-1.5 text-[11px] text-ink-extra-muted">
+                Outside the calendar's navigable range
+              </span>
+            </div>
+          )}
+        </Match>
+        <Match when={!previewQuery.isLoading}>
+          <div class="px-3 py-4 text-center text-xs text-ink-muted">
+            Couldn't load this event
+          </div>
+        </Match>
+      </Switch>
+    </div>
+  );
+}
+
+/**
  * Keyword search over the caller's calendar events, opened from the calendar
  * header. Selecting a result re-aims the singleton calendar block at that
  * occurrence, the same navigation an event mention or soup row performs.
@@ -99,6 +229,10 @@ function CalendarSearchControl() {
   let inputRef: HTMLInputElement | undefined;
   let listRef: HTMLDivElement | undefined;
   const [activeRow, setActiveRow] = createSignal(0);
+  // Set when a chosen result falls outside the navigable range: the popover
+  // then floats a read-only preview in place of the search body.
+  const [previewTarget, setPreviewTarget] =
+    createSignal<CalendarMentionPreviewInput | null>(null);
 
   const query = createMemo(() => rawQuery().trim());
   const debouncedQuery = debouncedDependent(query, 250);
@@ -152,15 +286,37 @@ function CalendarSearchControl() {
   };
 
   const openResult = (event: CalendarSearchResult) => {
-    setOpen(false);
-    setRawQuery('');
-    // An occurrence key anchors the locator range on its own; without one the
-    // master span stands in (a series with no occurrence in the window).
-    void openCalendarEventSplit({
+    // Resolve the same locator range a go-to would build: the occurrence key
+    // anchors it on its own; without one the master's own time stands in.
+    const time = event.occurrenceKey
+      ? eventTimeFromOccurrenceKey(event.occurrenceKey)
+      : event.time;
+    const range = time ? createCalendarBlockRange(time) : undefined;
+
+    if (range && isCalendarRangeSupported(range)) {
+      setOpen(false);
+      setRawQuery('');
+      void openCalendarEventSplit({
+        eventId: event.id,
+        occurrenceKey: event.occurrenceKey,
+        time: event.occurrenceKey ? undefined : event.time,
+      });
+      return;
+    }
+
+    // Older than the backend's rolling window: the calendar can't navigate to
+    // this occurrence, so float a read-only preview instead of a dead click.
+    setPreviewTarget({
       eventId: event.id,
       occurrenceKey: event.occurrenceKey,
-      time: event.occurrenceKey ? undefined : event.time,
     });
+  };
+
+  const closePreview = () => {
+    // The <Show> swaps the input back in synchronously, so the ref is live by
+    // the next line — no rAF needed to refocus.
+    setPreviewTarget(null);
+    focusInput();
   };
 
   const focusInput = () => {
@@ -208,6 +364,7 @@ function CalendarSearchControl() {
         if (!next) {
           setRawQuery('');
           setActiveRow(0);
+          setPreviewTarget(null);
         }
       }}
       placement="bottom-end"
@@ -235,96 +392,111 @@ function CalendarSearchControl() {
             onKeyDown={handleContentKeyDown}
           >
             <div class="w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl bg-surface text-ink shadow-menu ring ring-edge-muted">
-              <div class="flex items-center gap-2 px-3 py-2">
-                <SearchIcon class="size-4 shrink-0 text-ink-muted" />
-                <input
-                  ref={inputRef}
-                  type="text"
-                  value={rawQuery()}
-                  onInput={(event) => {
-                    setRawQuery(event.currentTarget.value);
-                    setActiveRow(0);
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key === 'ArrowDown') {
-                      event.preventDefault();
-                      moveActive(1);
-                    } else if (event.key === 'ArrowUp') {
-                      event.preventDefault();
-                      moveActive(-1);
-                    } else if (event.key === 'Enter') {
-                      const active = results()[activeIndex()];
-                      if (active) openResult(active);
-                    }
-                  }}
-                  placeholder="Search by event name"
-                  class="min-w-0 flex-1 bg-transparent text-sm caret-accent outline-none placeholder:text-ink-placeholder"
-                />
-              </div>
+              <Show
+                when={previewTarget()}
+                fallback={
+                  <>
+                    <div class="flex items-center gap-2 px-3 py-2">
+                      <SearchIcon class="size-4 shrink-0 text-ink-muted" />
+                      <input
+                        ref={inputRef}
+                        type="text"
+                        value={rawQuery()}
+                        onInput={(event) => {
+                          setRawQuery(event.currentTarget.value);
+                          setActiveRow(0);
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === 'ArrowDown') {
+                            event.preventDefault();
+                            moveActive(1);
+                          } else if (event.key === 'ArrowUp') {
+                            event.preventDefault();
+                            moveActive(-1);
+                          } else if (event.key === 'Enter') {
+                            const active = results()[activeIndex()];
+                            if (active) openResult(active);
+                          }
+                        }}
+                        placeholder="Search by event name"
+                        class="min-w-0 flex-1 bg-transparent text-sm caret-accent outline-none placeholder:text-ink-placeholder"
+                      />
+                    </div>
 
-              <Show when={query().length >= MIN_QUERY_LENGTH}>
-                <div
-                  ref={listRef}
-                  class="max-h-80 overflow-y-auto border-t border-edge-muted p-1"
-                >
-                  <Show
-                    when={!isLoading()}
-                    fallback={
-                      <div class="px-2 py-3 text-center text-xs text-ink-muted">
-                        Searching…
-                      </div>
-                    }
-                  >
-                    <Show
-                      when={results().length > 0}
-                      fallback={
-                        <div class="px-2 py-3 text-center text-xs text-ink-muted">
-                          No events found
-                        </div>
-                      }
-                    >
-                      <For each={results()}>
-                        {(event, index) => (
-                          <button
-                            type="button"
-                            data-result-index={index()}
-                            class={cn(
-                              'flex w-full items-center gap-2 rounded-lg p-1.5 px-2 text-left outline-none',
-                              index() === activeIndex() && 'bg-ink/5'
-                            )}
-                            onMouseMove={() => setActiveRow(index())}
-                            onClick={() => openResult(event)}
+                    <Show when={query().length >= MIN_QUERY_LENGTH}>
+                      <div
+                        ref={listRef}
+                        class="max-h-80 overflow-y-auto border-t border-edge-muted p-1"
+                      >
+                        <Show
+                          when={!isLoading()}
+                          fallback={
+                            <div class="px-2 py-3 text-center text-xs text-ink-muted">
+                              Searching…
+                            </div>
+                          }
+                        >
+                          <Show
+                            when={results().length > 0}
+                            fallback={
+                              <div class="px-2 py-3 text-center text-xs text-ink-muted">
+                                No events found
+                              </div>
+                            }
                           >
-                            <span class="flex size-4 shrink-0 items-center justify-center">
-                              <EntityIcon
-                                targetType="calendar"
-                                size="xs"
-                                theme="monochrome"
-                              />
-                            </span>
-                            <span class="min-w-0 flex-1">
-                              <span class="block truncate text-sm text-ink">
-                                {event.name || 'Untitled event'}
-                              </span>
-                              <Show
-                                when={formatEventWhen(
-                                  event.time,
-                                  calendarView.displaySettings.timeFormat
-                                )}
-                              >
-                                {(label) => (
-                                  <span class="block truncate text-xs text-ink-muted">
-                                    {label()}
+                            <For each={results()}>
+                              {(event, index) => (
+                                <button
+                                  type="button"
+                                  data-result-index={index()}
+                                  class={cn(
+                                    'flex w-full items-center gap-2 rounded-lg p-1.5 px-2 text-left outline-none',
+                                    index() === activeIndex() && 'bg-ink/5'
+                                  )}
+                                  onMouseMove={() => setActiveRow(index())}
+                                  onClick={() => openResult(event)}
+                                >
+                                  <span class="flex size-4 shrink-0 items-center justify-center">
+                                    <EntityIcon
+                                      targetType="calendar"
+                                      size="xs"
+                                      theme="monochrome"
+                                    />
                                   </span>
-                                )}
-                              </Show>
-                            </span>
-                          </button>
-                        )}
-                      </For>
+                                  <span class="min-w-0 flex-1">
+                                    <span class="block truncate text-sm text-ink">
+                                      {event.name || 'Untitled event'}
+                                    </span>
+                                    <Show
+                                      when={formatEventWhen(
+                                        event.time,
+                                        calendarView.displaySettings.timeFormat
+                                      )}
+                                    >
+                                      {(label) => (
+                                        <span class="block truncate text-xs text-ink-muted">
+                                          {label()}
+                                        </span>
+                                      )}
+                                    </Show>
+                                  </span>
+                                </button>
+                              )}
+                            </For>
+                          </Show>
+                        </Show>
+                      </div>
                     </Show>
-                  </Show>
-                </div>
+                  </>
+                }
+              >
+                {(target) => (
+                  <CalendarEventPreviewContent
+                    target={target()}
+                    timeFormat={calendarView.displaySettings.timeFormat}
+                    onBack={closePreview}
+                  />
+                )}
               </Show>
             </div>
           </Popover.Content>

--- a/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
+++ b/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
@@ -13,7 +13,7 @@ import SearchIcon from '@icon/macro-magnifying-glass.svg';
 import { Popover } from '@kobalte/core/popover';
 import { useSearchSoupQuery } from '@queries/soup/search';
 import type { EntityFilters } from '@service-search/generated/models';
-import { Button, Layer } from '@ui';
+import { Button, cn, Layer } from '@ui';
 import { createMemo, createSignal, For, onCleanup, Show } from 'solid-js';
 import { openCalendarEventSplit } from '../open-calendar-event';
 
@@ -96,6 +96,8 @@ function CalendarSearchControl() {
   const [open, setOpen] = createSignal(false);
   const [rawQuery, setRawQuery] = createSignal('');
   let inputRef: HTMLInputElement | undefined;
+  let listRef: HTMLDivElement | undefined;
+  const [activeRow, setActiveRow] = createSignal(0);
 
   const query = createMemo(() => rawQuery().trim());
   const debouncedQuery = debouncedDependent(query, 250);
@@ -132,6 +134,21 @@ function CalendarSearchControl() {
   });
 
   const isLoading = () => query().length >= MIN_QUERY_LENGTH && !isCurrent();
+
+  // Keyboard-highlighted result, clamped so it stays valid as results change.
+  const activeIndex = () => {
+    const len = results().length;
+    return len === 0 ? -1 : Math.min(Math.max(activeRow(), 0), len - 1);
+  };
+  const moveActive = (delta: number) => {
+    const len = results().length;
+    if (len === 0) return;
+    const next = Math.min(Math.max(activeIndex() + delta, 0), len - 1);
+    setActiveRow(next);
+    listRef
+      ?.querySelector(`[data-result-index="${next}"]`)
+      ?.scrollIntoView({ block: 'nearest' });
+  };
 
   const openResult = (event: CalendarSearchResult) => {
     setOpen(false);
@@ -170,7 +187,10 @@ function CalendarSearchControl() {
       open={open()}
       onOpenChange={(next) => {
         setOpen(next);
-        if (!next) setRawQuery('');
+        if (!next) {
+          setRawQuery('');
+          setActiveRow(0);
+        }
       }}
       placement="bottom-end"
       gutter={6}
@@ -202,11 +222,20 @@ function CalendarSearchControl() {
                   ref={inputRef}
                   type="text"
                   value={rawQuery()}
-                  onInput={(event) => setRawQuery(event.currentTarget.value)}
+                  onInput={(event) => {
+                    setRawQuery(event.currentTarget.value);
+                    setActiveRow(0);
+                  }}
                   onKeyDown={(event) => {
-                    if (event.key === 'Enter') {
-                      const first = results()[0];
-                      if (first) openResult(first);
+                    if (event.key === 'ArrowDown') {
+                      event.preventDefault();
+                      moveActive(1);
+                    } else if (event.key === 'ArrowUp') {
+                      event.preventDefault();
+                      moveActive(-1);
+                    } else if (event.key === 'Enter') {
+                      const active = results()[activeIndex()];
+                      if (active) openResult(active);
                     }
                   }}
                   placeholder="Search by event name"
@@ -215,7 +244,10 @@ function CalendarSearchControl() {
               </div>
 
               <Show when={query().length >= MIN_QUERY_LENGTH}>
-                <div class="max-h-80 overflow-y-auto border-t border-edge-muted p-1">
+                <div
+                  ref={listRef}
+                  class="max-h-80 overflow-y-auto border-t border-edge-muted p-1"
+                >
                   <Show
                     when={!isLoading()}
                     fallback={
@@ -233,10 +265,15 @@ function CalendarSearchControl() {
                       }
                     >
                       <For each={results()}>
-                        {(event) => (
+                        {(event, index) => (
                           <button
                             type="button"
-                            class="flex w-full items-center gap-2 rounded-lg p-1.5 px-2 text-left outline-none hover:bg-ink/5 focus-visible:bg-ink/5"
+                            data-result-index={index()}
+                            class={cn(
+                              'flex w-full items-center gap-2 rounded-lg p-1.5 px-2 text-left outline-none',
+                              index() === activeIndex() && 'bg-ink/5'
+                            )}
+                            onMouseEnter={() => setActiveRow(index())}
                             onClick={() => openResult(event)}
                           >
                             <span class="flex size-4 shrink-0 items-center justify-center">

--- a/apps/web/src/lib/core/hotkey/tokens.ts
+++ b/apps/web/src/lib/core/hotkey/tokens.ts
@@ -90,6 +90,7 @@ export const TOKENS = {
       next: 'calendar.period.next',
       today: 'calendar.period.today',
     },
+    search: 'calendar.search',
   },
 
   // global

--- a/apps/web/src/lib/queries/calendar/mention-preview.ts
+++ b/apps/web/src/lib/queries/calendar/mention-preview.ts
@@ -1,9 +1,25 @@
 import { queryClient } from '@queries/client';
 import { storageServiceClient } from '@service-storage/client';
 import type { CalendarMentionEvent } from '@service-storage/generated/schemas/calendarMentionEvent';
+import { useQuery } from '@tanstack/solid-query';
+import type { Accessor } from 'solid-js';
 import { calendarKeys } from './keys';
 
 const MENTION_PREVIEW_STALE_TIME = 60_000;
+
+async function fetchPreview(
+  eventId: string,
+  occurrenceKey?: string
+): Promise<CalendarMentionEvent | null> {
+  const result = await storageServiceClient.getBatchCalendarEventPreviews({
+    items: [{ eventId, occurrenceKey }],
+  });
+  if (result.isErr()) {
+    throw new Error('Failed to fetch calendar mention preview');
+  }
+  const item = result.value.items[0];
+  return item?.type === 'access' && item.event ? item.event : null;
+}
 
 /**
  * Resolve one mentioned event to the viewer's own copy of the meeting,
@@ -16,16 +32,41 @@ export async function fetchCalendarMentionPreview(
 ): Promise<CalendarMentionEvent | null> {
   return queryClient.fetchQuery({
     queryKey: calendarKeys.mentionPreview(eventId, occurrenceKey).queryKey,
-    queryFn: async () => {
-      const result = await storageServiceClient.getBatchCalendarEventPreviews({
-        items: [{ eventId, occurrenceKey }],
-      });
-      if (result.isErr()) {
-        throw new Error('Failed to fetch calendar mention preview');
-      }
-      const item = result.value.items[0];
-      return item?.type === 'access' && item.event ? item.event : null;
-    },
+    queryFn: () => fetchPreview(eventId, occurrenceKey),
     staleTime: MENTION_PREVIEW_STALE_TIME,
+  });
+}
+
+/** Target of a reactive mention-preview lookup. */
+export interface CalendarMentionPreviewInput {
+  eventId: string;
+  occurrenceKey?: string;
+}
+
+/**
+ * Reactive form of {@link fetchCalendarMentionPreview}: the viewer's copy of
+ * one event, refetched as the target changes. Shares the cache and stale
+ * window with the imperative fetch through the same query key.
+ */
+export function useCalendarMentionPreviewQuery(
+  input: Accessor<CalendarMentionPreviewInput | undefined>,
+  options?: Accessor<{ enabled?: boolean }>
+) {
+  return useQuery(() => {
+    const target = input();
+    return {
+      queryKey: calendarKeys.mentionPreview(
+        target?.eventId ?? '',
+        target?.occurrenceKey
+      ).queryKey,
+      queryFn: () => {
+        if (!target) {
+          throw new Error('Calendar mention preview target is unavailable');
+        }
+        return fetchPreview(target.eventId, target.occurrenceKey);
+      },
+      enabled: target !== undefined && options?.().enabled !== false,
+      staleTime: MENTION_PREVIEW_STALE_TIME,
+    };
   });
 }


### PR DESCRIPTION
Polishes the in-calendar search popover: binds Cmd+F to open it (matching the channel find-bar), drops the input focus ring and the "type at least 3 characters" hint (the popover is just the input until you type), and changes the placeholder to "Search by event name".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to calendar search UI, hotkey registration, and a read-only preview path; navigation for in-range events is unchanged.
> 
> **Overview**
> **In-calendar event search** gets keyboard and UX polish, plus a fallback when a hit cannot be opened on the grid.
> 
> **Cmd+F** (split-scoped, with portal handling so it does not trigger the browser find dialog) opens the popover or refocuses/selects the query; a **`calendar.search`** hotkey token is registered. The popover drops the “type at least 3 characters” empty state and input focus ring, uses **“Search by event name”** as the placeholder, and adds **arrow-key** highlighting with **Enter** opening the active row (not always the first).
> 
> Selecting a result now checks **`isCalendarRangeSupported`** on the same locator range as normal go-to navigation. In-range hits still call **`openCalendarEventSplit`**; **out-of-range** occurrences show an in-popover **read-only preview** (title/when/organizer from the search row, location/guest count from **`useCalendarMentionPreviewQuery`**) with a note that the event is outside the navigable range. **`mention-preview`** gains a shared **`fetchPreview`** helper and reactive **`useCalendarMentionPreviewQuery`** hook for that card.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a771bf10413fd9f1696d1272bd293c759e235dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->