### PR TITLE
fix(web): handle async-graphql legacy projection errors

### DIFF
--- a/apps/web/src/lib/service-clients/service-storage/graphql-soup.test.ts
+++ b/apps/web/src/lib/service-clients/service-storage/graphql-soup.test.ts
@@ -216,47 +216,46 @@ describe('GraphQL Soup browser cache session gate', () => {
     expect(soup.graphqlSoupProjectionSupported()).toBe(true);
   });
 
-  it('retries a new client against an old server without projection local authority', async () => {
-    mocks.platformFetch
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            errors: [
-              {
-                message:
-                  'Cannot query field "cacheProjection" on type "GraphqlSoupEntity".',
-              },
-            ],
-          }),
-          { status: 200, headers: { 'content-type': 'application/json' } }
+  it.each([
+    'Cannot query field "cacheProjection" on type "GraphqlSoupEntity".',
+    'Unknown field "cacheProjection" on type "GraphqlSoupEntity".',
+  ])(
+    'retries a new client against an old server without projection local authority: %s',
+    async (validationMessage) => {
+      mocks.platformFetch
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ errors: [{ message: validationMessage }] }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          )
         )
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({ data: { user: { soup: { items: [] } } } }),
-          {
-            status: 200,
-            headers: { 'content-type': 'application/json' },
-          }
-        )
-      );
-    const soup = await import('./graphql-soup');
-    const query = `query Soup {
-      user { soup { items { __typename id cacheProjection @cacheOnly } } }
-    }`;
-    const response = await soup.dssGraphqlFetch('http://dss.test/graphql', {
-      method: 'POST',
-      body: JSON.stringify({ query }),
-    });
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ data: { user: { soup: { items: [] } } } }),
+            {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            }
+          )
+        );
+      const soup = await import('./graphql-soup');
+      const query = `query Soup {
+        user { soup { items { __typename id cacheProjection @cacheOnly } } }
+      }`;
+      const response = await soup.dssGraphqlFetch('http://dss.test/graphql', {
+        method: 'POST',
+        body: JSON.stringify({ query }),
+      });
 
