### PR TITLE
fix(calendar): stop in-calendar search preview from flashing and resetting grid scroll

### DIFF
--- a/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
+++ b/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
@@ -124,6 +124,7 @@ function CalendarEventPreviewContent(props: {
   const organizer = () =>
     props.event.organizer?.name || props.event.organizer?.email || '';
   const detail = () => {
+    if (previewQuery.isPending) return '';
     const preview = previewQuery.data;
     if (!preview) return '';
     const guests =

--- a/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
+++ b/apps/web/src/features/block-calendar/components/CalendarSearch.tsx
@@ -389,7 +389,10 @@ function CalendarSearchControl() {
                             moveActive(-1);
                           } else if (event.key === 'Enter') {
                             const active = results()[activeIndex()];
-                            if (active) openResult(active);
+                            if (active) {
+                              event.preventDefault();
+                              openResult(active);
+                            }
                           }
                         }}
                         placeholder="Search by event name"


### PR DESCRIPTION
Two follow-ups to #6057: cancel the Enter keydown so its default activation can't click the preview's freshly focused Back button (which instantly closed the preview and re-selected the input text), and guard the mention-preview query with `isPending` so reading `data` while pending no longer suspends the split's Suspense boundary — that detached the calendar behind the popover and the browser dropped its scroll position, snapping the grid back to midnight on the first Enter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX fixes in calendar search keyboard handling and preview loading; no auth, data, or API changes.
> 
> **Overview**
> Fixes two regressions in **in-calendar event search** when opening an out-of-range result or confirming a hit with **Enter**.
> 
> The read-only preview no longer reads mention-preview **`data` while the query is still pending**—it shows empty supplemental detail until load finishes—so the split **Suspense** boundary isn’t triggered and the calendar grid behind the popover keeps its scroll position instead of jumping back to midnight.
> 
> **Enter** on a highlighted result now calls **`preventDefault`** before opening the result, so the key’s default action can’t activate the preview’s auto-focused **Back** button (which immediately closed the preview and re-selected the search field).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8462695a61a12967b83bb8006cf551a473272bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->