### PR TITLE
style(core): add shared link hover card style

### DIFF
--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/core/LinkWithPreview.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/core/LinkWithPreview.tsx
@@ -1,4 +1,4 @@
-import { UnfurlLink } from '@core/component/Link';
+import { LinkHoverCard } from '@core/component/Link';
 import { ScopedPortal } from '@core/component/ScopedPortal';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { useUnfurl } from '@core/signal/unfurl';
@@ -10,13 +10,13 @@ import { floatWithElement } from '../../directive/floatWithElement';
 
 false && floatWithElement;
 
-type UnfurlLinkProps = ParentProps<{
+type LinkWithPreviewProps = ParentProps<{
   url: string;
   title?: string;
   class?: string;
 }>;
 
-export function LinkWithPreview(props: UnfurlLinkProps) {
+export function LinkWithPreview(props: LinkWithPreviewProps) {
   const [previewOpen, setPreviewOpen] = createSignal(false);
   const debouncedSetPreviewOpen = debounce((val: boolean) => {
     setPreviewOpen(val);
@@ -57,7 +57,7 @@ export function LinkWithPreview(props: UnfurlLinkProps) {
       <Show when={previewOpen()}>
         <ScopedPortal>
           <div
-            class="absolute bg-surface rounded-xs border border-edge-muted left-0 z-10 shadow-lg max-w-72"
+            class="absolute left-0 z-10"
             style={{
               transform: 'translateY(0)',
             }}
@@ -66,10 +66,10 @@ export function LinkWithPreview(props: UnfurlLinkProps) {
             {(() => {
               const data = unfurlData();
               if (data?.type === 'success') {
-                return <UnfurlLink unfurled={data.data} />;
+                return <LinkHoverCard unfurled={data.data} />;
               }
               return (
-                <UnfurlLink
+                <LinkHoverCard
                   unfurled={{
                     url: props.url,
                     title: props.title ?? '',

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/menu/FloatingLinkMenu.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/menu/FloatingLinkMenu.tsx
@@ -1,4 +1,4 @@
-import { UnfurlLink } from '@core/component/Link';
+import { LinkHoverCard } from '@core/component/Link';
 import { ScopedPortal } from '@core/component/ScopedPortal';
 import { toast } from '@core/component/Toast/Toast';
 import clickOutside from '@core/directive/clickOutside';
@@ -379,31 +379,25 @@ export function FloatingLinkMenu(props: {
           {(link) => (
             <ScopedPortal>
               <div
-                class="fixed top-0 left-0 z-modal-content w-80 max-w-[calc(100vw-1rem)]"
+                class="fixed top-0 left-0 z-modal-content"
                 use:floatWithElement={{
                   element: () => link().linkRef,
                   useBlockBoundary: true,
                 }}
               >
-                <Surface
-                  depth={2}
-                  class="rounded-xl p-1.5 shadow-lg shadow-drop-shadow"
+                <Show
+                  when={unfurledDetails()}
+                  fallback={
+                    <LinkHoverCard
+                      unfurled={{
+                        url: link().url ?? '',
+                        title: link().linkText ?? '',
+                      }}
+                    />
+                  }
                 >
-                  <Show
-                    when={unfurledDetails()}
-                    fallback={
-                      <UnfurlLink
-                        size="sm"
-                        unfurled={{
-                          url: link().url ?? '',
-                          title: link().linkText ?? '',
-                        }}
-                      />
-                    }
-                  >
-                    {(details) => <UnfurlLink size="sm" unfurled={details()} />}
-                  </Show>
-                </Surface>
+                  {(details) => <LinkHoverCard unfurled={details()} />}
+                </Show>
               </div>
             </ScopedPortal>
           )}

--- a/apps/web/src/lib/core/component/Link.tsx
+++ b/apps/web/src/lib/core/component/Link.tsx
@@ -36,9 +36,7 @@ export function LinkHoverCard(props: LinkHoverCardProps) {
   const title = () => props.unfurled.title || domain;
 
   return (
-    <div
-      class="flex w-80 max-w-[calc(100vw-1rem)] items-start gap-1 rounded-xl border border-edge p-2 text-left shadow-menu bg-menu"
-    >
+    <div class="flex w-80 max-w-[calc(100vw-1rem)] items-start gap-1 rounded-xl border border-edge p-2 text-left shadow-menu bg-menu">
       <div class="flex size-6 shrink-0 items-center justify-center">
         <Show
           when={props.unfurled.favicon_url}
@@ -63,9 +61,7 @@ export function LinkHoverCard(props: LinkHoverCardProps) {
         </Show>
       </div>
       <div class="min-w-0 flex-1">
-        <div class="truncate text-sm/6 font-medium text-ink">
-          {title()}
-        </div>
+        <div class="truncate text-sm/6 font-medium text-ink">{title()}</div>
         <div class="truncate text-xs text-ink-muted">{domain}</div>
       </div>
     </div>

--- a/apps/web/src/lib/core/component/Link.tsx
+++ b/apps/web/src/lib/core/component/Link.tsx
@@ -1,12 +1,9 @@
 import { openExternalUrl } from '@core/util/url';
-import CaretDown from '@phosphor/caret-down.svg';
-import CaretRight from '@phosphor/caret-right.svg';
-import GlobeIcon from '@phosphor/globe-simple.svg';
 import LinkIcon from '@phosphor/link.svg';
 import { proxyResource } from '@service-unfurl/client';
 import type { GetUnfurlResponse } from '@service-unfurl/generated/schemas/getUnfurlResponse';
 import { cn } from '@ui';
-import { createSignal, For, Show } from 'solid-js';
+import { Show } from 'solid-js';
 import { createStore } from 'solid-js/store';
 
 function extractDomain(url: string) {

--- a/apps/web/src/lib/core/component/Link.tsx
+++ b/apps/web/src/lib/core/component/Link.tsx
@@ -24,6 +24,54 @@ type UnfurlLinkProps = {
   size?: 'xs' | 'sm';
 };
 
+type LinkHoverCardProps = {
+  unfurled: GetUnfurlResponse;
+};
+
+/**
+ * The shared card shown when hovering a link in rendered or editable Markdown.
+ */
+export function LinkHoverCard(props: LinkHoverCardProps) {
+  const domain = extractDomain(props.unfurled.url);
+  const title = () => props.unfurled.title || domain;
+
+  return (
+    <div
+      class="flex w-80 max-w-[calc(100vw-1rem)] items-start gap-1 rounded-xl border border-edge p-2 text-left shadow-menu bg-menu"
+    >
+      <div class="flex size-6 shrink-0 items-center justify-center">
+        <Show
+          when={props.unfurled.favicon_url}
+          fallback={<LinkIcon class="size-4 text-ink-muted" />}
+        >
+          {(icon) => (
+            <Show
+              when={!badLinks[icon()]}
+              fallback={<LinkIcon class="size-4 text-ink-muted" />}
+            >
+              <img
+                src={proxyResource(icon())}
+                class="size-5 rounded-md object-cover"
+                crossorigin="anonymous"
+                alt=""
+                on:error={() => {
+                  setBadLinks(icon(), true);
+                }}
+              />
+            </Show>
+          )}
+        </Show>
+      </div>
+      <div class="min-w-0 flex-1">
+        <div class="truncate text-sm/6 font-medium text-ink">
+          {title()}
+        </div>
+        <div class="truncate text-xs text-ink-muted">{domain}</div>
+      </div>
+    </div>
+  );
+}
+
 export function UnfurlLink(props: UnfurlLinkProps) {
   const domain = extractDomain(props.unfurled.url);
 
@@ -72,72 +120,6 @@ export function UnfurlLink(props: UnfurlLinkProps) {
             {domain}
           </h2>
         </div>
-      </div>
-    </div>
-  );
-}
-
-interface UnfurledLinkCollection {
-  collapsed?: boolean;
-  links: GetUnfurlResponse[];
-}
-
-function _UnfurledLinkCollection(props: UnfurledLinkCollection) {
-  const [isCollapsed, setIsCollapsed] = createSignal(props.collapsed ?? true);
-
-  return (
-    <div class="border border-edge rounded-lg w-full text-sm cursor-default select-none">
-      <div
-        class={cn(
-          'flex justify-between items-center hover:bg-hover transition-colors hover:transition-none py-1 px-2',
-          isCollapsed() ? 'rounded-lg' : 'rounded-t-lg'
-        )}
-        onClick={() => setIsCollapsed((p) => !p)}
-      >
-        <div>
-          <div class="flex items-center gap-2">
-            <GlobeIcon class="size-6" />
-            <div>
-              <div class="flex items-center gap-1 font-medium">Sources</div>
-              <div class="flex gap-1 text-xs">
-                <p class="font-medium text-ink-muted">
-                  {props.links.length > 0
-                    ? extractDomain(
-                        typeof props.links[0] === 'string'
-                          ? props.links[0]
-                          : props.links[0].url
-                      )
-                    : ''}
-                </p>
-                <Show when={props.links.length > 1}>
-                  <p class="font-medium text-accent">
-                    +{props.links.length - 1} More
-                  </p>
-                </Show>
-              </div>
-            </div>
-          </div>
-        </div>
-        <Show
-          when={isCollapsed()}
-          fallback={<CaretDown width={20} height={20} />}
-        >
-          <CaretRight width={20} height={20} />
-        </Show>
-      </div>
-      <div
-        class={cn(
-          'flex flex-col divide-y divide-edge transition-all duration-150 ease-in-out overflow-clip',
-          isCollapsed() ? 'collapse max-h-0' : 'visible max-h-480'
-        )}
-      >
-        <For each={props.links}>
-          {(link) => (
-            <div class="first:border-edge first:border-t last:rounded-b-md overflow-clip">
-              <UnfurlLink unfurled={link} />
-            </div>
-          )}
-        </For>
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only refactor of link preview presentation in Lexical Markdown; no auth, data, or API changes.
> 
> **Overview**
> Introduces **`LinkHoverCard`** as the shared unfurl preview UI for Markdown link hovers (rendered and editor), replacing **`UnfurlLink`** in **`LinkWithPreview`** and **`FloatingLinkMenu`**.
> 
> The new card uses menu surface styling (`bg-menu`, `shadow-menu`, fixed width) with favicon, title, and domain only—no click-to-open row behavior. Preview wrappers drop redundant **`Surface`** / border classes so layout and chrome live on the card.
> 
> **`UnfurlLink`** stays for other contexts (e.g. web search results). Unused **`_UnfurledLinkCollection`** and related icons are removed from **`Link.tsx`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7871417407909f10cffa43341b1867486dc61e18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->