### PR TITLE
feat(notifications): match iOS new_email alerts to Gmail layout

### DIFF
--- a/crates/model_notifications/src/metadata.rs
+++ b/crates/model_notifications/src/metadata.rs
@@ -8,7 +8,7 @@ use model_entity::EntityType;
 pub use notification::domain::models::NotificationTitle;
 use notification::domain::models::{
     NotifCollapseKey, Notification, NotificationExtIos,
-    apple::{APNSPushNotification, AlertDictionary, Aps, PushNotificationData},
+    apple::{APNSPushNotification, Alert, AlertDictionary, Aps, PushNotificationData},
 };
 use rootcause::Report;
 use rootcause::report;
@@ -708,12 +708,25 @@ impl notification::domain::models::Notification for NewEmailMetadata {
     const TYPE_NAME: &'static str = "new_email";
 }
 
+impl NewEmailMetadata {
+    /// Lock-screen title: the sender's display name (or email), when present.
+    fn sender_line(&self) -> Option<&str> {
+        self.sender
+            .as_deref()
+            .map(str::trim)
+            .filter(|sender| !sender.is_empty())
+    }
+}
+
 impl NotificationTitle for NewEmailMetadata {
     fn format_title(
         &self,
         _sender_id: Option<MacroUserIdStr<'_>>,
     ) -> Result<String, rootcause::Report> {
-        Ok(self.subject.clone())
+        Ok(self
+            .sender_line()
+            .unwrap_or(self.subject.trim())
+            .to_string())
     }
 
     fn format_body(
@@ -740,6 +753,12 @@ impl NotificationExtIos for NewEmailMetadata {
         notification_id: Uuid,
     ) -> Option<APNSPushNotification<Self::NotifData>> {
         let mut apns = alert_apns(self, sender_id, notification_id, None).ok()?;
+        if let Some(Alert::Dictionary(alert)) = &mut apns.aps.alert {
+            let subject = self.subject.trim();
+            if self.sender_line().is_some() && !subject.is_empty() {
+                alert.subtitle = Some(subject.to_string());
+            }
+        }
         apns.aps.thread_id = Some(self.thread_id.clone());
         Some(apns)
     }

--- a/crates/model_notifications/src/metadata/test.rs
+++ b/crates/model_notifications/src/metadata/test.rs
@@ -1,4 +1,7 @@
 use super::*;
+use notification::domain::models::apple::{
+    APNSPushNotification, Alert, AlertDictionary, PushNotificationData,
+};
 
 fn uid(value: &str) -> MacroUserIdStr<'static> {
     MacroUserIdStr::parse_from_str(value).unwrap().into_owned()
@@ -762,28 +765,82 @@ fn new_email_metadata() -> NewEmailMetadata {
     }
 }
 
-#[test]
-fn new_email_apns_uses_subject_and_snippet() {
-    let metadata = new_email_metadata();
+fn new_email_apns(metadata: &NewEmailMetadata) -> APNSPushNotification<PushNotificationData> {
     let entity = EntityType::EmailThread.with_entity_str(&metadata.thread_id);
     let notification_id = Uuid::parse_str("55555555-5555-4555-8555-555555555555").unwrap();
-
-    let apns = metadata
+    metadata
         .as_apns(None, &entity, notification_id)
-        .expect("new_email should build an APNS alert");
+        .expect("new_email should build an APNS alert")
+}
 
-    match apns.aps.alert {
-        Some(notification::domain::models::apple::Alert::Dictionary(alert)) => {
-            assert_eq!(alert.title.as_deref(), Some("Quarterly plan"));
-            assert_eq!(alert.body.as_deref(), Some("Here is the draft"));
-        }
+fn new_email_alert(metadata: &NewEmailMetadata) -> AlertDictionary {
+    match new_email_apns(metadata).aps.alert {
+        Some(Alert::Dictionary(alert)) => alert,
         other => panic!("expected dictionary alert, got {other:?}"),
     }
+}
+
+#[test]
+fn new_email_title_prefers_sender() {
+    assert_eq!(
+        new_email_metadata().format_title(None).unwrap(),
+        "Ada Lovelace"
+    );
+}
+
+#[test]
+fn new_email_apns_matches_gmail_layout() {
+    let metadata = new_email_metadata();
+    let alert = new_email_alert(&metadata);
+    assert_eq!(alert.title.as_deref(), Some("Ada Lovelace"));
+    assert_eq!(alert.subtitle.as_deref(), Some("Quarterly plan"));
+    assert_eq!(alert.body.as_deref(), Some("Here is the draft"));
+
+    let apns = new_email_apns(&metadata);
     assert_eq!(
         apns.aps.thread_id.as_deref(),
         Some(metadata.thread_id.as_str())
     );
-    assert_eq!(apns.push_notification_data.notification_id, notification_id);
+    assert_eq!(
+        apns.push_notification_data.notification_id,
+        Uuid::parse_str("55555555-5555-4555-8555-555555555555").unwrap()
+    );
+
+    let json = serde_json::to_value(&apns).unwrap();
+    assert_eq!(json["aps"]["alert"]["title"], "Ada Lovelace");
+    assert_eq!(json["aps"]["alert"]["subtitle"], "Quarterly plan");
+    assert_eq!(json["aps"]["alert"]["body"], "Here is the draft");
+}
+
+#[test]
+fn new_email_apns_falls_back_to_subject_without_sender() {
+    let mut metadata = new_email_metadata();
+    metadata.sender = None;
+
+    let alert = new_email_alert(&metadata);
+    assert_eq!(alert.title.as_deref(), Some("Quarterly plan"));
+    assert_eq!(alert.subtitle, None);
+    assert_eq!(alert.body.as_deref(), Some("Here is the draft"));
+}
+
+#[test]
+fn new_email_apns_treats_blank_sender_as_missing() {
+    let mut metadata = new_email_metadata();
+    metadata.sender = Some("   ".to_string());
+
+    let alert = new_email_alert(&metadata);
+    assert_eq!(alert.title.as_deref(), Some("Quarterly plan"));
+    assert_eq!(alert.subtitle, None);
+}
+
+#[test]
+fn new_email_apns_omits_blank_subject_subtitle() {
+    let mut metadata = new_email_metadata();
+    metadata.subject = "  ".to_string();
+
+    let alert = new_email_alert(&metadata);
+    assert_eq!(alert.title.as_deref(), Some("Ada Lovelace"));
+    assert_eq!(alert.subtitle, None);
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change

iOS lock-screen email notifications currently put the subject on the first line and the snippet immediately below. Gmail puts the **sender** on the first line, the **subject** on the second, then the snippet.

`NewEmailMetadata` now builds that APNS layout:

1. **Title** — sender display name (or email), falling back to the subject when the sender is missing
2. **Subtitle** — subject
3. **Body** — snippet (unchanged)

This is payload-only. Delivery is still staff dogfood from #6044.

## Test plan

- [x] `cargo test -p model_notifications -- new_email` — 6 passed
- [x] `cargo test -p model_notifications` — 38 passed
- [ ] On a registered iOS device as `@macro.com`, receive a new inbox message and confirm the lock-screen alert shows sender / subject / snippet

Test log:

[new_email_apns_gmail_layout_tests.log](https://cursor.com/agents/bc-19f1a309-c72a-4d76-aead-4f3c202be525/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnew_email_apns_gmail_layout_tests.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19f1a309-c72a-4d76-aead-4f3c202be525?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19f1a309-c72a-4d76-aead-4f3c202be525&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

