### PR TITLE
feat(soup): share email threads from the context menu

### DIFF
--- a/apps/web/src/features/next-soup/actions/make-share-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-share-action.ts
@@ -1,8 +1,8 @@
+import { openGlobalShareModal } from '@app/features/sharing/global-share-modal/GlobalShareModal';
 import {
   isShareableEntityType,
-  openGlobalShareModal,
   type ShareableEntityData,
-} from '@app/features/sharing/global-share-modal/GlobalShareModal';
+} from '@app/features/sharing/global-share-modal/shareable-entity';
 import type { EntityData } from '@entity';
 import type { SoupState } from '../create-soup-state';
 

--- a/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
+++ b/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
@@ -6,7 +6,7 @@ import {
 } from '@app/features/next-soup/utils';
 import { useAllProperties } from '@app/features/property/editor/hooks/useAllProperties';
 import { openPropertyEditor } from '@app/features/property/editor/state/propertyEditor';
-import { isShareableEntityType } from '@app/features/sharing/global-share-modal/GlobalShareModal';
+import { isShareableEntityType } from '@app/features/sharing/global-share-modal/shareable-entity';
 import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
 import type { SplitHandle } from '@components/app/split-layout/layoutManager';
 import { useUserId } from '@core/context/user';

--- a/apps/web/src/features/sharing/global-share-modal/GlobalShareModal.tsx
+++ b/apps/web/src/features/sharing/global-share-modal/GlobalShareModal.tsx
@@ -3,16 +3,12 @@ import { Permissions } from '@core/component/SharePermissions';
 import { ShareModal } from '@core/component/TopBar/ShareButton';
 import { itemToBlockName } from '@core/constant/allBlocks';
 import { createControlledOpenSignal } from '@core/util/createControlledOpenSignal';
-import type { EntityData } from '@entity';
 import type { ItemType } from '@service-storage/client';
 import { createSignal, Show } from 'solid-js';
-
-type ShareableEntityType = 'document' | 'chat' | 'project';
-
-export type ShareableEntityData = Extract<
-  EntityData,
-  { type: ShareableEntityType }
->;
+import {
+  isShareableEntityType,
+  type ShareableEntityData,
+} from './shareable-entity';
 
 type GlobalShareModalProps = {
   entity: ShareableEntityData;
@@ -24,12 +20,6 @@ const [globalModalProps, setGlobalModalProps] =
 const [modalOpen, setModalOpen] = createControlledOpenSignal(false, {
   id: 'global-share',
 });
-
-export const isShareableEntityType = (
-  type: EntityData['type']
-): type is ShareableEntityType => {
-  return type === 'document' || type === 'chat' || type === 'project';
-};
 
 const getEntityBlockAlias = (
   entity: ShareableEntityData

--- a/apps/web/src/features/sharing/global-share-modal/shareable-entity.ts
+++ b/apps/web/src/features/sharing/global-share-modal/shareable-entity.ts
@@ -1,0 +1,25 @@
+import { ENABLE_EMAIL_SHARING } from '@core/constant/featureFlags';
+import type { EntityData } from '@entity';
+
+/** Entity types the global share modal knows how to open. */
+export type ShareableEntityType = 'document' | 'chat' | 'project' | 'email';
+
+/** The subset of {@link EntityData} the global share modal accepts. */
+export type ShareableEntityData = Extract<
+  EntityData,
+  { type: ShareableEntityType }
+>;
+
+/**
+ * Whether an entity type can be shared. Callers use this to decide whether to
+ * offer a Share affordance (soup context menu, hotkey) at all; the modal
+ * itself still enforces permissions.
+ */
+export const isShareableEntityType = (
+  type: EntityData['type']
+): type is ShareableEntityType => {
+  // Email threads share through the same modal, which forwards the thread to
+  // a channel. Gated by the flag that also gates the email block's Share tool.
+  if (type === 'email') return ENABLE_EMAIL_SHARING;
+  return type === 'document' || type === 'chat' || type === 'project';
+};

--- a/apps/web/src/features/sharing/global-share-modal/tests/shareable-entity.test.ts
+++ b/apps/web/src/features/sharing/global-share-modal/tests/shareable-entity.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { isShareableEntityType } from '../shareable-entity';
+
+describe('isShareableEntityType', () => {
+  it('accepts the entity types the share modal can open', () => {
+    expect(isShareableEntityType('document')).toBe(true);
+    expect(isShareableEntityType('chat')).toBe(true);
+    expect(isShareableEntityType('project')).toBe(true);
+    expect(isShareableEntityType('email')).toBe(true);
+  });
+
+  it('rejects entity types with no share flow', () => {
+    expect(isShareableEntityType('channel')).toBe(false);
+    expect(isShareableEntityType('call')).toBe(false);
+    expect(isShareableEntityType('reminder')).toBe(false);
+  });
+});


### PR DESCRIPTION
Email threads were the only shareable entity without a **Share** item in the soup context menu (and its `cmd+shift+s` hotkey).

`isShareableEntityType` covered only `document`, `chat` and `project`, so `makeShareAction.canExecute` returned `false` for email rows and `create-soup-entity-actions` never pushed the item.

## Changes

- Add `email` to the shareable entity types, gated on `ENABLE_EMAIL_SHARING` — the same flag that gates the email block's Share tool. The share modal already handles `email`: it forwards the thread to a channel via `editThread`, hides the access-level selector, and disables link sharing for that item type.
- Move `ShareableEntityType` / `ShareableEntityData` / `isShareableEntityType` into `shareable-entity.ts`, so callers that only need the predicate (`use-entity-action-hotkeys`) no longer import the modal and its transitive websocket clients. That also makes the predicate unit-testable, and a test covers it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEEgcNHpgY6GUWc4oNd8xi)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to when Share UI appears and a small module split; email sharing still goes through the existing global share modal and is feature-flagged.
> 
> **Overview**
> **Email threads** can now show **Share** in the soup context menu and share hotkey, matching document/chat/project behavior when **`ENABLE_EMAIL_SHARING`** is on—the same flag as the email block’s Share tool.
> 
> Share eligibility moves into **`shareable-entity.ts`**: **`isShareableEntityType`** now treats **`email`** as shareable only under that flag, while **`ShareableEntityType` / `ShareableEntityData`** live there too. Soup actions and hotkeys import this module instead of **`GlobalShareModal`**, avoiding heavy modal/websocket dependencies; the modal still imports the shared helper. Unit tests cover accepted vs rejected entity types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6277084c5823ca9834b18ab8494af7371cf325f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->