### PR TITLE
style(task): fix inline task pills styling

### DIFF
--- a/apps/web/src/features/block-md/component/InlinePropertyValue.tsx
+++ b/apps/web/src/features/block-md/component/InlinePropertyValue.tsx
@@ -3,13 +3,13 @@ import { Property } from '@property';
 import { usePropertiesContext } from '@property/context/PropertiesContext';
 import type { Property as PropertyT } from '@property/types';
 import { getEntityValues } from '@property/utils';
-import { Layer } from '@ui';
 import { type Component, type JSX, Match, Switch } from 'solid-js';
 
 type InlinePropertyValueProps = {
   property: PropertyT;
   /** Label rendered when the property is empty. Defaults to "None". */
   emptyLabel?: JSX.Element;
+  class?: string;
 };
 
 /**
@@ -39,34 +39,32 @@ export const InlinePropertyValue: Component<InlinePropertyValueProps> = (
       onRefresh={ctx.onRefresh}
     >
       <Property.Tooltip property={props.property}>
-        <Layer depth={2}>
-          <Property.Pill>
-            <Switch
-              fallback={
-                <Property.Icon
-                  property={props.property}
-                  class="size-3 shrink-0"
-                />
-              }
-            >
-              <Match when={isMultiUserEntity()}>
-                <Property.UserStack property={props.property} maxUsers={2} />
-              </Match>
-              <Match when={isUserEntity()}>
-                <Property.Icon property={props.property} />
-              </Match>
-            </Switch>
-            <Property.Text
-              property={props.property}
-              fallback={
-                <Property.Empty
-                  label={props.emptyLabel ?? props.property.displayName}
-                />
-              }
-            />
-            <Property.Caret />
-          </Property.Pill>
-        </Layer>
+        <Property.Pill class={props.class} variant="outline">
+          <Switch
+            fallback={
+              <Property.Icon
+                property={props.property}
+                class="size-3 shrink-0"
+              />
+            }
+          >
+            <Match when={isMultiUserEntity()}>
+              <Property.UserStack property={props.property} maxUsers={2} />
+            </Match>
+            <Match when={isUserEntity()}>
+              <Property.Icon property={props.property} />
+            </Match>
+          </Switch>
+          <Property.Text
+            property={props.property}
+            fallback={
+              <Property.Empty
+                label={props.emptyLabel ?? props.property.displayName}
+              />
+            }
+          />
+          <Property.Caret />
+        </Property.Pill>
       </Property.Tooltip>
       <Property.PopoverEditor
         entitySelfFilter={{ entityType: ctx.entityType, blockId }}

--- a/apps/web/src/features/block-md/component/InlineTaskProperties.tsx
+++ b/apps/web/src/features/block-md/component/InlineTaskProperties.tsx
@@ -88,11 +88,14 @@ export function InlineTaskProperties() {
           saveHandler={saveHandler}
         >
           <For each={inlineProperties()}>
-            {(property) => <InlinePropertyValue property={property} />}
+            {(property) => (
+              <InlinePropertyValue property={property} class="bg-surface-2 border border-edge" />
+            )}
           </For>
           <InlineFetchedEntityTagsPill
             entityId={blockId}
             entityType={entityType}
+            class="bg-surface-2"
           />
           <Show when={blockName === 'task' && md.progressStats}>
             {(progressStats) => (

--- a/apps/web/src/features/block-md/component/InlineTaskProperties.tsx
+++ b/apps/web/src/features/block-md/component/InlineTaskProperties.tsx
@@ -89,7 +89,10 @@ export function InlineTaskProperties() {
         >
           <For each={inlineProperties()}>
             {(property) => (
-              <InlinePropertyValue property={property} class="bg-surface-2 border border-edge" />
+              <InlinePropertyValue
+                property={property}
+                class="bg-surface-2 border border-edge"
+              />
             )}
           </For>
           <InlineFetchedEntityTagsPill

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/status/Progress.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/status/Progress.tsx
@@ -58,7 +58,7 @@ export function ProgressChip(props: ProgressProps) {
         <Tooltip label={progress.tooltip()} as="span">
           <div
             class={cn(
-              'inline-flex min-w-0 items-center gap-1.5 rounded-full border border-edge-muted',
+              'h-6 inline-flex min-w-0 items-center gap-1.5 rounded-full border border-edge-muted',
               'bg-surface px-2 py-1 leading-tight',
               props.class
             )}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only changes to inline task UI with no auth, data, or save-path changes.
> 
> **Overview**
> **Inline task property pills** no longer use the `Layer` wrapper; styling is applied via an optional `class` on `InlinePropertyValue` and `Property.Pill` with **`variant="outline"`**. The inline row passes **`bg-surface-2 border border-edge`** on status/priority/assignee pills and **`bg-surface-2`** on the tags pill so they match visually.
> 
> **Progress chip** gets a fixed **`h-6`** so its height lines up with the other inline pills in the row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a6226441029b2666ab58d61bb1f3342bb925146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->