### PR TITLE
fix(web): key recent channel rows by entity id

### DIFF
--- a/apps/web/src/features/channel/sidebar/channels-recent-widget.tsx
+++ b/apps/web/src/features/channel/sidebar/channels-recent-widget.tsx
@@ -35,6 +35,7 @@ import {
 import { getChannelNotificationParams } from '@notifications/notification-navigation';
 import type { UnifiedNotification } from '@notifications/types';
 import { useSoupAstItemsQuery } from '@queries/soup/items';
+import { Key } from '@solid-primitives/keyed';
 import { makePersisted } from '@solid-primitives/storage';
 import { cn, NavRow, Surface, ToggleSwitch, Tooltip } from '@ui';
 import {
@@ -511,14 +512,14 @@ export const ChannelsRecentWidget = (props: {
               lastUserScrollAt = Date.now();
             }}
           >
-            <For each={visibleChannels()}>
+            <Key each={visibleChannels()} by={(channel) => channel.entity.id}>
               {(channel) => (
                 <ChannelRow
-                  channel={channel}
+                  channel={channel()}
                   onFloatingOpenChange={props.onDropdownOpenChange}
                 />
               )}
-            </For>
+            </Key>
             <Show when={showAllCaughtUp()}>
               <div class="flex h-7 w-full items-center gap-2 px-2 py-1 text-sm font-medium text-ink-extra-muted/60">
                 <span class="truncate">All caught up</span>
@@ -549,9 +550,9 @@ export const ChannelsRecentWidget = (props: {
       fallback={
         <Show when={slimVisible().length > 0}>
           <section class="w-full py-1.5 flex flex-col items-start gap-0.5">
-            <For each={slimVisible()}>
-              {(channel) => <ChannelRow channel={channel} isSlim />}
-            </For>
+            <Key each={slimVisible()} by={(channel) => channel.entity.id}>
+              {(channel) => <ChannelRow channel={channel()} isSlim />}
+            </Key>
             <Show when={slimOverflow() > 0}>
               <span class="w-full text-center text-xxs text-ink-muted mt-1">
                 +{slimOverflow()}

--- a/apps/web/src/lib/queries/soup/backfill.test.tsx
+++ b/apps/web/src/lib/queries/soup/backfill.test.tsx
@@ -213,9 +213,8 @@ describe('runSoupBackfills', () => {
     rendered.unmount();
   });
 
-  it('retries cache-host lookup after it was initially unavailable', async () => {
-    const [isLeader, setIsLeader] = createSignal(true);
-    leaderMocks.createTabLeaderSignal.mockReturnValue(isLeader);
+  it('starts when only the cache host becomes available', async () => {
+    vi.useFakeTimers();
     let cacheHost: object | undefined;
     graphqlMocks.getGraphqlSoupCacheHost.mockImplementation(() => cacheHost);
     graphqlMocks.hydrateGraphqlSoup.mockResolvedValue({ nextCursor: null });
@@ -225,12 +224,10 @@ describe('runSoupBackfills', () => {
     expect(graphqlMocks.hydrateGraphqlSoup).not.toHaveBeenCalled();
 
     cacheHost = {};
-    setIsLeader(false);
-    setIsLeader(true);
+    await vi.advanceTimersByTimeAsync(100);
 
-    await vi.waitFor(() =>
-      expect(graphqlMocks.hydrateGraphqlSoup).toHaveBeenCalled()
-    );
+    expect(graphqlMocks.getGraphqlSoupCacheHost).toHaveBeenCalledTimes(2);
+    expect(graphqlMocks.hydrateGraphqlSoup).toHaveBeenCalled();
     rendered.unmount();
   });
 

--- a/apps/web/src/lib/queries/soup/backfill.ts
+++ b/apps/web/src/lib/queries/soup/backfill.ts
@@ -29,6 +29,7 @@ const EMAIL_CONTENT_PAGE_LIMIT = 5;
 const PAGE_DELAY_MS = 2_000;
 const BACKFILL_RETRY_COUNT = 5;
 const BACKFILL_RETRY_SCHEDULE = Schedule.exponential('1 second');
+const CACHE_HOST_RETRY_DELAYS_MS = [100, 250, 500, 1_000, 2_000, 4_000];
 const BACKFILL_PROGRESS_PAGE_INTERVAL = 10;
 const EXCLUDED_ENTITY_ID = '00000000-0000-0000-0000-000000000000';
 
@@ -482,20 +483,37 @@ export function useSoupBackfills(userId: string): void {
   );
 
   createEffect(() => {
-    // Read reactive gates before the non-reactive cache-host lookup so a host
-    // that becomes available after flag loading or leader election is retried.
-    if (
-      !ENABLE_GRAPHQL_BACKFILL ||
-      !graphqlSoupFlag().enabled ||
-      !isLeader() ||
-      getGraphqlSoupCacheHost() === undefined
-    ) {
+    if (!ENABLE_GRAPHQL_BACKFILL || !graphqlSoupFlag().enabled || !isLeader()) {
       return;
     }
 
-    const fiber = Effect.runFork(runSoupBackfills(userId));
+    let disposed = false;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let interruptBackfill: (() => void) | undefined;
+    const startWhenCacheReady = (retryIndex: number): void => {
+      if (disposed) return;
+
+      if (getGraphqlSoupCacheHost() !== undefined) {
+        const fiber = Effect.runFork(runSoupBackfills(userId));
+        interruptBackfill = () => {
+          Effect.runFork(Fiber.interrupt(fiber));
+        };
+        return;
+      }
+
+      const retryDelay = CACHE_HOST_RETRY_DELAYS_MS[retryIndex];
+      if (retryDelay === undefined) return;
+      retryTimer = setTimeout(
+        () => startWhenCacheReady(retryIndex + 1),
+        retryDelay
+      );
+    };
+
+    startWhenCacheReady(0);
     onCleanup(() => {
-      Effect.runFork(Fiber.interrupt(fiber));
+      disposed = true;
+      if (retryTimer !== undefined) clearTimeout(retryTimer);
+      interruptBackfill?.();
     });
   });
 }

--- a/apps/web/src/lib/queries/soup/backfill.ts
+++ b/apps/web/src/lib/queries/soup/backfill.ts
@@ -29,7 +29,8 @@ const EMAIL_CONTENT_PAGE_LIMIT = 5;
 const PAGE_DELAY_MS = 2_000;
 const BACKFILL_RETRY_COUNT = 5;
 const BACKFILL_RETRY_SCHEDULE = Schedule.exponential('1 second');
-const CACHE_HOST_RETRY_DELAYS_MS = [100, 250, 500, 1_000, 2_000, 4_000];
+const CACHE_HOST_RETRY_COUNT = 6;
+const CACHE_HOST_RETRY_SCHEDULE = Schedule.exponential('100 millis');
 const BACKFILL_PROGRESS_PAGE_INTERVAL = 10;
 const EXCLUDED_ENTITY_ID = '00000000-0000-0000-0000-000000000000';
 
@@ -470,9 +471,21 @@ export const runSoupBackfills = Effect.fn('runSoupBackfills')(function* (
   );
 });
 
+const waitForGraphqlSoupCacheHost = Effect.suspend(() =>
+  getGraphqlSoupCacheHost() === undefined
+    ? Effect.fail('cache-host-unavailable' as const)
+    : Effect.void
+).pipe(
+  Effect.retry({
+    times: CACHE_HOST_RETRY_COUNT,
+    schedule: CACHE_HOST_RETRY_SCHEDULE,
+  })
+);
+
 /**
  * Runs the checkpointed backfill Effect while this tab owns leadership.
- * Interrupting the fiber cancels the active fetch or inter-page sleep.
+ * Interrupting the fiber cancels cache readiness waits, active fetches, and
+ * inter-page sleeps.
  */
 export function useSoupBackfills(userId: string): void {
   const graphqlSoupFlag = useFeatureFlag(ENABLE_GRAPHQL_SOUP_FLAG, {
@@ -487,33 +500,14 @@ export function useSoupBackfills(userId: string): void {
       return;
     }
 
-    let disposed = false;
-    let retryTimer: ReturnType<typeof setTimeout> | undefined;
-    let interruptBackfill: (() => void) | undefined;
-    const startWhenCacheReady = (retryIndex: number): void => {
-      if (disposed) return;
-
-      if (getGraphqlSoupCacheHost() !== undefined) {
-        const fiber = Effect.runFork(runSoupBackfills(userId));
-        interruptBackfill = () => {
-          Effect.runFork(Fiber.interrupt(fiber));
-        };
-        return;
-      }
-
-      const retryDelay = CACHE_HOST_RETRY_DELAYS_MS[retryIndex];
-      if (retryDelay === undefined) return;
-      retryTimer = setTimeout(
-        () => startWhenCacheReady(retryIndex + 1),
-        retryDelay
-      );
-    };
-
-    startWhenCacheReady(0);
+    const fiber = Effect.runFork(
+      waitForGraphqlSoupCacheHost.pipe(
+        Effect.flatMap(() => runSoupBackfills(userId)),
+        Effect.ignore
+      )
+    );
     onCleanup(() => {
-      disposed = true;
-      if (retryTimer !== undefined) clearTimeout(retryTimer);
-      interruptBackfill?.();
+      Effect.runFork(Fiber.interrupt(fiber));
     });
   });
 }


### PR DESCRIPTION
Fixes an issue where channel rows were compared by referential equality rather than Id

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI list reconciliation and deferred backfill startup are localized; no auth or data-mutation paths change beyond when background cache hydration begins.
> 
> **Overview**
> **Recent channels sidebar** now lists rows with Solid **`Key`** keyed by **`channel.entity.id`** (full and slim layouts) instead of **`For`**, so reordering or refreshed query objects reuse DOM/state by id rather than by referential equality.
> 
> **GraphQL soup backfill** no longer bails out permanently when **`getGraphqlSoupCacheHost()`** is undefined at effect time. The leader tab forks an Effect that **retries cache-host readiness** (exponential **100ms** schedule, **6** attempts) and then runs **`runSoupBackfills`**; fiber interrupt still cancels that wait along with fetches and page delays. The unit test was updated to assert startup when the host appears after **100ms**, without toggling tab leadership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64db6041ea04d88591e014ddafcb90c172e9407b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->