### PR TITLE
fix(email): send iOS push only for Signal-tab mail

### DIFF
--- a/services/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
+++ b/services/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
@@ -678,9 +678,9 @@ async fn send_notifications(
         return Ok(());
     }
 
-    let notifiable_message = filter_notifiable_message(ctx, link, new_message_provider_id).await?;
-
-    let Some(NotifiableMessage { message, is_signal }) = notifiable_message else {
+    let Some((message, tier)) =
+        filter_notifiable_message(ctx, link, new_message_provider_id).await?
+    else {
         return Ok(());
     };
 
@@ -737,10 +737,9 @@ async fn send_notifications(
     let notification_entity =
         EntityType::EmailThread.with_entity_string(message.thread_db_id.to_string());
 
-    // Staff get a lock-screen alert only for Signal-tab mail. Noise stays
-    // inbox / websocket so this dogfood does not buzz the phone for every
-    // newsletter. Customers stay websocket-only. Split the send so a mixed
-    // owner/delegate set still creates one inbox row per recipient.
+    // Staff get a lock-screen alert only for Signal-tab mail; customers stay
+    // websocket-only. Split the send so a mixed owner/delegate set still
+    // creates one inbox row per recipient.
     if !staff_recipients.is_empty() {
         let request = SendNotificationRequestBuilder {
             notification_entity: notification_entity.clone(),
@@ -751,10 +750,9 @@ async fn send_notifications(
         }
         .into_request()
         .with_conn_gateway();
-        if is_signal {
-            publish_new_email_notification(ctx, request.with_apns()).await;
-        } else {
-            publish_new_email_notification(ctx, request).await;
+        match tier {
+            NewEmailTier::Signal => publish_new_email_notification(ctx, request.with_apns()).await,
+            NewEmailTier::StaffInbox => publish_new_email_notification(ctx, request).await,
         }
     }
 
@@ -799,63 +797,41 @@ fn partition_email_push_recipients(
         .partition(|id| id.is_macro_staff())
 }
 
-/// Who should get a `new_email` inbox / websocket notification for a synced
-/// inbox message. Lock-screen APNS is attached separately: staff only, and
-/// only when the thread is on the Signal tab.
+/// Where a synced inbox thread lands for `new_email` fan-out.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NewEmailNotifyPolicy {
-    /// Every non-sent, non-draft inbox message. Used for `@macro.com` dogfood
-    /// of the in-app inbox row. APNS is still Signal-only.
-    AllInbox,
-    /// Signal-tab messages only. Default for customers.
-    SignalOnly,
+enum NewEmailTier {
+    /// Signal tab: inbox, important sender, not shared. Everyone gets the
+    /// in-app row; staff also get a lock-screen alert.
+    Signal,
+    /// Inbox but not Signal. Staff dogfood only: in-app row, no alert.
+    StaffInbox,
 }
 
-fn new_email_notify_policy(user_id: &MacroUserIdStr<'_>) -> NewEmailNotifyPolicy {
-    if user_id.is_macro_staff() {
-        NewEmailNotifyPolicy::AllInbox
-    } else {
-        NewEmailNotifyPolicy::SignalOnly
-    }
-}
-
-/// Inbox-view filter for a synced thread. `AllInbox` keeps the Inbox view
-/// (so spam, trash, and archive stay out) and skips only Signal predicates.
-fn new_email_preview_filter(thread_id: Uuid, policy: NewEmailNotifyPolicy) -> Expr<EmailLiteral> {
-    let thread = Expr::Literal(EmailLiteral::ThreadId(thread_id));
-    match policy {
-        NewEmailNotifyPolicy::AllInbox => thread,
-        NewEmailNotifyPolicy::SignalOnly => Expr::and(
-            thread,
-            Expr::and(
-                Expr::Literal(EmailLiteral::Importance(true)),
-                Expr::Literal(EmailLiteral::Shared(SharedEmailFilter::Exclude)),
-            ),
+/// The Signal-tab predicate, scoped to one thread.
+fn signal_filter(thread_id: Uuid) -> Expr<EmailLiteral> {
+    Expr::and(
+        Expr::Literal(EmailLiteral::ThreadId(thread_id)),
+        Expr::and(
+            Expr::Literal(EmailLiteral::Importance(true)),
+            Expr::Literal(EmailLiteral::Shared(SharedEmailFilter::Exclude)),
         ),
-    }
+    )
 }
 
-/// A synced inbox message that should create a `new_email` notification.
-struct NotifiableMessage {
-    message: SimpleMessage,
-    /// True when the thread is on the Signal tab (inbox + importance + unshared).
-    is_signal: bool,
-}
-
-async fn thread_matches_notify_policy(
+/// True when the Inbox view (no spam, trash, or archive) has a thread matching
+/// `filter` for this link.
+async fn thread_in_inbox(
     ctx: &PubSubContext,
     link: &link::Link,
-    thread_id: Uuid,
-    policy: NewEmailNotifyPolicy,
+    filter: Expr<EmailLiteral>,
 ) -> result::Result<bool, ProcessingError> {
-    let preview_filter = new_email_preview_filter(thread_id, policy);
     let query = PreviewCursorQuery {
         view: PreviewView::StandardLabel(PreviewViewStandardLabel::Inbox),
         link_ids: vec![link.id],
         limit: 1,
         query: models_pagination::Query::Sort(
             models_pagination::SimpleSortMethod::UpdatedAt,
-            Some(Arc::new(preview_filter)),
+            Some(Arc::new(filter)),
         ),
         team_id: None,
     };
@@ -866,12 +842,24 @@ async fn thread_matches_notify_policy(
         .map_err(|e| {
             ProcessingError::Retryable(DetailedError {
                 reason: FailureReason::DatabaseQueryFailed,
-                source: anyhow::Error::new(e)
-                    .context("Failed to evaluate inbox notification membership"),
+                source: anyhow::Error::new(e).context("Failed to evaluate inbox membership"),
             })
         })?;
 
     Ok(!previews.is_empty())
+}
+
+async fn new_email_tier(
+    ctx: &PubSubContext,
+    link: &link::Link,
+    thread_id: Uuid,
+) -> result::Result<Option<NewEmailTier>, ProcessingError> {
+    if thread_in_inbox(ctx, link, signal_filter(thread_id)).await? {
+        return Ok(Some(NewEmailTier::Signal));
+    }
+    let staff_inbox = link.macro_id.is_macro_staff()
+        && thread_in_inbox(ctx, link, Expr::Literal(EmailLiteral::ThreadId(thread_id))).await?;
+    Ok(staff_inbox.then_some(NewEmailTier::StaffInbox))
 }
 
 // filter out messages we don't want to send notifications for
@@ -880,7 +868,7 @@ async fn filter_notifiable_message(
     ctx: &PubSubContext,
     link: &link::Link,
     new_message_provider_id: &str,
-) -> result::Result<Option<NotifiableMessage>, ProcessingError> {
+) -> result::Result<Option<(SimpleMessage, NewEmailTier)>, ProcessingError> {
     let new_message =
         email_db_client::messages::get_simple_messages::get_simple_message_by_provider_and_link(
             &ctx.db,
@@ -899,42 +887,10 @@ async fn filter_notifiable_message(
         return Ok(None);
     };
 
-    // 1. filter out sent and draft messages
     if new_message.is_sent || new_message.is_draft {
         return Ok(None);
     }
 
-    // 2. Signal-tab membership first: inbox + Importance + Shared(exclude).
-    //    A hit is enough for every policy, and is what unlocks staff APNS.
-    let is_signal = thread_matches_notify_policy(
-        ctx,
-        link,
-        new_message.thread_db_id,
-        NewEmailNotifyPolicy::SignalOnly,
-    )
-    .await?;
-    if is_signal {
-        return Ok(Some(NotifiableMessage {
-            message: new_message,
-            is_signal: true,
-        }));
-    }
-
-    // Staff dogfood still writes an in-app row for other inbox mail.
-    if new_email_notify_policy(&link.macro_id) == NewEmailNotifyPolicy::AllInbox
-        && thread_matches_notify_policy(
-            ctx,
-            link,
-            new_message.thread_db_id,
-            NewEmailNotifyPolicy::AllInbox,
-        )
-        .await?
-    {
-        return Ok(Some(NotifiableMessage {
-            message: new_message,
-            is_signal: false,
-        }));
-    }
-
-    Ok(None)
+    let tier = new_email_tier(ctx, link, new_message.thread_db_id).await?;
+    Ok(tier.map(|tier| (new_message, tier)))
 }

--- a/services/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
+++ b/services/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
@@ -680,7 +680,7 @@ async fn send_notifications(
 
     let notifiable_message = filter_notifiable_message(ctx, link, new_message_provider_id).await?;
 
-    let Some(message) = notifiable_message else {
+    let Some(NotifiableMessage { message, is_signal }) = notifiable_message else {
         return Ok(());
     };
 
@@ -737,10 +737,10 @@ async fn send_notifications(
     let notification_entity =
         EntityType::EmailThread.with_entity_string(message.thread_db_id.to_string());
 
-    // Staff get APNS as well as the inbox / websocket row. Customers stay
-    // websocket-only so this dogfood does not turn on email lock-screen
-    // push for everyone. Split the send so a mixed owner/delegate set
-    // still creates one inbox row per recipient.
+    // Staff get a lock-screen alert only for Signal-tab mail. Noise stays
+    // inbox / websocket so this dogfood does not buzz the phone for every
+    // newsletter. Customers stay websocket-only. Split the send so a mixed
+    // owner/delegate set still creates one inbox row per recipient.
     if !staff_recipients.is_empty() {
         let request = SendNotificationRequestBuilder {
             notification_entity: notification_entity.clone(),
@@ -750,9 +750,12 @@ async fn send_notifications(
             recipient_ids: staff_recipients,
         }
         .into_request()
-        .with_conn_gateway()
-        .with_apns();
-        publish_new_email_notification(ctx, request).await;
+        .with_conn_gateway();
+        if is_signal {
+            publish_new_email_notification(ctx, request.with_apns()).await;
+        } else {
+            publish_new_email_notification(ctx, request).await;
+        }
     }
 
     if !customer_recipients.is_empty() {
@@ -797,11 +800,12 @@ fn partition_email_push_recipients(
 }
 
 /// Who should get a `new_email` inbox / websocket notification for a synced
-/// inbox message. Lock-screen APNS is attached separately, and only for
-/// `@macro.com` recipients.
+/// inbox message. Lock-screen APNS is attached separately: staff only, and
+/// only when the thread is on the Signal tab.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NewEmailNotifyPolicy {
-    /// Every non-sent, non-draft inbox message. Used for `@macro.com` dogfood.
+    /// Every non-sent, non-draft inbox message. Used for `@macro.com` dogfood
+    /// of the in-app inbox row. APNS is still Signal-only.
     AllInbox,
     /// Signal-tab messages only. Default for customers.
     SignalOnly,
@@ -831,13 +835,52 @@ fn new_email_preview_filter(thread_id: Uuid, policy: NewEmailNotifyPolicy) -> Ex
     }
 }
 
+/// A synced inbox message that should create a `new_email` notification.
+struct NotifiableMessage {
+    message: SimpleMessage,
+    /// True when the thread is on the Signal tab (inbox + importance + unshared).
+    is_signal: bool,
+}
+
+async fn thread_matches_notify_policy(
+    ctx: &PubSubContext,
+    link: &link::Link,
+    thread_id: Uuid,
+    policy: NewEmailNotifyPolicy,
+) -> result::Result<bool, ProcessingError> {
+    let preview_filter = new_email_preview_filter(thread_id, policy);
+    let query = PreviewCursorQuery {
+        view: PreviewView::StandardLabel(PreviewViewStandardLabel::Inbox),
+        link_ids: vec![link.id],
+        limit: 1,
+        query: models_pagination::Query::Sort(
+            models_pagination::SimpleSortMethod::UpdatedAt,
+            Some(Arc::new(preview_filter)),
+        ),
+        team_id: None,
+    };
+
+    let previews = EmailPgRepo::new(ctx.db.clone())
+        .previews_for_view_cursor(query, link.macro_id.clone())
+        .await
+        .map_err(|e| {
+            ProcessingError::Retryable(DetailedError {
+                reason: FailureReason::DatabaseQueryFailed,
+                source: anyhow::Error::new(e)
+                    .context("Failed to evaluate inbox notification membership"),
+            })
+        })?;
+
+    Ok(!previews.is_empty())
+}
+
 // filter out messages we don't want to send notifications for
 #[tracing::instrument(skip(ctx, link))]
 async fn filter_notifiable_message(
     ctx: &PubSubContext,
     link: &link::Link,
     new_message_provider_id: &str,
-) -> result::Result<Option<SimpleMessage>, ProcessingError> {
+) -> result::Result<Option<NotifiableMessage>, ProcessingError> {
     let new_message =
         email_db_client::messages::get_simple_messages::get_simple_message_by_provider_and_link(
             &ctx.db,
@@ -861,33 +904,37 @@ async fn filter_notifiable_message(
         return Ok(None);
     }
 
-    // 2. Inbox view membership, scoped to this thread. SignalOnly also
-    //    requires Importance(true) AND Shared(exclude).
-    let preview_filter = new_email_preview_filter(
+    // 2. Signal-tab membership first: inbox + Importance + Shared(exclude).
+    //    A hit is enough for every policy, and is what unlocks staff APNS.
+    let is_signal = thread_matches_notify_policy(
+        ctx,
+        link,
         new_message.thread_db_id,
-        new_email_notify_policy(&link.macro_id),
-    );
+        NewEmailNotifyPolicy::SignalOnly,
+    )
+    .await?;
+    if is_signal {
+        return Ok(Some(NotifiableMessage {
+            message: new_message,
+            is_signal: true,
+        }));
+    }
 
-    let query = PreviewCursorQuery {
-        view: PreviewView::StandardLabel(PreviewViewStandardLabel::Inbox),
-        link_ids: vec![link.id],
-        limit: 1,
-        query: models_pagination::Query::Sort(
-            models_pagination::SimpleSortMethod::UpdatedAt,
-            Some(Arc::new(preview_filter)),
-        ),
-        team_id: None,
-    };
+    // Staff dogfood still writes an in-app row for other inbox mail.
+    if new_email_notify_policy(&link.macro_id) == NewEmailNotifyPolicy::AllInbox
+        && thread_matches_notify_policy(
+            ctx,
+            link,
+            new_message.thread_db_id,
+            NewEmailNotifyPolicy::AllInbox,
+        )
+        .await?
+    {
+        return Ok(Some(NotifiableMessage {
+            message: new_message,
+            is_signal: false,
+        }));
+    }
 
-    let previews = EmailPgRepo::new(ctx.db.clone())
-        .previews_for_view_cursor(query, link.macro_id.clone())
-        .await
-        .map_err(|e| {
-            ProcessingError::Retryable(DetailedError {
-                reason: FailureReason::DatabaseQueryFailed,
-                source: anyhow::Error::new(e).context("Failed to evaluate Signal tab membership"),
-            })
-        })?;
-
-    Ok((!previews.is_empty()).then_some(new_message))
+    Ok(None)
 }

--- a/services/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
+++ b/services/email_service/src/pubsub/inbox_sync/operations/upsert_message.rs
@@ -737,9 +737,6 @@ async fn send_notifications(
     let notification_entity =
         EntityType::EmailThread.with_entity_string(message.thread_db_id.to_string());
 
-    // Staff get a lock-screen alert only for Signal-tab mail; customers stay
-    // websocket-only. Split the send so a mixed owner/delegate set still
-    // creates one inbox row per recipient.
     if !staff_recipients.is_empty() {
         let request = SendNotificationRequestBuilder {
             notification_entity: notification_entity.clone(),
@@ -797,17 +794,14 @@ fn partition_email_push_recipients(
         .partition(|id| id.is_macro_staff())
 }
 
-/// Where a synced inbox thread lands for `new_email` fan-out.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NewEmailTier {
-    /// Signal tab: inbox, important sender, not shared. Everyone gets the
-    /// in-app row; staff also get a lock-screen alert.
+    /// Everyone gets the in-app row; staff also get APNS.
     Signal,
-    /// Inbox but not Signal. Staff dogfood only: in-app row, no alert.
+    /// Staff dogfood: in-app row only.
     StaffInbox,
 }
 
-/// The Signal-tab predicate, scoped to one thread.
 fn signal_filter(thread_id: Uuid) -> Expr<EmailLiteral> {
     Expr::and(
         Expr::Literal(EmailLiteral::ThreadId(thread_id)),
@@ -818,8 +812,6 @@ fn signal_filter(thread_id: Uuid) -> Expr<EmailLiteral> {
     )
 }
 
-/// True when the Inbox view (no spam, trash, or archive) has a thread matching
-/// `filter` for this link.
 async fn thread_in_inbox(
     ctx: &PubSubContext,
     link: &link::Link,
@@ -862,7 +854,6 @@ async fn new_email_tier(
     Ok(staff_inbox.then_some(NewEmailTier::StaffInbox))
 }
 
-// filter out messages we don't want to send notifications for
 #[tracing::instrument(skip(ctx, link))]
 async fn filter_notifiable_message(
     ctx: &PubSubContext,

--- a/services/email_service/src/pubsub/inbox_sync/operations/upsert_message/test.rs
+++ b/services/email_service/src/pubsub/inbox_sync/operations/upsert_message/test.rs
@@ -195,30 +195,6 @@ fn suppresses_existing_immutable_non_drafts() {
 }
 
 #[test]
-fn macro_staff_gets_all_inbox_new_email_policy() {
-    assert_eq!(
-        new_email_notify_policy(&id("macro|teo@macro.com")),
-        NewEmailNotifyPolicy::AllInbox
-    );
-}
-
-#[test]
-fn macro_staff_plus_alias_gets_all_inbox_new_email_policy() {
-    assert_eq!(
-        new_email_notify_policy(&id("macro|teo+notify@macro.com")),
-        NewEmailNotifyPolicy::AllInbox
-    );
-}
-
-#[test]
-fn customer_gets_signal_only_new_email_policy() {
-    assert_eq!(
-        new_email_notify_policy(&id("macro|user@example.com")),
-        NewEmailNotifyPolicy::SignalOnly
-    );
-}
-
-#[test]
 fn staff_recipients_are_split_onto_the_apns_path() {
     let (staff, customers) = partition_email_push_recipients(HashSet::from([
         id("macro|teo@macro.com"),
@@ -243,18 +219,9 @@ fn customer_only_recipients_do_not_take_the_apns_path() {
 }
 
 #[test]
-fn all_inbox_preview_filter_is_thread_only() {
+fn signal_filter_requires_importance_and_unshared() {
     let thread_id = Uuid::nil();
-    match new_email_preview_filter(thread_id, NewEmailNotifyPolicy::AllInbox) {
-        Expr::Literal(EmailLiteral::ThreadId(id)) => assert_eq!(id, thread_id),
-        other => panic!("expected thread-only filter, got {other:?}"),
-    }
-}
-
-#[test]
-fn signal_only_preview_filter_requires_importance_and_unshared() {
-    let thread_id = Uuid::nil();
-    match new_email_preview_filter(thread_id, NewEmailNotifyPolicy::SignalOnly) {
+    match signal_filter(thread_id) {
         Expr::And(thread, rest) => {
             assert!(matches!(
                 *thread,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change

Staff lock-screen APNS for `new_email` was firing for every inbox message. It now fires only when the thread is on the **Signal** tab (inbox + importance + not shared).

- Signal mail: staff still get inbox/websocket **and** APNS
- Other inbox mail: staff still get the in-app row (dogfood), no lock-screen alert
- Customers stay websocket-only and Signal-only, unchanged

## Shape

One `NewEmailTier` (`Signal` / `StaffInbox`) drives both the inbox membership query and the send:

- `signal_filter(thread_id)` — the Signal-tab predicate, same one the Signal view uses
- `thread_in_inbox(ctx, link, filter)` — one Inbox-view `limit 1` preview query
- `new_email_tier(...)` — Signal first; otherwise `StaffInbox` only for `@macro.com` owners
- `send_notifications` matches on the tier to decide `.with_apns()`

The previous `NewEmailNotifyPolicy` enum, `is_signal` flag, and policy-keyed filter builder are gone. Net diff against `main` is smaller than the original change.

## Test plan

- [x] `cargo test -p email_service -- upsert_message::test` — 21 passed
- [x] `cargo clippy -p email_service --tests` — clean
- [ ] On a registered iOS device as `@macro.com`, confirm a Signal email still pushes and a Noise/inbox email does not

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19f1a309-c72a-4d76-aead-4f3c202be525?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19f1a309-c72a-4d76-aead-4f3c202be525&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

