### PR TITLE
feat(settings): add API Keys tab for user API key management

### DIFF
--- a/apps/web/src/features/settings/ApiKeys.tsx
+++ b/apps/web/src/features/settings/ApiKeys.tsx
@@ -1,0 +1,411 @@
+import { CredentialField } from '@channel/Bots/CredentialField';
+import { LoadingSpinner } from '@core/component/LoadingSpinner';
+import { toast } from '@core/component/Toast/Toast';
+import { formatRelativeTimestamp } from '@entity';
+import KeyIcon from '@phosphor/key.svg';
+import PlusIcon from '@phosphor/plus.svg';
+import SpinnerIcon from '@phosphor/spinner.svg';
+import TrashIcon from '@phosphor/trash.svg';
+import XIcon from '@phosphor/x.svg';
+import {
+  MAX_USER_API_KEYS,
+  normalizeUserApiKeyName,
+} from '@queries/user-api-keys/name';
+import {
+  useCreateUserApiKeyMutation,
+  useDeleteUserApiKeyMutation,
+  useUserApiKeysQuery,
+} from '@queries/user-api-keys/user-api-keys';
+import type { CreatedUserApiKey } from '@service-storage/generated/schemas/createdUserApiKey';
+import type { UserApiKeyInfo } from '@service-storage/generated/schemas/userApiKeyInfo';
+import { Button, Dialog, Panel, Tooltip } from '@ui';
+import { createSignal, For, type JSX, Show } from 'solid-js';
+import { SettingsCard, SettingsPage, SettingsSection } from './primitives';
+
+const USER_API_KEY_HEADER = 'x-macro-user-api-key';
+
+export function ApiKeys() {
+  const keysQuery = useUserApiKeysQuery();
+  const createKey = useCreateUserApiKeyMutation();
+  const deleteKey = useDeleteUserApiKeyMutation();
+  const [createOpen, setCreateOpen] = createSignal(false);
+  const [pendingDelete, setPendingDelete] = createSignal<UserApiKeyInfo | null>(
+    null
+  );
+
+  const keys = () => keysQuery.data ?? [];
+  const atLimit = () => keys().length >= MAX_USER_API_KEYS;
+  const createDisabled = () => keysQuery.isLoading || atLimit();
+
+  const openCreate = () => {
+    if (createDisabled()) return;
+    setCreateOpen(true);
+  };
+
+  return (
+    <SettingsPage
+      title="API Keys"
+      description={
+        <>
+          Authenticate as yourself from scripts and integrations. Send the key
+          in the <code class="font-mono text-xs">{USER_API_KEY_HEADER}</code>{' '}
+          header. The secret is shown only once when you create a key.
+        </>
+      }
+      actions={
+        <Tooltip
+          label={`You can have at most ${MAX_USER_API_KEYS} API keys`}
+          disabled={!atLimit()}
+        >
+          <Button
+            variant="cta"
+            size="sm"
+            disabled={createDisabled()}
+            onClick={openCreate}
+          >
+            <PlusIcon />
+            Create key
+          </Button>
+        </Tooltip>
+      }
+    >
+      <SettingsSection
+        title="Your keys"
+        description={`Up to ${MAX_USER_API_KEYS} keys. Anyone with a key can act as you, so treat them like passwords.`}
+      >
+        <SettingsCard>
+          <Show
+            when={!keysQuery.isLoading}
+            fallback={
+              <div class="flex min-h-36 items-center justify-center">
+                <LoadingSpinner class="size-10 p-2" />
+              </div>
+            }
+          >
+            <Show
+              when={!keysQuery.isError}
+              fallback={
+                <div class="px-6 py-8 text-center text-sm text-ink-muted">
+                  Couldn’t load API keys.
+                </div>
+              }
+            >
+              <Show
+                when={keys().length > 0}
+                fallback={
+                  <div class="flex min-h-52 flex-col items-center justify-center px-8 text-center">
+                    <div class="flex size-11 items-center justify-center rounded-xl bg-accent-bg text-accent">
+                      <KeyIcon class="size-6" />
+                    </div>
+                    <div class="mt-3 text-sm font-medium text-ink">
+                      Create your first API key
+                    </div>
+                    <div class="mt-1 max-w-80 text-xs text-ink-muted">
+                      Use a key to call Macro on your behalf. The full secret is
+                      shown only at creation.
+                    </div>
+                    <Button
+                      class="mt-4"
+                      variant="cta"
+                      size="sm"
+                      onClick={openCreate}
+                    >
+                      <PlusIcon />
+                      Create key
+                    </Button>
+                  </div>
+                }
+              >
+                <For each={keys()}>
+                  {(key) => (
+                    <ApiKeyRow
+                      keyInfo={key}
+                      deleting={
+                        deleteKey.isPending && pendingDelete()?.id === key.id
+                      }
+                      onDelete={() => setPendingDelete(key)}
+                    />
+                  )}
+                </For>
+              </Show>
+            </Show>
+          </Show>
+        </SettingsCard>
+      </SettingsSection>
+
+      <CreateApiKeyDialog
+        open={createOpen()}
+        pending={createKey.isPending}
+        onCreate={async (name) => {
+          try {
+            return await createKey.mutateAsync({ name });
+          } catch (error) {
+            toast.failure(
+              error instanceof Error
+                ? error.message
+                : 'Failed to create API key'
+            );
+            return undefined;
+          }
+        }}
+        onClose={() => setCreateOpen(false)}
+      />
+
+      <ConfirmDialog
+        open={pendingDelete() !== null}
+        title="Delete API key"
+        confirmLabel="Delete key"
+        pending={deleteKey.isPending}
+        danger
+        onConfirm={async () => {
+          const key = pendingDelete();
+          if (!key) return;
+          try {
+            await deleteKey.mutateAsync({ id: key.id });
+            toast.success('API key deleted');
+            setPendingDelete(null);
+          } catch {
+            toast.failure('Failed to delete API key');
+          }
+        }}
+        onClose={() => !deleteKey.isPending && setPendingDelete(null)}
+      >
+        <Show when={pendingDelete()}>
+          {(key) => (
+            <>
+              Delete <span class="font-medium text-ink">{key().name}</span>?
+              This cannot be undone. Anything using this key will stop working.
+            </>
+          )}
+        </Show>
+      </ConfirmDialog>
+    </SettingsPage>
+  );
+}
+
+function ApiKeyRow(props: {
+  keyInfo: UserApiKeyInfo;
+  deleting: boolean;
+  onDelete: () => void;
+}) {
+  return (
+    <div class="flex min-h-14 items-center gap-3 px-6 py-3.5">
+      <div class="min-w-0 flex-1">
+        <div class="truncate text-sm font-medium text-ink">
+          {props.keyInfo.name}
+        </div>
+        <div
+          class="mt-0.5 text-xs text-ink-extra-muted"
+          title={props.keyInfo.createdAt}
+        >
+          Created {formatRelativeTimestamp(props.keyInfo.createdAt)}
+        </div>
+      </div>
+      <Tooltip label="Delete key">
+        <button
+          type="button"
+          aria-label={`Delete ${props.keyInfo.name}`}
+          class="flex size-7 shrink-0 items-center justify-center rounded-md text-ink-extra-muted outline-none hover:bg-failure/10 hover:text-failure focus-visible:border focus-visible:border-failure disabled:opacity-30"
+          disabled={props.deleting}
+          onClick={props.onDelete}
+        >
+          <Show when={props.deleting} fallback={<TrashIcon class="size-4" />}>
+            <SpinnerIcon class="size-4 animate-spin" />
+          </Show>
+        </button>
+      </Tooltip>
+    </div>
+  );
+}
+
+function CreateApiKeyDialog(props: {
+  open: boolean;
+  pending: boolean;
+  onCreate: (name: string) => Promise<CreatedUserApiKey | undefined>;
+  onClose: () => void;
+}) {
+  const [name, setName] = createSignal('');
+  const [created, setCreated] = createSignal<CreatedUserApiKey>();
+  const [nameError, setNameError] = createSignal<string>();
+
+  const reset = () => {
+    setName('');
+    setCreated(undefined);
+    setNameError(undefined);
+  };
+
+  const close = () => {
+    if (props.pending) return;
+    props.onClose();
+    reset();
+  };
+
+  const submit = async () => {
+    if (props.pending || created()) return;
+    const normalized = normalizeUserApiKeyName(name());
+    if (!normalized.ok) {
+      setNameError(normalized.error);
+      return;
+    }
+    setNameError(undefined);
+    const result = await props.onCreate(normalized.name);
+    if (result) setCreated(result);
+  };
+
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={(open) => (open ? undefined : close())}
+      onEscapeKeyDown={(event) => props.pending && event.preventDefault()}
+      position="center"
+      class="w-105"
+    >
+      <Panel depth={2} active class="rounded-xl text-ink">
+        <Panel.Header class="px-5">
+          <Dialog.Title class="text-sm font-semibold">
+            {created() ? 'API key created' : 'New API key'}
+          </Dialog.Title>
+          <div class="ml-auto">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              label="Close"
+              aria-label="Close"
+              disabled={props.pending}
+              onClick={close}
+            >
+              <XIcon />
+            </Button>
+          </div>
+        </Panel.Header>
+        <Panel.Body class="p-5">
+          <Show
+            when={created()}
+            fallback={
+              <div class="flex flex-col gap-5">
+                <label class="flex flex-col gap-1.5">
+                  <span class="text-xs font-medium text-ink">Name</span>
+                  <input
+                    autofocus
+                    value={name()}
+                    placeholder="e.g. CI, local scripts"
+                    class="settings-input w-full"
+                    aria-invalid={nameError() ? true : undefined}
+                    onInput={(event) => {
+                      setName(event.currentTarget.value);
+                      setNameError(undefined);
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') void submit();
+                    }}
+                  />
+                  <Show
+                    when={nameError()}
+                    fallback={
+                      <span class="text-xs text-ink-muted">
+                        A label so you can tell keys apart later.
+                      </span>
+                    }
+                  >
+                    {(error) => (
+                      <span class="text-xs text-failure">{error()}</span>
+                    )}
+                  </Show>
+                </label>
+                <div class="flex justify-end gap-2 border-t border-edge-muted pt-4">
+                  <Button variant="ghost" size="sm" onClick={close}>
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="cta"
+                    size="sm"
+                    disabled={props.pending}
+                    onClick={() => void submit()}
+                  >
+                    {props.pending ? 'Creating…' : 'Create key'}
+                  </Button>
+                </div>
+              </div>
+            }
+          >
+            {(key) => (
+              <div class="flex flex-col gap-5">
+                <CredentialField
+                  label="API key"
+                  value={key().key}
+                  help="Shown only once"
+                />
+                <div class="rounded-lg border border-alert/30 bg-alert-bg px-3 py-2.5 text-xs text-alert-ink">
+                  Store this key somewhere secure before closing. Send it as{' '}
+                  <code class="font-mono">{USER_API_KEY_HEADER}</code>.
+                </div>
+                <div class="flex justify-end border-t border-edge-muted pt-4">
+                  <Button variant="cta" size="sm" onClick={close}>
+                    Done
+                  </Button>
+                </div>
+              </div>
+            )}
+          </Show>
+        </Panel.Body>
+      </Panel>
+    </Dialog>
+  );
+}
+
+function ConfirmDialog(props: {
+  open: boolean;
+  title: string;
+  confirmLabel: string;
+  pending: boolean;
+  danger?: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+  children: JSX.Element;
+}) {
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={(open) => !open && !props.pending && props.onClose()}
+    >
+      <Panel depth={2} class="max-h-[75vh] rounded-xl text-ink">
+        <Panel.Header class="gap-1 px-2">
+          <Dialog.CloseButton
+            as={Button}
+            variant="ghost"
+            size="icon-sm"
+            disabled={props.pending}
+          >
+            <XIcon />
+          </Dialog.CloseButton>
+          <Dialog.Title as="span" class="m-0 p-0 text-sm font-medium">
+            {props.title}
+          </Dialog.Title>
+        </Panel.Header>
+        <Panel.Body class="flex flex-col gap-3 p-3">
+          <p class="text-sm text-ink-muted">{props.children}</p>
+          <div class="flex justify-end gap-1 pt-2">
+            <Button
+              variant="ghost"
+              class="rounded-xs"
+              disabled={props.pending}
+              onClick={props.onClose}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant={props.danger ? 'danger' : 'accent'}
+              class="rounded-xs"
+              disabled={props.pending}
+              onClick={props.onConfirm}
+            >
+              <Show when={props.pending} fallback={props.confirmLabel}>
+                <SpinnerIcon class="size-4 animate-spin" />
+              </Show>
+            </Button>
+          </div>
+        </Panel.Body>
+      </Panel>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/settings/Settings.tsx
+++ b/apps/web/src/features/settings/Settings.tsx
@@ -39,6 +39,7 @@ import {
 import { Account } from './Account';
 import { Admin } from './Admin';
 import { Agent } from './Agent';
+import { ApiKeys } from './ApiKeys';
 import { Appearance } from './Appearance';
 import { ConnectedAccounts } from './ConnectedAccounts';
 import { Crm } from './Crm';
@@ -388,6 +389,11 @@ export function SettingsPanel(props: SettingsPanelProps) {
                 <Show when={isCurrentTab('Account')}>
                   <Suspense>
                     <Account />
+                  </Suspense>
+                </Show>
+                <Show when={isCurrentTab('API Keys')}>
+                  <Suspense>
+                    <ApiKeys />
                   </Suspense>
                 </Show>
                 <Show when={isCurrentTab('Notifications')}>

--- a/apps/web/src/lib/core/constant/SettingsState.tsx
+++ b/apps/web/src/lib/core/constant/SettingsState.tsx
@@ -15,6 +15,7 @@ import { settingsSlugToTab, settingsTabToSlug } from './settingsTabsConfig';
 
 export type SettingsTab =
   | 'Account'
+  | 'API Keys'
   | 'Notifications'
   | 'Billing'
   | 'Subscription'

--- a/apps/web/src/lib/core/constant/settingsTabsConfig.tsx
+++ b/apps/web/src/lib/core/constant/settingsTabsConfig.tsx
@@ -6,6 +6,7 @@ import BuildingsIcon from '@phosphor/buildings.svg';
 import CpuIcon from '@phosphor/cpu.svg';
 import CreditCardIcon from '@phosphor/credit-card.svg';
 import DeviceMobileIcon from '@phosphor/device-mobile-speaker.svg';
+import KeyIcon from '@phosphor/key.svg';
 import KeyboardIcon from '@phosphor/keyboard.svg';
 import PlugIcon from '@phosphor/plug.svg';
 import SwatchesIcon from '@phosphor/swatches.svg';
@@ -53,6 +54,7 @@ export const SETTINGS_TAB_GROUPS: SettingsTabGroup[] = [
     label: 'General',
     items: [
       { tab: 'Account', label: 'Account', icon: UserIconPhosphor },
+      { tab: 'API Keys', label: 'API Keys', icon: KeyIcon },
       { tab: 'Notifications', label: 'Notifications', icon: BellIcon },
       { tab: 'Billing', label: 'Billing', icon: CreditCardIcon },
       { tab: 'Appearance', label: 'Appearance', icon: SwatchesIcon },
@@ -92,6 +94,7 @@ const SETTINGS_TAB_ITEMS = SETTINGS_TAB_GROUPS.flatMap((group) => group.items);
  */
 const SETTINGS_TAB_SLUGS: Record<SettingsTab, string> = {
   Account: 'account',
+  'API Keys': 'api-keys',
   Notifications: 'notifications',
   Billing: 'billing',
   Subscription: 'subscription',
@@ -164,6 +167,7 @@ export const useSettingsTabAvailable = () => {
     switch (tab) {
       case 'Appearance':
       case 'Account':
+      case 'API Keys':
       case 'Billing':
         return true;
       case 'Notifications':

--- a/apps/web/src/lib/queries/user-api-keys/keys.ts
+++ b/apps/web/src/lib/queries/user-api-keys/keys.ts
@@ -1,0 +1,5 @@
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+
+export const userApiKeyKeys = createQueryKeys('userApiKeys', {
+  list: null,
+});

--- a/apps/web/src/lib/queries/user-api-keys/name.test.ts
+++ b/apps/web/src/lib/queries/user-api-keys/name.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_USER_API_KEY_NAME_LEN, normalizeUserApiKeyName } from './name';
+
+describe('normalizeUserApiKeyName', () => {
+  it('trims surrounding whitespace', () => {
+    expect(normalizeUserApiKeyName('  CI  ')).toEqual({
+      ok: true,
+      name: 'CI',
+    });
+  });
+
+  it('rejects a blank name', () => {
+    expect(normalizeUserApiKeyName('   ')).toEqual({
+      ok: false,
+      error: 'API key name must not be empty',
+    });
+  });
+
+  it('accepts a name at the character limit', () => {
+    const name = 'a'.repeat(MAX_USER_API_KEY_NAME_LEN);
+    expect(normalizeUserApiKeyName(name)).toEqual({ ok: true, name });
+  });
+
+  it('rejects a name over the character limit', () => {
+    const name = 'a'.repeat(MAX_USER_API_KEY_NAME_LEN + 1);
+    expect(normalizeUserApiKeyName(name)).toEqual({
+      ok: false,
+      error: `API key name must be at most ${MAX_USER_API_KEY_NAME_LEN} characters`,
+    });
+  });
+
+  it('counts Unicode scalar values, not UTF-16 code units', () => {
+    const name = '🔑'.repeat(MAX_USER_API_KEY_NAME_LEN);
+    expect(normalizeUserApiKeyName(name)).toEqual({ ok: true, name });
+    expect(normalizeUserApiKeyName(`${name}x`)).toEqual({
+      ok: false,
+      error: `API key name must be at most ${MAX_USER_API_KEY_NAME_LEN} characters`,
+    });
+  });
+});

--- a/apps/web/src/lib/queries/user-api-keys/name.ts
+++ b/apps/web/src/lib/queries/user-api-keys/name.ts
@@ -1,0 +1,30 @@
+/** Matches `user_api_key::domain::models::MAX_KEY_NAME_LEN`. */
+export const MAX_USER_API_KEY_NAME_LEN = 100;
+
+/** Matches `user_api_key::domain::service::MAX_KEYS_PER_USER`. */
+export const MAX_USER_API_KEYS = 20;
+
+export type NormalizedUserApiKeyName =
+  | { ok: true; name: string }
+  | { ok: false; error: string };
+
+/**
+ * Trim and validate a user-facing API key name the same way the backend does:
+ * non-empty after trim, at most {@link MAX_USER_API_KEY_NAME_LEN} Unicode
+ * scalar values.
+ */
+export function normalizeUserApiKeyName(
+  name: string
+): NormalizedUserApiKeyName {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, error: 'API key name must not be empty' };
+  }
+  if ([...trimmed].length > MAX_USER_API_KEY_NAME_LEN) {
+    return {
+      ok: false,
+      error: `API key name must be at most ${MAX_USER_API_KEY_NAME_LEN} characters`,
+    };
+  }
+  return { ok: true, name: trimmed };
+}

--- a/apps/web/src/lib/queries/user-api-keys/user-api-keys.ts
+++ b/apps/web/src/lib/queries/user-api-keys/user-api-keys.ts
@@ -1,0 +1,49 @@
+import { throwOnErr } from '@core/util/result';
+import { queryClient } from '@queries/client';
+import { storageServiceClient } from '@service-storage/client';
+import type { CreatedUserApiKey } from '@service-storage/generated/schemas/createdUserApiKey';
+import type { UserApiKeyInfo } from '@service-storage/generated/schemas/userApiKeyInfo';
+import { useMutation, useQuery } from '@tanstack/solid-query';
+import { userApiKeyKeys } from './keys';
+import { normalizeUserApiKeyName } from './name';
+
+export function useUserApiKeysQuery() {
+  return useQuery(() => ({
+    queryKey: userApiKeyKeys.list.queryKey,
+    queryFn: async (): Promise<UserApiKeyInfo[]> =>
+      await throwOnErr(() => storageServiceClient.listUserApiKeys()),
+  }));
+}
+
+export function invalidateUserApiKeys() {
+  return queryClient.invalidateQueries({
+    queryKey: userApiKeyKeys.list.queryKey,
+  });
+}
+
+export function useCreateUserApiKeyMutation() {
+  return useMutation(() => ({
+    gcTime: 0,
+    mutationFn: async (vars: { name: string }): Promise<CreatedUserApiKey> => {
+      const normalized = normalizeUserApiKeyName(vars.name);
+      if (!normalized.ok) {
+        throw new Error(normalized.error);
+      }
+      return await throwOnErr(() =>
+        storageServiceClient.createUserApiKey({ name: normalized.name })
+      );
+    },
+    onSuccess: invalidateUserApiKeys,
+    onError: (error) => console.error('failed to create user api key', error),
+  }));
+}
+
+export function useDeleteUserApiKeyMutation() {
+  return useMutation(() => ({
+    gcTime: 0,
+    mutationFn: async (vars: { id: string }) =>
+      await throwOnErr(() => storageServiceClient.deleteUserApiKey(vars)),
+    onSuccess: invalidateUserApiKeys,
+    onError: (error) => console.error('failed to delete user api key', error),
+  }));
+}

--- a/apps/web/src/lib/service-clients/service-storage/client.ts
+++ b/apps/web/src/lib/service-clients/service-storage/client.ts
@@ -63,6 +63,7 @@ import type { CreateCrmCompanyRequest } from './generated/schemas/createCrmCompa
 import type { CreateCrmContactRequest } from './generated/schemas/createCrmContactRequest';
 import type { CreateDocument200 as CreateDocumentResponse } from './generated/schemas/createDocument200';
 import type { CreateDocumentRequest } from './generated/schemas/createDocumentRequest';
+import type { CreatedUserApiKey } from './generated/schemas/createdUserApiKey';
 import type { CreateEntityMentionRequest } from './generated/schemas/createEntityMentionRequest';
 import type { CreateEntityMentionResponse } from './generated/schemas/createEntityMentionResponse';
 import type { CreateInstructionsDocumentResponse } from './generated/schemas/createInstructionsDocumentResponse';
@@ -156,6 +157,7 @@ import type { TypedSuccessResponse } from './generated/schemas/typedSuccessRespo
 import type { UpdateCrmTeamSettingsRequest } from './generated/schemas/updateCrmTeamSettingsRequest';
 import type { UpdateReminderRequest } from './generated/schemas/updateReminderRequest';
 import type { UploadExtractFolderHandler200 } from './generated/schemas/uploadExtractFolderHandler200';
+import type { UserApiKeysList } from './generated/schemas/userApiKeysList';
 import type { UserPinsResponse } from './generated/schemas/userPinsResponse';
 import type { UserViewsResponse } from './generated/schemas/userViewsResponse';
 import type { View } from './generated/schemas/view';
@@ -582,6 +584,29 @@ export const storageServiceClient = {
 
   async revokeBotToken(args: WithBotId & { token_id: string }) {
     return await dssFetch(`/bots/${args.bot_id}/tokens/${args.token_id}`, {
+      method: 'DELETE',
+    });
+  },
+
+  async listUserApiKeys() {
+    return (
+      await dssFetch<UserApiKeysList>(`/user-api-keys`, {
+        method: 'GET',
+      })
+    ).map((result) => result.keys);
+  },
+
+  async createUserApiKey(args: { name: string }) {
+    return (
+      await dssFetch<CreatedUserApiKey>(`/user-api-keys`, {
+        method: 'POST',
+        body: JSON.stringify({ name: args.name }),
+      })
+    ).map((result) => result);
+  },
+
+  async deleteUserApiKey(args: { id: string }) {
+    return await dssFetch(`/user-api-keys/${encodeURIComponent(args.id)}`, {
       method: 'DELETE',
     });
   },

--- a/docs/AGENT_GUIDE/navigation.md
+++ b/docs/AGENT_GUIDE/navigation.md
@@ -21,7 +21,7 @@
 | `/app/chat/<uuid>` | A standalone AI chat |
 | `/app/md/<doc>/chat/<chat>` | Doc + doc-scoped chat in a split |
 | `/app/md/<doc>/channel/<channel>` | Doc + channel in a split |
-| `/app/settings/account` | Settings (also `/app/settings/mcp-server`, `/shortcuts`, etc.) |
+| `/app/settings/account` | Settings (also `/app/settings/api-keys`, `/mcp-server`, `/shortcuts`, etc.) |
 
 Splits: the app is a tiling window manager. A second pane appends its own segment to the URL
 (`/app/<left>/<right>`). Each pane has its own Close / Go Back / Go Forward buttons.

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -54,7 +54,9 @@ Greeting, getting-started checklist, example prompt buttons (`Draft a document`,
 
 ## Settings — `/app/settings/<section>`
 
-Left nav: General → `Account` (profile, delete account), `Notifications`, `Billing`,
+Left nav: General → `Account` (profile, delete account), `API Keys` (create /
+list / delete personal keys; the secret is shown only once and is sent as
+`x-macro-user-api-key`), `Notifications`, `Billing`,
 `Appearance`, `Mobile App`, `Shortcuts` (interactive keyboard visualization, not a list);
 Workspace → `Team`, `Tags`, `CRM`, `Connections` (email/tool OAuth), `MCP server`
 (setup snippets for Claude Code / Codex CLI / Claude.ai / ChatGPT / IDE), `Bots`; `Log out`.


### PR DESCRIPTION
Add a General → API Keys settings page to list, create, and delete personal keys. The raw secret is shown only once after create.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Users can create credentials that act as their account; mistakes in create/delete UX or secret handling could cause lockouts or leakage, though changes are mostly UI and API wiring to existing endpoints.
> 
> **Overview**
> Adds a **General → API Keys** settings tab at `/app/settings/api-keys` so users can manage personal API keys from the app.
> 
> The new **ApiKeys** page lists keys (name + created time), enforces a **20-key cap**, and supports **create** (named key, secret shown once via `CredentialField`) and **delete** with confirmation. Copy explains using the **`x-macro-user-api-key`** header.
> 
> Client support includes **TanStack Query** hooks (`list` / `create` / `delete`), **name validation** aligned with backend limits (100 chars, Unicode scalars), unit tests for normalization, and **`storageServiceClient`** methods on `/user-api-keys`. Tab config, slug routing, and agent docs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77e5d1612eb8672d6c5dc614c0497ea24058d84a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->