-    expect(response.status).toBe(200);
-    expect(mocks.platformFetch).toHaveBeenCalledTimes(2);
-    const retry = mocks.platformFetch.mock.calls[1]?.[1] as RequestInit;
-    expect(JSON.parse(retry.body as string).query).not.toContain(
-      'cacheProjection'
-    );
-    expect(soup.graphqlSoupProjectionSupported()).toBe(false);
-  });
+      expect(response.status).toBe(200);
+      expect(mocks.platformFetch).toHaveBeenCalledTimes(2);
+      const retry = mocks.platformFetch.mock.calls[1]?.[1] as RequestInit;
+      expect(JSON.parse(retry.body as string).query).not.toContain(
+        'cacheProjection'
+      );
+      expect(soup.graphqlSoupProjectionSupported()).toBe(false);
+    }
+  );
 
   it('keeps GraphQL notification subscriptions active when the cache is disabled', async () => {
     mocks.enabled = false;

--- a/apps/web/src/lib/service-clients/service-storage/graphql-soup.test.ts
+++ b/apps/web/src/lib/service-clients/service-storage/graphql-soup.test.ts
@@ -216,6 +216,37 @@ describe('GraphQL Soup browser cache session gate', () => {
     expect(soup.graphqlSoupProjectionSupported()).toBe(true);
   });
 
+  it('strips client-only directives from GraphQL transport documents', async () => {
+    mocks.platformFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: { user: { id: 'user-1' } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    const soup = await import('./graphql-soup');
+    const query = `query Soup($includeId: Boolean!) {
+      user {
+        id @include(if: $includeId)
+        soup { items { cacheProjection @cacheOnly } }
+      }
+    }`;
+    await soup.dssGraphqlFetch('http://dss.test/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query, variables: { includeId: true } }),
+    });
+
+    expect(mocks.platformFetch).toHaveBeenCalledOnce();
+    const transport = mocks.platformFetch.mock.calls[0]?.[1] as RequestInit;
+    const payload = JSON.parse(transport.body as string) as {
+      query: string;
+      variables: { includeId: boolean };
+    };
+    expect(payload.query).not.toContain('@cacheOnly');
+    expect(payload.query).toContain('cacheProjection');
+    expect(payload.query).toContain('@include');
+    expect(payload.variables).toEqual({ includeId: true });
+  });
+
   it.each([
     'Cannot query field "cacheProjection" on type "GraphqlSoupEntity".',
     'Unknown field "cacheProjection" on type "GraphqlSoupEntity".',

--- a/apps/web/src/lib/service-clients/service-storage/graphql-soup.ts
+++ b/apps/web/src/lib/service-clients/service-storage/graphql-soup.ts
@@ -176,7 +176,9 @@ async function isLegacyProjectionValidationError(
           typeof error === 'object' &&
           'message' in error &&
           typeof error.message === 'string' &&
-          /Cannot query field ["']cacheProjection["']/.test(error.message)
+          /(?:Cannot query|Unknown) field ["']cacheProjection["']/.test(
+            error.message
+          )
       )
     );
   } catch {

--- a/apps/web/src/lib/service-clients/service-storage/graphql-soup.ts
+++ b/apps/web/src/lib/service-clients/service-storage/graphql-soup.ts
@@ -39,7 +39,7 @@ import {
   type RequestPolicy,
   subscriptionExchange,
 } from '@urql/core';
-import { parse, print, visit } from 'graphql';
+import { type DocumentNode, parse, print, visit } from 'graphql';
 import {
   createClient as createGraphqlWsClient,
   type Client as GraphqlWsClient,
@@ -117,6 +117,48 @@ export function graphqlSoupProjectionSupported(): boolean {
   return soupProjectionServerSupported;
 }
 
+function stripGraphqlSoupClientDirectives(
+  document: DocumentNode
+): DocumentNode {
+  return visit(document, {
+    Directive(node) {
+      return node.name.value === 'cacheOnly' ? null : undefined;
+    },
+  });
+}
+
+/** Removes client-only directives from a document before network transport. */
+export function graphqlSoupTransportDocument(query: string): string {
+  return print(stripGraphqlSoupClientDirectives(parse(query)));
+}
+
+function graphqlSoupTransportRequest(
+  init: RequestInit | undefined
+): RequestInit | undefined {
+  if (typeof init?.body !== 'string') return init;
+  try {
+    const payload: unknown = JSON.parse(init.body);
+    if (
+      payload === null ||
+      typeof payload !== 'object' ||
+      !('query' in payload) ||
+      typeof payload.query !== 'string' ||
+      !payload.query.includes('@cacheOnly')
+    ) {
+      return init;
+    }
+    return {
+      ...init,
+      body: JSON.stringify({
+        ...payload,
+        query: graphqlSoupTransportDocument(payload.query),
+      }),
+    };
+  } catch {
+    return init;
+  }
+}
+
 /** Removes only the additive cache metadata field for a legacy-server retry. */
 export function legacySoupProjectionDocument(query: string): string {
   return print(
@@ -190,8 +232,9 @@ export async function dssGraphqlFetch(
   input: RequestInfo | URL,
   init?: RequestInit
 ): Promise<Response> {
-  const response = await authorizedDssGraphqlFetch(input, init);
-  const legacyInit = legacyProjectionRequest(init);
+  const transportInit = graphqlSoupTransportRequest(init);
+  const response = await authorizedDssGraphqlFetch(input, transportInit);
+  const legacyInit = legacyProjectionRequest(transportInit);
   if (
     legacyInit === undefined ||
     !(await isLegacyProjectionValidationError(response))
@@ -239,7 +282,7 @@ function graphqlSoupSubscriptionExchange(websocketClient: GraphqlWsClient) {
   return subscriptionExchange({
     forwardSubscription(payload, request) {
       const graphqlWsPayload = {
-        query: print(request.query),
+        query: print(stripGraphqlSoupClientDirectives(request.query)),
         operationName: payload.operationName,
         variables: payload.variables,
         extensions: payload.extensions,


### PR DESCRIPTION
This PR improves the error handling for gql errors so they are identified correctly, we also make sure to strip the client only @cacheOnly directive for the subscription transport as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core DSS GraphQL fetch and subscription paths; mis-stripping directives or retry logic could break mixed client/server deployments, but scope is limited to soup transport and projection fallback.
> 
> **Overview**
> GraphQL Soup **network transport** now strips the client-only `@cacheOnly` directive before HTTP and WebSocket requests, so servers never see directives meant only for the normalized cache layer. **`cacheProjection`** and standard directives like `@include` stay on the wire unless a legacy retry removes projection fields.
> 
> **Legacy server compatibility** is tightened: validation errors that say **Unknown field** `cacheProjection` (async-graphql) are treated like **Cannot query field**, triggering the same retry without projection and session latch that disables projection support. Tests cover transport stripping and both error message shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12d8a2bf53aa41d08f3f1b18a79bcabde8aaa2ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->