### PR TITLE
feat(calls): support multiple languages for call transcriptions

### DIFF
--- a/services/transcription/requirements.txt
+++ b/services/transcription/requirements.txt
@@ -2,3 +2,4 @@ python-dotenv
 livekit-agents[silero]==1.5.7
 httpx
 resemblyzer==0.1.4
+setuptools==80.10.2  # resemblyzer's webrtcvad dependency imports pkg_resources

--- a/services/transcription/test_transcriber.py
+++ b/services/transcription/test_transcriber.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import patch, sentinel
+
+import transcriber
+
+
+class TranscriberConfigurationTest(unittest.TestCase):
+    def test_configures_multilingual_deepgram_transcription(self):
+        with (
+            patch.object(
+                transcriber.inference,
+                "STT",
+                return_value=sentinel.stt,
+            ) as create_stt,
+            patch.object(transcriber.Agent, "__init__", return_value=None) as init_agent,
+        ):
+            transcriber.Transcriber(
+                participant_identity="participant-id",
+                channel_id="channel-id",
+                http_client=sentinel.http_client,
+            )
+
+        create_stt.assert_called_once()
+        args, kwargs = create_stt.call_args
+        self.assertEqual(args, ("deepgram/nova-3",))
+        self.assertEqual(kwargs["language"], "multi")
+        self.assertTrue(kwargs["extra_kwargs"]["diarize"])
+        self.assertNotIn("detect_language", kwargs["extra_kwargs"])
+        init_agent.assert_called_once_with(
+            instructions="Transcribe user speech.",
+            stt=sentinel.stt,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/transcription/transcriber.py
+++ b/services/transcription/transcriber.py
@@ -161,7 +161,7 @@ class Transcriber(Agent):
             instructions="Transcribe user speech.",
             stt=inference.STT(
                 "deepgram/nova-3",
-                language="en-US",
+                language="multi",
                 extra_kwargs={
                     # ms of silence before Deepgram finalizes an utterance.
                     # Library default is 25ms, which cuts hesitant speakers mid-thought.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default STT language for all call transcriptions, which may shift accuracy or behavior for English-only calls while improving multilingual coverage.
> 
> **Overview**
> Call transcription now uses Deepgram **nova-3** with **`language="multi"`** instead of **`en-US`**, so mixed-language and non-English speech on calls can be transcribed without locking to a single locale. Existing Deepgram options (endpointing, diarization, etc.) are unchanged.
> 
> A new **`test_transcriber.py`** unit test asserts the **`Transcriber`** wires STT with **`multi`**, **`diarize`**, and no **`detect_language`** in **`extra_kwargs`**.
> 
> **`requirements.txt`** pins **`setuptools==80.10.2`** so Resemblyzer’s **`webrtcvad`** dependency can still import **`pkg_resources`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd84e07b8841d2c43fc5a170d7e69bd88e2bb5e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->