### PR TITLE
fix(calendar): allow the organizer to edit invitees on an existing event

### DIFF
--- a/apps/web/src/features/calendar/components/composer/event-form-model.ts
+++ b/apps/web/src/features/calendar/components/composer/event-form-model.ts
@@ -173,14 +173,23 @@ function initialConferenceChoice(
     : 'existing';
 }
 
+/**
+ * Guest emails an existing event seeds into the editor: every attendee except
+ * the viewer when they are a mere guest. The organizer is kept even when it is
+ * the viewer, so a replacement attendee list submitted by the organizer never
+ * drops them.
+ */
+export function eventGuestEmails(event: CalendarEvent): string[] {
+  return event.attendees
+    .filter((attendee) => attendee.isOrganizer || !attendee.isSelf)
+    .map((attendee) => attendee.email);
+}
+
 /** Converts an existing event into values for the shared editor. */
 export function calendarEventToEditorInitialValues(
   event: CalendarEvent
 ): EventEditorInitialValues {
-  const guests = event.attendees
-    .filter((attendee) => attendee.isOrganizer || !attendee.isSelf)
-    .map((attendee) => attendee.email)
-    .join(', ');
+  const guests = eventGuestEmails(event).join(', ');
 
   if (event.allDay) {
     const start = isDateOnly(event.start)

--- a/apps/web/src/features/calendar/hooks/use-event-editor.ts
+++ b/apps/web/src/features/calendar/hooks/use-event-editor.ts
@@ -17,10 +17,13 @@ import {
   calendarDisplayLabel,
   spansMultipleInboxes,
 } from '../utils/calendar-label';
+import {
+  guestListChanged,
+  viewerCanEditGuests,
+} from '../utils/event-guest-editing';
 
 const EDIT_DISABLED_FIELDS = {
   calendar: true,
-  guests: true,
 } satisfies EventEditorDisabledFields;
 
 interface UseEventEditorProps {
@@ -110,6 +113,11 @@ export function useEventEditor(props: UseEventEditorProps) {
           ...(recurrenceChanged
             ? { recurrenceLines: values.recurrenceLines }
             : {}),
+          ...(guestListChanged(event, values.guestEmails)
+            ? {
+                attendees: values.guestEmails.map((email) => ({ email })),
+              }
+            : {}),
           ...(values.conference ? { conference: values.conference } : {}),
           ...(values.reminders ? { reminders: values.reminders } : {}),
         },
@@ -134,8 +142,15 @@ export function useEventEditor(props: UseEventEditorProps) {
     isEdit() &&
     ((props.event()?.recurrenceLines.length ?? 0) > 0 ||
       props.event()?.recurrenceId !== undefined);
-  const disabledFields = createMemo(() =>
-    isEdit() ? EDIT_DISABLED_FIELDS : undefined
+  const disabledFields = createMemo<EventEditorDisabledFields | undefined>(
+    () => {
+      const event = props.event();
+      if (!event) return undefined;
+      return {
+        ...EDIT_DISABLED_FIELDS,
+        guests: !viewerCanEditGuests(event),
+      };
+    }
   );
 
   return {

--- a/apps/web/src/features/calendar/utils/event-guest-editing.test.ts
+++ b/apps/web/src/features/calendar/utils/event-guest-editing.test.ts
@@ -1,0 +1,122 @@
+import type { CalendarAttendee } from '@service-storage/generated/schemas/calendarAttendee';
+import { describe, expect, it } from 'vitest';
+import type { CalendarEvent } from '../types';
+import { guestListChanged, viewerCanEditGuests } from './event-guest-editing';
+
+function attendee(overrides: Partial<CalendarAttendee>): CalendarAttendee {
+  return {
+    email: 'guest@example.com',
+    isOptional: false,
+    isOrganizer: false,
+    isSelf: false,
+    responseStatus: 'needs_action',
+    ...overrides,
+  };
+}
+
+function event(overrides: Partial<CalendarEvent>): CalendarEvent {
+  return {
+    id: '["event","occurrence"]',
+    eventId: 'event',
+    occurrenceKey: 'occurrence',
+    isCancelled: false,
+    isReadOnly: false,
+    attendees: [],
+    recurrenceLines: [],
+    title: 'Sync',
+    start: '2026-08-27T19:00:00.000Z',
+    end: '2026-08-27T20:00:00.000Z',
+    allDay: false,
+    calendar: { id: 'cal', name: 'Calendar', color: 'orange' },
+    ...overrides,
+  };
+}
+
+describe('viewerCanEditGuests', () => {
+  it('allows the organizer to edit guests', () => {
+    expect(
+      viewerCanEditGuests(
+        event({
+          attendees: [
+            attendee({
+              email: 'me@example.com',
+              isOrganizer: true,
+              isSelf: true,
+            }),
+            attendee({ email: 'teo@example.com' }),
+          ],
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('blocks a mere guest from editing the list', () => {
+    expect(
+      viewerCanEditGuests(
+        event({
+          attendees: [
+            attendee({ email: 'host@example.com', isOrganizer: true }),
+            attendee({ email: 'me@example.com', isSelf: true }),
+          ],
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('allows editing a writable event that has no attendees yet', () => {
+    expect(viewerCanEditGuests(event({ attendees: [] }))).toBe(true);
+  });
+
+  it('blocks editing a read-only event with no attendees', () => {
+    expect(
+      viewerCanEditGuests(event({ attendees: [], isReadOnly: true }))
+    ).toBe(false);
+  });
+});
+
+describe('guestListChanged', () => {
+  const organized = event({
+    attendees: [
+      attendee({ email: 'me@example.com', isOrganizer: true, isSelf: true }),
+      attendee({ email: 'teo@example.com' }),
+    ],
+  });
+
+  it('is false when the submitted list matches the seed', () => {
+    expect(
+      guestListChanged(organized, ['me@example.com', 'teo@example.com'])
+    ).toBe(false);
+  });
+
+  it('ignores order and case differences', () => {
+    expect(
+      guestListChanged(organized, ['TEO@example.com', 'me@example.com'])
+    ).toBe(false);
+  });
+
+  it('is true when a guest is added', () => {
+    expect(
+      guestListChanged(organized, [
+        'me@example.com',
+        'teo@example.com',
+        'ada@example.com',
+      ])
+    ).toBe(true);
+  });
+
+  it('is true when a guest is removed', () => {
+    expect(guestListChanged(organized, ['me@example.com'])).toBe(true);
+  });
+
+  it('does not count the viewer-as-guest against the seed', () => {
+    // A non-organizer self attendee is excluded from the seed, so resubmitting
+    // the visible guest list alone is not a change.
+    const invited = event({
+      attendees: [
+        attendee({ email: 'host@example.com', isOrganizer: true }),
+        attendee({ email: 'me@example.com', isSelf: true }),
+      ],
+    });
+    expect(guestListChanged(invited, ['host@example.com'])).toBe(false);
+  });
+});

--- a/apps/web/src/features/calendar/utils/event-guest-editing.test.ts
+++ b/apps/web/src/features/calendar/utils/event-guest-editing.test.ts
@@ -72,6 +72,24 @@ describe('viewerCanEditGuests', () => {
       viewerCanEditGuests(event({ attendees: [], isReadOnly: true }))
     ).toBe(false);
   });
+
+  it('blocks editing a read-only event even when self organizes it', () => {
+    expect(
+      viewerCanEditGuests(
+        event({
+          isReadOnly: true,
+          attendees: [
+            attendee({
+              email: 'me@example.com',
+              isOrganizer: true,
+              isSelf: true,
+            }),
+            attendee({ email: 'teo@example.com' }),
+          ],
+        })
+      )
+    ).toBe(false);
+  });
 });
 
 describe('guestListChanged', () => {

--- a/apps/web/src/features/calendar/utils/event-guest-editing.ts
+++ b/apps/web/src/features/calendar/utils/event-guest-editing.ts
@@ -1,0 +1,42 @@
+import { eventGuestEmails } from '../components/composer/event-form-model';
+import type { CalendarEvent } from '../types';
+
+function normalizeGuestEmails(emails: readonly string[]): string[] {
+  return [...new Set(emails.map((email) => email.trim().toLowerCase()))].sort();
+}
+
+function emailListsEqual(first: readonly string[], second: readonly string[]) {
+  const left = normalizeGuestEmails(first);
+  const right = normalizeGuestEmails(second);
+  return (
+    left.length === right.length &&
+    left.every((email, index) => email === right[index])
+  );
+}
+
+/**
+ * Whether the viewer may change the guest list of an existing event. Only the
+ * organizer can: the editor's replacement attendee list would otherwise drop
+ * the viewer, whose own email is seeded only when they organize the event.
+ *
+ * A writable event with no attendees at all is treated as the viewer's own
+ * (a solo event they created), so the first guest can still be added — there
+ * is no attendee to drop in that case.
+ */
+export function viewerCanEditGuests(event: CalendarEvent): boolean {
+  const organizer = event.attendees.find((attendee) => attendee.isOrganizer);
+  if (organizer) return organizer.isSelf;
+  return event.attendees.length === 0 && !event.isReadOnly;
+}
+
+/**
+ * Whether a submitted guest list differs from the event's current one.
+ * Attendee updates replace the whole list and notify every guest, so the
+ * update omits attendees when nothing changed.
+ */
+export function guestListChanged(
+  event: CalendarEvent,
+  nextGuestEmails: readonly string[]
+): boolean {
+  return !emailListsEqual(eventGuestEmails(event), nextGuestEmails);
+}

--- a/apps/web/src/features/calendar/utils/event-guest-editing.ts
+++ b/apps/web/src/features/calendar/utils/event-guest-editing.ts
@@ -15,18 +15,20 @@ function emailListsEqual(first: readonly string[], second: readonly string[]) {
 }
 
 /**
- * Whether the viewer may change the guest list of an existing event. Only the
- * organizer can: the editor's replacement attendee list would otherwise drop
- * the viewer, whose own email is seeded only when they organize the event.
+ * Whether the viewer may change the guest list of an existing event. A
+ * read-only event never qualifies. Otherwise only the organizer can: the
+ * editor's replacement attendee list would otherwise drop the viewer, whose
+ * own email is seeded only when they organize the event.
  *
  * A writable event with no attendees at all is treated as the viewer's own
  * (a solo event they created), so the first guest can still be added — there
  * is no attendee to drop in that case.
  */
 export function viewerCanEditGuests(event: CalendarEvent): boolean {
+  if (event.isReadOnly) return false;
   const organizer = event.attendees.find((attendee) => attendee.isOrganizer);
   if (organizer) return organizer.isSelf;
-  return event.attendees.length === 0 && !event.isReadOnly;
+  return event.attendees.length === 0;
 }
 
 /**

--- a/crates/calendar_events/src/domain/mutations.rs
+++ b/crates/calendar_events/src/domain/mutations.rs
@@ -6,15 +6,18 @@
 //! projection is read-your-writes fresh and the next incremental sync
 //! no-ops on the idempotency short-circuit.
 
+use std::collections::HashMap;
+
 use chrono::Utc;
 use uuid::Uuid;
 
 use super::{
     models::{
-        ActorInboxes, AttendeeResponseStatus, CalendarAttendeeInput, CalendarEvent,
-        CalendarEventDraft, CalendarEventMutationTarget, CalendarEventPatch, CalendarEventUpsert,
-        DisconnectedGoogleCalendar, EventReminders, EventTime, OccurrenceRange,
-        REMINDER_METHOD_EMAIL, REMINDER_METHOD_POPUP, REMINDER_MINUTES_MAX, REMINDER_OVERRIDES_MAX,
+        ActorInboxes, AttendeeResponseStatus, CalendarAttendee, CalendarAttendeeInput,
+        CalendarEvent, CalendarEventDraft, CalendarEventMutationTarget, CalendarEventPatch,
+        CalendarEventUpsert, DisconnectedGoogleCalendar, EventReminders, EventTime,
+        OccurrenceRange, REMINDER_METHOD_EMAIL, REMINDER_METHOD_POPUP, REMINDER_MINUTES_MAX,
+        REMINDER_OVERRIDES_MAX,
     },
     ports::{
         CalendarAccessTokenProvider, CalendarDeletionScope, CalendarEventChange,
@@ -200,7 +203,7 @@ where
         &self,
         requester_id: &str,
         event_id: Uuid,
-        patch: CalendarEventPatch,
+        mut patch: CalendarEventPatch,
         scope: CalendarUpdateScope,
     ) -> Result<CalendarEvent, CalendarMutationError> {
         if patch.is_empty() {
@@ -229,6 +232,14 @@ where
         let target = self.resolve_mutation_target(requester_id, event_id).await?;
         if target.is_read_only {
             return Err(CalendarMutationError::ReadOnly);
+        }
+        if let Some(attendees) = patch.attendees.as_mut() {
+            let stored = self
+                .repository
+                .get_event_attendees(event_id)
+                .await
+                .map_err(internal)?;
+            preserve_retained_attendee_state(attendees, &stored);
         }
         let access_token = self.fetch_token(&target.token_identity).await?;
         let google_target = target.google_target(OccurrenceRange::maintenance_horizon(Utc::now()));
@@ -577,6 +588,33 @@ fn ensure_organizer_attendee(attendees: &mut Vec<CalendarAttendeeInput>, organiz
             response_status: Some(AttendeeResponseStatus::Accepted),
         },
     );
+}
+
+/// Carries each retained attendee's stored RSVP and optional flag forward
+/// into a replacement attendee list. A patch replaces the whole list, and
+/// Google reads an attendee whose `responseStatus` is omitted as
+/// `needs_action` — so without this, adding or dropping one guest would reset
+/// everyone else's RSVP and clear their optional flag. The caller's own values
+/// still win when supplied (a set `response_status`, an explicit `optional`).
+fn preserve_retained_attendee_state(
+    attendees: &mut [CalendarAttendeeInput],
+    stored: &[CalendarAttendee],
+) {
+    let by_email: HashMap<String, &CalendarAttendee> = stored
+        .iter()
+        .map(|attendee| (attendee.email.to_lowercase(), attendee))
+        .collect();
+    for attendee in attendees.iter_mut() {
+        let Some(existing) = by_email.get(&attendee.email.to_lowercase()) else {
+            continue;
+        };
+        if attendee.response_status.is_none() {
+            attendee.response_status = Some(existing.response_status);
+        }
+        if !attendee.is_optional {
+            attendee.is_optional = existing.is_optional;
+        }
+    }
 }
 
 fn validate_attendee_emails<'a>(

--- a/crates/calendar_events/src/domain/mutations.rs
+++ b/crates/calendar_events/src/domain/mutations.rs
@@ -234,11 +234,23 @@ where
             return Err(CalendarMutationError::ReadOnly);
         }
         if let Some(attendees) = patch.attendees.as_mut() {
-            let stored = self
+            // The series attendees are the baseline; an occurrence-scoped patch
+            // overlays that occurrence's overrides on top, so a retained guest's
+            // per-instance RSVP wins over their series status.
+            let mut stored = self
                 .repository
                 .get_event_attendees(event_id)
                 .await
                 .map_err(internal)?;
+            if let CalendarUpdateScope::ThisEvent { recurrence_id } = &scope
+                && let Some(overrides) = self
+                    .repository
+                    .get_occurrence_override_attendees(event_id, recurrence_id)
+                    .await
+                    .map_err(internal)?
+            {
+                stored.extend(overrides);
+            }
             preserve_retained_attendee_state(attendees, &stored);
         }
         let access_token = self.fetch_token(&target.token_identity).await?;
@@ -596,14 +608,17 @@ fn ensure_organizer_attendee(attendees: &mut Vec<CalendarAttendeeInput>, organiz
 /// `needs_action` — so without this, adding or dropping one guest would reset
 /// everyone else's RSVP and clear their optional flag. The caller's own values
 /// still win when supplied (a set `response_status`, an explicit `optional`).
+///
+/// `stored` is matched by email, later entries winning — so an occurrence's
+/// override attendees, appended after the series attendees, take precedence.
 fn preserve_retained_attendee_state(
     attendees: &mut [CalendarAttendeeInput],
     stored: &[CalendarAttendee],
 ) {
-    let by_email: HashMap<String, &CalendarAttendee> = stored
-        .iter()
-        .map(|attendee| (attendee.email.to_lowercase(), attendee))
-        .collect();
+    let mut by_email: HashMap<String, &CalendarAttendee> = HashMap::new();
+    for attendee in stored {
+        by_email.insert(attendee.email.to_lowercase(), attendee);
+    }
     for attendee in attendees.iter_mut() {
         let Some(existing) = by_email.get(&attendee.email.to_lowercase()) else {
             continue;

--- a/crates/calendar_events/src/domain/mutations/test.rs
+++ b/crates/calendar_events/src/domain/mutations/test.rs
@@ -135,6 +135,8 @@ fn draft() -> CalendarEventDraft {
 #[derive(Clone)]
 struct FakeRepo {
     mutation_target: Option<CalendarEventMutationTarget>,
+    /// Attendees a mutation carries forward RSVP/optional state from.
+    stored_attendees: Vec<CalendarAttendee>,
     creation_target: Option<CalendarCreationTarget>,
     persisted_event_id: Option<Uuid>,
     /// What the upsert reports doing to the row. `Created` by default, since
@@ -155,6 +157,7 @@ impl Default for FakeRepo {
     fn default() -> Self {
         Self {
             mutation_target: None,
+            stored_attendees: Vec::new(),
             creation_target: None,
             persisted_event_id: None,
             write_change: CalendarEventChange::Created,
@@ -302,6 +305,13 @@ impl CalendarRepository for FakeRepo {
         Ok(self.mutation_target.clone())
     }
 
+    async fn get_event_attendees(
+        &self,
+        _event_id: Uuid,
+    ) -> Result<Vec<CalendarAttendee>, rootcause::Report> {
+        Ok(self.stored_attendees.clone())
+    }
+
     async fn get_creation_target(
         &self,
         _requester_id: &str,
@@ -365,6 +375,7 @@ struct FakeProvider {
     rsvp_self_emails: Arc<Mutex<Vec<Vec<String>>>>,
     echo_attendees: Vec<CalendarAttendee>,
     created_drafts: Arc<Mutex<Vec<CalendarEventDraft>>>,
+    updated_patches: Arc<Mutex<Vec<CalendarEventPatch>>>,
 }
 
 impl FakeProvider {
@@ -375,6 +386,7 @@ impl FakeProvider {
             rsvp_self_emails: Arc::new(Mutex::new(Vec::new())),
             echo_attendees: Vec::new(),
             created_drafts: Arc::new(Mutex::new(Vec::new())),
+            updated_patches: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -414,12 +426,13 @@ impl GoogleCalendarMutationProvider for FakeProvider {
         _access_token: &str,
         target: &GoogleCalendarTarget,
         provider_event_id: &str,
-        _patch: &CalendarEventPatch,
+        patch: &CalendarEventPatch,
     ) -> Result<Option<CalendarEventUpsert>, GoogleProviderError> {
         self.calls
             .lock()
             .unwrap()
             .push(format!("update:{provider_event_id}"));
+        self.updated_patches.lock().unwrap().push(patch.clone());
         if let Some(error) = self.fail() {
             return Err(error);
         }
@@ -1197,6 +1210,111 @@ async fn update_validates_lookup_policy_and_addresses_the_series_master() {
         calls.lock().unwrap().as_slice(),
         ["update:master-id"],
         "instance-backed targets patch their recurring master"
+    );
+}
+
+#[test]
+fn preserving_retained_attendee_state_carries_rsvp_and_optional_forward() {
+    let stored = vec![
+        CalendarAttendee {
+            email: "teo@example.com".to_string(),
+            display_name: None,
+            response_status: AttendeeResponseStatus::Accepted,
+            is_organizer: false,
+            is_optional: true,
+            is_self: false,
+            comment: None,
+        },
+        echo_attendee("ada@example.com", false),
+    ];
+    let mut attendees = vec![
+        // Retained guest resent bare: keep the stored RSVP and optional flag,
+        // matched case-insensitively.
+        CalendarAttendeeInput {
+            email: "TEO@example.com".to_string(),
+            is_optional: false,
+            response_status: None,
+        },
+        // Retained guest the caller explicitly re-answers: the caller wins.
+        CalendarAttendeeInput {
+            email: "ada@example.com".to_string(),
+            is_optional: false,
+            response_status: Some(AttendeeResponseStatus::Declined),
+        },
+        // Brand-new invite: no stored state, stays a fresh needs_action.
+        CalendarAttendeeInput {
+            email: "new@example.com".to_string(),
+            is_optional: false,
+            response_status: None,
+        },
+    ];
+
+    preserve_retained_attendee_state(&mut attendees, &stored);
+
+    assert_eq!(
+        attendees[0].response_status,
+        Some(AttendeeResponseStatus::Accepted)
+    );
+    assert!(attendees[0].is_optional);
+    assert_eq!(
+        attendees[1].response_status,
+        Some(AttendeeResponseStatus::Declined)
+    );
+    assert_eq!(attendees[2].response_status, None);
+    assert!(!attendees[2].is_optional);
+}
+
+#[tokio::test]
+async fn updating_attendees_carries_retained_guests_rsvp_through_to_the_provider() {
+    let provider = FakeProvider::new(FakeProviderBehavior::Echo);
+    let patches = provider.updated_patches.clone();
+    let mut accepted = echo_attendee("teo@example.com", false);
+    accepted.response_status = AttendeeResponseStatus::Accepted;
+
+    service(
+        FakeRepo {
+            mutation_target: Some(mutation_target(false)),
+            stored_attendees: vec![accepted],
+            ..FakeRepo::default()
+        },
+        provider,
+        FakeTokens::ok(),
+    )
+    .update_event(
+        "macro|user",
+        Uuid::now_v7(),
+        CalendarEventPatch {
+            attendees: Some(vec![
+                CalendarAttendeeInput {
+                    email: "teo@example.com".to_string(),
+                    is_optional: false,
+                    response_status: None,
+                },
+                CalendarAttendeeInput {
+                    email: "ada@example.com".to_string(),
+                    is_optional: false,
+                    response_status: None,
+                },
+            ]),
+            ..CalendarEventPatch::default()
+        },
+        CalendarUpdateScope::All,
+    )
+    .await
+    .unwrap();
+
+    let sent = patches.lock().unwrap();
+    let attendees = sent[0].attendees.as_ref().expect("attendees forwarded");
+    assert_eq!(attendees[0].email, "teo@example.com");
+    assert_eq!(
+        attendees[0].response_status,
+        Some(AttendeeResponseStatus::Accepted),
+        "a retained guest keeps their RSVP instead of resetting to needs_action"
+    );
+    assert_eq!(attendees[1].email, "ada@example.com");
+    assert_eq!(
+        attendees[1].response_status, None,
+        "a newly invited guest carries no prior RSVP"
     );
 }
 

--- a/crates/calendar_events/src/domain/mutations/test.rs
+++ b/crates/calendar_events/src/domain/mutations/test.rs
@@ -135,8 +135,11 @@ fn draft() -> CalendarEventDraft {
 #[derive(Clone)]
 struct FakeRepo {
     mutation_target: Option<CalendarEventMutationTarget>,
-    /// Attendees a mutation carries forward RSVP/optional state from.
+    /// Series attendees a mutation carries forward RSVP/optional state from.
     stored_attendees: Vec<CalendarAttendee>,
+    /// Occurrence override attendees; `None` means the occurrence inherits the
+    /// series list.
+    occurrence_override_attendees: Option<Vec<CalendarAttendee>>,
     creation_target: Option<CalendarCreationTarget>,
     persisted_event_id: Option<Uuid>,
     /// What the upsert reports doing to the row. `Created` by default, since
@@ -158,6 +161,7 @@ impl Default for FakeRepo {
         Self {
             mutation_target: None,
             stored_attendees: Vec::new(),
+            occurrence_override_attendees: None,
             creation_target: None,
             persisted_event_id: None,
             write_change: CalendarEventChange::Created,
@@ -312,6 +316,14 @@ impl CalendarRepository for FakeRepo {
         Ok(self.stored_attendees.clone())
     }
 
+    async fn get_occurrence_override_attendees(
+        &self,
+        _event_id: Uuid,
+        _recurrence_id: &str,
+    ) -> Result<Option<Vec<CalendarAttendee>>, rootcause::Report> {
+        Ok(self.occurrence_override_attendees.clone())
+    }
+
     async fn get_creation_target(
         &self,
         _requester_id: &str,
@@ -448,11 +460,12 @@ impl GoogleCalendarMutationProvider for FakeProvider {
         target: &GoogleCalendarTarget,
         master_provider_event_id: &str,
         original_start: &str,
-        _patch: &CalendarEventPatch,
+        patch: &CalendarEventPatch,
     ) -> Result<GoogleInstanceUpdateOutcome, GoogleProviderError> {
         self.calls.lock().unwrap().push(format!(
             "instance-update:{master_provider_event_id}:{original_start}"
         ));
+        self.updated_patches.lock().unwrap().push(patch.clone());
         if let Some(error) = self.fail() {
             return Err(error);
         }
@@ -1315,6 +1328,53 @@ async fn updating_attendees_carries_retained_guests_rsvp_through_to_the_provider
     assert_eq!(
         attendees[1].response_status, None,
         "a newly invited guest carries no prior RSVP"
+    );
+}
+
+#[tokio::test]
+async fn occurrence_scoped_attendee_update_prefers_the_occurrence_rsvp_over_the_series() {
+    let provider = FakeProvider::new(FakeProviderBehavior::Echo);
+    let patches = provider.updated_patches.clone();
+
+    let mut series = echo_attendee("teo@example.com", false);
+    series.response_status = AttendeeResponseStatus::Accepted;
+    let mut occurrence = echo_attendee("teo@example.com", false);
+    occurrence.response_status = AttendeeResponseStatus::Declined;
+
+    service(
+        FakeRepo {
+            mutation_target: Some(mutation_target(false)),
+            stored_attendees: vec![series],
+            occurrence_override_attendees: Some(vec![occurrence]),
+            ..FakeRepo::default()
+        },
+        provider,
+        FakeTokens::ok(),
+    )
+    .update_event(
+        "macro|user",
+        Uuid::now_v7(),
+        CalendarEventPatch {
+            attendees: Some(vec![CalendarAttendeeInput {
+                email: "teo@example.com".to_string(),
+                is_optional: false,
+                response_status: None,
+            }]),
+            ..CalendarEventPatch::default()
+        },
+        CalendarUpdateScope::ThisEvent {
+            recurrence_id: "2026-08-18T20:00:00+00:00".to_string(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let sent = patches.lock().unwrap();
+    let attendees = sent[0].attendees.as_ref().expect("attendees forwarded");
+    assert_eq!(
+        attendees[0].response_status,
+        Some(AttendeeResponseStatus::Declined),
+        "an occurrence-scoped edit keeps the guest's per-instance RSVP, not the series status"
     );
 }
 

--- a/crates/calendar_events/src/domain/ports.rs
+++ b/crates/calendar_events/src/domain/ports.rs
@@ -7,16 +7,17 @@ use rootcause::Report;
 use uuid::Uuid;
 
 use super::models::{
-    ActorInboxes, AppliedGoogleGrant, AttendeeResponseStatus, CalendarBackfillClaim,
-    CalendarBackfillFailureDisposition, CalendarBackfillFailureOutcome, CalendarBackfillJobKey,
-    CalendarCreationTarget, CalendarEvent, CalendarEventDraft, CalendarEventMutationTarget,
-    CalendarEventPatch, CalendarEventUpsert, CalendarGrantIntent, CalendarLinkTokenIdentity,
-    CalendarMentionPreview, CalendarMentionRequestItem, CalendarOccurrence,
-    CalendarOccurrenceCursor, CalendarReminderDeliveryOutcome, CalendarReminderDispatchMessage,
-    CalendarReminderFiring, CalendarReminderSweepSummary, CalendarSyncStatus,
-    DisconnectedGoogleCalendar, DueCalendarReminder, GoogleCalendarSyncSnapshot,
-    GoogleCalendarTarget, GoogleEventSyncBatch, GoogleScopeSet, GoogleSyncPlan, GoogleWatchChannel,
-    GoogleWatchConfig, OccurrenceRange, ProviderCalendar, StoredGoogleCalendar, VisibleCalendar,
+    ActorInboxes, AppliedGoogleGrant, AttendeeResponseStatus, CalendarAttendee,
+    CalendarBackfillClaim, CalendarBackfillFailureDisposition, CalendarBackfillFailureOutcome,
+    CalendarBackfillJobKey, CalendarCreationTarget, CalendarEvent, CalendarEventDraft,
+    CalendarEventMutationTarget, CalendarEventPatch, CalendarEventUpsert, CalendarGrantIntent,
+    CalendarLinkTokenIdentity, CalendarMentionPreview, CalendarMentionRequestItem,
+    CalendarOccurrence, CalendarOccurrenceCursor, CalendarReminderDeliveryOutcome,
+    CalendarReminderDispatchMessage, CalendarReminderFiring, CalendarReminderSweepSummary,
+    CalendarSyncStatus, DisconnectedGoogleCalendar, DueCalendarReminder,
+    GoogleCalendarSyncSnapshot, GoogleCalendarTarget, GoogleEventSyncBatch, GoogleScopeSet,
+    GoogleSyncPlan, GoogleWatchChannel, GoogleWatchConfig, OccurrenceRange, ProviderCalendar,
+    StoredGoogleCalendar, VisibleCalendar,
 };
 
 /// Classification supplied by provider adapters to backfill policy.
@@ -487,6 +488,14 @@ pub trait CalendarRepository: Send + Sync + 'static {
         requester_id: &str,
         event_id: Uuid,
     ) -> impl Future<Output = Result<Option<CalendarEventMutationTarget>, Report>> + Send;
+
+    /// The stored attendees of a canonical event. Used to carry each retained
+    /// attendee's RSVP and optional state forward when a mutation replaces the
+    /// attendee list, so adding or dropping one guest does not reset the rest.
+    fn get_event_attendees(
+        &self,
+        event_id: Uuid,
+    ) -> impl Future<Output = Result<Vec<CalendarAttendee>, Report>> + Send;
 
     /// Resolve the calendar a requester-created event lands in: the exact
     /// calendar when one is supplied, otherwise the supplied inbox's primary

--- a/crates/calendar_events/src/domain/ports.rs
+++ b/crates/calendar_events/src/domain/ports.rs
@@ -497,6 +497,17 @@ pub trait CalendarRepository: Send + Sync + 'static {
         event_id: Uuid,
     ) -> impl Future<Output = Result<Vec<CalendarAttendee>, Report>> + Send;
 
+    /// The override attendees of one occurrence, when it carries its own list.
+    /// `None` means the occurrence inherits the series attendees; `Some` (even
+    /// empty) is the occurrence's authoritative list, whose per-instance RSVPs
+    /// must win over the series when an occurrence-scoped mutation replaces the
+    /// attendee list.
+    fn get_occurrence_override_attendees(
+        &self,
+        event_id: Uuid,
+        recurrence_id: &str,
+    ) -> impl Future<Output = Result<Option<Vec<CalendarAttendee>>, Report>> + Send;
+
     /// Resolve the calendar a requester-created event lands in: the exact
     /// calendar when one is supplied, otherwise the supplied inbox's primary
     /// calendar, otherwise the requester's primary inbox's primary calendar.

--- a/crates/calendar_events/src/domain/service/test.rs
+++ b/crates/calendar_events/src/domain/service/test.rs
@@ -100,6 +100,10 @@ impl CalendarRepository for FakeRepo {
         unreachable!("mutation lookups are not exercised by sync tests")
     }
 
+    async fn get_event_attendees(&self, _event_id: Uuid) -> Result<Vec<CalendarAttendee>, Report> {
+        unreachable!("mutation lookups are not exercised by sync tests")
+    }
+
     async fn get_creation_target(
         &self,
         _requester_id: &str,

--- a/crates/calendar_events/src/domain/service/test.rs
+++ b/crates/calendar_events/src/domain/service/test.rs
@@ -104,6 +104,14 @@ impl CalendarRepository for FakeRepo {
         unreachable!("mutation lookups are not exercised by sync tests")
     }
 
+    async fn get_occurrence_override_attendees(
+        &self,
+        _event_id: Uuid,
+        _recurrence_id: &str,
+    ) -> Result<Option<Vec<CalendarAttendee>>, Report> {
+        unreachable!("mutation lookups are not exercised by sync tests")
+    }
+
     async fn get_creation_target(
         &self,
         _requester_id: &str,

--- a/crates/calendar_events/src/outbound/pg.rs
+++ b/crates/calendar_events/src/outbound/pg.rs
@@ -1607,6 +1607,17 @@ impl CalendarRepository for PgCalendarRepository {
             .unwrap_or_default())
     }
 
+    #[tracing::instrument(skip(self), err)]
+    async fn get_occurrence_override_attendees(
+        &self,
+        event_id: Uuid,
+        recurrence_id: &str,
+    ) -> Result<Option<Vec<CalendarAttendee>>, Report> {
+        Ok(fetch_override_attendees(&self.pool, &[event_id])
+            .await?
+            .remove(&(event_id, recurrence_id.to_string())))
+    }
+
     #[tracing::instrument(skip(self, requester_id), err)]
     async fn get_creation_target(
         &self,

--- a/crates/calendar_events/src/outbound/pg.rs
+++ b/crates/calendar_events/src/outbound/pg.rs
@@ -1599,6 +1599,14 @@ impl CalendarRepository for PgCalendarRepository {
         }))
     }
 
+    #[tracing::instrument(skip(self), err)]
+    async fn get_event_attendees(&self, event_id: Uuid) -> Result<Vec<CalendarAttendee>, Report> {
+        Ok(fetch_attendees(&self.pool, &[event_id])
+            .await?
+            .remove(&event_id)
+            .unwrap_or_default())
+    }
+
     #[tracing::instrument(skip(self, requester_id), err)]
     async fn get_creation_target(
         &self,


### PR DESCRIPTION
The event edit composer hard-disabled the guests pill and never sent attendees on update, so invitees couldn't be changed after an event was created. This enables the guests pill for the event's organizer — read-only events and non-organizers stay read-only, since the replacement list is seeded without the viewer-as-guest and would otherwise drop them — and sends the attendee list on update only when it changed. Because a replacement attendee list drops omitted guests' RSVP and optional state (Google reads an omitted responseStatus as needs_action), update_event now carries each retained guest's stored response_status and is_optional forward before writing through to the provider.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes calendar mutation behavior and Google attendee writes; incorrect gating or RSVP merge could drop guests or reset responses, though organizer-only UI rules and new tests narrow the blast radius.
> 
> **Overview**
> **Organizers can change guests when editing an event.** The guests field is no longer always locked in edit mode: it stays read-only for non-organizers, read-only events, and cases where seeding would drop the viewer-as-guest. Shared helpers (`eventGuestEmails`, `viewerCanEditGuests`, `guestListChanged`) drive editor seeding, field disablement, and **conditional** `attendees` on update patches so unchanged lists do not re-notify everyone.
> 
> **Backend attendee updates preserve existing RSVP/optional state.** Before a replacement attendee list is sent to Google, `update_event` loads series attendees (and occurrence overrides for single-instance edits) and merges stored `response_status` and `is_optional` onto retained emails. New repository methods (`get_event_attendees`, `get_occurrence_override_attendees`) back this with Postgres implementations and tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14cc84fb7dd9c3ec11c5c1d4fa39f1bb8d8f27e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->