### PR TITLE
feat(settings): gate the Agents and Harness settings tabs behind enable-chat-v3-agents

### DIFF
--- a/apps/web/src/lib/core/constant/settingsTabsConfig.tsx
+++ b/apps/web/src/lib/core/constant/settingsTabsConfig.tsx
@@ -24,6 +24,8 @@ import {
   BOT_MANAGEMENT_OVERRIDE,
   DEV_MODE_ENV,
   ENABLE_APP_STORE_QR_CODE,
+  ENABLE_CHAT_V3_AGENTS_FLAG,
+  ENABLE_CHAT_V3_AGENTS_OVERRIDE,
   ENABLE_CRM_FLAG,
   ENABLE_CRM_OVERRIDE,
   ENABLE_NOTIFICATION_SETTINGS_FLAG,
@@ -163,6 +165,9 @@ export const useSettingsTabAvailable = () => {
   const botManagementFlag = useFeatureFlag(BOT_MANAGEMENT_FLAG, {
     enabledOverride: BOT_MANAGEMENT_OVERRIDE,
   });
+  const chatV3AgentsFlag = useFeatureFlag(ENABLE_CHAT_V3_AGENTS_FLAG, {
+    enabledOverride: ENABLE_CHAT_V3_AGENTS_OVERRIDE,
+  });
   const crmFlag = useFeatureFlag(ENABLE_CRM_FLAG, {
     enabledOverride: ENABLE_CRM_OVERRIDE,
   });
@@ -199,9 +204,12 @@ export const useSettingsTabAvailable = () => {
         return ENABLE_APP_STORE_QR_CODE && !isNativeMobilePlatform();
       case 'Agent':
         return !isNativeMobilePlatform();
+      // Configurable agents are still rolling out; keep both tabs behind the
+      // same enable-chat-v3-agents gate as the channel mention surfaces, so
+      // settings never advertises agents to a user who cannot mention one.
       case 'Harness':
       case 'Agents':
-        return true;
+        return chatV3AgentsFlag().enabled;
       case 'Bots':
         return botManagementFlag().enabled;
       case 'Mobile':


### PR DESCRIPTION
Stacked on #6031.

The new Agents and Harness settings tabs (and their sidebar group) were unconditionally visible — `useSettingsTabAvailable` returned `true` for both, while sibling tabs sit behind flags (`Bots` → `bot-management`, `CRM` → `enable-crm`).

This gates both tabs behind `enable-chat-v3-agents`, the same PostHog flag that already gates the channel agent-mention surfaces (`useChatV3AgentsFlag`), resolved through the tab config's existing `useFeatureFlag` pattern. The sidebar group disappears automatically when both items are hidden, and `useSettingsTabAvailable` is the single gate the settings panel and app sidebar both consult, so nothing else needs touching.

Known behavior while the flag is off: the macrod pairing deep link (`/app/settings/harness?pair=CODE`) dead-ends — intended for a gated rollout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single gate change in settings tab visibility; no auth or data-path changes, only rollout alignment with an existing feature flag.
> 
> **Overview**
> **Agents** and **Harness** settings tabs (and the sidebar **Agents** group when both are hidden) are no longer always shown. They now follow the same **`enable-chat-v3-agents`** PostHog flag—and dev override—as channel agent-mention UI, via `useFeatureFlag` in `useSettingsTabAvailable`.
> 
> With the flag off, users won’t see agent settings they can’t use in chat; direct URLs such as `/app/settings/harness?pair=CODE` won’t surface those tabs until the flag is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 962fd7f664dcdc00f6b8e4080dbffb0c340da938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->