### PR TITLE
fix(web): avoid re-parsing tool responses on every streamed character

### DIFF
--- a/apps/web/src/lib/core/component/AI/component/tool/handler.tsx
+++ b/apps/web/src/lib/core/component/AI/component/tool/handler.tsx
@@ -3,6 +3,7 @@ import {
   deserializeToolResponse,
   type ToolName,
 } from '@service-cognition/generated/tools/tool';
+import { createMemo } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
 import { bashCodeExecutionHandler } from './BashCodeExecution';
 import {
@@ -215,18 +216,47 @@ export function RenderTool(props: ToolProps) {
     isComplete: props.isComplete,
   };
 
-  const response = () => {
-    if (!props.response) return undefined;
+  /*
+   Every streamed character rebuilds the message parts (and the response map),
+   giving `props.response` a fresh object identity even though its `json`
+   payload is reference-stable once the tool result has arrived. Compare by
+   field identity so the expensive parse below only re-runs when the response
+   actually changes.
+  */
+  const responseInput = createMemo(
+    () =>
+      props.response
+        ? {
+            id: props.tool_id,
+            json: props.response.json,
+            name: props.response.name,
+          }
+        : undefined,
+    undefined,
+    {
+      equals: (a, b) =>
+        a?.id === b?.id && a?.json === b?.json && a?.name === b?.name,
+    }
+  );
+
+  /*
+   Deserializing runs a full zod parse of the tool payload. Unmemoized, it
+   re-ran per read site in every tool component on each streamed character,
+   which made streaming crawl on messages with completed tool calls.
+  */
+  const response = createMemo(() => {
+    const input = responseInput();
+    if (!input) return undefined;
 
     const maybeResponse = deserializeToolResponse({
-      id: props.tool_id,
-      json: props.response.json,
-      name: props.response.name as ToolName,
+      id: input.id,
+      json: input.json,
+      name: input.name as ToolName,
     });
 
     if (maybeResponse.isErr()) return undefined;
     return maybeResponse.value;
-  };
+  });
 
   return (
     <ToolErrorContext.Provider


### PR DESCRIPTION
---
_Generated by [Claude Code](https://claude.ai/code/session_01BWgis9f8oZ13Uw9o5JgUE3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only change in AI tool rendering; deserialization logic and outputs are unchanged when tool response data changes.
> 
> **Overview**
> **Fixes sluggish chat streaming** when a message already has completed tool calls by memoizing tool response handling in `RenderTool`.
> 
> Streaming rebuilds message parts so `props.response` gets a new object reference on every character even when `json` is unchanged. A **`responseInput` memo** with custom equality on `id`, `json`, and `name` gates updates, and a second **`response` memo** runs `deserializeToolResponse` (full Zod parse) only when that input actually changes instead of on every render/read during streaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd02f1c9a4e1c5f227e16e94d321300d7432857c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->