### PR TITLE
fix(calendar): stop event details popover from blocking inbox arrow-key navigation

### DIFF
--- a/apps/web/src/features/block-calendar/components/SelectedEventDetails.tsx
+++ b/apps/web/src/features/block-calendar/components/SelectedEventDetails.tsx
@@ -415,6 +415,14 @@ function EventDetailsPopover(props: EventDetailsPopoverProps) {
                 event.preventDefault();
               }
             }}
+            onOpenAutoFocus={(event) => {
+              // Aims can arrive while the keyboard is elsewhere — arrow-key
+              // scanning in the inbox previews a calendar notification here,
+              // and auto-focusing the popover would silence the list's
+              // navigation hotkeys (hotkey scope follows focus). Escape
+              // still closes it from anywhere via the document listener.
+              event.preventDefault();
+            }}
             onFocusOutside={(event) => {
               // Deep links open this popover while their freshly-opened
               // split is still claiming focus; that focus movement lands


### PR DESCRIPTION
Arrow-key navigation in the inbox previews a calendar notification into the viewer split, where the event details popover auto-focused its first button on mount; hotkey scope follows focus, so the list's arrow-key hotkeys went silent and navigation got stuck. Prevent the popover's open auto-focus (matching the composer popovers) — it is already built to live without focus, and Escape still closes it via the document listener.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UX/focus handler on a calendar popover with no auth, data, or API changes.
> 
> **Overview**
> When inbox arrow-key navigation previews a calendar notification, the **event details popover** no longer steals focus on open.
> 
> `EventDetailsPopover` now sets **`onOpenAutoFocus`** with `preventDefault()`, aligned with calendar composer popovers. Hotkey scope stays on the inbox list so arrow keys keep working; the popover still dismisses via pointer-outside and **Escape** (document listener), and existing **`onFocusOutside`** / **`onCloseAutoFocus`** behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdca84d332a244c54f10a73f1178a76881ecd2f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->