### PR TITLE
Remove half-baked Discussion Thread button and fix agent shimmer behavior

### DIFF
--- a/apps/web/src/features/block-agent/component/AgentSplitHeader.tsx
+++ b/apps/web/src/features/block-agent/component/AgentSplitHeader.tsx
@@ -3,7 +3,6 @@ import {
   ResponsiveBlockToolbar,
   ToolButton,
 } from '@components/app/ResponsiveBlockToolbar';
-import { useDrawerControl } from '@components/app/split-layout/components/SplitDrawerContext';
 import type { FileOperation } from '@components/app/split-layout/components/SplitFileMenu';
 import {
   SplitHeaderLeft,
@@ -17,16 +16,11 @@ import { buildSimpleEntityUrl, openExternalUrl } from '@core/util/url';
 import ArrowSquareOut from '@phosphor/arrow-square-out.svg';
 import GitBranch from '@phosphor/git-branch.svg';
 import LinkIcon from '@phosphor/link.svg';
-import TreeStructure from '@phosphor/tree-structure.svg';
 import { handleAgentSessionRenamed } from '@queries/agent-session/session-metadata-sync';
 import { agentHarnessServiceClient } from '@service-agent-harness/client';
 import type { AgentSessionResponse } from '@service-agent-harness/generated/schemas';
 import { For, Show } from 'solid-js';
 import { useAgentSession } from '../context/AgentSessionContext';
-import {
-  ORIGIN_THREAD_DRAWER_ID,
-  sessionOriginThread,
-} from '../context/origin-thread';
 
 /** 'claude-code' → 'Claude Code'; the fallback when the fold has no title. */
 export function harnessTitle(harness: string | undefined): string {
@@ -60,7 +54,6 @@ export function AgentSplitHeader(props: {
       return persistedName;
     return props.title ?? persistedName ?? harnessTitle(props.session?.harness);
   };
-  const originThreadDrawer = useDrawerControl(ORIGIN_THREAD_DRAWER_ID);
 
   const rename = async (name: string) => {
     const id = sessionId();
@@ -83,13 +76,6 @@ export function AgentSplitHeader(props: {
   };
 
   const tools: BlockTool[] = [
-    {
-      label: 'Discussion Thread',
-      icon: TreeStructure,
-      action: originThreadDrawer.toggle,
-      isActive: originThreadDrawer.isOpen,
-      condition: () => sessionOriginThread(props.session) !== undefined,
-    },
     {
       label: () => {
         const provider = props.session?.external?.provider;

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.test.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.test.ts
@@ -131,7 +131,7 @@ describe('deriveMagicChipPresentation', () => {
     expect(presentation).toEqual({
       kind: 'answering',
       markdown: 'Looking at t',
-      activity: { label: 'Writing response', busy: true },
+      activity: { label: 'Writing response', busy: false },
     });
   });
 

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.ts
@@ -84,7 +84,7 @@ function toolActivity(
 
 function partActivity(part: MessagePart): MagicChipActivity {
   return match(part)
-    .with({ kind: 'text' }, () => ({ label: 'Writing response', busy: true }))
+    .with({ kind: 'text' }, () => ({ label: 'Writing response', busy: false }))
     .with({ kind: 'thought' }, ({ text }) => ({
       label: 'Thinking',
       detail: text.trim() || undefined,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

### Removed Discussion Thread Button
- Removed the half-baked "Discussion Thread" button from `AgentSplitHeader`
- Cleaned up unused imports and variables:
  - `TreeStructure` icon
  - `useDrawerControl` hook and `ORIGIN_THREAD_DRAWER_ID`
  - `sessionOriginThread` function from `origin-thread.ts`

### Fixed Agent Session Shimmer Behavior
- Changed text parts in the magic chip presentation to `busy: false`
- **Before**: Shimmer continued while the agent was writing response text
- **After**: Shimmer stops as soon as thinking/tool call completes
- Updated test to reflect the new behavior

## Testing
- ✅ TypeScript type checking passes
- ✅ All MagicChip presentation tests pass
- ✅ Updated test expectations to match new shimmer behavior

## Rationale
The shimmer animation is meant to indicate active work (thinking, running tools), not passive text streaming. By stopping the shimmer when the tool/thought completes, the UI better communicates when the agent is actively processing vs. just writing output.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-225ee309-0fe0-4a77-8a26-adfccfa577ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-225ee309-0fe0-4a77-8a26-adfccfa577ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

