### PR TITLE
fix(web): keep task composer tags aligned to the title's first line

### DIFF
--- a/apps/web/src/features/block-md/component/ComposeTask.tsx
+++ b/apps/web/src/features/block-md/component/ComposeTask.tsx
@@ -82,6 +82,14 @@ import { SimilarTasksSection } from './TaskDuplicateList';
 
 type ComposerTagLayoutMode = 'bottom' | 'title';
 
+/**
+ * Wrapper for controls that sit beside the composer title (the inline tags
+ * pill) so they stay centered on the title's *first* line rather than drifting
+ * to the middle of a title that wraps onto several lines. `h-7` matches the
+ * `text-xl/7` line box of {@link ComposeTaskTitleEditor}; keep the two in sync.
+ */
+export const COMPOSER_TITLE_LINE_CLASS = 'flex h-7 shrink-0 items-center';
+
 function composerTitleNavigationPlugin(
   bodyEditor: Accessor<LexicalEditor | undefined>,
   ignoreNavigation: Accessor<boolean>
@@ -283,7 +291,7 @@ export function ComposeTaskTitleEditor(props: {
     <div class="relative w-full">
       <div
         contentEditable={!props.disabled()}
-        class="ph-no-capture w-full text-xl font-medium outline-none whitespace-pre-wrap wrap-break-word"
+        class="ph-no-capture w-full text-xl/7 font-medium outline-none whitespace-pre-wrap wrap-break-word [&_p]:my-0! [&_p:empty]:min-h-7"
         ref={(el) => {
           props.ref?.(el);
           onElementConnect(el, () => onConnect(el));
@@ -302,7 +310,7 @@ export function ComposeTaskTitleEditor(props: {
         portalScope={props.portalScope}
       />
       <Show when={showPlaceholder()}>
-        <div class="pointer-events-none absolute top-1.5 text-xl font-medium text-ink-placeholder">
+        <div class="pointer-events-none absolute top-0 text-xl/7 font-medium text-ink-placeholder">
           New task
         </div>
       </Show>
@@ -829,13 +837,15 @@ export function ComposeTask(props: ComposeTaskProps) {
         </Show>
       </div>
       <div class="flex-1 min-h-0 flex flex-col overflow-hidden">
-        <div class="shrink-0 flex gap-2 items-center px-2 mb-4">
+        <div class="shrink-0 flex gap-2 items-start px-2 mb-4">
           <Show when={tagLayoutMode() === 'title'}>
-            <InlineTagsPill
-              docTags={composerTags}
-              showPlaceholder
-              class="shrink-0"
-            />
+            <div class={COMPOSER_TITLE_LINE_CLASS}>
+              <InlineTagsPill
+                docTags={composerTags}
+                showPlaceholder
+                class="shrink-0"
+              />
+            </div>
           </Show>
           <ComposeTaskTitleEditor
             value={title}

--- a/apps/web/src/features/block-md/component/ComposeTask.tsx
+++ b/apps/web/src/features/block-md/component/ComposeTask.tsx
@@ -471,6 +471,16 @@ export function ComposeTask(props: ComposeTaskProps) {
     });
   });
 
+  // A title-mode pill that ends a picker session with no tags left has nothing
+  // to show, so drop it back to the property row instead of leaving an empty
+  // "Tags" chip beside the title. Collapsing on the session end rather than on
+  // the tag removal itself keeps the open picker from unmounting under the user.
+  const handleTitleTagPickerActive = (active: boolean) => {
+    if (active) return;
+    if (composerTags.appliedTags().length > 0) return;
+    setTagLayoutMode('bottom');
+  };
+
   const deleteTitleTagsAtStart = () => {
     if (tagLayoutMode() !== 'title') return false;
     clearComposerTags();
@@ -844,6 +854,7 @@ export function ComposeTask(props: ComposeTaskProps) {
                 docTags={composerTags}
                 showPlaceholder
                 class="shrink-0"
+                onActiveChange={handleTitleTagPickerActive}
               />
             </div>
           </Show>

--- a/apps/web/src/features/channel/Input/TaskComposer.tsx
+++ b/apps/web/src/features/channel/Input/TaskComposer.tsx
@@ -1,4 +1,7 @@
-import { ComposeTaskTitleEditor } from '@block-md/component/ComposeTask';
+import {
+  COMPOSER_TITLE_LINE_CLASS,
+  ComposeTaskTitleEditor,
+} from '@block-md/component/ComposeTask';
 import { InlinePropertyValue } from '@block-md/component/InlinePropertyValue';
 import {
   createTaskComposerProperties,
@@ -279,13 +282,15 @@ export function TaskComposer(props: {
       data-input-task-composer
     >
       <div class="flex flex-col gap-4 px-3 pt-2">
-        <div class="shrink-0 flex gap-2 items-center">
+        <div class="shrink-0 flex gap-2 items-start">
           <Show when={tagLayoutMode() === 'title'}>
-            <InlineTagsPill
-              docTags={composerTags}
-              showPlaceholder
-              class="shrink-0"
-            />
+            <div class={COMPOSER_TITLE_LINE_CLASS}>
+              <InlineTagsPill
+                docTags={composerTags}
+                showPlaceholder
+                class="shrink-0"
+              />
+            </div>
           </Show>
           <ComposeTaskTitleEditor
             value={title}

--- a/apps/web/src/features/channel/Input/TaskComposer.tsx
+++ b/apps/web/src/features/channel/Input/TaskComposer.tsx
@@ -150,6 +150,16 @@ export function TaskComposer(props: {
     });
   }
 
+  // A title-mode pill that ends a picker session with no tags left has nothing
+  // to show, so drop it back to the property row instead of leaving an empty
+  // "Tags" chip beside the title. Collapsing on the session end rather than on
+  // the tag removal itself keeps the open picker from unmounting under the user.
+  const handleTitleTagPickerActive = (active: boolean) => {
+    if (active) return;
+    if (composerTags.appliedTags().length > 0) return;
+    setTagLayoutMode('bottom');
+  };
+
   const deleteTitleTagsAtStart = () => {
     if (tagLayoutMode() !== 'title') return false;
     clearComposerTags();
@@ -289,6 +299,7 @@ export function TaskComposer(props: {
                 docTags={composerTags}
                 showPlaceholder
                 class="shrink-0"
+                onActiveChange={handleTitleTagPickerActive}
               />
             </div>
           </Show>

--- a/apps/web/src/features/property/tags/EntityRowTags.tsx
+++ b/apps/web/src/features/property/tags/EntityRowTags.tsx
@@ -337,6 +337,12 @@ export function InlineTagsPill(props: {
   docTags: DocTags;
   class?: string;
   showPlaceholder?: boolean;
+  /**
+   * Fires when the tag picker session (popover or its editor dialog) opens or
+   * closes. Callers that hide the pill once it has no tags should collapse on
+   * the close rather than mid-interaction, which would tear down the open menu.
+   */
+  onActiveChange?: (active: boolean) => void;
 }) {
   const tags = () => props.docTags.appliedTags();
   const first = () => tags()[0];
@@ -349,11 +355,14 @@ export function InlineTagsPill(props: {
       <Layer depth={2}>
         <TagPicker
           docTags={props.docTags}
+          onActiveChange={props.onActiveChange}
           triggerClass={badgeTriggerClasses({
             variant: 'outline',
             size: 'sm',
             class: cn(
-              'min-w-0 gap-1.5 text-left',
+              // Capped so a long tag label truncates instead of squeezing
+              // whatever shares the row with the pill (e.g. a task title).
+              'min-w-0 max-w-35 gap-1.5 text-left',
               tags().length === 0 && 'text-ink-extra-muted',
               props.class
             ),

--- a/apps/web/src/features/property/tags/TagPicker.tsx
+++ b/apps/web/src/features/property/tags/TagPicker.tsx
@@ -27,6 +27,7 @@ import {
   createSignal,
   For,
   type JSX,
+  on,
   onCleanup,
   onMount,
   Show,
@@ -79,6 +80,14 @@ export type TagPickerProps = {
   children: JSX.Element;
   onOpenChange?: (open: boolean) => void;
   /**
+   * Fires when a picker session starts or ends, where a session covers both the
+   * popover and the tag editor dialog it can hand off to. Consumers that
+   * unmount the trigger once the picker is done (a chip that disappears with
+   * its last tag, say) should wait for this instead of `onOpenChange`, which
+   * reports closed while the editor dialog is still up.
+   */
+  onActiveChange?: (active: boolean) => void;
+  /**
    * Prevent the click that dismisses the picker from activating the element
    * behind it. This matches inline property editors rendered in soup rows.
    */
@@ -100,6 +109,13 @@ export function TagPicker(props: TagPickerProps) {
       triggerRef?.isConnected && triggerRef.focus();
     }, 0);
   };
+
+  const pickerActive = () => open() || editorMode() !== null;
+  createEffect(
+    on(pickerActive, (active) => props.onActiveChange?.(active), {
+      defer: true,
+    })
+  );
 
   const setOpenState = (
     value: boolean,


### PR DESCRIPTION
The title row centered the inline tags pill against the whole title, so a title that wrapped onto several lines dragged the pill down to the middle of the block. Align the row to the top and pin the title's line box with an explicit `text-xl/7`, dropping the editor theme's paragraph margins so the first line starts at the top of the editor. Leading controls now sit in an h-7 wrapper that matches that line box, keeping them on the first line no matter how long the title gets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout and tag-picker interaction changes in task compose UI only; no backend, auth, or persistence logic changes.
> 
> **Overview**
> Fixes **multi-line task titles** dragging the inline tags pill to vertical center: the title row uses **`items-start`**, the title editor gets an explicit **`text-xl/7`** line box (with paragraph margins cleared), and title-adjacent controls sit in the shared **`COMPOSER_TITLE_LINE_CLASS`** (`h-7`) wrapper—applied in both **`ComposeTask`** and channel **`TaskComposer`**.
> 
> Also improves **title-mode tag UX**: **`TagPicker`** exposes **`onActiveChange`** for the full picker session (popover plus editor dialog), so composers can move tags back to the property row only after the user finishes clearing tags—not mid-picker. The inline pill trigger gets **`max-w-35`** so long labels truncate instead of crowding the title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 113265d4b304c1190367ec5b7f6e6d207e368ce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->