### PR TITLE
fix(calendar): all day event creation

### DIFF
--- a/apps/web/src/components/app/app-sidebar/calendar-sidebar-preview.tsx
+++ b/apps/web/src/components/app/app-sidebar/calendar-sidebar-preview.tsx
@@ -303,6 +303,7 @@ function PreviewContent(props: { dropdownMount?: HTMLElement }) {
         <ScrollIndicators
           scrollRef={scrollElement}
           appearance="gradient"
+          gradientColor="panel"
           noBorderStart
           noBorderEnd
         />

--- a/apps/web/src/features/block-calendar/components/Page.tsx
+++ b/apps/web/src/features/block-calendar/components/Page.tsx
@@ -116,6 +116,7 @@ function CalendarScrollIndicators(props: {
           <ScrollIndicators
             scrollRef={() => scrollTarget.scrollElement}
             appearance="gradient"
+            gradientColor="panel"
             class="h-6"
           />
         </Portal>

--- a/apps/web/src/features/calendar/calendar.css
+++ b/apps/web/src/features/calendar/calendar.css
@@ -281,16 +281,28 @@
 	pointer-events: none;
 }
 
+.calendar-view
+	.fc
+	.fc-timegrid-col-events
+	.calendar-multi-day-selection-preview-event,
+.calendar-view
+	.fc
+	.fc-timegrid-bg
+	.calendar-multi-day-selection-preview-event,
+.calendar-view
+	.fc
+	.fc-timegrid-col-bg
+	.calendar-multi-day-selection-preview-event {
+	display: none;
+}
+
 .calendar-view .fc .fc-highlight {
 	inset: 2px;
 }
 
-.calendar-view .fc .fc-dayGridMonth-view .fc-highlight {
-	top: 1.5rem;
-	right: 0.375rem;
-	bottom: auto;
-	left: 0.375rem;
-	height: 1rem;
+/* All-day and month selections render as a stacked preview chip. */
+.calendar-view .fc .fc-daygrid-body .fc-highlight {
+	display: none;
 }
 
 /* Timed selections already render an event mirror; hide its backing fill. */

--- a/apps/web/src/features/calendar/calendar.css
+++ b/apps/web/src/features/calendar/calendar.css
@@ -539,12 +539,77 @@
 	background: transparent;
 }
 
-.calendar-view .fc .fc-event:hover .calendar-event-content {
-	background-color: var(--color-hover);
-}
-
 .calendar-view .fc .fc-event:focus-visible .calendar-event-content {
 	background-color: var(--color-active);
+}
+
+@media (hover: hover) {
+	.calendar-view
+		.fc
+		.fc-event:hover:not(.fc-event-mirror):not(
+			.calendar-multi-day-selection-preview-event
+		):not(:has(.calendar-event-content-selected)) {
+		--fc-event-bg-color: color-mix(
+			in oklch,
+			var(--event-calendar-color, var(--color-calendar)) 18%,
+			var(--color-surface)
+		);
+		--fc-event-text-color: var(--color-ink);
+		box-shadow:
+			0 0 0 1px
+			color-mix(
+				in oklch,
+				var(--event-calendar-color, var(--color-calendar)) 55%,
+				transparent
+			);
+	}
+
+	.calendar-view
+		.fc
+		.fc-event:hover:not(.fc-event-mirror):not(
+			.calendar-multi-day-selection-preview-event
+		):not(:has(.calendar-event-content-selected))
+		.calendar-event-content {
+		background-color: color-mix(
+			in oklch,
+			var(--event-calendar-color, var(--color-calendar)) 20%,
+			transparent
+		);
+	}
+
+	.calendar-view
+		.fc
+		.fc-event:hover:not(.fc-event-mirror):not(
+			.calendar-multi-day-selection-preview-event
+		):not(:has(.calendar-event-content-selected)):has(
+			[data-response-status="accepted"]
+		) {
+		background-image: linear-gradient(
+			color-mix(
+				in oklch,
+				var(--event-calendar-color, var(--color-calendar)) 42%,
+				transparent
+			),
+			color-mix(
+				in oklch,
+				var(--event-calendar-color, var(--color-calendar)) 42%,
+				transparent
+			)
+		);
+	}
+
+	.calendar-view
+		.fc
+		.fc-dayGridMonth-view
+		.fc-daygrid-dot-event:hover:not(:has(.calendar-event-content-selected)) {
+		--fc-event-bg-color: color-mix(
+			in oklch,
+			var(--event-calendar-color, var(--color-calendar)) 16%,
+			var(--color-surface)
+		);
+		background-color: var(--fc-event-bg-color);
+		background-image: none;
+	}
 }
 
 .calendar-view .fc .fc-event:has(.calendar-event-content-selected) {

--- a/apps/web/src/features/calendar/calendar.css
+++ b/apps/web/src/features/calendar/calendar.css
@@ -646,11 +646,16 @@
 
 .calendar-view .fc .fc-timegrid .fc-daygrid-day-frame,
 .calendar-view .fc .fc-timegrid .fc-daygrid-day-events {
-	min-height: 1.5rem;
+	min-height: 3rem;
 }
 
 .calendar-view .fc .fc-timegrid .fc-daygrid-day-events {
 	margin-bottom: 0;
+}
+
+/* Empty create strip after the chip stack, including when events already exist. */
+.calendar-view .fc .fc-timegrid .fc-daygrid-day-bottom {
+	min-height: 1.5rem;
 }
 
 .calendar-view .fc .fc-timegrid-divider {

--- a/apps/web/src/features/calendar/calendar.css
+++ b/apps/web/src/features/calendar/calendar.css
@@ -658,6 +658,69 @@
 	min-height: 1.5rem;
 }
 
+/*
+ * Keep a fixed all-day slot in the scrollgrid so extra chips grow over the
+ * time grid instead of shrinking it and shifting the hour rows.
+ */
+.calendar-view
+	.fc
+	.fc-timegrid
+	.fc-scrollgrid-section-body:not(.fc-scrollgrid-section-liquid):has(
+		.fc-daygrid-body
+	)
+	> td {
+	position: relative;
+	z-index: 4;
+	height: 3rem;
+	max-height: 3rem;
+	overflow: visible;
+	vertical-align: top;
+	border-bottom-width: 0;
+}
+
+.calendar-view
+	.fc
+	.fc-timegrid
+	.fc-scrollgrid-section-body:not(.fc-scrollgrid-section-liquid):has(
+		.fc-daygrid-body
+	)
+	.fc-scroller-harness {
+	position: absolute;
+	top: 0;
+	right: 0;
+	left: 0;
+	z-index: 4;
+	height: auto;
+	min-height: 100%;
+	overflow: visible;
+}
+
+.calendar-view
+	.fc
+	.fc-timegrid
+	.fc-scrollgrid-section-body:not(.fc-scrollgrid-section-liquid):has(
+		.fc-daygrid-body
+	)
+	.fc-daygrid-body,
+.calendar-view
+	.fc
+	.fc-timegrid
+	.fc-scrollgrid-section-body:not(.fc-scrollgrid-section-liquid):has(
+		.fc-daygrid-body
+	)
+	.fc-daygrid-body
+	> table {
+	height: auto;
+}
+
+.calendar-view .fc .fc-timegrid .fc-daygrid-body {
+	border-bottom: var(--app-border-width) solid var(--fc-border-color);
+}
+
+.calendar-view .fc .fc-timegrid .fc-scrollgrid-section-liquid > td {
+	border-top-width: 0;
+}
+
 .calendar-view .fc .fc-timegrid-divider {
 	height: 0;
 	padding: 0;

--- a/apps/web/src/features/calendar/components/CalendarGridSkeleton.tsx
+++ b/apps/web/src/features/calendar/components/CalendarGridSkeleton.tsx
@@ -47,13 +47,13 @@ export function CalendarGridSkeleton(props: {
           class="grid shrink-0 border-b border-edge-muted"
           style={{ 'grid-template-columns': dayColumns() }}
         >
-          <div class="flex h-8 items-center justify-end pr-2">
+          <div class="flex h-12 items-center justify-end pr-2">
             <div class="h-2 w-7 rounded-full bg-skeleton" />
           </div>
           <For each={days()}>
             {() => (
-              <div class="h-8 border-l border-edge-muted px-1 py-2">
-                <div class="h-full w-1/3 rounded bg-skeleton" />
+              <div class="h-12 border-l border-edge-muted px-1 py-2">
+                <div class="h-5 w-1/3 rounded bg-skeleton" />
               </div>
             )}
           </For>

--- a/apps/web/src/features/calendar/utils/fullcalendar-multi-day-selection.ts
+++ b/apps/web/src/features/calendar/utils/fullcalendar-multi-day-selection.ts
@@ -15,6 +15,8 @@ const PREVIEW_INSTANCE_ID = '__calendar-multi-day-selection-preview-instance__';
 const PREVIEW_EXTENDED_PROP = 'calendarMultiDaySelectionPreview';
 
 const previewUi: EventUi = {
+  // Block + all-day only. Background all-day events are also painted through
+  // the timed columns, which stretches the preview down the hour grid.
   display: 'block',
   startEditable: false,
   durationEditable: false,
@@ -27,11 +29,26 @@ const previewUi: EventUi = {
   classNames: ['calendar-multi-day-selection-preview-event'],
 };
 
-/** Whether a rendered FullCalendar event is the multi-day selection preview. */
+/** Whether a rendered FullCalendar event is the date-selection preview. */
 export function isMultiDaySelectionPreview(
   event: Pick<EventApi, 'extendedProps'>
 ) {
   return event.extendedProps[PREVIEW_EXTENDED_PROP] === true;
+}
+
+/**
+ * Whether a date selection should render as an all-day preview chip
+ * rather than FullCalendar's cell highlight overlay.
+ */
+export function shouldRenderSelectionAsAllDayPreview(selection: {
+  allDay: boolean;
+  start: Date;
+  end: Date;
+}) {
+  return (
+    selection.allDay ||
+    multiDayTimedDisplayRange(selection.start, selection.end) !== undefined
+  );
 }
 
 function createPreviewStore(range: EventInstance['range']): EventStore {
@@ -68,21 +85,17 @@ function createPreviewStore(range: EventInstance['range']): EventStore {
 class MultiDaySelectionViewPropsTransformer implements ViewPropsTransformer {
   transform(viewProps: ViewProps, calendarProps: CalendarContentProps) {
     const selection = viewProps.dateSelection;
-    if (!selection || selection.allDay) return {};
+    if (!selection) return {};
 
-    const displayRange = multiDayTimedDisplayRange(
-      calendarProps.dateEnv.toDate(selection.range.start),
-      calendarProps.dateEnv.toDate(selection.range.end)
-    );
-    if (!displayRange) return {};
+    const previewRange = selection.allDay
+      ? selection.range
+      : timedSelectionPreviewRange(selection.range, calendarProps);
+    if (!previewRange) return {};
 
-    const previewStore = createPreviewStore({
-      start: calendarProps.dateEnv.createMarker(displayRange.start),
-      end: calendarProps.dateEnv.createMarker(displayRange.end),
-    });
+    const previewStore = createPreviewStore(previewRange);
 
     // Replace only the view projection. FullCalendar's canonical selection and
-    // select callback retain the exact timed range used by the event composer.
+    // select callback retain the exact range used by the event composer.
     return {
       dateSelection: null,
       eventStore: {
@@ -99,7 +112,23 @@ class MultiDaySelectionViewPropsTransformer implements ViewPropsTransformer {
   }
 }
 
-/** Renders multi-day timed selections as foreground all-day preview events. */
+function timedSelectionPreviewRange(
+  range: EventInstance['range'],
+  calendarProps: CalendarContentProps
+) {
+  const displayRange = multiDayTimedDisplayRange(
+    calendarProps.dateEnv.toDate(range.start),
+    calendarProps.dateEnv.toDate(range.end)
+  );
+  if (!displayRange) return undefined;
+
+  return {
+    start: calendarProps.dateEnv.createMarker(displayRange.start),
+    end: calendarProps.dateEnv.createMarker(displayRange.end),
+  };
+}
+
+/** Renders all-day and multi-day selections as a chip above existing all-day events. */
 export const multiDaySelectionRenderingPlugin = createPlugin({
   name: 'calendar-multi-day-selection-rendering',
   viewPropsTransformers: [MultiDaySelectionViewPropsTransformer],

--- a/apps/web/src/lib/core/component/VerticalScrollIndicators.tsx
+++ b/apps/web/src/lib/core/component/VerticalScrollIndicators.tsx
@@ -3,6 +3,19 @@ import { type Accessor, createEffect, onCleanup } from 'solid-js';
 
 const SCROLL_THRESHOLD = 20;
 
+const GRADIENT_COLOR = {
+  surface: 'var(--color-surface)',
+  panel: 'var(--color-panel)',
+  page: 'var(--color-page)',
+  inset: 'var(--color-inset)',
+  lift: 'var(--color-lift)',
+  dialog: 'var(--color-dialog)',
+  menu: 'var(--color-menu)',
+} as const;
+
+/** Fade start color for `appearance="gradient"`. Defaults to surface. */
+export type ScrollIndicatorGradientColor = keyof typeof GRADIENT_COLOR;
+
 function thresholdOpacity(distance: number) {
   return Math.max(0, Math.min(distance, SCROLL_THRESHOLD) / SCROLL_THRESHOLD);
 }
@@ -16,6 +29,7 @@ export const ScrollIndicators = (props: {
   scrollRef: Accessor<HTMLElement | undefined>;
   direction?: 'vertical' | 'horizontal';
   appearance?: 'pattern' | 'gradient';
+  gradientColor?: ScrollIndicatorGradientColor;
   class?: string;
   noBorderStart?: boolean;
   noBorderEnd?: boolean;
@@ -25,6 +39,12 @@ export const ScrollIndicators = (props: {
 
   const isHorizontal = () => props.direction === 'horizontal';
   const isGradient = () => props.appearance === 'gradient';
+  const gradientColor = () =>
+    GRADIENT_COLOR[props.gradientColor ?? 'surface'];
+  const gradientStyle = () =>
+    isGradient()
+      ? { '--scroll-indicator-from': gradientColor() }
+      : undefined;
 
   const updateIndicators = () => {
     const ref = props.scrollRef();
@@ -72,12 +92,13 @@ export const ScrollIndicators = (props: {
       <div
         ref={startIndicator}
         aria-hidden="true"
+        style={gradientStyle()}
         class={cn(
           'pointer-events-none absolute z-annotation-layer',
           isGradient()
             ? isHorizontal()
-              ? 'inset-y-0 left-0 w-4 bg-linear-to-r from-surface to-transparent transition-opacity'
-              : 'inset-x-0 top-0 h-4 bg-linear-to-b from-surface to-transparent transition-opacity'
+              ? 'inset-y-0 left-0 w-4 bg-linear-to-r from-(--scroll-indicator-from) to-transparent transition-opacity'
+              : 'inset-x-0 top-0 h-4 bg-linear-to-b from-(--scroll-indicator-from) to-transparent transition-opacity'
             : isHorizontal()
               ? cn(
                   'inset-y-px left-0 w-3 mask-r-from-0% pattern-diagonal-4 pattern-edge',
@@ -93,12 +114,13 @@ export const ScrollIndicators = (props: {
       <div
         ref={endIndicator}
         aria-hidden="true"
+        style={gradientStyle()}
         class={cn(
           'pointer-events-none absolute z-annotation-layer',
           isGradient()
             ? isHorizontal()
-              ? 'inset-y-0 right-0 w-4 bg-linear-to-l from-surface to-transparent transition-opacity'
-              : 'inset-x-0 bottom-0 h-4 bg-linear-to-t from-surface to-transparent transition-opacity'
+              ? 'inset-y-0 right-0 w-4 bg-linear-to-l from-(--scroll-indicator-from) to-transparent transition-opacity'
+              : 'inset-x-0 bottom-0 h-4 bg-linear-to-t from-(--scroll-indicator-from) to-transparent transition-opacity'
             : isHorizontal()
               ? cn(
                   'inset-y-px right-0 w-3 mask-l-from-0% pattern-diagonal-4 pattern-edge',

--- a/apps/web/src/lib/core/component/VerticalScrollIndicators.tsx
+++ b/apps/web/src/lib/core/component/VerticalScrollIndicators.tsx
@@ -39,12 +39,9 @@ export const ScrollIndicators = (props: {
 
   const isHorizontal = () => props.direction === 'horizontal';
   const isGradient = () => props.appearance === 'gradient';
-  const gradientColor = () =>
-    GRADIENT_COLOR[props.gradientColor ?? 'surface'];
+  const gradientColor = () => GRADIENT_COLOR[props.gradientColor ?? 'surface'];
   const gradientStyle = () =>
-    isGradient()
-      ? { '--scroll-indicator-from': gradientColor() }
-      : undefined;
+    isGradient() ? { '--scroll-indicator-from': gradientColor() } : undefined;
 
   const updateIndicators = () => {
     const ref = props.scrollRef();


### PR DESCRIPTION
- Fixes calendar event hover styling
- Fixes all day new event previews showing under existing all day events
- Updates the all day row to resize in height without pushing the rest of the calendar grid
- Updates scroll indicators component to support color prop and update calendar to use proper color for scroll indicators

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only calendar styling and selection preview rendering; no auth, data, or API changes.
> 
> **Overview**
> Fixes **all-day and multi-day date selection** so new events preview as a chip in the all-day row instead of FullCalendar’s highlight overlay (including hiding duplicate preview rendering in the time grid). The selection plugin now treats **all-day** selections like multi-day timed ranges by projecting a foreground preview event while keeping the real selection range for the composer.
> 
> **Calendar layout/CSS** locks the time-grid all-day section to a fixed height so extra chips grow over the hour grid without shifting rows, bumps all-day skeleton/row sizing, and hides daygrid highlights in favor of the stacked preview. **Event hover** is reworked behind `@media (hover: hover)` with calendar-color `color-mix` styling and exclusions for mirrors, selection previews, and selected events.
> 
> **Scroll indicators** gain an optional `gradientColor` prop (theme tokens via CSS variable) and calendar surfaces pass `gradientColor="panel"` so fades match panel backgrounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a9c6a57618e6cedaecfc15036e94b5d0305c5a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->