### PR TITLE
refactor(web): use new feature flag interface

### DIFF
--- a/apps/web/src/components/app/GlobalHotkeys.tsx
+++ b/apps/web/src/components/app/GlobalHotkeys.tsx
@@ -22,11 +22,7 @@ import {
 import { useLogout } from '@core/auth/logout';
 import { useOpenInstructionsMd } from '@core/component/AI/util/instructions';
 import { toast } from '@core/component/Toast/Toast';
-import {
-  ENABLE_SNIPPETS_FLAG,
-  ENABLE_SNIPPETS_OVERRIDE,
-  LOCAL_ONLY,
-} from '@core/constant/featureFlags';
+import { enableSnippets, LOCAL_ONLY } from '@core/constant/featureFlags';
 import {
   type SettingsTab,
   useSettingsState,
@@ -146,9 +142,7 @@ export default function GlobalShortcuts() {
   const logout = useLogout();
 
   const handleFileUpload = useHandleFileUpload();
-  const snippetsFlag = useFeatureFlag(ENABLE_SNIPPETS_FLAG, {
-    enabledOverride: ENABLE_SNIPPETS_OVERRIDE,
-  });
+  const snippetsFlag = useFeatureFlag(enableSnippets);
 
   const handleCommandMenu = () => {
     const willOpen = !CommandState.isOpen();

--- a/apps/web/src/components/app/Layout.tsx
+++ b/apps/web/src/components/app/Layout.tsx
@@ -49,10 +49,7 @@ import {
   SidebarVisibilityContext,
 } from '@components/app/sidebarVisibility';
 import { useIsAuthenticated } from '@core/auth';
-import {
-  ENABLE_REMINDERS_FLAG,
-  ENABLE_REMINDERS_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableReminders } from '@core/constant/featureFlags';
 import { usePaywallState } from '@core/constant/PaywallState';
 import { isSoloSettings } from '@core/constant/SettingsState';
 import { attachGlobalDOMScope } from '@core/hotkey/hotkeys';
@@ -463,13 +460,10 @@ function LayoutInner(props: RouteSectionProps) {
           <CreateChannelModal />
           <CreateCompanyModal />
           <CreateContactModal />
-          {/* Reactive, unlike the imperative ENABLE_REMINDERS() gate on the
+          {/* Reactive, unlike the imperative isFeatureEnabled(enableReminders) gate on the
               action: this decides whether the composer is mounted at all, so it
               has to pick up a late PostHog answer. */}
-          <ShowFeatureFlag
-            key={ENABLE_REMINDERS_FLAG}
-            enabledOverride={ENABLE_REMINDERS_OVERRIDE}
-          >
+          <ShowFeatureFlag flag={enableReminders}>
             <ReminderComposerModal />
           </ShowFeatureFlag>
           <Show when={isAddInboxDialogOpen()}>

--- a/apps/web/src/components/app/app-sidebar/sidebar.tsx
+++ b/apps/web/src/components/app/app-sidebar/sidebar.tsx
@@ -51,8 +51,9 @@ import { toast } from '@core/component/Toast/Toast';
 import { UserIcon } from '@core/component/UserIcon';
 import {
   ENABLE_CALLS,
-  ENABLE_CRM,
-  ENABLE_NEW_PRICING_OVERRIDE,
+  enableCrm,
+  enableNewPricing,
+  isFeatureEnabled,
 } from '@core/constant/featureFlags';
 import {
   type SettingsTab,
@@ -1071,7 +1072,7 @@ const RECENT_LINK: SidebarItem = {
  * their correct positions.
  * Shared by the rendered sidebar (`AppSidebar.visibleLinks`) and the
  * always-mounted `GoToHotkeys` registrar so their link sets can't drift. Call
- * from a reactive context — it reads `ENABLE_CALLS()` / `ENABLE_CRM()`.
+ * from a reactive context — it reads `ENABLE_CALLS` / `isFeatureEnabled(enableCrm)`.
  * `showGettingStarted` is the account-age gate (`useGettingStartedEnabled`),
  * passed in because this runs outside a component; when false the link is
  * fully absent — row, `g s` hotkey, and command menu entry.
@@ -1106,14 +1107,14 @@ const buildSidebarLinks = (
     ];
   }
 
-  if (ENABLE_CALLS()) {
+  if (ENABLE_CALLS) {
     const idx = links.findIndex((l) => l.id === 'channels');
     links = [...links.slice(0, idx + 1), CALLS_LINK, ...links.slice(idx + 1)];
   }
 
-  if (ENABLE_CRM()) {
+  if (isFeatureEnabled(enableCrm)) {
     // Customers sits just after Channels (and Calls when present).
-    const anchorId = ENABLE_CALLS() ? 'calls' : 'channels';
+    const anchorId = ENABLE_CALLS ? 'calls' : 'channels';
     const idx = links.findIndex((l) => l.id === anchorId);
     links = [
       ...links.slice(0, idx + 1),
@@ -1176,9 +1177,7 @@ export const AppSidebar = (props: AppSidebarProps) => {
     { name: 'sidebar-premium-card-dismissed' }
   );
 
-  const newPricingFF = useFeatureFlag('enable-new-pricing', {
-    enabledOverride: ENABLE_NEW_PRICING_OVERRIDE,
-  });
+  const newPricingFF = useFeatureFlag(enableNewPricing);
 
   const gettingStartedEnabled = useGettingStartedEnabled();
   const calendarUiEnabled = useCalendarUiFlag();

--- a/apps/web/src/components/app/sidebar-next/footer-actions.tsx
+++ b/apps/web/src/components/app/sidebar-next/footer-actions.tsx
@@ -2,7 +2,10 @@ import { runCreateAction } from '@app/features/command/Launcher';
 import { globalSplitManager } from '@app/signal/splitLayout';
 import { CALENDAR_BLOCK_ID } from '@block-calendar/types';
 import { SidebarSettingsWidget } from '@components/app/app-sidebar/sidebar';
-import { ENABLE_CHAT_V3_AGENTS } from '@core/constant/featureFlags';
+import {
+  enableChatV3Agents,
+  isFeatureEnabled,
+} from '@core/constant/featureFlags';
 import {
   type SettingsTab,
   useSettingsState,
@@ -65,10 +68,13 @@ export const FooterActions = (props: {
             // The two creatables both bind `a` and are mutually exclusive on the
             // agents flag, so pick the one that is actually registered.
             // `shouldInsert` is what `createBlock` turns into `preferNewSplit`.
-            runCreateAction(ENABLE_CHAT_V3_AGENTS() ? 'agent' : 'chat', {
-              shouldInsert: true,
-              source: 'sidebar',
-            })
+            runCreateAction(
+              isFeatureEnabled(enableChatV3Agents) ? 'agent' : 'chat',
+              {
+                shouldInsert: true,
+                source: 'sidebar',
+              }
+            )
           }
         >
           <SparkleIcon />

--- a/apps/web/src/components/app/sidebar-next/use-nav-item-gates.ts
+++ b/apps/web/src/components/app/sidebar-next/use-nav-item-gates.ts
@@ -1,9 +1,6 @@
 import { useCalendarUiFlag } from '@app/features/calendar/hooks/use-calendar-ui-flag';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
-import {
-  ENABLE_CRM_FLAG,
-  ENABLE_CRM_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableCrm } from '@core/constant/featureFlags';
 import type { Accessor } from 'solid-js';
 import type { NavItemGates } from './nav-items';
 
@@ -15,9 +12,7 @@ import type { NavItemGates } from './nav-items';
  */
 export function useNavItemGates(): Accessor<NavItemGates> {
   const calendar = useCalendarUiFlag();
-  const crm = useFeatureFlag(ENABLE_CRM_FLAG, {
-    enabledOverride: ENABLE_CRM_OVERRIDE,
-  });
+  const crm = useFeatureFlag(enableCrm);
   return () => ({
     showCalendar: calendar(),
     showCustomers: crm().enabled,

--- a/apps/web/src/components/app/sidebar-next/use-sidebar-next-flag.ts
+++ b/apps/web/src/components/app/sidebar-next/use-sidebar-next-flag.ts
@@ -1,8 +1,5 @@
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
-import {
-  ENABLE_SIDEBAR_NEXT_FLAG,
-  ENABLE_SIDEBAR_NEXT_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableSidebarNext } from '@core/constant/featureFlags';
 import type { Accessor } from 'solid-js';
 
 /**
@@ -11,8 +8,6 @@ import type { Accessor } from 'solid-js';
  * VITE_ENABLE_SIDEBAR_NEXT=true to force it on locally without PostHog.
  */
 export function useSidebarNextFlag(): Accessor<boolean> {
-  const flag = useFeatureFlag(ENABLE_SIDEBAR_NEXT_FLAG, {
-    enabledOverride: ENABLE_SIDEBAR_NEXT_OVERRIDE,
-  });
+  const flag = useFeatureFlag(enableSidebarNext);
   return () => flag().enabled;
 }

--- a/apps/web/src/components/app/split-layout/componentRegistry.tsx
+++ b/apps/web/src/components/app/split-layout/componentRegistry.tsx
@@ -32,10 +32,10 @@ import { useIsAuthenticated } from '@core/auth';
 import { LoadingBlock } from '@core/component/LoadingBlock';
 import {
   DEV_MODE_ENV,
-  ENABLE_CRM,
-  ENABLE_NEW_APP_VIEWS_FLAG,
-  ENABLE_NEW_APP_VIEWS_OVERRIDE,
-  ENABLE_REMINDERS,
+  enableCrm,
+  enableNewAppViews,
+  enableReminders,
+  isFeatureEnabled,
   LOCAL_ONLY,
 } from '@core/constant/featureFlags';
 import { useUserContext } from '@core/context/user';
@@ -69,11 +69,9 @@ function usePageViewTracking(pageTitle: string) {
 function useNewAppViews() {
   const panel = useSplitPanelOrThrow();
   const posthog = usePosthog();
-  const flag = useFeatureFlag(ENABLE_NEW_APP_VIEWS_FLAG, {
-    enabledOverride: ENABLE_NEW_APP_VIEWS_OVERRIDE,
-  });
+  const flag = useFeatureFlag(enableNewAppViews);
   const ready = () =>
-    ENABLE_NEW_APP_VIEWS_OVERRIDE !== undefined || posthog.flagsLoaded();
+    enableNewAppViews.override !== undefined || posthog.flagsLoaded();
   const enabled = () => ready() && flag().enabled;
 
   createRenderEffect(() => {
@@ -333,7 +331,7 @@ registerComponent(
   withAuth(() => {
     // Registered even when the flag is closed so a bookmarked /reminders or a
     // restored split recovers to the inbox instead of an empty split.
-    if (!ENABLE_REMINDERS()) {
+    if (!isFeatureEnabled(enableReminders)) {
       return <RedirectSplit to={{ type: 'component', id: 'inbox' }} />;
     }
     usePageViewTracking('reminders');
@@ -508,7 +506,7 @@ registerComponent(
   withAuth(() => {
     // Registered even when the CRM feature is off so direct navigation /
     // restored splits redirect instead of throwing in resolveComponent.
-    if (!ENABLE_CRM()) {
+    if (!isFeatureEnabled(enableCrm)) {
       return <RedirectSplit to={{ type: 'component', id: 'inbox' }} />;
     }
     usePageViewTracking('companies');

--- a/apps/web/src/components/app/split-layout/components/SplitFileMenu.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitFileMenu.tsx
@@ -16,10 +16,7 @@ import type { BlockTool } from '@components/app/ResponsiveBlockToolbar';
 import { type BlockName, useBlockAliasedName, useBlockName } from '@core/block';
 import { useItemOperations } from '@core/component/FileList/useItemOperations';
 import { toast } from '@core/component/Toast/Toast';
-import {
-  ENABLE_REMINDERS_FLAG,
-  ENABLE_REMINDERS_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableReminders } from '@core/constant/featureFlags';
 import { useQuickAccess } from '@core/context/quickAccess';
 import { useUserId } from '@core/context/user';
 import { triggerFocusInput } from '@core/directive/focusInput';
@@ -445,9 +442,7 @@ export function SplitFileMenu(props: {
   // is a memo, so without a reactive dependency the item would stay missing for
   // the life of this menu if PostHog answered after it was first computed. The
   // other reminder surfaces re-evaluate per interaction and don't need this.
-  const remindersFlag = useFeatureFlag(ENABLE_REMINDERS_FLAG, {
-    enabledOverride: ENABLE_REMINDERS_OVERRIDE,
-  });
+  const remindersFlag = useFeatureFlag(enableReminders);
 
   // Injected here rather than per-block so every block rendering this menu gets
   // it, the way Favorite does. Entity types the reminders API cannot mint an

--- a/apps/web/src/features/activity/use-activity-feed-flag.ts
+++ b/apps/web/src/features/activity/use-activity-feed-flag.ts
@@ -1,8 +1,5 @@
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
-import {
-  ENABLE_ACTIVITY_FEED_FLAG,
-  ENABLE_ACTIVITY_FEED_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableActivityFeed } from '@core/constant/featureFlags';
 import type { Accessor } from 'solid-js';
 
 /**
@@ -11,8 +8,6 @@ import type { Accessor } from 'solid-js';
  * and the feed query is never issued.
  */
 export function useActivityFeedFlag(): Accessor<boolean> {
-  const flag = useFeatureFlag(ENABLE_ACTIVITY_FEED_FLAG, {
-    enabledOverride: ENABLE_ACTIVITY_FEED_OVERRIDE,
-  });
+  const flag = useFeatureFlag(enableActivityFeed);
   return () => flag().enabled;
 }

--- a/apps/web/src/features/activity/use-entity-activity-flag.ts
+++ b/apps/web/src/features/activity/use-entity-activity-flag.ts
@@ -1,8 +1,5 @@
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
-import {
-  ENABLE_ENTITY_ACTIVITY_SECTION_FLAG,
-  ENABLE_ENTITY_ACTIVITY_SECTION_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableEntityActivitySection } from '@core/constant/featureFlags';
 import type { Accessor } from 'solid-js';
 
 /**
@@ -11,8 +8,6 @@ import type { Accessor } from 'solid-js';
  * issued while off.
  */
 export function useEntityActivityFlag(): Accessor<boolean> {
-  const flag = useFeatureFlag(ENABLE_ENTITY_ACTIVITY_SECTION_FLAG, {
-    enabledOverride: ENABLE_ENTITY_ACTIVITY_SECTION_OVERRIDE,
-  });
+  const flag = useFeatureFlag(enableEntityActivitySection);
   return () => flag().enabled;
 }

--- a/apps/web/src/features/block-calendar/open-calendar-event.ts
+++ b/apps/web/src/features/block-calendar/open-calendar-event.ts
@@ -1,5 +1,8 @@
 import { globalSplitManager } from '@app/signal/splitLayout';
-import { ENABLE_CALENDAR_UI } from '@core/constant/featureFlags';
+import {
+  enableCalendarUi,
+  isFeatureEnabled,
+} from '@core/constant/featureFlags';
 import {
   type CalendarBlockEventTime,
   createCalendarBlockRange,
@@ -38,7 +41,7 @@ export function eventTimeFromOccurrenceKey(
  * opens re-aim the already-open split instead of stacking another calendar.
  */
 export async function openCalendarEventSplit(target: CalendarEventOpenTarget) {
-  if (!ENABLE_CALENDAR_UI()) return;
+  if (!isFeatureEnabled(enableCalendarUi)) return;
   const splitManager = globalSplitManager();
   if (!splitManager) return;
 

--- a/apps/web/src/features/block-call/definition.ts
+++ b/apps/web/src/features/block-call/definition.ts
@@ -18,7 +18,7 @@ export const definition = defineBlock({
   defaultFilename: 'Call',
   component: CallBlockAdapter,
   async load(source, _intent) {
-    if (!ENABLE_CALLS()) return LoadErrors.MISSING;
+    if (!ENABLE_CALLS) return LoadErrors.MISSING;
     if (source.type !== 'dss') return LoadErrors.MISSING;
 
     const callId = source.id;

--- a/apps/web/src/features/block-channel/component/NewChannelBlockAdapter.tsx
+++ b/apps/web/src/features/block-channel/component/NewChannelBlockAdapter.tsx
@@ -150,7 +150,7 @@ function NewTop(props: { channelId: string }) {
   // the tab is being displayed (e.g. via the auto-join flow that flips
   // `activeTab` to `call` before the join request resolves).
   const showCallTab = () =>
-    ENABLE_CALLS() &&
+    ENABLE_CALLS &&
     canUseInlineCallTab() &&
     (call.isInThisChannel() ||
       call.isJoining() ||
@@ -240,7 +240,7 @@ function NewTop(props: { channelId: string }) {
         />
       </SplitTitleFileMenu>
       {/* Hidden once the user has joined — the call surface owns the UI. */}
-      <Show when={ENABLE_CALLS() && !call.isInThisChannel()}>
+      <Show when={ENABLE_CALLS && !call.isInThisChannel()}>
         <SplitHeaderRight>
           <HeaderIsland
             class={cn(

--- a/apps/web/src/features/block-channel/component/useChannelBotManagement.ts
+++ b/apps/web/src/features/block-channel/component/useChannelBotManagement.ts
@@ -5,10 +5,7 @@ import {
 } from '@channel/Bots/botSettingsState';
 import { channelWebhookUrl } from '@channel/Bots/webhook';
 import { toast } from '@core/component/Toast/Toast';
-import {
-  BOT_MANAGEMENT_FLAG,
-  BOT_MANAGEMENT_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { botManagement } from '@core/constant/featureFlags';
 import { useSettingsState } from '@core/constant/SettingsState';
 import { useChannelType } from '@core/context/channels';
 import { createHotkeyGroup, registerHotkey } from '@core/hotkey/hotkeys';
@@ -29,9 +26,7 @@ export function useChannelBotManagement(
 ) {
   const { openSettings } = useSettingsState();
   const channelType = useChannelType(options.channelId);
-  const featureFlag = useFeatureFlag(BOT_MANAGEMENT_FLAG, {
-    enabledOverride: BOT_MANAGEMENT_OVERRIDE,
-  });
+  const featureFlag = useFeatureFlag(botManagement);
   const [inviteFocusRequest, setInviteFocusRequest] = createSignal(0);
 
   const enabled = () => featureFlag().enabled;

--- a/apps/web/src/features/block-email/component/BaseInput.tsx
+++ b/apps/web/src/features/block-email/component/BaseInput.tsx
@@ -24,9 +24,9 @@ import { RecipientSelector } from '@core/component/RecipientSelector';
 import { toast } from '@core/component/Toast/Toast';
 import {
   ENABLE_EMAIL_SCHEDULED_SEND,
-  ENABLE_EMAIL_SIGNATURES_FLAG,
-  ENABLE_EMAIL_SIGNATURES_OVERRIDE,
-  ENABLE_GRAPHQL_SOUP,
+  enableEmailSignatures,
+  enableGraphqlSoup,
+  isFeatureEnabled,
 } from '@core/constant/featureFlags';
 import { useEmail } from '@core/context/user';
 import { fileFolderDrop } from '@core/directive/fileFolderDrop';
@@ -358,9 +358,7 @@ export function BaseInput(props: {
     emailLinksQuery.data?.links.find((l) => l.id === activeLinkId())
   );
   const signature = useEmailSignature(activeLinkId);
-  const emailSignaturesFlag = useFeatureFlag(ENABLE_EMAIL_SIGNATURES_FLAG, {
-    enabledOverride: ENABLE_EMAIL_SIGNATURES_OVERRIDE,
-  });
+  const emailSignaturesFlag = useFeatureFlag(enableEmailSignatures);
   // Whether this reply includes the signature. Defaults on, reset per reply,
   // and dismissable via the preview ✕.
   const [includeSignature, setIncludeSignature] = createSignal(true);
@@ -525,7 +523,7 @@ export function BaseInput(props: {
     // survives navigation — while the context read covers snapshotless undos
     // in a still-mounted thread.
     const threadId = snapshot?.threadId ?? ctx.thread()?.db_id;
-    if (threadId && !ENABLE_GRAPHQL_SOUP()) {
+    if (threadId && !isFeatureEnabled(enableGraphqlSoup)) {
       queryClient.setQueryData(
         emailKeys.threadMessages(threadId).queryKey,
         (old: any) => {
@@ -561,7 +559,7 @@ export function BaseInput(props: {
     // After the draft-body restore, so the single fetch returns the message
     // as a draft with the pre-send content, dropping it from the message
     // list and re-seeding the draft map in one pass.
-    if (threadId && ENABLE_GRAPHQL_SOUP()) {
+    if (threadId && isFeatureEnabled(enableGraphqlSoup)) {
       void fetchAndCacheThread(threadId);
     }
 

--- a/apps/web/src/features/block-email/component/compose/Compose.tsx
+++ b/apps/web/src/features/block-email/component/compose/Compose.tsx
@@ -35,9 +35,9 @@ import { useHasPaidAccess } from '@core/auth';
 import { EmailPermissionsBanner } from '@core/component/EmailPermissionsBanner';
 import { toast } from '@core/component/Toast/Toast';
 import {
-  ENABLE_EMAIL_SIGNATURES_FLAG,
-  ENABLE_EMAIL_SIGNATURES_OVERRIDE,
-  ENABLE_GRAPHQL_SOUP,
+  enableEmailSignatures,
+  enableGraphqlSoup,
+  isFeatureEnabled,
 } from '@core/constant/featureFlags';
 import { isMobile } from '@core/mobile/isMobile';
 import { WrapUnlessMobile } from '@core/mobile/WrapUnlessMobile';
@@ -172,9 +172,7 @@ export function EmailCompose(props: EmailComposeProps) {
   // message. The backend injects it on send (see include_signature below); the
   // FE only renders the preview and signals an explicit dismiss.
   const signature = useEmailSignature(() => link()?.id);
-  const emailSignaturesFlag = useFeatureFlag(ENABLE_EMAIL_SIGNATURES_FLAG, {
-    enabledOverride: ENABLE_EMAIL_SIGNATURES_OVERRIDE,
-  });
+  const emailSignaturesFlag = useFeatureFlag(enableEmailSignatures);
   const [includeSignature, setIncludeSignature] = createSignal(true);
 
   const hasLinkError = createMemo(() => {
@@ -427,7 +425,8 @@ export function EmailCompose(props: EmailComposeProps) {
   ) => {
     // Wipe the new thread's cache when its view unmounts (replaceSplit
     // below) so the next visit fetches fresh data without the sent message.
-    if (threadId && !ENABLE_GRAPHQL_SOUP()) markThreadDraftSaved(threadId);
+    if (threadId && !isFeatureEnabled(enableGraphqlSoup))
+      markThreadDraftSaved(threadId);
 
     // Overwrite the server-side draft with the pre-send content. The
     // snapshot itself stays for the compose remount below to restore the
@@ -452,7 +451,7 @@ export function EmailCompose(props: EmailComposeProps) {
     // markThreadDraftSaved's TanStack cleanup can't reach — refetch through
     // it (after the draft-body restore) so a revisit doesn't replay the
     // undone message from cache.
-    if (threadId && ENABLE_GRAPHQL_SOUP()) {
+    if (threadId && isFeatureEnabled(enableGraphqlSoup)) {
       void fetchAndCacheThread(threadId);
     }
 

--- a/apps/web/src/features/block-md/component/MarkdownEditor.tsx
+++ b/apps/web/src/features/block-md/component/MarkdownEditor.tsx
@@ -136,11 +136,12 @@ import { useUrlParams } from '@core/component/ParamsProvider';
 import { toast } from '@core/component/Toast/Toast';
 import { itemToBlockName } from '@core/constant/allBlocks';
 import {
-  ENABLE_GIT_BLAME,
   ENABLE_MARKDOWN_AI_GENERATE,
   ENABLE_MARKDOWN_COMMENTS,
   ENABLE_MARKDOWN_DIFF,
   ENABLE_MARKDOWN_LIVE_COLLABORATION,
+  enableGitBlame,
+  isFeatureEnabled,
 } from '@core/constant/featureFlags';
 import { IS_MAC } from '@core/constant/isMac';
 import { useUserId } from '@core/context/user';
@@ -954,7 +955,7 @@ export function MarkdownEditor(props: {
   });
 
   const [blameTooltipStore, setBlameTooltipStore] = createBlameTooltipStore();
-  if (ENABLE_GIT_BLAME()) {
+  if (isFeatureEnabled(enableGitBlame)) {
     plugins.use(
       blameTooltipPlugin({ setState: (s) => setBlameTooltipStore(s) })
     );
@@ -1047,7 +1048,7 @@ export function MarkdownEditor(props: {
             {getBlankMarkdownPlaceholder(canEdit())}
           </div>
         </Show>
-        <Show when={ENABLE_GIT_BLAME()}>
+        <Show when={isFeatureEnabled(enableGitBlame)}>
           <Suspense>
             <BlameTooltip state={blameTooltipStore} documentId={blockId} />
           </Suspense>

--- a/apps/web/src/features/block-md/component/MarkdownPopup.tsx
+++ b/apps/web/src/features/block-md/component/MarkdownPopup.tsx
@@ -48,10 +48,7 @@ import {
 } from '@core/component/LexicalMarkdown/plugins/popup/popupPlugin';
 import { ScopedPortal } from '@core/component/ScopedPortal';
 import { toast } from '@core/component/Toast/Toast';
-import {
-  INLINE_AI_EDITING_FLAG,
-  INLINE_AI_EDITING_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableInlineAiEditing } from '@core/constant/featureFlags';
 import { useUserId } from '@core/context/user';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import {
@@ -201,9 +198,7 @@ export function MarkdownPopup(props: {
   });
 
   const canEdit = useCanEdit();
-  const inlineAiEditing = useFeatureFlag(INLINE_AI_EDITING_FLAG, {
-    enabledOverride: INLINE_AI_EDITING_OVERRIDE,
-  });
+  const inlineAiEditing = useFeatureFlag(enableInlineAiEditing);
   const canComment = useCanComment();
   const currentUserId = useUserId();
 

--- a/apps/web/src/features/block-md/component/Notebook.tsx
+++ b/apps/web/src/features/block-md/component/Notebook.tsx
@@ -18,10 +18,10 @@ import {
 import { ParamsProvider } from '@core/component/ParamsProvider';
 import {
   DEV_MODE_ENV,
-  ENABLE_HISTORY_COMPONENT,
   ENABLE_MARKDOWN_COMMENTS,
-  INLINE_AI_EDITING_FLAG,
-  INLINE_AI_EDITING_OVERRIDE,
+  enableHistoryComponent,
+  enableInlineAiEditing,
+  isFeatureEnabled,
   LOCAL_ONLY,
 } from '@core/constant/featureFlags';
 import { useIsMacroTeam } from '@core/context/team';
@@ -132,9 +132,7 @@ export function Notebook(props: {
   const canAutofocusSplitContent = useCanAutofocusSplitContent();
   const documentId = props.documentId;
   const canEdit = useCanEdit();
-  const inlineAiEditing = useFeatureFlag(INLINE_AI_EDITING_FLAG, {
-    enabledOverride: INLINE_AI_EDITING_OVERRIDE,
-  });
+  const inlineAiEditing = useFeatureFlag(enableInlineAiEditing);
 
   let notebookRef!: HTMLDivElement;
   let commentMarginRef: HTMLDivElement | undefined;
@@ -409,7 +407,7 @@ export function Notebook(props: {
                 setShowLexicalStateDebugger(false)
               }
             />
-            <Show when={ENABLE_HISTORY_COMPONENT()}>
+            <Show when={isFeatureEnabled(enableHistoryComponent)}>
               <HistoryOverlay
                 currentState={currentEditorState}
                 selectedAt={history.selectedAt()}

--- a/apps/web/src/features/block-md/component/TaskDuplicateList.tsx
+++ b/apps/web/src/features/block-md/component/TaskDuplicateList.tsx
@@ -1,10 +1,7 @@
 import { QUERY_FILTERS_BASE } from '@app/features/next-soup/filters/query-filters';
 import { TaskListEntity } from '@app/features/next-soup/soup-view/views/tasks/TaskListEntity';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
-import {
-  ENABLE_TASK_DUPLICATES_FLAG,
-  ENABLE_TASK_DUPLICATES_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableTaskDuplicates } from '@core/constant/featureFlags';
 import { ListLayoutProvider } from '@entity';
 import CaretRightIcon from '@phosphor/caret-right.svg';
 import CopyIcon from '@phosphor/copy.svg';
@@ -132,9 +129,7 @@ export function SimilarTasksSection(props: {
   content: Accessor<string>;
   onOpenTask: (taskId: string) => void;
 }) {
-  const flag = useFeatureFlag(ENABLE_TASK_DUPLICATES_FLAG, {
-    enabledOverride: ENABLE_TASK_DUPLICATES_OVERRIDE,
-  });
+  const flag = useFeatureFlag(enableTaskDuplicates);
 
   const [debounced, setDebounced] = createSignal<DebouncedInput>({
     title: props.title(),

--- a/apps/web/src/features/block-md/component/TaskDuplicateMatches.tsx
+++ b/apps/web/src/features/block-md/component/TaskDuplicateMatches.tsx
@@ -3,10 +3,7 @@ import { SidePanel } from '@components/app/side-panel';
 import { useBlockId } from '@core/block';
 import { DocumentMention } from '@core/component/LexicalMarkdown/component/decorator/DocumentMention';
 import { toast } from '@core/component/Toast/Toast';
-import {
-  ENABLE_TASK_DUPLICATES_FLAG,
-  ENABLE_TASK_DUPLICATES_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableTaskDuplicates } from '@core/constant/featureFlags';
 import CaretDownIcon from '@phosphor/caret-down.svg';
 import WarningIcon from '@phosphor/warning.svg';
 import {
@@ -18,9 +15,7 @@ import { Button, cn, Dropdown } from '@ui';
 import { createMemo, createSignal, For, Show, Suspense } from 'solid-js';
 
 export function TaskDuplicateMatchPill() {
-  const flag = useFeatureFlag(ENABLE_TASK_DUPLICATES_FLAG, {
-    enabledOverride: ENABLE_TASK_DUPLICATES_OVERRIDE,
-  });
+  const flag = useFeatureFlag(enableTaskDuplicates);
   const matches = useTaskDuplicateMatches();
   const [open, setOpen] = createSignal(false);
 
@@ -58,9 +53,7 @@ export function TaskDuplicateMatchPill() {
 }
 
 export function TaskDuplicateMatchesSidePanelSection() {
-  const flag = useFeatureFlag(ENABLE_TASK_DUPLICATES_FLAG, {
-    enabledOverride: ENABLE_TASK_DUPLICATES_OVERRIDE,
-  });
+  const flag = useFeatureFlag(enableTaskDuplicates);
   const matches = useTaskDuplicateMatches();
 
   return (

--- a/apps/web/src/features/block-md/component/sidepanel/MarkdownSidePanelSections.tsx
+++ b/apps/web/src/features/block-md/component/sidepanel/MarkdownSidePanelSections.tsx
@@ -24,7 +24,8 @@ import { Notifications } from '@core/component/Notifications';
 import { References } from '@core/component/References';
 import { UserIcon } from '@core/component/UserIcon';
 import {
-  ENABLE_HISTORY_COMPONENT,
+  enableHistoryComponent,
+  isFeatureEnabled,
   USE_MACRO_PR_SUMMARY_BLOCK,
 } from '@core/constant/featureFlags';
 import { useUserId } from '@core/context/user';
@@ -123,7 +124,7 @@ export function MarkdownSidePanelSections(
           <StatsSectionContent />
         </SidePanel.Section>
       </Show>
-      <Show when={ENABLE_HISTORY_COMPONENT()}>
+      <Show when={isFeatureEnabled(enableHistoryComponent)}>
         <SidePanel.Section id="history" title="History" order={35}>
           <HistorySectionContent />
         </SidePanel.Section>

--- a/apps/web/src/features/calendar/components/CalendarSettingsDropdown.tsx
+++ b/apps/web/src/features/calendar/components/CalendarSettingsDropdown.tsx
@@ -1,6 +1,6 @@
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { MobileDrawer } from '@components/app/mobile/MobileDrawer';
-import { ENABLE_MULTI_INBOX_OVERRIDE } from '@core/constant/featureFlags';
+import { enableMultiInbox } from '@core/constant/featureFlags';
 import { useAddInboxFlow } from '@core/email-link';
 import { isMobile } from '@core/mobile/isMobile';
 import CaretRightIcon from '@phosphor/caret-right.svg';
@@ -42,9 +42,7 @@ function createCalendarSettingsControls(isNarrow: () => boolean) {
   const calendarView = useCalendarView();
   const accounts = useCalendarAccounts();
   const startAddInbox = useAddInboxFlow();
-  const multiInboxFlag = useFeatureFlag('enable-multi-inbox', {
-    enabledOverride: ENABLE_MULTI_INBOX_OVERRIDE,
-  });
+  const multiInboxFlag = useFeatureFlag(enableMultiInbox);
   const [turnOffTarget, setTurnOffTarget] =
     createSignal<TurnOffCalendarTarget | null>(null);
 

--- a/apps/web/src/features/calendar/hooks/use-calendar-ui-flag.ts
+++ b/apps/web/src/features/calendar/hooks/use-calendar-ui-flag.ts
@@ -1,21 +1,15 @@
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import {
-  ENABLE_CALENDAR_PROMPT_MOBILE_FLAG,
-  ENABLE_CALENDAR_PROMPT_MOBILE_OVERRIDE,
-  ENABLE_CALENDAR_PROMPT_WEB_FLAG,
-  ENABLE_CALENDAR_PROMPT_WEB_OVERRIDE,
-  ENABLE_CALENDAR_SEARCH_UI_FLAG,
-  ENABLE_CALENDAR_SEARCH_UI_OVERRIDE,
-  ENABLE_CALENDAR_UI_FLAG,
-  ENABLE_CALENDAR_UI_OVERRIDE,
+  enableCalendarPromptMobile,
+  enableCalendarPromptWeb,
+  enableCalendarSearchUi,
+  enableCalendarUi,
 } from '@core/constant/featureFlags';
 import { isMobile } from '@core/mobile/isMobile';
 import type { Accessor } from 'solid-js';
 
 export function useCalendarUiFlag(): Accessor<boolean> {
-  const flag = useFeatureFlag(ENABLE_CALENDAR_UI_FLAG, {
-    enabledOverride: ENABLE_CALENDAR_UI_OVERRIDE,
-  });
+  const flag = useFeatureFlag(enableCalendarUi);
   return () => flag().enabled;
 }
 
@@ -26,9 +20,7 @@ export function useCalendarUiFlag(): Accessor<boolean> {
  */
 export function useCalendarSearchUiFlag(): Accessor<boolean> {
   const calendarUi = useCalendarUiFlag();
-  const searchFlag = useFeatureFlag(ENABLE_CALENDAR_SEARCH_UI_FLAG, {
-    enabledOverride: ENABLE_CALENDAR_SEARCH_UI_OVERRIDE,
-  });
+  const searchFlag = useFeatureFlag(enableCalendarSearchUi);
   return () => calendarUi() && searchFlag().enabled;
 }
 
@@ -41,11 +33,7 @@ export function useCalendarSearchUiFlag(): Accessor<boolean> {
  * call site.
  */
 export function useCalendarPromptAllowed(): Accessor<boolean> {
-  const mobileFlag = useFeatureFlag(ENABLE_CALENDAR_PROMPT_MOBILE_FLAG, {
-    enabledOverride: ENABLE_CALENDAR_PROMPT_MOBILE_OVERRIDE,
-  });
-  const webFlag = useFeatureFlag(ENABLE_CALENDAR_PROMPT_WEB_FLAG, {
-    enabledOverride: ENABLE_CALENDAR_PROMPT_WEB_OVERRIDE,
-  });
+  const mobileFlag = useFeatureFlag(enableCalendarPromptMobile);
+  const webFlag = useFeatureFlag(enableCalendarPromptWeb);
   return () => (isMobile() ? mobileFlag() : webFlag()).enabled;
 }

--- a/apps/web/src/features/channel/Call/ChannelCallAutoJoin.tsx
+++ b/apps/web/src/features/channel/Call/ChannelCallAutoJoin.tsx
@@ -30,7 +30,7 @@ export function ChannelCallAutoJoin(props: {
     if (!props.pendingJoinCall()) return;
 
     untrack(() => {
-      if (!ENABLE_CALLS()) {
+      if (!ENABLE_CALLS) {
         props.onHandled();
         return;
       }

--- a/apps/web/src/features/channel/Call/call-events.ts
+++ b/apps/web/src/features/channel/Call/call-events.ts
@@ -187,7 +187,7 @@ export function createCallEventsEffect(handlers: CallEventHandlers) {
     // Check the type before parsing so we don't JSON.parse every frame the app
     // receives just to discard it.
     if (!isCallEventType(data.type)) return;
-    if (!ENABLE_CALLS()) return;
+    if (!ENABLE_CALLS) return;
 
     const event = parseCallEvent(data.type, data.data);
     if (!event) return;

--- a/apps/web/src/features/channel/Input/ChannelInput.tsx
+++ b/apps/web/src/features/channel/Input/ChannelInput.tsx
@@ -12,7 +12,10 @@ import {
   updateDragInsertPreviewFromCoordinates,
 } from '@core/component/LexicalMarkdown/utils/dragInsertUtils';
 import { isCursorBotId } from '@core/constant/cursorAgent';
-import { ENABLE_CHAT_V3_AGENTS } from '@core/constant/featureFlags';
+import {
+  enableChatV3Agents,
+  isFeatureEnabled,
+} from '@core/constant/featureFlags';
 import { useCursorAgentsAccess } from '@core/cursor/flag';
 import { registerHotkey, useHotkeyDOMScope } from '@core/hotkey/hotkeys';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
@@ -273,13 +276,13 @@ export function ChannelInput(props: ChannelInputProps) {
       ...(props.bots?.() ?? []),
     ].filter((user) => cursorEnabled || !isCursorBotId(user.id));
     if (
-      ENABLE_CHAT_V3_AGENTS() &&
+      isFeatureEnabled(enableChatV3Agents) &&
       !base.some((user) => isMacroCoderId(user.id))
     ) {
       base.unshift(macroCoderMentionUser());
     }
     if (
-      ENABLE_CHAT_V3_AGENTS() &&
+      isFeatureEnabled(enableChatV3Agents) &&
       !base.some((user) => isMacroNewId(user.id))
     ) {
       base.unshift(macroNewMentionUser());

--- a/apps/web/src/features/channel/use-chat-v3-agents-flag.ts
+++ b/apps/web/src/features/channel/use-chat-v3-agents-flag.ts
@@ -1,8 +1,5 @@
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
-import {
-  ENABLE_CHAT_V3_AGENTS_FLAG,
-  ENABLE_CHAT_V3_AGENTS_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableChatV3Agents } from '@core/constant/featureFlags';
 import type { Accessor } from 'solid-js';
 
 /**
@@ -11,8 +8,6 @@ import type { Accessor } from 'solid-js';
  * gated surfaces appear once PostHog answers rather than only on remount.
  */
 export function useChatV3AgentsFlag(): Accessor<boolean> {
-  const flag = useFeatureFlag(ENABLE_CHAT_V3_AGENTS_FLAG, {
-    enabledOverride: ENABLE_CHAT_V3_AGENTS_OVERRIDE,
-  });
+  const flag = useFeatureFlag(enableChatV3Agents);
   return () => flag().enabled;
 }

--- a/apps/web/src/features/command/Launcher.tsx
+++ b/apps/web/src/features/command/Launcher.tsx
@@ -15,14 +15,10 @@ import { CHAT_INPUT_TEXT_AREA_ID } from '@core/component/AI/component/input/Chat
 import { getIconConfig } from '@core/component/EntityIcon';
 import {
   ENABLE_ANIMATED_ICONS,
-  ENABLE_CHAT_V3_AGENTS,
-  ENABLE_CHAT_V3_AGENTS_FLAG,
-  ENABLE_CHAT_V3_AGENTS_OVERRIDE,
-  ENABLE_REMINDERS,
-  ENABLE_REMINDERS_FLAG,
-  ENABLE_REMINDERS_OVERRIDE,
-  ENABLE_SNIPPETS_FLAG,
-  ENABLE_SNIPPETS_OVERRIDE,
+  enableChatV3Agents,
+  enableReminders,
+  enableSnippets,
+  isFeatureEnabled,
 } from '@core/constant/featureFlags';
 import { triggerFocusInput } from '@core/directive/focusInput';
 import {
@@ -411,7 +407,7 @@ export function runCreateAction(
     // A reminder has no block to open: the composer asks what and when, and the
     // reminder lives in the Reminders lists from there.
     case 'reminder':
-      if (!ENABLE_REMINDERS()) return;
+      if (!isFeatureEnabled(enableReminders)) return;
       setCreateMenuOpen(false, false);
       openStandaloneReminderComposer();
       return;
@@ -471,7 +467,7 @@ export const CREATABLE_BLOCKS: CreatableBlock[] = [
     // pick between them by condition; the default 'override' would let the
     // later one silently replace the earlier.
     registrationType: 'add',
-    enabled: () => !ENABLE_CHAT_V3_AGENTS(),
+    enabled: () => !isFeatureEnabled(enableChatV3Agents),
     keyDownHandler: () => {
       runCreateAction('chat', { shouldInsert: pressedKeys().has('shift') });
       return true;
@@ -502,7 +498,7 @@ export const CREATABLE_BLOCKS: CreatableBlock[] = [
     altHotkeyToken: TOKENS.create.agentNewSplit,
     hotkey: 'a',
     registrationType: 'add',
-    enabled: () => ENABLE_CHAT_V3_AGENTS(),
+    enabled: () => isFeatureEnabled(enableChatV3Agents),
     keyDownHandler: () => {
       runCreateAction('agent', { shouldInsert: pressedKeys().has('shift') });
       return true;
@@ -563,7 +559,7 @@ export const CREATABLE_BLOCKS: CreatableBlock[] = [
     // No `altHotkeyToken`: a reminder opens no split, so there is no
     // shift-variant to bind.
     hotkey: 'r',
-    enabled: () => ENABLE_REMINDERS(),
+    enabled: () => isFeatureEnabled(enableReminders),
     keyDownHandler: () => {
       runCreateAction('reminder');
       return true;
@@ -676,18 +672,12 @@ export const CREATABLE_BLOCKS: CreatableBlock[] = [
 export function useCreateMenuBlocks(
   source: () => CreatableBlock[] = () => CREATABLE_BLOCKS
 ): Accessor<CreatableBlock[]> {
-  const snippetsFlag = useFeatureFlag(ENABLE_SNIPPETS_FLAG, {
-    enabledOverride: ENABLE_SNIPPETS_OVERRIDE,
-  });
+  const snippetsFlag = useFeatureFlag(enableSnippets);
   // Subscribed to rather than left to the block's own `enabled`, which reads
   // PostHog without tracking it: this memo has no other reason to re-run, so a
   // flag that resolves after mount would leave the menu as it was until reload.
-  const remindersFlag = useFeatureFlag(ENABLE_REMINDERS_FLAG, {
-    enabledOverride: ENABLE_REMINDERS_OVERRIDE,
-  });
-  const agentsFlag = useFeatureFlag(ENABLE_CHAT_V3_AGENTS_FLAG, {
-    enabledOverride: ENABLE_CHAT_V3_AGENTS_OVERRIDE,
-  });
+  const remindersFlag = useFeatureFlag(enableReminders);
+  const agentsFlag = useFeatureFlag(enableChatV3Agents);
   return createMemo(() => {
     remindersFlag();
     agentsFlag();

--- a/apps/web/src/features/entity/queries/rename.ts
+++ b/apps/web/src/features/entity/queries/rename.ts
@@ -1,6 +1,9 @@
 import { renameItem } from '@core/component/FileList/itemOperations';
 import { toast } from '@core/component/Toast/Toast';
-import { ENABLE_GRAPHQL_SOUP } from '@core/constant/featureFlags';
+import {
+  enableGraphqlSoup,
+  isFeatureEnabled,
+} from '@core/constant/featureFlags';
 import { callKeys } from '@queries/call/keys';
 import { channelKeys } from '@queries/channel/keys';
 import { queryClient } from '@queries/client';
@@ -326,7 +329,7 @@ const bulkRenameMutationFn = async (
 ): Promise<BulkRenameDssEntityMutationData> => {
   validateBulkRename(params);
 
-  if (!ENABLE_GRAPHQL_SOUP()) {
+  if (!isFeatureEnabled(enableGraphqlSoup)) {
     return await Promise.all(params.map(performEntityRename));
   }
 

--- a/apps/web/src/features/favorites/sidebar/favorites-section.tsx
+++ b/apps/web/src/features/favorites/sidebar/favorites-section.tsx
@@ -22,7 +22,10 @@ import {
   MenuSeparator,
 } from '@core/component/ContextMenu';
 import type { EntityIconSelector } from '@core/component/EntityIcon';
-import { ENABLE_GRAPHQL_SOUP } from '@core/constant/featureFlags';
+import {
+  enableGraphqlSoup,
+  isFeatureEnabled,
+} from '@core/constant/featureFlags';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import type { EntityData } from '@entity';
 import { ContextMenu } from '@kobalte/core/context-menu';
@@ -192,7 +195,7 @@ export const FavoritesSection = (props: {
   const unreadNotificationsByChannel = createMemo(() => {
     // TODO(dev-rb/notifications): Restore favorite notification badges,
     // previews, and actions from notifications attached to favorite Soup items.
-    if (ENABLE_GRAPHQL_SOUP()) {
+    if (isFeatureEnabled(enableGraphqlSoup)) {
       return new Map<string, UnifiedNotification[]>();
     }
 

--- a/apps/web/src/features/home/home.tsx
+++ b/apps/web/src/features/home/home.tsx
@@ -13,9 +13,8 @@ import { useGetChatAttachmentInfo } from '@core/component/AI/signal/attachment';
 import { setPendingSendData } from '@core/component/AI/signal/pendingSend';
 import { deriveChatName } from '@core/component/AI/util/deriveName';
 import {
-  ENABLE_HOME_OVERRIDE,
-  ENABLE_HOME_RECOMMENDATIONS_FLAG,
-  ENABLE_HOME_RECOMMENDATIONS_OVERRIDE,
+  enableHomeRecommendations,
+  enableHomeView,
 } from '@core/constant/featureFlags';
 import { PaywallKey, usePaywallState } from '@core/constant/PaywallState';
 import { useUserContext } from '@core/context/user';
@@ -76,11 +75,7 @@ function getGreeting() {
 
 export function Home() {
   return (
-    <ShowFeatureFlag
-      key="enable-home-view"
-      enabledOverride={ENABLE_HOME_OVERRIDE}
-      fallback={<Navigate href="/" />}
-    >
+    <ShowFeatureFlag flag={enableHomeView} fallback={<Navigate href="/" />}>
       <ChatInputProvider>
         <DragDropWrapper class="relative size-full">
           <HomeContent />
@@ -138,10 +133,7 @@ function HomeContent() {
             <HomeBackfillProgress />
           </HomeSectionBoundary>
 
-          <ShowFeatureFlag
-            key={ENABLE_HOME_RECOMMENDATIONS_FLAG}
-            enabledOverride={ENABLE_HOME_RECOMMENDATIONS_OVERRIDE}
-          >
+          <ShowFeatureFlag flag={enableHomeRecommendations}>
             <HomeSectionBoundary title="recommendations" fallback={null}>
               <RecommendedSection />
             </HomeSectionBoundary>

--- a/apps/web/src/features/inbox-view/queries/use-inbox-query.ts
+++ b/apps/web/src/features/inbox-view/queries/use-inbox-query.ts
@@ -12,13 +12,12 @@ import { withEntityNotifications } from '@app/features/soup/entity-notifications
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
 import {
-  ENABLE_CALENDAR_UI,
-  ENABLE_INBOX_NOTIFIED_SORT_FLAG,
-  ENABLE_INBOX_NOTIFIED_SORT_OVERRIDE,
-  ENABLE_REMINDERS,
-  ENABLE_SNIPPETS,
-  ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_FLAG,
-  ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE,
+  enableCalendarUi,
+  enableInboxNotifiedSort,
+  enableReminders,
+  enableSnippets,
+  enableSupportedSoupForeignEntities,
+  isFeatureEnabled,
 } from '@core/constant/featureFlags';
 import { useUserId } from '@core/context/user';
 import {
@@ -106,22 +105,17 @@ export function useInboxDataSource(
   const notificationSource = useGlobalNotificationSource();
   const userId = useUserId();
 
-  const foreignEntities = useFeatureFlag(
-    ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_FLAG,
-    { enabledOverride: ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE }
-  );
-  const notifiedSort = useFeatureFlag(ENABLE_INBOX_NOTIFIED_SORT_FLAG, {
-    enabledOverride: ENABLE_INBOX_NOTIFIED_SORT_OVERRIDE,
-  });
+  const foreignEntities = useFeatureFlag(enableSupportedSoupForeignEntities);
+  const notifiedSort = useFeatureFlag(enableInboxNotifiedSort);
 
   const facetContext = (): InboxFacetContext => ({ notificationSource });
 
   const capabilities = (): InboxQueryCapabilities => ({
-    calendar: ENABLE_CALENDAR_UI(),
+    calendar: isFeatureEnabled(enableCalendarUi),
     foreignEntities: foreignEntities().enabled,
     notifiedSort: notifiedSort().enabled,
-    reminders: ENABLE_REMINDERS(),
-    snippets: ENABLE_SNIPPETS(),
+    reminders: isFeatureEnabled(enableReminders),
+    snippets: isFeatureEnabled(enableSnippets),
   });
 
   const viewContext = createMemo(

--- a/apps/web/src/features/next-soup/actions/make-create-reminder-action.test.ts
+++ b/apps/web/src/features/next-soup/actions/make-create-reminder-action.test.ts
@@ -1,21 +1,38 @@
 import type { EntityData } from '@entity';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({
-  openReminderComposer: vi.fn(),
-  remindersEnabled: true,
-}));
+const mocks = vi.hoisted(() => {
+  const store: Record<string, string> = {};
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, value: string) => {
+        store[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        for (const key of Object.keys(store)) delete store[key];
+      },
+    },
+  });
+  return {
+    openReminderComposer: vi.fn(),
+    remindersEnabled: true,
+  };
+});
 
 vi.mock('@app/features/reminders/reminder-composer', () => ({
   openReminderComposer: mocks.openReminderComposer,
 }));
 
-// Spread the original so the other flags in this module keep working; only the
-// reminders gate is driven by the tests. Under vitest MODE is not
-// 'development', so the real ENABLE_REMINDERS would resolve to false.
-vi.mock('@core/constant/featureFlags', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@core/constant/featureFlags')>()),
-  ENABLE_REMINDERS: () => mocks.remindersEnabled,
+vi.mock('@core/constant/featureFlags', () => ({
+  ENABLE_BEARER_TOKEN_AUTH: false,
+  enableReminders: { key: 'enable-reminders' },
+  isFeatureEnabled: (flag: { key?: string }) =>
+    flag.key === 'enable-reminders' ? mocks.remindersEnabled : false,
 }));
 
 import type { SoupState } from '../create-soup-state';

--- a/apps/web/src/features/next-soup/actions/make-create-reminder-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-create-reminder-action.ts
@@ -1,5 +1,5 @@
 import { openReminderComposer } from '@app/features/reminders/reminder-composer';
-import { ENABLE_REMINDERS } from '@core/constant/featureFlags';
+import { enableReminders, isFeatureEnabled } from '@core/constant/featureFlags';
 import type { EntityData } from '@entity';
 import { reminderTarget } from '@queries/reminders/reminders';
 import type { EntityActionListState } from './entity-action-context';
@@ -49,7 +49,7 @@ export const makeCreateReminderAction = (
   options?: MakeCreateReminderOptions
 ) => {
   const canExecute = (entity: EntityData): boolean =>
-    ENABLE_REMINDERS() && reminderTarget(entity) !== undefined;
+    isFeatureEnabled(enableReminders) && reminderTarget(entity) !== undefined;
 
   const execute = (entities: EntityData[]) => {
     const [entity] = entities;

--- a/apps/web/src/features/next-soup/actions/make-edit-reminder-action.test.ts
+++ b/apps/web/src/features/next-soup/actions/make-edit-reminder-action.test.ts
@@ -16,12 +16,10 @@ vi.mock('@app/signal/splitLayout', () => ({
   globalSplitManager: () => ({ activeSplit: () => mocks.activeSplit }),
 }));
 
-// Spread the original so the other flags in this module keep working; only the
-// reminders gate is driven by the tests. Under vitest MODE is not
-// 'development', so the real ENABLE_REMINDERS would resolve to false.
-vi.mock('@core/constant/featureFlags', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@core/constant/featureFlags')>()),
-  ENABLE_REMINDERS: () => mocks.remindersEnabled,
+vi.mock('@core/constant/featureFlags', () => ({
+  enableReminders: { key: 'enable-reminders' },
+  isFeatureEnabled: (flag: { key?: string }) =>
+    flag.key === 'enable-reminders' ? mocks.remindersEnabled : false,
 }));
 
 import { makeEditReminderAction } from './make-edit-reminder-action';

--- a/apps/web/src/features/next-soup/actions/make-edit-reminder-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-edit-reminder-action.ts
@@ -1,5 +1,5 @@
 import { globalSplitManager } from '@app/signal/splitLayout';
-import { ENABLE_REMINDERS } from '@core/constant/featureFlags';
+import { enableReminders, isFeatureEnabled } from '@core/constant/featureFlags';
 import type { EntityData } from '@entity';
 import { openEntityInSplitFromUnifiedList } from '../utils';
 import type { EntityActionListState } from './entity-action-context';
@@ -14,7 +14,7 @@ import type { EntityActionListState } from './entity-action-context';
  */
 export const makeEditReminderAction = () => {
   const canExecute = (entity: EntityData): boolean =>
-    ENABLE_REMINDERS() && entity.type === 'reminder';
+    isFeatureEnabled(enableReminders) && entity.type === 'reminder';
 
   const execute = (entities: EntityData[]) => {
     const [entity] = entities;

--- a/apps/web/src/features/next-soup/actions/make-mark-done-action.test.ts
+++ b/apps/web/src/features/next-soup/actions/make-mark-done-action.test.ts
@@ -30,7 +30,8 @@ vi.mock('@components/app/split-layout/layoutUtils', () => ({
 }));
 
 vi.mock('@core/constant/featureFlags', () => ({
-  ENABLE_GRAPHQL_SOUP: mocks.graphqlSoupEnabled,
+  enableGraphqlSoup: { key: 'enable-graphql-soup' },
+  isFeatureEnabled: mocks.graphqlSoupEnabled,
 }));
 
 vi.mock(

--- a/apps/web/src/features/next-soup/actions/make-mark-done-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-mark-done-action.ts
@@ -10,7 +10,10 @@ import {
 } from '@app/features/next-soup/utils';
 import { useSplitPanel } from '@components/app/split-layout/layoutUtils';
 import { toast } from '@core/component/Toast/Toast';
-import { ENABLE_GRAPHQL_SOUP } from '@core/constant/featureFlags';
+import {
+  enableGraphqlSoup,
+  isFeatureEnabled,
+} from '@core/constant/featureFlags';
 import type { HotkeyGroup } from '@core/hotkey/types';
 import type { EntityData } from '@entity';
 import type { NotificationSource } from '@notifications';
@@ -253,7 +256,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
       scopeChannelNotificationsToEntity: scopeChannelNotifications,
     });
 
-    const useEntityMutations = ENABLE_GRAPHQL_SOUP();
+    const useEntityMutations = isFeatureEnabled(enableGraphqlSoup);
     // A whole-channel row in the new inbox intentionally excludes notification
     // stacks rendered as separate thread rows. The entity endpoint cannot
     // express "channel except its threads", so only that selective case keeps

--- a/apps/web/src/features/next-soup/actions/make-mark-notifications-read-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-mark-notifications-read-action.ts
@@ -1,5 +1,8 @@
 import { toast } from '@core/component/Toast/Toast';
-import { ENABLE_GRAPHQL_SOUP } from '@core/constant/featureFlags';
+import {
+  enableGraphqlSoup,
+  isFeatureEnabled,
+} from '@core/constant/featureFlags';
 import type { EntityData } from '@entity';
 import { isWithNotification } from '@entity/types/notification';
 import {
@@ -57,7 +60,7 @@ export const makeMarkNotificationsReadAction = (
   const execute = async (entities: EntityData[]) => {
     const notificationsById = new Map<string, UnifiedNotification>();
     const entityRefs: NotificationEntityRef[] = [];
-    const useEntityMutations = ENABLE_GRAPHQL_SOUP();
+    const useEntityMutations = isFeatureEnabled(enableGraphqlSoup);
     let targetCount = 0;
 
     for (const entity of entities) {

--- a/apps/web/src/features/next-soup/sidebar/soup-filter-presets.test.ts
+++ b/apps/web/src/features/next-soup/sidebar/soup-filter-presets.test.ts
@@ -8,11 +8,27 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@core/constant/featureFlags', () => ({
-  ENABLE_CALENDAR_UI: () => mocks.calendarUiEnabled,
-  ENABLE_CALENDAR_SEARCH_UI: () => mocks.calendarSearchEnabled,
-  ENABLE_REMINDERS: () => mocks.remindersEnabled,
-  ENABLE_SNIPPETS: () => mocks.snippetsEnabled,
-  ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE: false,
+  enableCalendarUi: { key: 'enable-calendar-ui' },
+  enableReminders: { key: 'enable-reminders' },
+  enableSnippets: { key: 'enable-snippets' },
+  enableSupportedSoupForeignEntities: {
+    key: 'enable-supported-soup-foreign-entities',
+  },
+  isCalendarSearchUiEnabled: () => mocks.calendarSearchEnabled,
+  isFeatureEnabled: (flag: { key?: string }) => {
+    switch (flag.key) {
+      case 'enable-calendar-ui':
+        return mocks.calendarUiEnabled;
+      case 'enable-reminders':
+        return mocks.remindersEnabled;
+      case 'enable-snippets':
+        return mocks.snippetsEnabled;
+      case 'enable-supported-soup-foreign-entities':
+        return false;
+      default:
+        return false;
+    }
+  },
 }));
 
 afterEach(() => {

--- a/apps/web/src/features/next-soup/sidebar/soup-filter-presets.ts
+++ b/apps/web/src/features/next-soup/sidebar/soup-filter-presets.ts
@@ -7,11 +7,12 @@ import {
   type Query,
 } from '@app/features/next-soup/filters/filter-store';
 import {
-  ENABLE_CALENDAR_SEARCH_UI,
-  ENABLE_CALENDAR_UI,
-  ENABLE_REMINDERS,
-  ENABLE_SNIPPETS,
-  ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE,
+  enableCalendarUi,
+  enableReminders,
+  enableSnippets,
+  enableSupportedSoupForeignEntities,
+  isCalendarSearchUiEnabled,
+  isFeatureEnabled,
 } from '@core/constant/featureFlags';
 import { PROPERTY_OPTION_IDS, SYSTEM_PROPERTY_IDS } from '@property/constants';
 import type { Params } from '@service-storage/generated/schemas/params';
@@ -87,10 +88,10 @@ const OPEN_TASK_STATUS_INCLUDE_PROPS = [
 ];
 
 const getExcludedDocumentSubTypes = (...subTypes: string[]) =>
-  ENABLE_SNIPPETS() ? subTypes : [...subTypes, 'snippet'];
+  isFeatureEnabled(enableSnippets) ? subTypes : [...subTypes, 'snippet'];
 
 const getDisabledSnippetSubtypeExclude = (): Query['exclude'] =>
-  ENABLE_SNIPPETS() ? {} : { subType: ['snippet'] };
+  isFeatureEnabled(enableSnippets) ? {} : { subType: ['snippet'] };
 
 /** Filters for inbox/signal: not done, importance=true for emails, 2-week window */
 const getInboxSignalFilters = () => {
@@ -122,11 +123,13 @@ const getInboxSignalFilters = () => {
       // tab below sends it too, for the not-yet-fired slice. Behind the flag
       // so an unflagged user never pays for the reminders lookup on every
       // Signal fetch.
-      ...(ENABLE_REMINDERS() ? { includeReminders: true } : {}),
+      ...(isFeatureEnabled(enableReminders) ? { includeReminders: true } : {}),
       // Calendar events with a not-done notification (a fired event alarm).
       // Referencing `calf` opts the calendar arm into the signal query, which
       // `defineQueryFilters` otherwise excludes with a nil id filter.
-      ...(ENABLE_CALENDAR_UI() ? { calendarEventDone: false } : {}),
+      ...(isFeatureEnabled(enableCalendarUi)
+        ? { calendarEventDone: false }
+        : {}),
     },
     exclude: getDisabledSnippetSubtypeExclude(),
     emailView: 'inbox',
@@ -211,7 +214,7 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
           include: {
             calendarEventId: [NIL_UUID],
             crmCompanyId: [NIL_UUID],
-            ...(ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE
+            ...(isFeatureEnabled(enableSupportedSoupForeignEntities)
               ? { foreignEntitySource: ['github_pull_request'] }
               : {}),
             foreignEntityIncludesMe: true,
@@ -222,8 +225,11 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
             channelId: [NIL_UUID],
             chatId: [NIL_UUID],
             folderId: [NIL_UUID],
-            foreignEntityRecordId:
-              ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE ? [NIL_UUID] : [],
+            foreignEntityRecordId: isFeatureEnabled(
+              enableSupportedSoupForeignEntities
+            )
+              ? [NIL_UUID]
+              : [],
             ...getDisabledSnippetSubtypeExclude(),
           },
           emailView: 'all',
@@ -620,7 +626,7 @@ export const VIEW_TAB_PRESETS: Record<ListView, ViewTabConfig> = {
             // Events are title-indexed, so search returns them — but opening
             // one needs the calendar block, which the flag gates. Without it
             // a hit would render an inert row, so exclude the type instead.
-            ...(ENABLE_CALENDAR_SEARCH_UI()
+            ...(isCalendarSearchUiEnabled()
               ? {}
               : { calendarEventId: [NIL_UUID] }),
           },

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/inbox-selector.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/inbox-selector.tsx
@@ -1,7 +1,7 @@
 import { useSoupView } from '@app/features/next-soup/soup-view/soup-view-context';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { CollapsibleHeaderItem } from '@components/app/split-layout/components/CollapsibleItem';
-import { ENABLE_MULTI_INBOX_OVERRIDE } from '@core/constant/featureFlags';
+import { enableMultiInbox } from '@core/constant/featureFlags';
 import { useAddInboxFlow } from '@core/email-link';
 import { Combobox } from '@kobalte/core/combobox';
 import CaretDownIcon from '@phosphor/caret-down.svg';
@@ -27,9 +27,7 @@ export function InboxSelector() {
     selectedIds: inboxFilter,
     setSelectedIds: setInboxFilter,
   });
-  const multiInboxFlag = useFeatureFlag('enable-multi-inbox', {
-    enabledOverride: ENABLE_MULTI_INBOX_OVERRIDE,
-  });
+  const multiInboxFlag = useFeatureFlag(enableMultiInbox);
   const addInbox = useAddInboxFlow();
 
   const label = () => {

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/mobile-filter-drawer.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/mobile-filter-drawer.tsx
@@ -29,7 +29,7 @@ import { pressPulse } from '@components/app/mobile/pressPulse';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { UserIcon } from '@core/component/UserIcon';
 import { ScrollIndicators } from '@core/component/VerticalScrollIndicators';
-import { ENABLE_MULTI_INBOX_OVERRIDE } from '@core/constant/featureFlags';
+import { enableMultiInbox } from '@core/constant/featureFlags';
 import { useUserId } from '@core/context/user';
 import { useAddInboxFlow } from '@core/email-link';
 import { Accordion } from '@kobalte/core/accordion';
@@ -135,9 +135,7 @@ export const MobileFilterDrawer = (props: {
     selectedIds: inboxFilter,
     setSelectedIds: setInboxFilter,
   });
-  const multiInboxFlag = useFeatureFlag('enable-multi-inbox', {
-    enabledOverride: ENABLE_MULTI_INBOX_OVERRIDE,
-  });
+  const multiInboxFlag = useFeatureFlag(enableMultiInbox);
   const addInbox = useAddInboxFlow();
 
   // Mirrors the desktop InboxSelector's visibility rule so the "Connect

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/soup-view-context-group.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/soup-view-context-group.tsx
@@ -9,15 +9,13 @@ import {
 import { useSoupView } from '@app/features/next-soup/soup-view/soup-view-context';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
-import { ENABLE_SOUP_GROUP_BY_OVERRIDE } from '@core/constant/featureFlags';
+import { enableSoupGroupBy } from '@core/constant/featureFlags';
 import { createMemo, createSignal, Show } from 'solid-js';
 
 export const SoupViewContextGroup = (props: { hideLabel?: boolean }) => {
   const panel = useSplitPanelOrThrow();
   const { soup, viewMode } = useSoupView();
-  const groupByEnabled = useFeatureFlag('enable-soup-group-by', {
-    enabledOverride: ENABLE_SOUP_GROUP_BY_OVERRIDE,
-  });
+  const groupByEnabled = useFeatureFlag(enableSoupGroupBy);
 
   const [groupOpen, setGroupOpen] = createSignal(false);
 

--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -52,11 +52,10 @@ import { useEntryState } from '@components/app/split-layout/entry-state';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import {
   ENABLE_FEATURED_SEARCH_RESULTS,
-  ENABLE_INBOX_NOTIFIED_SORT_FLAG,
-  ENABLE_INBOX_NOTIFIED_SORT_OVERRIDE,
-  ENABLE_REMINDERS,
-  ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_FLAG,
-  ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE,
+  enableInboxNotifiedSort,
+  enableReminders,
+  enableSupportedSoupForeignEntities,
+  isFeatureEnabled,
 } from '@core/constant/featureFlags';
 import { useUserId } from '@core/context/user';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
@@ -268,7 +267,11 @@ const resolveTabId = (
   // A remembered tab can also be flag-gated out of the tab bar (see
   // `useVisibleViewTabs`): restoring the inbox onto Reminders with the flag
   // off would leave a hidden tab active, still querying reminders.
-  if (view === 'inbox' && remembered === 'reminders' && !ENABLE_REMINDERS()) {
+  if (
+    view === 'inbox' &&
+    remembered === 'reminders' &&
+    !isFeatureEnabled(enableReminders)
+  ) {
     return config.default;
   }
   return remembered;
@@ -670,9 +673,7 @@ export const SoupViewContextProvider: FlowComponent<
   const notificationSource = useGlobalNotificationSource();
   const userId = useUserId();
   const isTeamAdmin = useIsTeamAdmin();
-  const notifiedSortFF = useFeatureFlag(ENABLE_INBOX_NOTIFIED_SORT_FLAG, {
-    enabledOverride: ENABLE_INBOX_NOTIFIED_SORT_OVERRIDE,
-  });
+  const notifiedSortFF = useFeatureFlag(enableInboxNotifiedSort);
 
   // Sits below `activeTab`/`userId` because the page direction comes from the
   // active tab's preset, which some views resolve against user context.
@@ -926,10 +927,7 @@ export const SoupViewContextProvider: FlowComponent<
   };
 
   const showSupportedForeignEntitiesFF = useFeatureFlag(
-    ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_FLAG,
-    {
-      enabledOverride: ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE,
-    }
+    enableSupportedSoupForeignEntities
   );
   // Create filter context for context-aware filter predicates
   const getFilterContext = (): FilterContext => ({

--- a/apps/web/src/features/next-soup/soup-view/soup-view-tabs.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-tabs.tsx
@@ -28,10 +28,7 @@ import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import type { TabItem } from '@core/component/Tabs';
 import { TabsInset } from '@core/component/TabsInset';
 import { TabsInsetDropdown } from '@core/component/TabsInsetDropdown';
-import {
-  ENABLE_REMINDERS_FLAG,
-  ENABLE_REMINDERS_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableReminders } from '@core/constant/featureFlags';
 import { useUserContext } from '@core/context/user';
 import { useIsTeamAdmin } from '@queries/team/teams';
 import { batch, createMemo, For, Match, Show, Switch } from 'solid-js';
@@ -55,9 +52,7 @@ const useCurrentListView = () => {
  * pills, and the number/cycle hotkeys — agrees on which tabs exist.
  */
 export const useVisibleViewTabs = () => {
-  const remindersFlag = useFeatureFlag(ENABLE_REMINDERS_FLAG, {
-    enabledOverride: ENABLE_REMINDERS_OVERRIDE,
-  });
+  const remindersFlag = useFeatureFlag(enableReminders);
 
   return (view: TabbedListView): TabItem[] =>
     view === 'inbox' && !remindersFlag().enabled

--- a/apps/web/src/features/next-soup/use-recent-view-flag.ts
+++ b/apps/web/src/features/next-soup/use-recent-view-flag.ts
@@ -1,8 +1,5 @@
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
-import {
-  ENABLE_RECENT_VIEW_FLAG,
-  ENABLE_RECENT_VIEW_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableRecentView } from '@core/constant/featureFlags';
 import type { Accessor } from 'solid-js';
 
 /**
@@ -11,8 +8,6 @@ import type { Accessor } from 'solid-js';
  * never issued.
  */
 export function useRecentViewFlag(): Accessor<boolean> {
-  const flag = useFeatureFlag(ENABLE_RECENT_VIEW_FLAG, {
-    enabledOverride: ENABLE_RECENT_VIEW_OVERRIDE,
-  });
+  const flag = useFeatureFlag(enableRecentView);
   return () => flag().enabled;
 }

--- a/apps/web/src/features/next-soup/utils.test.ts
+++ b/apps/web/src/features/next-soup/utils.test.ts
@@ -1,19 +1,40 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const { toastAlert, ...operationMocks } = vi.hoisted(() => ({
-  toastAlert: vi.fn(),
-  bulkMarkNotificationsAsDone: vi.fn(async () => {}),
-  bulkMarkNotificationsAsUndone: vi.fn(async () => {}),
-  cancelQueries: vi.fn(async () => {}),
-  flagArchived: vi.fn(async () => ({ isErr: () => false, value: undefined })),
-  invalidateQueries: vi.fn(async () => {}),
-  invalidateRemindersById: vi.fn(),
-  invalidateSoupEntity: vi.fn(async () => {}),
-  setReminderCompleted: vi.fn(async () => {}),
-  updateNotificationsForEntities: vi.fn(
-    async (): Promise<Array<{ id: string }>> => []
-  ),
-}));
+const { toastAlert, ...operationMocks } = vi.hoisted(() => {
+  const store: Record<string, string> = {};
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, value: string) => {
+        store[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        for (const key of Object.keys(store)) delete store[key];
+      },
+    },
+  });
+  return {
+    toastAlert: vi.fn(),
+    bulkMarkNotificationsAsDone: vi.fn(async () => {}),
+    bulkMarkNotificationsAsUndone: vi.fn(async () => {}),
+    cancelQueries: vi.fn(async () => {}),
+    flagArchived: vi.fn(async () => ({
+      isErr: () => false,
+      value: undefined,
+    })),
+    invalidateQueries: vi.fn(async () => {}),
+    invalidateRemindersById: vi.fn(),
+    invalidateSoupEntity: vi.fn(async () => {}),
+    setReminderCompleted: vi.fn(async () => {}),
+    updateNotificationsForEntities: vi.fn(
+      async (): Promise<Array<{ id: string }>> => []
+    ),
+  };
+});
 
 // utils.ts transitively imports the websocket client modules, which open real
 // sockets at module scope and reject under jsdom.
@@ -62,10 +83,18 @@ vi.mock('@queries/soup/cache', () => ({
 vi.mock('@service-email/client', () => ({
   emailClient: { flagArchived: operationMocks.flagArchived },
 }));
-vi.mock('@core/constant/featureFlags', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@core/constant/featureFlags')>()),
-  ENABLE_CALENDAR_UI: () => true,
-}));
+vi.mock('@core/constant/featureFlags', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@core/constant/featureFlags')>();
+  return {
+    ...actual,
+    enableCalendarUi: { key: 'enable-calendar-ui' },
+    isFeatureEnabled: (flag: Parameters<typeof actual.isFeatureEnabled>[0]) =>
+      'key' in flag && flag.key === 'enable-calendar-ui'
+        ? true
+        : actual.isFeatureEnabled(flag),
+  };
+});
 
 import { setGlobalSplitManager } from '@app/signal/splitLayout';
 import type {

--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -24,7 +24,8 @@ import type {
 import { toast } from '@core/component/Toast/Toast';
 import { fileTypeToBlockName } from '@core/constant/allBlocks';
 import {
-  ENABLE_CALENDAR_UI,
+  enableCalendarUi,
+  isFeatureEnabled,
   USE_MACRO_PR_SUMMARY_BLOCK,
 } from '@core/constant/featureFlags';
 import {
@@ -644,7 +645,7 @@ export const openEntityInSplitFromUnifiedList = async (
   // Calendar is a singleton block. Event opens retarget that one instance
   // with a locator range, including repeat clicks on an already-open split.
   if (entity.type === 'calendar_event') {
-    if (!ENABLE_CALENDAR_UI()) return;
+    if (!isFeatureEnabled(enableCalendarUi)) return;
     const params = calendarBlockParamsForEntity(entity);
     const existing = splitManager.getSplitByContent(
       'calendar',

--- a/apps/web/src/features/notifications/notification-helpers.ts
+++ b/apps/web/src/features/notifications/notification-helpers.ts
@@ -1,4 +1,7 @@
-import { ENABLE_GRAPHQL_SOUP } from '@core/constant/featureFlags';
+import {
+  enableGraphqlSoup,
+  isFeatureEnabled,
+} from '@core/constant/featureFlags';
 import type { Entity, EntityType } from '@core/types';
 import { isMutedItem } from '@entity/utils/notification';
 import { queryClient } from '@queries/client';
@@ -199,7 +202,7 @@ export async function markNotificationsForEntityAsRead(
   entity: Entity
 ): Promise<void> {
   const entityRef = toNotificationEntityRef(entity);
-  if (ENABLE_GRAPHQL_SOUP() && entityRef) {
+  if (isFeatureEnabled(enableGraphqlSoup) && entityRef) {
     await updateNotificationsForEntities({
       entities: [entityRef],
       operation: 'MARK_SEEN',

--- a/apps/web/src/features/notifications/notification-navigation.ts
+++ b/apps/web/src/features/notifications/notification-navigation.ts
@@ -17,8 +17,9 @@ import {
   resolveBlockAlias,
 } from '@core/constant/allBlocks';
 import {
-  ENABLE_CALENDAR_UI,
-  ENABLE_REMINDERS,
+  enableCalendarUi,
+  enableReminders,
+  isFeatureEnabled,
   USE_MACRO_PR_SUMMARY_BLOCK,
 } from '@core/constant/featureFlags';
 import type { EntityType, NotificationType } from '@core/types';
@@ -345,7 +346,7 @@ function getSupportedHandler(
         // A reminder created before the flag closed still has a live
         // notification; opening it would reach reminder surfaces the user is
         // no longer meant to have.
-        if (!ENABLE_REMINDERS()) return;
+        if (!isFeatureEnabled(enableReminders)) return;
         const reminder = await getReminderById(notification.entity_id);
         const entityType = reminder?.entityType;
         const entityId = reminder?.entityId;
@@ -371,7 +372,7 @@ function getSupportedHandler(
         // A reminder delivered before the flag closed still has a live
         // notification; opening it must not reach a surface the user is no
         // longer meant to have.
-        if (!ENABLE_CALENDAR_UI()) return;
+        if (!isFeatureEnabled(enableCalendarUi)) return;
         const content = meta.content;
         const time = content.startsAt
           ? {

--- a/apps/web/src/features/notifications/notification-source.ts
+++ b/apps/web/src/features/notifications/notification-source.ts
@@ -1,6 +1,7 @@
 import {
   ENABLE_DOCUMENT_MENTION_NOTIFICATIONS,
-  ENABLE_GRAPHQL_SOUP,
+  enableGraphqlSoup,
+  isFeatureEnabled,
 } from '@core/constant/featureFlags';
 import type { Entity } from '@core/types';
 import { muteItemForRef } from '@entity/utils/notification';
@@ -245,7 +246,7 @@ export function createNotificationSource(
     // TODO(dev-rb/notifications): Remove this legacy eager pagination when the
     // REST notification source is retired. GraphQL consumers should use Soup
     // notification edges or dedicated notification queries instead.
-    if (ENABLE_GRAPHQL_SOUP()) return;
+    if (isFeatureEnabled(enableGraphqlSoup)) return;
     if (!notificationsQuery.data) return;
     if (notificationsQuery.hasNextPage && !notificationsQuery.isFetching) {
       notificationsQuery.fetchNextPage();
@@ -320,7 +321,7 @@ export function createNotificationSource(
 
   const unsubscribeFromGraphql = subscribeToGraphqlNotificationPatches(
     (patch) => {
-      if (!ENABLE_GRAPHQL_SOUP()) return;
+      if (!isFeatureEnabled(enableGraphqlSoup)) return;
       scheduleGraphqlNotificationRefetch();
       if (patch.__typename !== 'GraphqlNewNotification') return;
       dispatchIncomingNotification(mapGraphqlNotification(patch.notification));
@@ -342,7 +343,10 @@ export function createNotificationSource(
   };
 
   createSocketEffect(ws, (wsData) => {
-    if (wsData.type !== NOTIFICATION_EVENT_TYPE || ENABLE_GRAPHQL_SOUP()) {
+    if (
+      wsData.type !== NOTIFICATION_EVENT_TYPE ||
+      isFeatureEnabled(enableGraphqlSoup)
+    ) {
       return;
     }
     let parsedNotification: UnifiedNotification;

--- a/apps/web/src/features/notifications/tests/notification-source.test.ts
+++ b/apps/web/src/features/notifications/tests/notification-source.test.ts
@@ -27,7 +27,8 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@core/constant/featureFlags', () => ({
   ENABLE_DOCUMENT_MENTION_NOTIFICATIONS: true,
-  ENABLE_GRAPHQL_SOUP: () => mocks.graphqlEnabled,
+  enableGraphqlSoup: { key: 'enable-graphql-soup' },
+  isFeatureEnabled: () => mocks.graphqlEnabled,
 }));
 
 vi.mock('@macro-inc/collaboration/websocket', () => ({

--- a/apps/web/src/features/property/tags/use-tag-team-sharing-flag.ts
+++ b/apps/web/src/features/property/tags/use-tag-team-sharing-flag.ts
@@ -1,8 +1,5 @@
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
-import {
-  ENABLE_TAG_TEAM_SHARING_FLAG,
-  ENABLE_TAG_TEAM_SHARING_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableTagTeamSharing } from '@core/constant/featureFlags';
 import type { Accessor } from 'solid-js';
 
 /**
@@ -11,8 +8,6 @@ import type { Accessor } from 'solid-js';
  * stays promoted when this is off.
  */
 export function useTagTeamSharingFlag(): Accessor<boolean> {
-  const flag = useFeatureFlag(ENABLE_TAG_TEAM_SHARING_FLAG, {
-    enabledOverride: ENABLE_TAG_TEAM_SHARING_OVERRIDE,
-  });
+  const flag = useFeatureFlag(enableTagTeamSharing);
   return () => flag().enabled;
 }

--- a/apps/web/src/features/settings/Account.tsx
+++ b/apps/web/src/features/settings/Account.tsx
@@ -9,11 +9,10 @@ import {
   blockNameToMimeTypes,
 } from '@core/constant/allBlocks';
 import {
-  DISABLE_AUTO_UPDATE_UI_FLAG,
-  ENABLE_AUTO_UPDATE_UI_OVERRIDE,
-  ENABLE_NOTIFICATION_SETTINGS_FLAG,
-  ENABLE_NOTIFICATION_SETTINGS_OVERRIDE,
+  disableAutoUpdateUi,
   ENABLE_PROFILE_PICTURES,
+  enableAutoUpdateUiOverride,
+  enableNotificationSettings,
 } from '@core/constant/featureFlags';
 import { staticFileIdEndpoint } from '@core/constant/servers';
 import { useEmail, useUserId } from '@core/context/user';
@@ -316,16 +315,11 @@ export function Account() {
   const email = useEmail();
   const userId = useUserId();
   const logout = useLogout();
-  const disableAutoUpdateUIFlag = useFeatureFlag(DISABLE_AUTO_UPDATE_UI_FLAG);
+  const disableAutoUpdateUIFlag = useFeatureFlag(disableAutoUpdateUi);
   const autoUpdateUIEnabled = createMemo(
-    () => ENABLE_AUTO_UPDATE_UI_OVERRIDE ?? !disableAutoUpdateUIFlag().enabled
+    () => enableAutoUpdateUiOverride ?? !disableAutoUpdateUIFlag().enabled
   );
-  const notificationSettingsFlag = useFeatureFlag(
-    ENABLE_NOTIFICATION_SETTINGS_FLAG,
-    {
-      enabledOverride: ENABLE_NOTIFICATION_SETTINGS_OVERRIDE,
-    }
-  );
+  const notificationSettingsFlag = useFeatureFlag(enableNotificationSettings);
   const [showDeleteModal, setShowDeleteModal] = createSignal<boolean>(false);
   const [showDeleteConfirmModal, setShowDeleteConfirmModal] =
     createSignal<boolean>(false);

--- a/apps/web/src/features/settings/Admin.tsx
+++ b/apps/web/src/features/settings/Admin.tsx
@@ -8,10 +8,7 @@ import {
   getDebugSetting,
   setDebugSetting,
 } from '@app/lib/debugSettings';
-import {
-  ENABLE_SOUP_FILTER_PERSISTENCE_FLAG,
-  ENABLE_SOUP_FILTER_PERSISTENCE_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableSoupFilterPersistence } from '@core/constant/featureFlags';
 import { Button, ToggleSwitch } from '@ui';
 import { For, Show } from 'solid-js';
 import { SettingsCard, SettingsPage, SettingsRow } from './primitives';
@@ -35,10 +32,7 @@ function DebugSettingRow(props: { setting: DebugSettingDef }) {
 
 export function Admin() {
   const hasActiveSettings = () => Object.keys(debugSettings()).length > 0;
-  const soupFilterPersistenceFlag = useFeatureFlag(
-    ENABLE_SOUP_FILTER_PERSISTENCE_FLAG,
-    { enabledOverride: ENABLE_SOUP_FILTER_PERSISTENCE_OVERRIDE }
-  );
+  const soupFilterPersistenceFlag = useFeatureFlag(enableSoupFilterPersistence);
   const [shouldPersistSoupFilters, setShouldPersistSoupFilters] =
     useSoupFilterPersistence();
 

--- a/apps/web/src/features/settings/Email.tsx
+++ b/apps/web/src/features/settings/Email.tsx
@@ -7,11 +7,10 @@ import { openAddInboxDialog } from '@app/features/inbox/AddInboxDialog';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { toast } from '@core/component/Toast/Toast';
 import {
-  ENABLE_EMAIL_SIGNATURES_FLAG,
-  ENABLE_EMAIL_SIGNATURES_OVERRIDE,
   ENABLE_INBOX_RESYNC,
   ENABLE_INBOX_SYNC_STATUS,
-  ENABLE_MULTI_INBOX_OVERRIDE,
+  enableEmailSignatures,
+  enableMultiInbox,
 } from '@core/constant/featureFlags';
 import { useEmail, useUserId } from '@core/context/user';
 import {
@@ -59,9 +58,7 @@ import {
 export function EmailCard() {
   const email = useEmail();
   const userId = useUserId();
-  const multiInboxFlag = useFeatureFlag('enable-multi-inbox', {
-    enabledOverride: ENABLE_MULTI_INBOX_OVERRIDE,
-  });
+  const multiInboxFlag = useFeatureFlag(enableMultiInbox);
 
   const { query: emailLinksQuery, resyncInbox } = useEmailLinks();
   const emailActive = useEmailLinksStatus();
@@ -418,9 +415,7 @@ function InboxRow(props: {
   onRemove: () => void;
   onTurnOffCalendar: () => void;
 }) {
-  const emailSignaturesFlag = useFeatureFlag(ENABLE_EMAIL_SIGNATURES_FLAG, {
-    enabledOverride: ENABLE_EMAIL_SIGNATURES_OVERRIDE,
-  });
+  const emailSignaturesFlag = useFeatureFlag(enableEmailSignatures);
   const calendarUiEnabled = useCalendarUiFlag();
   const showSignature = () => isSignatureExpanded(props.link.id);
   const signatureSectionId = `signature-section-${props.link.id}`;

--- a/apps/web/src/features/setup/flow/useOnboardingV4Flag.ts
+++ b/apps/web/src/features/setup/flow/useOnboardingV4Flag.ts
@@ -1,8 +1,5 @@
 import { useFeatureFlag, usePosthog } from '@app/lib/analytics/posthog';
-import {
-  ENABLE_ONBOARDING_V4_FLAG,
-  ENABLE_ONBOARDING_V4_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableOnboardingV4 } from '@core/constant/featureFlags';
 import { type Accessor, createSignal, onCleanup } from 'solid-js';
 
 /**
@@ -30,9 +27,7 @@ export type OnboardingV4Flag = {
  */
 export function useOnboardingV4Flag(): Accessor<OnboardingV4Flag> {
   const posthog = usePosthog();
-  const flag = useFeatureFlag(ENABLE_ONBOARDING_V4_FLAG, {
-    enabledOverride: ENABLE_ONBOARDING_V4_OVERRIDE,
-  });
+  const flag = useFeatureFlag(enableOnboardingV4);
 
   const [waited, setWaited] = createSignal(false);
   const timer = setTimeout(() => setWaited(true), FLAG_WAIT_MS);
@@ -41,7 +36,7 @@ export function useOnboardingV4Flag(): Accessor<OnboardingV4Flag> {
   return () => ({
     enabled: flag().enabled,
     loading:
-      ENABLE_ONBOARDING_V4_OVERRIDE === undefined &&
+      enableOnboardingV4.override === undefined &&
       !posthog.featureFlags().length &&
       !waited(),
   });

--- a/apps/web/src/lib/core/component/AI/component/tool/email/ChatCompose.tsx
+++ b/apps/web/src/lib/core/component/AI/component/tool/email/ChatCompose.tsx
@@ -17,10 +17,7 @@ import { convertContactInfoToEmailRecipient } from '@block-email/util/recipientC
 import { useChatContext } from '@core/component/AI/context';
 import type { AssistantMessagePart } from '@core/component/AI/types';
 import { toast } from '@core/component/Toast/Toast';
-import {
-  ENABLE_EMAIL_SIGNATURES_FLAG,
-  ENABLE_EMAIL_SIGNATURES_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableEmailSignatures } from '@core/constant/featureFlags';
 
 import { useChatQuery } from '@queries/chat';
 import { useEmailLinksQuery, useEmailSignature } from '@queries/email/link';
@@ -175,9 +172,7 @@ export function ComposeTool(props: ComposeToolProps) {
   const sendingLink = createMemo(() => emailLinksQuery.data?.links?.[0]);
   const fromAddress = () => sendingLink()?.email_address;
   const signature = useEmailSignature(() => sendingLink()?.id);
-  const emailSignaturesFlag = useFeatureFlag(ENABLE_EMAIL_SIGNATURES_FLAG, {
-    enabledOverride: ENABLE_EMAIL_SIGNATURES_OVERRIDE,
-  });
+  const emailSignaturesFlag = useFeatureFlag(enableEmailSignatures);
   // Whether this email includes the signature. Defaults on; the preview's ✕
   // drops it for this one message. Mirrors the normal composer.
   // Initialize from the persisted tool args so a dismiss survives re-render /

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/menu/MentionsMenu/MentionsMenu.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/menu/MentionsMenu/MentionsMenu.tsx
@@ -4,7 +4,7 @@ import type { BlockName } from '@core/block';
 import { useMaybeBlockId, useMaybeBlockName } from '@core/block';
 import { SUPPORTED_CHAT_ATTACHMENT_BLOCKS } from '@core/component/AI/constant/fileType';
 import { type PortalScope, ScopedPortal } from '@core/component/ScopedPortal';
-import { ENABLE_CRM } from '@core/constant/featureFlags';
+import { enableCrm, isFeatureEnabled } from '@core/constant/featureFlags';
 import { type EntityItem, useQuickAccess } from '@core/context/quickAccess';
 import clickOutside from '@core/directive/clickOutside';
 import { isMobile } from '@core/mobile/isMobile';
@@ -127,7 +127,7 @@ function MentionsMenuInner(props: MentionsMenuProps) {
     : undefined;
 
   const customCompanies =
-    ENABLE_CRM() && props.entities
+    isFeatureEnabled(enableCrm) && props.entities
       ? useEntityMentionFromList({
           items: props.entities,
           buckets: ['crm_company'],
@@ -153,7 +153,7 @@ function MentionsMenuInner(props: MentionsMenuProps) {
 
   // CRM companies only surface in mentions when the feature is enabled —
   // the mention hook isn't even wired up otherwise.
-  const companyMention = ENABLE_CRM()
+  const companyMention = isFeatureEnabled(enableCrm)
     ? (customCompanies ??
       useEntityMention({
         buckets: ['crm_company'],

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/snippets/snippetsPlugin.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/snippets/snippetsPlugin.ts
@@ -1,4 +1,4 @@
-import { ENABLE_SNIPPETS } from '@core/constant/featureFlags';
+import { enableSnippets, isFeatureEnabled } from '@core/constant/featureFlags';
 import { $dfsIterator, mergeRegister } from '@lexical/utils';
 import type { PeerIdValidator } from '@macro-inc/lexical-core';
 import {
@@ -218,7 +218,7 @@ function registerSnippetsPlugin(
   function typeSymbolCommand() {
     // Checked per keystroke so the PostHog flag applies without a reload;
     // when disabled the `;` falls through as regular text.
-    if (!ENABLE_SNIPPETS()) return false;
+    if (!isFeatureEnabled(enableSnippets)) return false;
     const shouldTrigger = validTriggerPosition(editor);
     if (shouldTrigger) {
       editor.update(() => {

--- a/apps/web/src/lib/core/component/UserTooltip.tsx
+++ b/apps/web/src/lib/core/component/UserTooltip.tsx
@@ -1,10 +1,7 @@
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { useSplitLayout } from '@components/app/split-layout/layout';
 import { toast } from '@core/component/Toast/Toast';
-import {
-  ENABLE_CRM_FLAG,
-  ENABLE_CRM_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableCrm } from '@core/constant/featureFlags';
 import { useUserId } from '@core/context/user';
 import { useIsConnectedSecondaryInbox } from '@core/user';
 import WideChat from '@icon/wide-chat.svg';
@@ -50,9 +47,7 @@ export function UserTooltip(props: UserTooltipProps) {
   const canTreatAsUser = () =>
     !!props.id && !props.isDeleted && !isConnectedSecondaryInbox(props.id);
   const { openWithSplit, popoverSplit } = useSplitLayout();
-  const crmFlag = useFeatureFlag(ENABLE_CRM_FLAG, {
-    enabledOverride: ENABLE_CRM_OVERRIDE,
-  });
+  const crmFlag = useFeatureFlag(enableCrm);
   const getOrCreateDmMutation = useGetOrCreateDirectMessageMutation({
     onError: () => toast.failure('Failed to open direct message'),
   });

--- a/apps/web/src/lib/core/constant/featureFlags.ts
+++ b/apps/web/src/lib/core/constant/featureFlags.ts
@@ -38,8 +38,8 @@ export const DEV_MODE_ENV = import.meta.env.MODE === 'development';
 
 type EnvFlagConfig = {
   key?: never;
-  env?: string;
-  default: boolean;
+  env: string;
+  default?: boolean;
 };
 
 type RemoteFlagConfig = {
@@ -66,12 +66,12 @@ function envOverride(env: string | undefined): boolean | undefined {
 }
 
 /**
- * Define a feature flag. Pass `key` for PostHog, or `default` (and no `key`)
+ * Define a feature flag. Pass `key` for PostHog, or `env` (and no `key`)
  * for env-only. `env` is the name after `VITE_`, e.g. `'ENABLE_REMINDERS'`.
  *
- * `default` is used when env is unset. For remote flags, omit it (or pass
- * `undefined`) to defer to PostHog. The caller decides when that default
- * applies, e.g. `DEV_MODE_ENV || undefined` or `LOCAL_ONLY || undefined`.
+ * `default` is used when env is unset. Omit it on env-only flags for `false`.
+ * For remote flags, omit it (or pass `undefined`) to defer to PostHog.
+ * The caller decides when a default applies, e.g. `DEV_MODE_ENV || undefined`.
  *
  * Remote: `useFeatureFlag(flag)` or `isFeatureEnabled(flag)`.
  * Env-only: `isFeatureEnabled(flag)` only.
@@ -87,7 +87,7 @@ export function defineFlag(config: RemoteFlagConfig | EnvFlagConfig): Flag {
   }
 
   return {
-    enabled: envOverride(config.env) ?? config.default,
+    enabled: envOverride(config.env) ?? config.default ?? false,
   };
 }
 
@@ -110,10 +110,10 @@ export function isFeatureEnabled(flag: Flag): boolean {
  * to the new composable view implementations. Override locally with
  * VITE_ENABLE_NEW_APP_VIEWS.
  */
-export const ENABLE_NEW_APP_VIEWS_FLAG = 'enable-new-app-views';
-export const ENABLE_NEW_APP_VIEWS_OVERRIDE = getFeatureFlagOverride(
-  'ENABLE_NEW_APP_VIEWS'
-);
+export const enableNewAppViews = defineFlag({
+  key: 'enable-new-app-views',
+  env: 'ENABLE_NEW_APP_VIEWS',
+});
 
 /**
  * This constant reflects whether the app is running in production mode with prod backend environment
@@ -122,105 +122,283 @@ export const ENABLE_NEW_APP_VIEWS_OVERRIDE = getFeatureFlagOverride(
  */
 export const PROD_MODE_ENV = import.meta.env.MODE === 'production';
 
-export const ENABLE_PDF_MODIFICATION_DATA_AUTOSAVE = resolveFeatureFlag(
-  'ENABLE_PDF_MODIFICATION_DATA_AUTOSAVE',
-  true
-);
+const onInDev = DEV_MODE_ENV || undefined;
 
-export const ENABLE_PDF_LOCATION_AUTOSAVE = resolveFeatureFlag(
-  'ENABLE_PDF_LOCATION_AUTOSAVE',
-  true
-);
+export const ENABLE_PDF_MODIFICATION_DATA_AUTOSAVE = defineFlag({
+  env: 'ENABLE_PDF_MODIFICATION_DATA_AUTOSAVE',
+  default: true,
+}).enabled;
 
-export const ENABLE_PDF_TABS = resolveFeatureFlag('ENABLE_PDF_TABS', true);
+export const ENABLE_PDF_LOCATION_AUTOSAVE = defineFlag({
+  env: 'ENABLE_PDF_LOCATION_AUTOSAVE',
+  default: true,
+}).enabled;
 
-export const ENABLE_PDF_MARKUP = resolveFeatureFlag('ENABLE_PDF_MARKUP', true);
+export const ENABLE_PDF_TABS = defineFlag({
+  env: 'ENABLE_PDF_TABS',
+  default: true,
+}).enabled;
+
+export const ENABLE_PDF_MARKUP = defineFlag({
+  env: 'ENABLE_PDF_MARKUP',
+  default: true,
+}).enabled;
 
 // NOTE: disabling scripting: event listener needs to be properly unmounted first
 // this is the offending line in our pdfjs repo, which has been fixed in the upstream
 // https://github.com/macro-inc/pdf.js/blob/d22768d78ebaaf038707d3d926992a7aeb88e730/web/pdf_scripting_manager.js?plain=1#L59
-export const ENABLE_SCRIPTING = resolveFeatureFlag('ENABLE_SCRIPTING', false);
+export const ENABLE_SCRIPTING = defineFlag({
+  env: 'ENABLE_SCRIPTING',
+  default: false,
+}).enabled;
 
-export const ENABLE_PDF_MULTISPLIT = resolveFeatureFlag(
-  'ENABLE_PDF_MULTISPLIT',
-  true
-);
+export const ENABLE_PDF_MULTISPLIT = defineFlag({
+  env: 'ENABLE_PDF_MULTISPLIT',
+  default: true,
+}).enabled;
 
-export const ENABLE_PROJECT_SHARING = resolveFeatureFlag(
-  'ENABLE_PROJECT_SHARING',
-  true
-);
+export const ENABLE_PROJECT_SHARING = defineFlag({
+  env: 'ENABLE_PROJECT_SHARING',
+  default: true,
+}).enabled;
 
-export const ENABLE_CANVAS_IMAGES = resolveFeatureFlag(
-  'ENABLE_CANVAS_IMAGES',
-  true
-);
+export const ENABLE_CANVAS_IMAGES = defineFlag({
+  env: 'ENABLE_CANVAS_IMAGES',
+  default: true,
+}).enabled;
 
-export const ENABLE_CANVAS_FILES = resolveFeatureFlag(
-  'ENABLE_CANVAS_FILES',
-  true
-);
+export const ENABLE_CANVAS_FILES = defineFlag({
+  env: 'ENABLE_CANVAS_FILES',
+  default: true,
+}).enabled;
 
-export const ENABLE_CANVAS_TEXT = resolveFeatureFlag(
-  'ENABLE_CANVAS_TEXT',
-  true
-);
+export const ENABLE_CANVAS_TEXT = defineFlag({
+  env: 'ENABLE_CANVAS_TEXT',
+  default: true,
+}).enabled;
 
-export const ENABLE_LIVE_INDICATORS = resolveFeatureFlag(
-  'ENABLE_LIVE_INDICATORS',
-  true
-);
+export const ENABLE_LIVE_INDICATORS = defineFlag({
+  env: 'ENABLE_LIVE_INDICATORS',
+  default: true,
+}).enabled;
 
-const _ENABLE_CONTACTS = resolveFeatureFlag('ENABLE_CONTACTS', true);
-const _ENABLE_GMAIL_BASED_CONTACTS = resolveFeatureFlag(
-  'ENABLE_GMAIL_BASED_CONTACTS',
-  DEV_MODE_ENV
-);
+export const ENABLE_PROFILE_PICTURES = defineFlag({
+  env: 'ENABLE_PROFILE_PICTURES',
+  default: true,
+}).enabled;
 
-export const ENABLE_PROFILE_PICTURES = resolveFeatureFlag(
-  'ENABLE_PROFILE_PICTURES',
-  true
-);
+export const ENABLE_VIDEO_BLOCK = defineFlag({
+  env: 'ENABLE_VIDEO_BLOCK',
+  default: true,
+}).enabled;
 
-export const ENABLE_VIDEO_BLOCK = resolveFeatureFlag(
-  'ENABLE_VIDEO_BLOCK',
-  true
-);
+export const ENABLE_DOCX_TO_PDF = defineFlag({
+  env: 'ENABLE_DOCX_TO_PDF',
+  default: true,
+}).enabled;
 
-export const ENABLE_DOCX_TO_PDF = resolveFeatureFlag(
-  'ENABLE_DOCX_TO_PDF',
-  true
-);
+export const ENABLE_MARKDOWN_LIVE_COLLABORATION = defineFlag({
+  env: 'ENABLE_MARKDOWN_LIVE_COLLABORATION',
+  default: true,
+}).enabled;
 
-export const ENABLE_MARKDOWN_LIVE_COLLABORATION = resolveFeatureFlag(
-  'ENABLE_MARKDOWN_LIVE_COLLABORATION',
-  true
-);
+export const ENABLE_EMAIL = defineFlag({
+  env: 'ENABLE_EMAIL',
+  default: true,
+}).enabled;
 
-export const ENABLE_EMAIL = resolveFeatureFlag('ENABLE_EMAIL', true);
+export const ENABLE_BLOCK_IN_BLOCK = defineFlag({
+  env: 'ENABLE_BLOCK_IN_BLOCK',
+  default: true,
+}).enabled;
+
+export const ENABLE_SEARCH_SERVICE = defineFlag({
+  env: 'ENABLE_SEARCH_SERVICE',
+  default: true,
+}).enabled;
+
+export const ENABLE_MARKDOWN_DIFF = defineFlag({
+  env: 'ENABLE_MARKDOWN_DIFF',
+  default: true,
+}).enabled;
+
+export const ENABLE_BEARER_TOKEN_AUTH = defineFlag({
+  env: 'ENABLE_BEARER_TOKEN_AUTH',
+  default: false,
+}).enabled;
+
+export const ENABLE_MARKDOWN_SEARCH_TEXT = defineFlag({
+  env: 'ENABLE_MARKDOWN_SEARCH_TEXT',
+  default: DEV_MODE_ENV,
+}).enabled;
+
+export const CANVAS_SVG_IMPORT = defineFlag({
+  env: 'CANVAS_SVG_IMPORT',
+  default: true,
+}).enabled;
+
+export const ENABLE_CANVAS_VIDEO = defineFlag({
+  env: 'ENABLE_CANVAS_VIDEO',
+  default: true,
+}).enabled;
+
+// TODO: figure out why the image does not load into canvas after upload
+export const ENABLE_CANVAS_HEIC = defineFlag({
+  env: 'ENABLE_CANVAS_HEIC',
+  default: false,
+}).enabled;
+
+// TODO - comments are not stable in markdown multiplayer, they will need more work.
+export const ENABLE_MARKDOWN_COMMENTS = defineFlag({
+  env: 'ENABLE_MARKDOWN_COMMENTS',
+  default: true,
+}).enabled;
+
+export const ENABLE_REFERENCES_MODAL = defineFlag({
+  env: 'ENABLE_REFERENCES_MODAL',
+  default: true,
+}).enabled;
+
+export const ENABLE_MENTION_TRACKING = defineFlag({
+  env: 'ENABLE_MENTION_TRACKING',
+  default: true,
+}).enabled;
+
+export const ENABLE_CHAT_CHANNEL_ATTACHMENT = defineFlag({
+  env: 'ENABLE_CHAT_CHANNEL_ATTACHMENT',
+  default: true,
+}).enabled;
+
+export const ENABLE_SVG_PREVIEW = defineFlag({
+  env: 'ENABLE_SVG_PREVIEW',
+  default: true,
+}).enabled;
+
+export const USE_WIDE_ICONS = defineFlag({
+  env: 'USE_WIDE_ICONS',
+  default: true,
+}).enabled;
+
+export const ENABLE_ANIMATED_ICONS = defineFlag({
+  env: 'ENABLE_ANIMATED_ICONS',
+  default: true,
+}).enabled;
+
+export const ENABLE_TTFT = defineFlag({
+  env: 'ENABLE_TTFT',
+  default: DEV_MODE_ENV,
+}).enabled;
+
+export const ENABLE_INBOX_RESYNC = defineFlag({
+  env: 'ENABLE_INBOX_RESYNC',
+  default: false,
+}).enabled;
+
+export const ENABLE_INBOX_SYNC_STATUS = defineFlag({
+  env: 'ENABLE_INBOX_SYNC_STATUS',
+  default: true,
+}).enabled;
+
+export const ENABLE_EMAIL_SHARING = defineFlag({
+  env: 'ENABLE_EMAIL_SHARING',
+  default: true,
+}).enabled;
+
+export const ENABLE_DOCUMENT_MENTION_NOTIFICATIONS = defineFlag({
+  env: 'ENABLE_DOCUMENT_MENTION_NOTIFICATIONS',
+  default: DEV_MODE_ENV,
+}).enabled;
+
+export const ENABLE_STATIC_DOCUMENT_CARDS = defineFlag({
+  env: 'ENABLE_STATIC_DOCUMENT_CARDS',
+  default: false,
+}).enabled;
+
+export const ENABLE_MARKDOWN_AI_GENERATE = defineFlag({
+  env: 'ENABLE_MARKDOWN_AI_GENERATE',
+  default: false,
+}).enabled;
+
+export const ENABLE_UNIFIED_LIST_AI_INPUT = defineFlag({
+  env: 'ENABLE_UNIFIED_LIST_AI_INPUT',
+  default: true,
+}).enabled;
+
+export const ENABLE_EMAIL_SCHEDULED_SEND = defineFlag({
+  env: 'ENABLE_EMAIL_SCHEDULED_SEND',
+  default: true,
+}).enabled;
+
+export const ENABLE_FEATURED_SEARCH_RESULTS = defineFlag({
+  env: 'ENABLE_FEATURED_SEARCH_RESULTS',
+  default: true,
+}).enabled;
+
+export const ENABLE_PROXY_EMAIL_IMAGES = defineFlag({
+  env: 'ENABLE_PROXY_EMAIL_IMAGES',
+  default: true,
+}).enabled;
+
+export const ENABLE_CLIENT_EMAIL_SIGNAL_FILTER = defineFlag({
+  env: 'ENABLE_CLIENT_EMAIL_SIGNAL_FILTER',
+  default: false,
+}).enabled;
+
+export const ENABLE_APP_STORE_QR_CODE = defineFlag({
+  env: 'ENABLE_APP_STORE_QR_CODE',
+  default: true,
+}).enabled;
+
+export const ENABLE_PR_DISCUSSION_INPUT = defineFlag({
+  env: 'ENABLE_PR_DISCUSSION_INPUT',
+  default: false,
+}).enabled;
+
+export const USE_MACRO_PR_SUMMARY_BLOCK = defineFlag({
+  env: 'USE_MACRO_PR_SUMMARY_BLOCK',
+  default: true,
+}).enabled;
+
+export const ENABLE_CALLKIT = defineFlag({
+  env: 'ENABLE_CALLKIT',
+  default: true,
+}).enabled;
+
+export const ENABLE_MARKDOWN_SIDE_PANEL = defineFlag({
+  env: 'ENABLE_MARKDOWN_SIDE_PANEL',
+  default: true,
+}).enabled;
+
+export const ENABLE_REFOCUS_HIGHLIGHT = defineFlag({
+  env: 'ENABLE_REFOCUS_HIGHLIGHT',
+  default: true,
+}).enabled;
+
+export const ENABLE_CREATE_PROPERTY = defineFlag({
+  env: 'ENABLE_CREATE_PROPERTY',
+  default: true,
+}).enabled;
+
+export const UNIFIED_CHANNEL_INPUT = defineFlag({
+  env: 'UNIFIED_CHANNEL_INPUT',
+  default: false,
+}).enabled;
+
+export const ENABLE_GRAPHQL_BACKFILL = defineFlag({
+  env: 'ENABLE_GRAPHQL_BACKFILL',
+  default: true,
+}).enabled;
+
+export const ENABLE_CALLS = true;
 
 // Email signatures: the settings editor, the compose / reply / AI-chat signature
 // previews, and the per-message include toggle. PostHog-gated with a dev-mode
 // default; override with VITE_ENABLE_EMAIL_SIGNATURES.
-export const ENABLE_EMAIL_SIGNATURES_FLAG = 'enable-email-signatures';
-// Honor an explicit VITE_ENABLE_EMAIL_SIGNATURES=false (don't coerce it to
-// undefined), else default on in dev and defer to PostHog in prod.
-export const ENABLE_EMAIL_SIGNATURES_OVERRIDE =
-  getFeatureFlagOverride('ENABLE_EMAIL_SIGNATURES') ??
-  (DEV_MODE_ENV ? true : undefined);
-
-/**
- * Non-reactive check for imperative call sites. For reactive UI, prefer
- * `useFeatureFlag(ENABLE_EMAIL_SIGNATURES_FLAG, { enabledOverride: ENABLE_EMAIL_SIGNATURES_OVERRIDE })`.
- */
-export function ENABLE_EMAIL_SIGNATURES(): boolean {
-  if (ENABLE_EMAIL_SIGNATURES_OVERRIDE !== undefined) {
-    return ENABLE_EMAIL_SIGNATURES_OVERRIDE;
-  }
-  return (
-    analytics.posthog.isFeatureEnabled(ENABLE_EMAIL_SIGNATURES_FLAG) ?? false
-  );
-}
+export const enableEmailSignatures = defineFlag({
+  key: 'enable-email-signatures',
+  env: 'ENABLE_EMAIL_SIGNATURES',
+  default: onInDev,
+});
 
 // SidebarNext: the rebuilt app sidebar — the narrow icon rail in
 // `components/app/sidebar-next` — rendered in place of `AppSidebar`.
@@ -251,486 +429,176 @@ export const ENABLE_SIDEBAR_NEXT_OVERRIDE: boolean | undefined =
 // company/contact detail blocks, CRM mentions / quick-access, and CRM rows in
 // global search. PostHog-gated (currently targeted at the Macro team in prod)
 // with a dev-mode default; override with VITE_ENABLE_CRM.
-export const ENABLE_CRM_FLAG = 'enable-crm';
-export const ENABLE_CRM_OVERRIDE =
-  resolveFeatureFlag('ENABLE_CRM', DEV_MODE_ENV) || undefined;
-
-/**
- * Non-reactive check for imperative call sites. For reactive UI, prefer
- * `useFeatureFlag(ENABLE_CRM_FLAG, { enabledOverride: ENABLE_CRM_OVERRIDE })`.
- */
-export function ENABLE_CRM(): boolean {
-  if (ENABLE_CRM_OVERRIDE !== undefined) return ENABLE_CRM_OVERRIDE;
-  return analytics.posthog.isFeatureEnabled(ENABLE_CRM_FLAG) ?? false;
-}
+export const enableCrm = defineFlag({
+  key: 'enable-crm',
+  env: 'ENABLE_CRM',
+  default: onInDev,
+});
 
 // Reminders: the "Remind me" entry in the command menu, the soup
 // context menu and the block ⋯ menu, its 'h' shortcut, and the composer modal.
 // Every surface routes through `makeCreateReminderAction().canExecute`, so this
 // is the single gate for all of them. PostHog-gated with a dev-mode default.
-export const ENABLE_REMINDERS_FLAG = 'enable-reminders';
-// Read statically rather than through `getFeatureFlagOverride`: Vite replaces
-// `import.meta.env.VITE_X` by text substitution at build time, so the dynamic
-// `import.meta.env[key]` lookup that helper does can come back undefined in a
-// production bundle. Same form as VITE_ENABLE_BROWSER_OTEL in observability/.
-//
-// Written out rather than using `|| undefined` so an explicit
-// VITE_ENABLE_REMINDERS=false stays false instead of being coerced to undefined
-// and falling through to PostHog.
-const REMINDERS_ENV_OVERRIDE = import.meta.env.VITE_ENABLE_REMINDERS;
-export const ENABLE_REMINDERS_OVERRIDE: boolean | undefined =
-  REMINDERS_ENV_OVERRIDE === 'true'
-    ? true
-    : REMINDERS_ENV_OVERRIDE === 'false'
-      ? false
-      : DEV_MODE_ENV
-        ? true
-        : undefined;
+export const enableReminders = defineFlag({
+  key: 'enable-reminders',
+  env: 'ENABLE_REMINDERS',
+  default: onInDev,
+});
 
-/**
- * Non-reactive check for imperative call sites. For reactive UI, prefer
- * `useFeatureFlag(ENABLE_REMINDERS_FLAG, { enabledOverride: ENABLE_REMINDERS_OVERRIDE })`.
- */
-export function ENABLE_REMINDERS(): boolean {
-  if (ENABLE_REMINDERS_OVERRIDE !== undefined) {
-    return ENABLE_REMINDERS_OVERRIDE;
-  }
-  return analytics.posthog.isFeatureEnabled(ENABLE_REMINDERS_FLAG) ?? false;
-}
+export const enableHistoryComponent = defineFlag({
+  key: 'enable-history-component',
+  env: 'ENABLE_HISTORY_COMPONENT',
+  default: onInDev,
+});
 
-export const ENABLE_BLOCK_IN_BLOCK = resolveFeatureFlag(
-  'ENABLE_BLOCK_IN_BLOCK',
-  true
-);
-
-export const ENABLE_SEARCH_SERVICE = resolveFeatureFlag(
-  'ENABLE_SEARCH_SERVICE',
-  true
-);
-
-export const ENABLE_MARKDOWN_DIFF = resolveFeatureFlag(
-  'ENABLE_MARKDOWN_DIFF',
-  true
-);
-
-export const ENABLE_HISTORY_COMPONENT_FLAG = 'enable-history-component';
-export const ENABLE_HISTORY_COMPONENT_OVERRIDE =
-  resolveFeatureFlag('ENABLE_HISTORY_COMPONENT', DEV_MODE_ENV) || undefined;
-
-export function ENABLE_HISTORY_COMPONENT(): boolean {
-  if (ENABLE_HISTORY_COMPONENT_OVERRIDE !== undefined) {
-    return ENABLE_HISTORY_COMPONENT_OVERRIDE;
-  }
-
-  return (
-    analytics.posthog.isFeatureEnabled(ENABLE_HISTORY_COMPONENT_FLAG) ?? false
-  );
-}
-
-export const ENABLE_BEARER_TOKEN_AUTH = resolveFeatureFlag(
-  'ENABLE_BEARER_TOKEN_AUTH',
-  false
-);
-
-export const ENABLE_GIT_BLAME_FLAG = 'enable-git-blame';
-export const ENABLE_GIT_BLAME_OVERRIDE =
-  resolveFeatureFlag('ENABLE_GIT_BLAME', DEV_MODE_ENV) || undefined;
-
-export function ENABLE_GIT_BLAME(): boolean {
-  if (ENABLE_GIT_BLAME_OVERRIDE !== undefined) return ENABLE_GIT_BLAME_OVERRIDE;
-  return analytics.posthog.isFeatureEnabled(ENABLE_GIT_BLAME_FLAG) ?? false;
-}
-
-export const ENABLE_MARKDOWN_SEARCH_TEXT = resolveFeatureFlag(
-  'ENABLE_MARKDOWN_SEARCH_TEXT',
-  DEV_MODE_ENV
-);
-
-export const CANVAS_SVG_IMPORT = resolveFeatureFlag('CANVAS_SVG_IMPORT', true);
-
-export const ENABLE_CANVAS_VIDEO = resolveFeatureFlag(
-  'ENABLE_CANVAS_VIDEO',
-  true
-);
-
-// TODO: figure out why the image does not load into canvas after upload
-export const ENABLE_CANVAS_HEIC = resolveFeatureFlag(
-  'ENABLE_CANVAS_HEIC',
-  false
-);
-
-// TODO - comments are not stable in markdown multiplayer, they will need more work.
-export const ENABLE_MARKDOWN_COMMENTS = resolveFeatureFlag(
-  'ENABLE_MARKDOWN_COMMENTS',
-  true
-);
-
-export const ENABLE_REFERENCES_MODAL = resolveFeatureFlag(
-  'ENABLE_REFERENCES_MODAL',
-  true
-);
-
-export const ENABLE_MENTION_TRACKING = resolveFeatureFlag(
-  'ENABLE_MENTION_TRACKING',
-  true
-);
-
-const _ENABLE_SEARCH_PAGINATION = resolveFeatureFlag(
-  'ENABLE_SEARCH_PAGINATION',
-  true
-);
-
-export const ENABLE_CHAT_CHANNEL_ATTACHMENT = resolveFeatureFlag(
-  'ENABLE_CHAT_CHANNEL_ATTACHMENT',
-  true
-);
-
-export const ENABLE_SVG_PREVIEW = resolveFeatureFlag(
-  'ENABLE_SVG_PREVIEW',
-  true
-);
-
-export const USE_WIDE_ICONS = resolveFeatureFlag('USE_WIDE_ICONS', true);
-
-export const ENABLE_ANIMATED_ICONS = resolveFeatureFlag(
-  'ENABLE_ANIMATED_ICONS',
-  true
-);
-
-const _ENABLE_PROPERTY_DISPLAY = resolveFeatureFlag(
-  'ENABLE_PROPERTY_DISPLAY',
-  DEV_MODE_ENV
-);
-const _ENABLE_PROPERTY_SORT = resolveFeatureFlag(
-  'ENABLE_PROPERTY_SORT',
-  DEV_MODE_ENV
-);
-const _ENABLE_PROPERTY_FILTER = resolveFeatureFlag(
-  'ENABLE_PROPERTY_FILTER',
-  DEV_MODE_ENV
-);
-
-// TODO: re-enable when supported in backend
-const _ENABLE_SOUP_FROM_FILTER = resolveFeatureFlag(
-  'ENABLE_SOUP_FROM_FILTER',
-  false
-);
-
-const _ENABLE_DOCK_NOTITIFCATIONS = resolveFeatureFlag(
-  'ENABLE_DOCK_NOTITIFCATIONS',
-  DEV_MODE_ENV
-);
-export const ENABLE_TTFT = resolveFeatureFlag('ENABLE_TTFT', DEV_MODE_ENV);
-
-export const ENABLE_MULTI_INBOX_OVERRIDE =
-  resolveFeatureFlag('ENABLE_MULTI_INBOX', DEV_MODE_ENV) || undefined;
-
-export const ENABLE_INBOX_RESYNC = resolveFeatureFlag(
-  'ENABLE_INBOX_RESYNC',
-  false
-);
-
-export const ENABLE_INBOX_SYNC_STATUS = resolveFeatureFlag(
-  'ENABLE_INBOX_SYNC_STATUS',
-  true
-);
-
-const _ENABLE_TASKS_TABS = resolveFeatureFlag('ENABLE_TASKS_TABS', true);
-
-export const ENABLE_EMAIL_SHARING = resolveFeatureFlag(
-  'ENABLE_EMAIL_SHARING',
-  true
-);
-
-export const ENABLE_DOCUMENT_MENTION_NOTIFICATIONS = resolveFeatureFlag(
-  'ENABLE_DOCUMENT_MENTION_NOTIFICATIONS',
-  DEV_MODE_ENV
-);
-
-// Auto expand stand-alone mentions to richer previews in channels
-export const ENABLE_STATIC_DOCUMENT_CARDS = resolveFeatureFlag(
-  'ENABLE_STATIC_DOCUMENT_CARDS',
-  false
-);
-
-export const ENABLE_MARKDOWN_AI_GENERATE = resolveFeatureFlag(
-  'ENABLE_MARKDOWN_AI_GENERATE',
-  false
-);
-
-export const ENABLE_UNIFIED_LIST_AI_INPUT = resolveFeatureFlag(
-  'ENABLE_UNIFIED_LIST_AI_INPUT',
-  true
-);
+export const enableGitBlame = defineFlag({
+  key: 'enable-git-blame',
+  env: 'ENABLE_GIT_BLAME',
+  default: onInDev,
+});
 
 // Inline AI editing: the floating document AI edit pill and the AI editing
-// tool in the selection formatting menu. Gated by PostHog; use the reactive
-// `useFeatureFlag(INLINE_AI_EDITING_FLAG, { enabledOverride: INLINE_AI_EDITING_OVERRIDE })`.
-export const INLINE_AI_EDITING_FLAG = 'inline-ai-editing';
-export const INLINE_AI_EDITING_OVERRIDE =
-  resolveFeatureFlag('INLINE_AI_EDITING', DEV_MODE_ENV) || undefined;
+// tool in the selection formatting menu.
+export const enableInlineAiEditing = defineFlag({
+  key: 'inline-ai-editing',
+  env: 'INLINE_AI_EDITING',
+  default: onInDev,
+});
 
-export const ENABLE_EMAIL_SCHEDULED_SEND = resolveFeatureFlag(
-  'ENABLE_EMAIL_SCHEDULED_SEND',
-  true
-);
+export const enableMultiInbox = defineFlag({
+  key: 'enable-multi-inbox',
+  env: 'ENABLE_MULTI_INBOX',
+  default: onInDev,
+});
 
-const _ENABLE_AI_AUTO_TAB_ATTACHMENTS = resolveFeatureFlag(
-  'ENABLE_AI_AUTO_TAB_ATTACHMENTS',
-  true
-);
-
-export const ENABLE_FEATURED_SEARCH_RESULTS = resolveFeatureFlag(
-  'ENABLE_FEATURED_SEARCH_RESULTS',
-  true
-);
-
-const _ENABLE_SEARCH_QUERY_OPERATORS = resolveFeatureFlag(
-  'ENABLE_SEARCH_QUERY_OPERATORS',
-  false
-);
-
-const ENABLE_NEW_CHANNELS_OVERRIDE = true;
-
-function _ENABLE_NEW_CHANNELS(): boolean {
-  if (ENABLE_NEW_CHANNELS_OVERRIDE !== undefined) {
-    return ENABLE_NEW_CHANNELS_OVERRIDE;
-  }
-
-  return analytics.posthog.isFeatureEnabled('enable-new-channels') ?? false;
-}
-
-export const ENABLE_PROXY_EMAIL_IMAGES = resolveFeatureFlag(
-  'ENABLE_PROXY_EMAIL_IMAGES',
-  true
-);
-
-export const ENABLE_CLIENT_EMAIL_SIGNAL_FILTER = resolveFeatureFlag(
-  'ENABLE_CLIENT_EMAIL_SIGNAL_FILTER',
-  false
-);
-
-export const ENABLE_APP_STORE_QR_CODE = resolveFeatureFlag(
-  'ENABLE_APP_STORE_QR_CODE',
-  true
-);
-
-export const ENABLE_PR_DISCUSSION_INPUT = resolveFeatureFlag(
-  'ENABLE_PR_DISCUSSION_INPUT',
-  false
-);
-
-export const USE_MACRO_PR_SUMMARY_BLOCK = resolveFeatureFlag(
-  'USE_MACRO_PR_SUMMARY_BLOCK',
-  true
-);
-
-// skips over posthog and sets the ENABLE_CALLS feature to true if we are in dev mode
-const ENABLE_CALLS_OVERRIDE = true;
-
-export function ENABLE_CALLS(): boolean {
-  if (ENABLE_CALLS_OVERRIDE !== undefined) {
-    return ENABLE_CALLS_OVERRIDE;
-  }
-
-  return analytics.posthog.isFeatureEnabled('enable-calls') ?? false;
-}
-
-export const ENABLE_NEW_ONBOARDING_OVERRIDE = DEV_MODE_ENV ? true : undefined;
-
-export const ENABLE_INVITE_TEAM_ONBOARDING_OVERRIDE = DEV_MODE_ENV
-  ? true
-  : undefined;
-
-export const ENABLE_TEAM_INVITE_TIERS_OVERRIDE = DEV_MODE_ENV
-  ? true
-  : undefined;
-
-export const ENABLE_SOUP_GROUP_BY_OVERRIDE = DEV_MODE_ENV ? true : undefined;
+export const enableSoupGroupBy = defineFlag({
+  key: 'enable-soup-group-by',
+  default: onInDev,
+});
 
 // Persist soup filters, predicates and tabs across reloads. PostHog controls
 // production rollout; VITE_ENABLE_SOUP_FILTER_PERSISTENCE overrides locally.
-export const ENABLE_SOUP_FILTER_PERSISTENCE_FLAG =
-  'enable-soup-filter-persistence';
-export const ENABLE_SOUP_FILTER_PERSISTENCE_OVERRIDE = getFeatureFlagOverride(
-  'ENABLE_SOUP_FILTER_PERSISTENCE'
-);
+export const enableSoupFilterPersistence = defineFlag({
+  key: 'enable-soup-filter-persistence',
+  env: 'ENABLE_SOUP_FILTER_PERSISTENCE',
+});
 
-export const ENABLE_TASK_DUPLICATES_FLAG = 'enable-task-duplicates';
-export const ENABLE_TASK_DUPLICATES_OVERRIDE = DEV_MODE_ENV ? true : undefined;
+export const enableTaskDuplicates = defineFlag({
+  key: 'enable-task-duplicates',
+  default: onInDev,
+});
 
 // Snippets: reusable markdown documents, the `c` launcher entry, and the `;`
 // insert menu. PostHog-gated (currently targeted at the Macro team) with a
 // dev-mode default; override with VITE_ENABLE_SNIPPETS.
-export const ENABLE_SNIPPETS_FLAG = 'enable-snippets';
-export const ENABLE_SNIPPETS_OVERRIDE =
-  resolveFeatureFlag('ENABLE_SNIPPETS', DEV_MODE_ENV) || undefined;
+export const enableSnippets = defineFlag({
+  key: 'enable-snippets',
+  env: 'ENABLE_SNIPPETS',
+  default: onInDev,
+});
 
-/** Non-reactive check for imperative call sites (e.g. editor key handlers). */
-export function ENABLE_SNIPPETS(): boolean {
-  if (ENABLE_SNIPPETS_OVERRIDE !== undefined) {
-    return ENABLE_SNIPPETS_OVERRIDE;
-  }
+export const enableSupportedSoupForeignEntities = defineFlag({
+  key: 'enable-supported-soup-foreign-entities',
+  default: onInDev,
+});
 
-  return analytics.posthog.isFeatureEnabled(ENABLE_SNIPPETS_FLAG) ?? false;
-}
+export const enableInboxNotifiedSort = defineFlag({
+  key: 'enable-inbox-notified-sort',
+  env: 'ENABLE_INBOX_NOTIFIED_SORT',
+  default: onInDev,
+});
 
-export const ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_FLAG =
-  'enable-supported-soup-foreign-entities';
-export const ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE = DEV_MODE_ENV
-  ? true
-  : undefined;
-
-export const ENABLE_INBOX_NOTIFIED_SORT_FLAG = 'enable-inbox-notified-sort';
-export const ENABLE_INBOX_NOTIFIED_SORT_OVERRIDE =
-  getFeatureFlagOverride('ENABLE_INBOX_NOTIFIED_SORT') ??
-  (DEV_MODE_ENV ? true : undefined);
-
-export const ENABLE_GRAPHQL_SOUP_FLAG = 'enable-graphql-soup';
-export const ENABLE_GRAPHQL_SOUP_OVERRIDE = getFeatureFlagOverride(
-  'ENABLE_GRAPHQL_SOUP'
-);
-
-/** Controls the cache-warming GraphQL soup backfill. */
-export const ENABLE_GRAPHQL_BACKFILL = resolveFeatureFlag(
-  'ENABLE_GRAPHQL_BACKFILL',
-  true
-);
+export const enableGraphqlSoup = defineFlag({
+  key: 'enable-graphql-soup',
+  env: 'ENABLE_GRAPHQL_SOUP',
+});
 
 /** Independent emergency stop. Any true env/PostHog source wins. */
-export const DISABLE_BROWSER_TURSO_CACHE_FLAG = 'disable-browser-turso-cache';
-const DISABLE_BROWSER_TURSO_CACHE_ENV = import.meta.env
-  .VITE_DISABLE_BROWSER_TURSO_CACHE;
-export const DISABLE_BROWSER_TURSO_CACHE_OVERRIDE = parseBooleanOverride(
-  DISABLE_BROWSER_TURSO_CACHE_ENV
-);
+export const disableBrowserTursoCache = defineFlag({
+  key: 'disable-browser-turso-cache',
+  env: 'DISABLE_BROWSER_TURSO_CACHE',
+});
 
-/**
- * Non-reactive check for imperative call sites (e.g. the soup GraphQL
- * client's normalized-cache gate). Env override first (dev), else the same
- * PostHog flag that gates the GraphQL transport — so cache and transport
- * activate together in previews/production.
- */
-export function ENABLE_GRAPHQL_SOUP(): boolean {
-  if (ENABLE_GRAPHQL_SOUP_OVERRIDE !== undefined) {
-    return ENABLE_GRAPHQL_SOUP_OVERRIDE;
-  }
-
-  return analytics.posthog.isFeatureEnabled(ENABLE_GRAPHQL_SOUP_FLAG) ?? false;
-}
-
-export const DISABLE_AUTO_UPDATE_UI_FLAG = 'disable-auto-update-ui';
-export const ENABLE_AUTO_UPDATE_UI_OVERRIDE = getFeatureFlagOverride(
+// Env is enable-space; PostHog key is disable-space. Invert at the call site.
+export const enableAutoUpdateUiOverride = getFeatureFlagOverride(
   'ENABLE_AUTO_UPDATE_UI'
 );
+export const disableAutoUpdateUi = defineFlag({
+  key: 'disable-auto-update-ui',
+});
 
-export function ENABLE_AUTO_UPDATE_UI(): boolean {
-  if (ENABLE_AUTO_UPDATE_UI_OVERRIDE !== undefined) {
-    return ENABLE_AUTO_UPDATE_UI_OVERRIDE;
+export function isAutoUpdateUiEnabled(): boolean {
+  if (enableAutoUpdateUiOverride !== undefined) {
+    return enableAutoUpdateUiOverride;
   }
-
-  return !(
-    analytics.posthog.isFeatureEnabled(DISABLE_AUTO_UPDATE_UI_FLAG) ?? false
-  );
+  return !isFeatureEnabled(disableAutoUpdateUi);
 }
 
-export const ENABLE_CALLKIT = resolveFeatureFlag('ENABLE_CALLKIT', true);
-
-export const ENABLE_MARKDOWN_SIDE_PANEL = resolveFeatureFlag(
-  'ENABLE_MARKDOWN_SIDE_PANEL',
-  true
-);
-
-export const ENABLE_REFOCUS_HIGHLIGHT = resolveFeatureFlag(
-  'ENABLE_REFOCUS_HIGHLIGHT',
-  true
-);
-
-export const ENABLE_CREATE_PROPERTY = resolveFeatureFlag(
-  'ENABLE_CREATE_PROPERTY',
-  true
-);
-
-export const ENABLE_HOME_OVERRIDE = DEV_MODE_ENV ? true : undefined;
+export const enableHomeView = defineFlag({
+  key: 'enable-home-view',
+  default: onInDev,
+});
 
 // AI-generated recommendations on Home. Keep the whole data-owning component
 // behind this gate so disabled users do not fetch notifications or start AI
 // projections. Override locally with VITE_ENABLE_HOME_RECOMMENDATIONS.
-export const ENABLE_HOME_RECOMMENDATIONS_FLAG = 'enable-home-recommendations';
-export const ENABLE_HOME_RECOMMENDATIONS_OVERRIDE =
-  resolveFeatureFlag('ENABLE_HOME_RECOMMENDATIONS', DEV_MODE_ENV) || undefined;
+export const enableHomeRecommendations = defineFlag({
+  key: 'enable-home-recommendations',
+  env: 'ENABLE_HOME_RECOMMENDATIONS',
+  default: onInDev,
+});
 
-export const ENABLE_NEW_PRICING_OVERRIDE =
-  resolveFeatureFlag('ENABLE_NEW_PRICING', DEV_MODE_ENV) || undefined;
-
-// Channel mode where replying and editing do not happen inline, but in a single unified input instead.
-export const UNIFIED_CHANNEL_INPUT = resolveFeatureFlag(
-  'UNIFIED_CHANNEL_INPUT',
-  false
-);
+export const enableNewPricing = defineFlag({
+  key: 'enable-new-pricing',
+  env: 'ENABLE_NEW_PRICING',
+  default: onInDev,
+});
 
 // Bot management in Settings, channels, and the command menu. Override locally
 // with VITE_BOT_MANAGEMENT.
-export const BOT_MANAGEMENT_FLAG = 'bot-management';
-export const BOT_MANAGEMENT_OVERRIDE =
-  resolveFeatureFlag('BOT_MANAGEMENT', DEV_MODE_ENV) || undefined;
+export const botManagement = defineFlag({
+  key: 'bot-management',
+  env: 'BOT_MANAGEMENT',
+  default: onInDev,
+});
 
 // Onboarding v4: the full-screen stepper new users land in after signup
 // (unified with /login), driving the import machinery with auto-import.
 // PostHog-gated; override with VITE_ENABLE_ONBOARDING_V4. Read it through
 // `useOnboardingV4Flag()` so the gate reacts when PostHog answers (and so
 // callers can wait instead of treating "flags not loaded yet" as "off").
-export const ENABLE_ONBOARDING_V4_FLAG = 'enable-onboarding-v4';
-// Honor an explicit VITE_ENABLE_ONBOARDING_V4=false (don't coerce it to
-// undefined), else default on in dev and defer to PostHog in prod.
 // `just run_local` sets the env to false unless `--enable-onboarding`.
-export const ENABLE_ONBOARDING_V4_OVERRIDE =
-  getFeatureFlagOverride('ENABLE_ONBOARDING_V4') ??
-  (DEV_MODE_ENV ? true : undefined);
+export const enableOnboardingV4 = defineFlag({
+  key: 'enable-onboarding-v4',
+  env: 'ENABLE_ONBOARDING_V4',
+  default: onInDev,
+});
 
 // Calendar UI: calendar surfaces and the elevated-permissions upgrade flow
 // that re-runs Google consent for inboxes connected before the calendar
 // scope existed. PostHog-gated with a dev-mode default; override with
 // VITE_ENABLE_CALENDAR_UI.
-export const ENABLE_CALENDAR_UI_FLAG = 'enable-calendar-ui';
-export const ENABLE_CALENDAR_UI_OVERRIDE =
-  getFeatureFlagOverride('ENABLE_CALENDAR_UI') ??
-  (DEV_MODE_ENV ? true : undefined);
-
-/**
- * Non-reactive check for imperative call sites (notification navigation).
- * For reactive UI, prefer `useCalendarUiFlag()`.
- */
-export function ENABLE_CALENDAR_UI(): boolean {
-  if (ENABLE_CALENDAR_UI_OVERRIDE !== undefined) {
-    return ENABLE_CALENDAR_UI_OVERRIDE;
-  }
-  return analytics.posthog.isFeatureEnabled(ENABLE_CALENDAR_UI_FLAG) ?? false;
-}
+export const enableCalendarUi = defineFlag({
+  key: 'enable-calendar-ui',
+  env: 'ENABLE_CALENDAR_UI',
+  default: onInDev,
+});
 
 // Calendar event search UI: the Search view's Calendar type (and calendar
 // rows) plus the in-calendar keyword search. A sub-feature of the calendar UI
 // — opening a hit needs the calendar block — so it only takes effect where
 // `enable-calendar-ui` is also on. PostHog-gated with a dev-mode default;
 // override with VITE_ENABLE_CALENDAR_SEARCH_UI.
-export const ENABLE_CALENDAR_SEARCH_UI_FLAG = 'enable-calendar-search-ui';
-export const ENABLE_CALENDAR_SEARCH_UI_OVERRIDE =
-  getFeatureFlagOverride('ENABLE_CALENDAR_SEARCH_UI') ??
-  (DEV_MODE_ENV ? true : undefined);
+export const enableCalendarSearchUi = defineFlag({
+  key: 'enable-calendar-search-ui',
+  env: 'ENABLE_CALENDAR_SEARCH_UI',
+  default: onInDev,
+});
 
-/**
- * Non-reactive check for imperative call sites (soup filter presets). Gated by
- * the calendar UI too. For reactive UI, prefer `useCalendarSearchUiFlag()`.
- */
-export function ENABLE_CALENDAR_SEARCH_UI(): boolean {
-  if (!ENABLE_CALENDAR_UI()) {
-    return false;
-  }
-  if (ENABLE_CALENDAR_SEARCH_UI_OVERRIDE !== undefined) {
-    return ENABLE_CALENDAR_SEARCH_UI_OVERRIDE;
-  }
+export function isCalendarSearchUiEnabled(): boolean {
   return (
-    analytics.posthog.isFeatureEnabled(ENABLE_CALENDAR_SEARCH_UI_FLAG) ?? false
+    isFeatureEnabled(enableCalendarUi) &&
+    isFeatureEnabled(enableCalendarSearchUi)
   );
 }
 
@@ -741,99 +609,88 @@ export function ENABLE_CALENDAR_SEARCH_UI(): boolean {
 // becomes unreachable while this is off. Flip it on in PostHog once the
 // mobile layout is fixed, or locally with
 // VITE_ENABLE_CALENDAR_PROMPT_MOBILE=true.
-export const ENABLE_CALENDAR_PROMPT_MOBILE_FLAG =
-  'enable-calendar-prompt-mobile';
-export const ENABLE_CALENDAR_PROMPT_MOBILE_OVERRIDE = getFeatureFlagOverride(
-  'ENABLE_CALENDAR_PROMPT_MOBILE'
-);
+export const enableCalendarPromptMobile = defineFlag({
+  key: 'enable-calendar-prompt-mobile',
+  env: 'ENABLE_CALENDAR_PROMPT_MOBILE',
+});
 
 // The "Enable calendar" prompt on desktop/web, the counterpart to
 // `enable-calendar-prompt-mobile`. Off by default everywhere, including dev,
 // until the PostHog rollout is raised; Settings › Email keeps a per-inbox
 // "Enable calendar" button, so nothing becomes unreachable while this is off.
 // Override locally with VITE_ENABLE_CALENDAR_PROMPT_WEB=true.
-export const ENABLE_CALENDAR_PROMPT_WEB_FLAG = 'enable-calendar-prompt-web';
-export const ENABLE_CALENDAR_PROMPT_WEB_OVERRIDE = getFeatureFlagOverride(
-  'ENABLE_CALENDAR_PROMPT_WEB'
-);
+export const enableCalendarPromptWeb = defineFlag({
+  key: 'enable-calendar-prompt-web',
+  env: 'ENABLE_CALENDAR_PROMPT_WEB',
+});
 
 // Sharing a personal tag with the team: the "Share with team" action on
 // personal tags in Settings › Tags, and the prompt that merges into an
 // existing team label when the names collide. The backend endpoints ship
 // ungated, so flipping this off only hides the entry point. PostHog-gated
 // with a dev-mode default; override with VITE_ENABLE_TAG_TEAM_SHARING.
-export const ENABLE_TAG_TEAM_SHARING_FLAG = 'enable-tag-team-sharing';
-export const ENABLE_TAG_TEAM_SHARING_OVERRIDE =
-  getFeatureFlagOverride('ENABLE_TAG_TEAM_SHARING') ??
-  (DEV_MODE_ENV ? true : undefined);
+export const enableTagTeamSharing = defineFlag({
+  key: 'enable-tag-team-sharing',
+  env: 'ENABLE_TAG_TEAM_SHARING',
+  default: onInDev,
+});
 
 // The "Activity" section in the entity side panel: the entity's recent
 // activity timeline from the GraphQL activity log (who did what, when).
 // Purely additive — when off, the section never mounts and no activity
 // query is issued. PostHog-gated with a dev-mode default; override with
 // VITE_ENABLE_ENTITY_ACTIVITY_SECTION.
-export const ENABLE_ENTITY_ACTIVITY_SECTION_FLAG =
-  'enable-entity-activity-section';
-export const ENABLE_ENTITY_ACTIVITY_SECTION_OVERRIDE =
-  getFeatureFlagOverride('ENABLE_ENTITY_ACTIVITY_SECTION') ??
-  (DEV_MODE_ENV ? true : undefined);
+export const enableEntityActivitySection = defineFlag({
+  key: 'enable-entity-activity-section',
+  env: 'ENABLE_ENTITY_ACTIVITY_SECTION',
+  default: onInDev,
+});
 
 // The Activity view: the user's own activity feed from the GraphQL activity
 // log, replacing the retired soup/notification-derived timeline. Gates the
 // view (the /activity route redirects to the inbox when off) and its
 // sidebar entry. PostHog-gated with a dev-mode default; override with
 // VITE_ENABLE_ACTIVITY_FEED.
-export const ENABLE_ACTIVITY_FEED_FLAG = 'enable-activity-feed';
-export const ENABLE_ACTIVITY_FEED_OVERRIDE =
-  getFeatureFlagOverride('ENABLE_ACTIVITY_FEED') ??
-  (DEV_MODE_ENV ? true : undefined);
+export const enableActivityFeed = defineFlag({
+  key: 'enable-activity-feed',
+  env: 'ENABLE_ACTIVITY_FEED',
+  default: onInDev,
+});
 
 // AI agents: the Macro Coder mention entry and the folded agent-session view
 // in channels. Override with VITE_ENABLE_CHAT_V3_AGENTS.
-export const ENABLE_CHAT_V3_AGENTS_FLAG = 'enable-chat-v3-agents';
-export const ENABLE_CHAT_V3_AGENTS_OVERRIDE =
-  getFeatureFlagOverride('ENABLE_CHAT_V3_AGENTS') ??
-  (DEV_MODE_ENV ? true : undefined);
-export function ENABLE_CHAT_V3_AGENTS(): boolean {
-  if (ENABLE_CHAT_V3_AGENTS_OVERRIDE !== undefined) {
-    return ENABLE_CHAT_V3_AGENTS_OVERRIDE;
-  }
-
-  return (
-    analytics.posthog.isFeatureEnabled(ENABLE_CHAT_V3_AGENTS_FLAG) ?? false
-  );
-}
+export const enableChatV3Agents = defineFlag({
+  key: 'enable-chat-v3-agents',
+  env: 'ENABLE_CHAT_V3_AGENTS',
+  default: onInDev,
+});
 
 // The `@cursor` mention entry: agent sessions served by Cursor cloud agents
 // on Macro's Cursor account. PostHog-gated per user; the backend additionally
 // restricts these sessions to @macro.com senders. Override with
 // VITE_ENABLE_CURSOR_AGENTS.
-export const ENABLE_CURSOR_AGENTS_FLAG = 'enable-cursor-agents';
-export const ENABLE_CURSOR_AGENTS_OVERRIDE =
-  getFeatureFlagOverride('ENABLE_CURSOR_AGENTS') ??
-  (DEV_MODE_ENV ? true : undefined);
-export function ENABLE_CURSOR_AGENTS(): boolean {
-  if (ENABLE_CURSOR_AGENTS_OVERRIDE !== undefined) {
-    return ENABLE_CURSOR_AGENTS_OVERRIDE;
-  }
-
-  return analytics.posthog.isFeatureEnabled(ENABLE_CURSOR_AGENTS_FLAG) ?? false;
-}
+export const enableCursorAgents = defineFlag({
+  key: 'enable-cursor-agents',
+  env: 'ENABLE_CURSOR_AGENTS',
+  default: onInDev,
+});
 
 // The Recent view: the touched-by-me feed (everything the viewer mutated,
 // newest own-touch first). Gates the view (the route redirects to the inbox
 // when off) and its sidebar entry. PostHog-gated with a dev-mode default;
 // override with VITE_ENABLE_RECENT_VIEW.
-export const ENABLE_RECENT_VIEW_FLAG = 'enable-recent-view';
-export const ENABLE_RECENT_VIEW_OVERRIDE =
-  getFeatureFlagOverride('ENABLE_RECENT_VIEW') ??
-  (DEV_MODE_ENV ? true : undefined);
+export const enableRecentView = defineFlag({
+  key: 'enable-recent-view',
+  env: 'ENABLE_RECENT_VIEW',
+  default: onInDev,
+});
 
 // Settings › Notifications: the dedicated preferences tab (delivery, per-type
 // opt-outs, muted items). When off, the tab is hidden and Account keeps the
 // existing desktop/mobile toggle. PostHog-gated with a dev-mode default;
 // override with VITE_ENABLE_NOTIFICATION_SETTINGS.
-export const ENABLE_NOTIFICATION_SETTINGS_FLAG = 'enable-notification-settings';
-export const ENABLE_NOTIFICATION_SETTINGS_OVERRIDE =
-  getFeatureFlagOverride('ENABLE_NOTIFICATION_SETTINGS') ??
-  (DEV_MODE_ENV ? true : undefined);
+export const enableNotificationSettings = defineFlag({
+  key: 'enable-notification-settings',
+  env: 'ENABLE_NOTIFICATION_SETTINGS',
+  default: onInDev,
+});

--- a/apps/web/src/lib/core/constant/featureFlags.ts
+++ b/apps/web/src/lib/core/constant/featureFlags.ts
@@ -408,22 +408,10 @@ export const enableEmailSignatures = defineFlag({
 //
 // The PostHog key is deliberately broader than the local names: `enable-new-app-views`
 // is the rollout switch for the rebuilt app surfaces, of which this sidebar is one.
-export const ENABLE_SIDEBAR_NEXT_FLAG = 'enable-new-app-views';
-// Read statically rather than through `getFeatureFlagOverride` for the same
-// reason as VITE_ENABLE_REMINDERS below: Vite substitutes `import.meta.env.VITE_X`
-// by text at build time, so that helper's dynamic lookup can come back
-// undefined in a production bundle.
-//
-// Written out rather than using `|| undefined` so an explicit
-// VITE_ENABLE_SIDEBAR_NEXT=false stays false instead of being coerced to
-// undefined and falling through to PostHog.
-const SIDEBAR_NEXT_ENV_OVERRIDE = import.meta.env.VITE_ENABLE_SIDEBAR_NEXT;
-export const ENABLE_SIDEBAR_NEXT_OVERRIDE: boolean | undefined =
-  SIDEBAR_NEXT_ENV_OVERRIDE === 'true'
-    ? true
-    : SIDEBAR_NEXT_ENV_OVERRIDE === 'false'
-      ? false
-      : undefined;
+export const enableSidebarNext = defineFlag({
+  key: 'enable-new-app-views',
+  env: 'ENABLE_SIDEBAR_NEXT',
+});
 
 // CRM companies & contacts frontend: the Companies view + sidebar entry, the
 // company/contact detail blocks, CRM mentions / quick-access, and CRM rows in

--- a/apps/web/src/lib/core/constant/settingsTabsConfig.tsx
+++ b/apps/web/src/lib/core/constant/settingsTabsConfig.tsx
@@ -20,16 +20,12 @@ import { useHasPermission } from '../context/user';
 import { isNativeMobilePlatform } from '../mobile/isNativeMobilePlatform';
 import { isTouchDevice } from '../mobile/isTouchDevice';
 import {
-  BOT_MANAGEMENT_FLAG,
-  BOT_MANAGEMENT_OVERRIDE,
+  botManagement,
   DEV_MODE_ENV,
   ENABLE_APP_STORE_QR_CODE,
-  ENABLE_CHAT_V3_AGENTS_FLAG,
-  ENABLE_CHAT_V3_AGENTS_OVERRIDE,
-  ENABLE_CRM_FLAG,
-  ENABLE_CRM_OVERRIDE,
-  ENABLE_NOTIFICATION_SETTINGS_FLAG,
-  ENABLE_NOTIFICATION_SETTINGS_OVERRIDE,
+  enableChatV3Agents,
+  enableCrm,
+  enableNotificationSettings,
 } from './featureFlags';
 import { PERMISSION_IDS } from './permissions';
 import type { SettingsTab } from './SettingsState';
@@ -162,21 +158,10 @@ export const getSettingsTabItem = (
  * surface a tab the panel won't render.
  */
 export const useSettingsTabAvailable = () => {
-  const botManagementFlag = useFeatureFlag(BOT_MANAGEMENT_FLAG, {
-    enabledOverride: BOT_MANAGEMENT_OVERRIDE,
-  });
-  const chatV3AgentsFlag = useFeatureFlag(ENABLE_CHAT_V3_AGENTS_FLAG, {
-    enabledOverride: ENABLE_CHAT_V3_AGENTS_OVERRIDE,
-  });
-  const crmFlag = useFeatureFlag(ENABLE_CRM_FLAG, {
-    enabledOverride: ENABLE_CRM_OVERRIDE,
-  });
-  const notificationSettingsFlag = useFeatureFlag(
-    ENABLE_NOTIFICATION_SETTINGS_FLAG,
-    {
-      enabledOverride: ENABLE_NOTIFICATION_SETTINGS_OVERRIDE,
-    }
-  );
+  const botManagementFlag = useFeatureFlag(botManagement);
+  const chatV3AgentsFlag = useFeatureFlag(enableChatV3Agents);
+  const crmFlag = useFeatureFlag(enableCrm);
+  const notificationSettingsFlag = useFeatureFlag(enableNotificationSettings);
   const hasAdminPanel = useHasPermission(PERMISSION_IDS.WRITE_ADMIN_PANEL);
 
   return (tab: SettingsTab): boolean => {

--- a/apps/web/src/lib/core/cursor/flag.ts
+++ b/apps/web/src/lib/core/cursor/flag.ts
@@ -1,17 +1,12 @@
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { isMacroStaffEmail } from '@core/constant/cursorAgent';
-import {
-  ENABLE_CURSOR_AGENTS_FLAG,
-  ENABLE_CURSOR_AGENTS_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableCursorAgents } from '@core/constant/featureFlags';
 import { useEmail } from '@core/context/user';
 import type { Accessor } from 'solid-js';
 
 /** Whether the current user may see and use Cursor-agent surfaces. */
 export function useCursorAgentsAccess(): Accessor<boolean> {
-  const flag = useFeatureFlag(ENABLE_CURSOR_AGENTS_FLAG, {
-    enabledOverride: ENABLE_CURSOR_AGENTS_OVERRIDE,
-  });
+  const flag = useFeatureFlag(enableCursorAgents);
   const email = useEmail();
 
   return () => flag().enabled && isMacroStaffEmail(email());

--- a/apps/web/src/lib/graphql-cache/rollout.test.ts
+++ b/apps/web/src/lib/graphql-cache/rollout.test.ts
@@ -8,9 +8,12 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@core/util/platform', () => ({ isTauri: mocks.isTauri }));
 vi.mock('@core/constant/featureFlags', () => ({
-  ENABLE_GRAPHQL_SOUP: mocks.graphqlEnabled,
-  DISABLE_BROWSER_TURSO_CACHE_FLAG: 'disable-browser-turso-cache',
-  DISABLE_BROWSER_TURSO_CACHE_OVERRIDE: undefined,
+  enableGraphqlSoup: { key: 'enable-graphql-soup' },
+  disableBrowserTursoCache: {
+    key: 'disable-browser-turso-cache',
+    override: undefined,
+  },
+  isFeatureEnabled: mocks.graphqlEnabled,
 }));
 vi.mock('@app/lib/analytics', () => ({
   analytics: {

--- a/apps/web/src/lib/graphql-cache/rollout.ts
+++ b/apps/web/src/lib/graphql-cache/rollout.ts
@@ -1,8 +1,8 @@
 import { analytics } from '@app/lib/analytics';
 import {
-  DISABLE_BROWSER_TURSO_CACHE_FLAG,
-  DISABLE_BROWSER_TURSO_CACHE_OVERRIDE,
-  ENABLE_GRAPHQL_SOUP,
+  disableBrowserTursoCache,
+  enableGraphqlSoup,
+  isFeatureEnabled,
 } from '@core/constant/featureFlags';
 import { isTauri } from '@core/util/platform';
 import {
@@ -13,7 +13,7 @@ import {
 /** Resolves the current gate without constructing a browser cache resource. */
 export function getBrowserTursoCacheRolloutDecision(): BrowserTursoCacheRolloutDecision {
   const native = isTauri();
-  const graphqlTransportEnabled = ENABLE_GRAPHQL_SOUP();
+  const graphqlTransportEnabled = isFeatureEnabled(enableGraphqlSoup);
   if (native) {
     // Do not touch browser rollout flags on Tauri. Besides preserving behavior,
     // this keeps native startup independent from PostHog browser-cache state.
@@ -28,9 +28,9 @@ export function getBrowserTursoCacheRolloutDecision(): BrowserTursoCacheRolloutD
   return resolveBrowserTursoCacheRollout({
     isTauri: false,
     graphqlTransportEnabled,
-    disableEnvOverride: DISABLE_BROWSER_TURSO_CACHE_OVERRIDE,
+    disableEnvOverride: disableBrowserTursoCache.override,
     posthogDisable: analytics.posthog.isFeatureEnabled(
-      DISABLE_BROWSER_TURSO_CACHE_FLAG
+      disableBrowserTursoCache.key
     ),
   });
 }

--- a/apps/web/src/lib/queries/blame.ts
+++ b/apps/web/src/lib/queries/blame.ts
@@ -1,4 +1,4 @@
-import { ENABLE_GIT_BLAME } from '@core/constant/featureFlags';
+import { enableGitBlame, isFeatureEnabled } from '@core/constant/featureFlags';
 import { syncServiceClient } from '@service-sync/client';
 import { useQuery } from '@tanstack/solid-query';
 
@@ -16,7 +16,7 @@ export function useNodeBlameQuery(
       if (!res.isOk()) throw new Error('blame_not_found');
       return res.value;
     },
-    enabled: ENABLE_GIT_BLAME() && nodeId() !== null,
+    enabled: isFeatureEnabled(enableGitBlame) && nodeId() !== null,
     staleTime: Infinity,
     retry: false,
   }));

--- a/apps/web/src/lib/queries/call/call.test.ts
+++ b/apps/web/src/lib/queries/call/call.test.ts
@@ -13,7 +13,7 @@ vi.mock('@service-call/client', () => ({ callServiceClient: {} }));
 vi.mock('@core/component/Toast/Toast', () => ({
   toast: { alert: vi.fn(), failure: vi.fn(), success: vi.fn() },
 }));
-vi.mock('@core/constant/featureFlags', () => ({ ENABLE_CALLS: () => true }));
+vi.mock('@core/constant/featureFlags', () => ({ ENABLE_CALLS: true }));
 
 import { queryClient } from '@queries/client';
 import { setActiveCallEndedCache, setActiveCallStartedCache } from './call';

--- a/apps/web/src/lib/queries/call/call.ts
+++ b/apps/web/src/lib/queries/call/call.ts
@@ -31,7 +31,7 @@ export function useActiveCallsQuery() {
       await throwOnErr(() => callServiceClient.getActiveCalls()),
     placeholderData: [] as ActiveCallSummary[],
     refetchInterval: 30_000,
-    enabled: ENABLE_CALLS(),
+    enabled: ENABLE_CALLS,
   }));
 }
 

--- a/apps/web/src/lib/queries/email/thread.ts
+++ b/apps/web/src/lib/queries/email/thread.ts
@@ -2,9 +2,8 @@ import { useAnalytics } from '@app/lib/analytics/analytics-context';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { toast } from '@core/component/Toast/Toast';
 import {
-  ENABLE_GRAPHQL_SOUP,
-  ENABLE_GRAPHQL_SOUP_FLAG,
-  ENABLE_GRAPHQL_SOUP_OVERRIDE,
+  enableGraphqlSoup,
+  isFeatureEnabled,
 } from '@core/constant/featureFlags';
 import { DEFAULT_THREAD_MESSAGES_LIMIT } from '@core/constant/pagination';
 import { catchToResult, throwOnErr } from '@core/util/result';
@@ -85,7 +84,7 @@ function flattenThreadPages(
 export async function fetchAndCacheThread(
   threadId: string
 ): ReturnType<typeof emailClient.getThread> {
-  if (!ENABLE_GRAPHQL_SOUP()) {
+  if (!isFeatureEnabled(enableGraphqlSoup)) {
     const result = await catchToResult(() =>
       queryClient.fetchInfiniteQuery(threadQueryOptions(threadId))
     );
@@ -184,9 +183,7 @@ export function useThreadQuery<TData = ThreadQueryData>(
   threadId: Accessor<string>,
   options?: Accessor<UseThreadQueryOptions<TData>>
 ): ThreadQueryResult<TData> {
-  const graphqlSoupFlag = useFeatureFlag(ENABLE_GRAPHQL_SOUP_FLAG, {
-    enabledOverride: ENABLE_GRAPHQL_SOUP_OVERRIDE,
-  });
+  const graphqlSoupFlag = useFeatureFlag(enableGraphqlSoup);
   const queryEnabled = () => options?.().enabled !== false;
   const usesGraphql = () => graphqlSoupFlag().enabled;
   const select = () =>

--- a/apps/web/src/lib/queries/history/history.ts
+++ b/apps/web/src/lib/queries/history/history.ts
@@ -1,8 +1,5 @@
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
-import {
-  ENABLE_GRAPHQL_SOUP_FLAG,
-  ENABLE_GRAPHQL_SOUP_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableGraphqlSoup } from '@core/constant/featureFlags';
 import { catchToResult, throwOnErr } from '@core/util/result';
 import { type MutationCallbacks, withCallbacks } from '@queries/utils';
 import { type ItemType, storageServiceClient } from '@service-storage/client';
@@ -94,9 +91,7 @@ type HistoryQueryKey =
   | typeof historyKeys.graphqlList.queryKey;
 
 export function useHistoryQuery() {
-  const graphqlSoupFlag = useFeatureFlag(ENABLE_GRAPHQL_SOUP_FLAG, {
-    enabledOverride: ENABLE_GRAPHQL_SOUP_OVERRIDE,
-  });
+  const graphqlSoupFlag = useFeatureFlag(enableGraphqlSoup);
   const graphqlCacheHost = () => {
     if (!graphqlSoupFlag().enabled) return undefined;
     const cacheHost = getGraphqlSoupCacheHost();

--- a/apps/web/src/lib/queries/notification/tests/user-notifications.test.tsx
+++ b/apps/web/src/lib/queries/notification/tests/user-notifications.test.tsx
@@ -45,7 +45,8 @@ const {
 }));
 
 vi.mock('@core/constant/featureFlags', () => ({
-  ENABLE_GRAPHQL_SOUP: graphqlSoupEnabledMock,
+  enableGraphqlSoup: { key: 'enable-graphql-soup' },
+  isFeatureEnabled: graphqlSoupEnabledMock,
 }));
 
 vi.mock('@service-notification/client', () => ({

--- a/apps/web/src/lib/queries/notification/user-notifications.ts
+++ b/apps/web/src/lib/queries/notification/user-notifications.ts
@@ -1,4 +1,7 @@
-import { ENABLE_GRAPHQL_SOUP } from '@core/constant/featureFlags';
+import {
+  enableGraphqlSoup,
+  isFeatureEnabled,
+} from '@core/constant/featureFlags';
 import type { Maybe } from '@core/types';
 import { throwOnErr } from '@core/util/result';
 import { channelThreadRootId } from '@notifications/channel-thread-root';
@@ -220,7 +223,8 @@ export function useUserNotificationsQuery(
 ): UserNotificationsQuery {
   const queryEnabled = () => options?.().enabled !== false;
 
-  const usesGraphql = () => ENABLE_GRAPHQL_SOUP() && args().done !== true;
+  const usesGraphql = () =>
+    isFeatureEnabled(enableGraphqlSoup) && args().done !== true;
 
   const graphqlQuery = createGraphqlNotificationsQuery(args, () => ({
     enabled: queryEnabled() && usesGraphql(),
@@ -391,7 +395,7 @@ export function invalidateUserNotifications() {
 }
 
 async function refreshSoupAfterUncachedGraphqlWrite(): Promise<void> {
-  if (ENABLE_GRAPHQL_SOUP() && !graphqlCacheEnabled()) {
+  if (isFeatureEnabled(enableGraphqlSoup) && !graphqlCacheEnabled()) {
     await refreshActiveGraphqlSoupQueries();
   }
 }
@@ -630,24 +634,24 @@ function createNotificationsMutation(
 
     return {
       get isPending() {
-        return ENABLE_GRAPHQL_SOUP()
+        return isFeatureEnabled(enableGraphqlSoup)
           ? graphqlMutation.isPending
           : restMutation.isPending;
       },
       get error() {
-        return ENABLE_GRAPHQL_SOUP()
+        return isFeatureEnabled(enableGraphqlSoup)
           ? graphqlMutation.error
           : (restMutation.error ?? null);
       },
       mutate(variables) {
-        if (ENABLE_GRAPHQL_SOUP()) {
+        if (isFeatureEnabled(enableGraphqlSoup)) {
           graphqlMutation.mutate(variables);
         } else {
           restMutation.mutate(variables);
         }
       },
       async mutateAsync(variables) {
-        if (!ENABLE_GRAPHQL_SOUP()) {
+        if (!isFeatureEnabled(enableGraphqlSoup)) {
           return await restMutation.mutateAsync(variables);
         }
 

--- a/apps/web/src/lib/queries/properties/entity.test.tsx
+++ b/apps/web/src/lib/queries/properties/entity.test.tsx
@@ -58,9 +58,8 @@ vi.mock('@core/component/Toast/Toast', () => ({
 }));
 
 vi.mock('@core/constant/featureFlags', () => ({
-  ENABLE_GRAPHQL_SOUP: graphqlSoupEnabledMock,
-  ENABLE_GRAPHQL_SOUP_FLAG: 'enable-graphql-soup',
-  ENABLE_GRAPHQL_SOUP_OVERRIDE: undefined,
+  enableGraphqlSoup: { key: 'enable-graphql-soup' },
+  isFeatureEnabled: graphqlSoupEnabledMock,
 }));
 
 vi.mock('@entity/extractors-property/property-helpers', () => ({
@@ -364,8 +363,8 @@ describe('useEntityPropertiesQuery transport', () => {
     getRestEntityPropertiesMock.mockResolvedValue(ok({ properties: [] }));
     renderEntityQuery(false);
     expect(graphqlExecutions).toHaveLength(1);
-    expect(useFeatureFlagMock).toHaveBeenCalledWith('enable-graphql-soup', {
-      enabledOverride: undefined,
+    expect(useFeatureFlagMock).toHaveBeenCalledWith({
+      key: 'enable-graphql-soup',
     });
 
     setGraphqlFlagEnabled(false);

--- a/apps/web/src/lib/queries/properties/entity.ts
+++ b/apps/web/src/lib/queries/properties/entity.ts
@@ -2,9 +2,8 @@ import { analytics } from '@app/lib/analytics';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { toast } from '@core/component/Toast/Toast';
 import {
-  ENABLE_GRAPHQL_SOUP,
-  ENABLE_GRAPHQL_SOUP_FLAG,
-  ENABLE_GRAPHQL_SOUP_OVERRIDE,
+  enableGraphqlSoup,
+  isFeatureEnabled,
 } from '@core/constant/featureFlags';
 import { thrownResultErrorHasCode, throwOnErr } from '@core/util/result';
 import {
@@ -94,9 +93,7 @@ export function useEntityPropertiesQuery(
   entityId: Accessor<string>,
   includeMetadata: boolean
 ) {
-  const graphqlSoupFlag = useFeatureFlag(ENABLE_GRAPHQL_SOUP_FLAG, {
-    enabledOverride: ENABLE_GRAPHQL_SOUP_OVERRIDE,
-  });
+  const graphqlSoupFlag = useFeatureFlag(enableGraphqlSoup);
 
   // Metadata properties are computed by the REST properties endpoint and are
   // not part of the GraphQL Soup property edge. USER is not represented in
@@ -202,7 +199,7 @@ function optimisticUpdateSoupEntityProperties(
     // A miss here means the write silently lost its optimism. Expected on the
     // GraphQL transport, whose rows live in the normalized cache instead and
     // carry their own optimistic write.
-    if (!ENABLE_GRAPHQL_SOUP()) {
+    if (!isFeatureEnabled(enableGraphqlSoup)) {
       console.warn(
         'no soup cache entry for entity; skipping optimistic property update',
         entityId
@@ -464,24 +461,24 @@ export function useAddEntityPropertyMutation(
 
   return {
     get isPending() {
-      return ENABLE_GRAPHQL_SOUP()
+      return isFeatureEnabled(enableGraphqlSoup)
         ? graphqlMutation.isPending
         : restMutation.isPending;
     },
     get error() {
-      return ENABLE_GRAPHQL_SOUP()
+      return isFeatureEnabled(enableGraphqlSoup)
         ? graphqlMutation.error
         : (restMutation.error ?? null);
     },
     mutate(variables) {
-      if (ENABLE_GRAPHQL_SOUP()) {
+      if (isFeatureEnabled(enableGraphqlSoup)) {
         graphqlMutation.mutate(variables);
       } else {
         restMutation.mutate(variables);
       }
     },
     async mutateAsync(variables) {
-      if (ENABLE_GRAPHQL_SOUP()) {
+      if (isFeatureEnabled(enableGraphqlSoup)) {
         const result = await graphqlMutation.mutateAsync(variables);
         if (result.error) throw result.error;
       } else {
@@ -646,7 +643,7 @@ export function useBulkUpdateEntityPropertyOptionsMutation(
       // The transport swaps, the mutation shell does not: the per-entity scope
       // that serializes commits and the in-flight overlay both read this
       // mutation's state, whichever cache the selection lands in.
-      if (ENABLE_GRAPHQL_SOUP()) {
+      if (isFeatureEnabled(enableGraphqlSoup)) {
         return updateGraphqlEntityPropertyOptions(variables);
       }
       const response = await throwOnErr(async () =>
@@ -990,24 +987,24 @@ export function useBulkSaveEntityPropertiesMutation(
 
   return {
     get isPending() {
-      return ENABLE_GRAPHQL_SOUP()
+      return isFeatureEnabled(enableGraphqlSoup)
         ? graphqlMutation.isPending
         : restMutation.isPending;
     },
     get error() {
-      return ENABLE_GRAPHQL_SOUP()
+      return isFeatureEnabled(enableGraphqlSoup)
         ? graphqlMutation.error
         : (restMutation.error ?? null);
     },
     mutate(variables) {
-      if (ENABLE_GRAPHQL_SOUP()) {
+      if (isFeatureEnabled(enableGraphqlSoup)) {
         graphqlMutation.mutate(variables);
       } else {
         restMutation.mutate(variables);
       }
     },
     async mutateAsync(variables) {
-      if (ENABLE_GRAPHQL_SOUP()) {
+      if (isFeatureEnabled(enableGraphqlSoup)) {
         const result = await graphqlMutation.mutateAsync(variables);
         if (result.error) throw result.error;
       } else {

--- a/apps/web/src/lib/queries/soup/backfill.test.tsx
+++ b/apps/web/src/lib/queries/soup/backfill.test.tsx
@@ -42,8 +42,7 @@ vi.mock('@app/lib/analytics/posthog', () => ({
 
 vi.mock('@core/constant/featureFlags', () => ({
   ENABLE_GRAPHQL_BACKFILL: true,
-  ENABLE_GRAPHQL_SOUP_FLAG: 'enable-graphql-soup',
-  ENABLE_GRAPHQL_SOUP_OVERRIDE: undefined,
+  enableGraphqlSoup: { key: 'enable-graphql-soup' },
 }));
 
 vi.mock('@core/cross-tab/tab-leader', () => ({

--- a/apps/web/src/lib/queries/soup/backfill.ts
+++ b/apps/web/src/lib/queries/soup/backfill.ts
@@ -1,8 +1,7 @@
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import {
   ENABLE_GRAPHQL_BACKFILL,
-  ENABLE_GRAPHQL_SOUP_FLAG,
-  ENABLE_GRAPHQL_SOUP_OVERRIDE,
+  enableGraphqlSoup,
 } from '@core/constant/featureFlags';
 import { createTabLeaderSignal } from '@core/cross-tab/tab-leader';
 import type { CacheHost } from '@graphql-cache/host/types';
@@ -528,9 +527,7 @@ const waitForGraphqlSoupCacheHost = Effect.suspend(() => {
  * cursors before restarting so they can never point past wiped cache data.
  */
 export function useSoupBackfills(userId: string): void {
-  const graphqlSoupFlag = useFeatureFlag(ENABLE_GRAPHQL_SOUP_FLAG, {
-    enabledOverride: ENABLE_GRAPHQL_SOUP_OVERRIDE,
-  });
+  const graphqlSoupFlag = useFeatureFlag(enableGraphqlSoup);
   const isLeader = createTabLeaderSignal(
     `graphql-soup-backfill:v${BACKFILL_VERSION}:coordinator`
   );

--- a/apps/web/src/lib/queries/soup/items.transport-refetch.test.ts
+++ b/apps/web/src/lib/queries/soup/items.transport-refetch.test.ts
@@ -30,8 +30,7 @@ vi.mock('@app/lib/analytics/posthog', () => ({
   useFeatureFlag: vi.fn(() => () => ({ enabled: testState.graphqlEnabled })),
 }));
 vi.mock('@core/constant/featureFlags', () => ({
-  ENABLE_GRAPHQL_SOUP_FLAG: 'enable-graphql-soup',
-  ENABLE_GRAPHQL_SOUP_OVERRIDE: undefined,
+  enableGraphqlSoup: { key: 'enable-graphql-soup' },
 }));
 vi.mock('@core/util/result', () => ({ throwOnErr: vi.fn() }));
 vi.mock('@queries/soup/grouped/api', () => ({

--- a/apps/web/src/lib/queries/soup/items.ts
+++ b/apps/web/src/lib/queries/soup/items.ts
@@ -1,9 +1,6 @@
 import { filterSoupItemByRequestBody } from '@app/features/next-soup/filters/query-filters';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
-import {
-  ENABLE_GRAPHQL_SOUP_FLAG,
-  ENABLE_GRAPHQL_SOUP_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableGraphqlSoup } from '@core/constant/featureFlags';
 import { throwOnErr } from '@core/util/result';
 import type { EntityData } from '@entity';
 import {
@@ -346,9 +343,7 @@ export function useSoupAstItemsQuery(
   args: Accessor<SoupAstItemsQueryArgs>,
   options?: Accessor<SoupItemsQueryOptions>
 ): SoupAstItemsQuery {
-  const graphqlSoupFlag = useFeatureFlag(ENABLE_GRAPHQL_SOUP_FLAG, {
-    enabledOverride: ENABLE_GRAPHQL_SOUP_OVERRIDE,
-  });
+  const graphqlSoupFlag = useFeatureFlag(enableGraphqlSoup);
 
   const queryEnabled = () => options?.().enabled !== false;
   const graphqlRequested = () => {

--- a/apps/web/src/lib/queries/soup/quick-access-crm-companies.ts
+++ b/apps/web/src/lib/queries/soup/quick-access-crm-companies.ts
@@ -1,9 +1,6 @@
 import { QUERY_FILTERS_BASE } from '@app/features/next-soup/filters/query-filters';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
-import {
-  ENABLE_CRM_FLAG,
-  ENABLE_CRM_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableCrm } from '@core/constant/featureFlags';
 import { type CrmCompanyEntity, isCrmCompanyEntity } from '@entity';
 import { useSoupItemsQuery } from '@queries/soup/items';
 import { createMemo } from 'solid-js';
@@ -24,9 +21,7 @@ const STALE_TIME = 5 * 60 * 1000;
  * Every other entity type is filtered out by extending `QUERY_FILTERS_BASE`.
  */
 export function useQuickAccessCrmCompaniesQuery() {
-  const crmFlag = useFeatureFlag(ENABLE_CRM_FLAG, {
-    enabledOverride: ENABLE_CRM_OVERRIDE,
-  });
+  const crmFlag = useFeatureFlag(enableCrm);
 
   const query = useSoupItemsQuery(
     () => ({

--- a/apps/web/src/lib/queries/soup/quick-access-snippets.ts
+++ b/apps/web/src/lib/queries/soup/quick-access-snippets.ts
@@ -1,9 +1,6 @@
 import { QUERY_FILTERS_BASE } from '@app/features/next-soup/filters/query-filters';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
-import {
-  ENABLE_SNIPPETS_FLAG,
-  ENABLE_SNIPPETS_OVERRIDE,
-} from '@core/constant/featureFlags';
+import { enableSnippets } from '@core/constant/featureFlags';
 import { isSnippetEntity, type SnippetEntity } from '@entity';
 import { useSoupItemsQuery } from '@queries/soup/items';
 import { createMemo } from 'solid-js';
@@ -24,9 +21,7 @@ const STALE_TIME = 5 * 60 * 1000;
  * documents are narrowed to the snippet sub type.
  */
 export function useQuickAccessSnippetsQuery() {
-  const snippetsFlag = useFeatureFlag(ENABLE_SNIPPETS_FLAG, {
-    enabledOverride: ENABLE_SNIPPETS_OVERRIDE,
-  });
+  const snippetsFlag = useFeatureFlag(enableSnippets);
 
   const query = useSoupItemsQuery(
     () => ({

--- a/apps/web/src/lib/queries/soup/recently-viewed.ts
+++ b/apps/web/src/lib/queries/soup/recently-viewed.ts
@@ -1,5 +1,5 @@
 import { QUERY_FILTERS_BASE } from '@app/features/next-soup/filters/query-filters';
-import { ENABLE_CRM } from '@core/constant/featureFlags';
+import { enableCrm, isFeatureEnabled } from '@core/constant/featureFlags';
 import { throwOnErr } from '@core/util/result';
 import { storageServiceClient } from '@service-storage/client';
 import { useQuery } from '@tanstack/solid-query';
@@ -32,7 +32,9 @@ function buildRecentlyViewedArgs(): SoupItemsQueryArgs {
       email_filters: undefined,
       project_filters: undefined,
       // CRM companies only surface in recently-viewed when the feature is enabled.
-      ...(ENABLE_CRM() ? { crm_company_filters: undefined } : {}),
+      ...(isFeatureEnabled(enableCrm)
+        ? { crm_company_filters: undefined }
+        : {}),
     },
   };
 }

--- a/apps/web/src/lib/queries/sync/SyncProvider.tsx
+++ b/apps/web/src/lib/queries/sync/SyncProvider.tsx
@@ -1,4 +1,7 @@
-import { ENABLE_GRAPHQL_SOUP } from '@core/constant/featureFlags';
+import {
+  enableGraphqlSoup,
+  isFeatureEnabled,
+} from '@core/constant/featureFlags';
 import { handleAgentSessionQueue } from '@queries/agent-session/queue-sync';
 import {
   AGENT_SESSION_LOG_EVENT,
@@ -107,7 +110,7 @@ export function QuerySyncProvider(props: SyncProviderProps) {
         );
       })
       .with({ type: 'notification_status_updated' }, () => {
-        if (ENABLE_GRAPHQL_SOUP()) return;
+        if (isFeatureEnabled(enableGraphqlSoup)) return;
         const result = notificationStatusUpdatePayloadSchema.safeParse(
           data.data
         );

--- a/apps/web/src/lib/service-clients/service-storage/graphql-activity-notifications.test.ts
+++ b/apps/web/src/lib/service-clients/service-storage/graphql-activity-notifications.test.ts
@@ -27,7 +27,8 @@ const {
 }));
 
 vi.mock('@core/constant/featureFlags', () => ({
-  ENABLE_GRAPHQL_SOUP: graphqlSoupEnabledMock,
+  enableGraphqlSoup: { key: 'enable-graphql-soup' },
+  isFeatureEnabled: graphqlSoupEnabledMock,
 }));
 
 vi.mock('./client', () => ({

--- a/apps/web/src/lib/service-clients/service-storage/graphql-channel-activity.ts
+++ b/apps/web/src/lib/service-clients/service-storage/graphql-channel-activity.ts
@@ -1,4 +1,7 @@
-import { ENABLE_GRAPHQL_SOUP } from '@core/constant/featureFlags';
+import {
+  enableGraphqlSoup,
+  isFeatureEnabled,
+} from '@core/constant/featureFlags';
 import { throwOnErr } from '@core/util/result';
 import { storageServiceClient } from './client';
 import type { ActivityType } from './generated/schemas/activityType';
@@ -20,7 +23,7 @@ export async function recordChannelActivity(args: {
   channelId: string;
   activityType: ActivityType;
 }): Promise<ApiActivity> {
-  if (!ENABLE_GRAPHQL_SOUP()) {
+  if (!isFeatureEnabled(enableGraphqlSoup)) {
     return await throwOnErr(
       async () =>
         await storageServiceClient.postActivity({

--- a/apps/web/src/lib/service-clients/service-storage/graphql-notifications.ts
+++ b/apps/web/src/lib/service-clients/service-storage/graphql-notifications.ts
@@ -1,4 +1,7 @@
-import { ENABLE_GRAPHQL_SOUP } from '@core/constant/featureFlags';
+import {
+  enableGraphqlSoup,
+  isFeatureEnabled,
+} from '@core/constant/featureFlags';
 import { throwOnErr } from '@core/util/result';
 import { notificationServiceClient } from '../service-notification/client';
 import type { NotificationUpdateOperation } from './graphql/generated/graphql';
@@ -18,7 +21,7 @@ export type { NotificationUpdateOperation };
 export async function updateNotifications(
   args: GraphqlUpdateNotificationsArgs
 ): Promise<GraphqlUpdateNotificationsResult> {
-  if (!ENABLE_GRAPHQL_SOUP()) {
+  if (!isFeatureEnabled(enableGraphqlSoup)) {
     const request = { notificationIds: args.notificationIds };
     switch (args.operation) {
       case 'MARK_SEEN':

--- a/apps/web/src/lib/service-clients/service-storage/graphql-soup.test.ts
+++ b/apps/web/src/lib/service-clients/service-storage/graphql-soup.test.ts
@@ -93,7 +93,8 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('@core/constant/featureFlags', () => ({
   ENABLE_BEARER_TOKEN_AUTH: false,
-  ENABLE_GRAPHQL_SOUP: () => mocks.graphqlEnabled,
+  enableGraphqlSoup: { key: 'enable-graphql-soup' },
+  isFeatureEnabled: () => mocks.graphqlEnabled,
 }));
 vi.mock('@core/constant/servers', () => ({
   SERVER_HOSTS: { 'document-storage-service': 'http://dss.test' },

--- a/apps/web/src/lib/service-clients/service-storage/graphql-soup.ts
+++ b/apps/web/src/lib/service-clients/service-storage/graphql-soup.ts
@@ -1,6 +1,7 @@
 import {
   ENABLE_BEARER_TOKEN_AUTH,
-  ENABLE_GRAPHQL_SOUP,
+  enableGraphqlSoup,
+  isFeatureEnabled,
 } from '@core/constant/featureFlags';
 import { SERVER_HOSTS } from '@core/constant/servers';
 import { fetchToken } from '@core/util/fetchWithToken';
@@ -352,7 +353,7 @@ function fallbackAfterInitializationFailure(): void {
   cachedCacheCleanup = undefined;
   cachedCacheHost = undefined;
   cacheInitializationFailed = true;
-  cachedClient = ENABLE_GRAPHQL_SOUP()
+  cachedClient = isFeatureEnabled(enableGraphqlSoup)
     ? getUncachedRealtimeClient()
     : graphqlSoupClient;
   browserCacheClientActivated = false;
@@ -385,7 +386,7 @@ export function getGraphqlSoupClient(): Client {
     return cachedClient;
   const rollout = getBrowserTursoCacheRolloutDecision();
   if (!rollout.enabled) {
-    return ENABLE_GRAPHQL_SOUP()
+    return isFeatureEnabled(enableGraphqlSoup)
       ? getUncachedRealtimeClient()
       : graphqlSoupClient;
   }
@@ -465,7 +466,7 @@ export function getGraphqlSoupClient(): Client {
       cachedCacheCleanup = undefined;
       cacheInitializationFailed = true;
       console.warn('graphql cache init failed; using uncached client', error);
-      return ENABLE_GRAPHQL_SOUP()
+      return isFeatureEnabled(enableGraphqlSoup)
         ? getUncachedRealtimeClient()
         : graphqlSoupClient;
     }

--- a/apps/web/src/routes/Root.tsx
+++ b/apps/web/src/routes/Root.tsx
@@ -36,7 +36,7 @@ import { publishLoginSuccess } from '@core/auth/login-events';
 import { ChatAttachmentsInit } from '@core/component/AI/signal/globalAttachments';
 import { LoadingBlock } from '@core/component/LoadingBlock';
 import { ToastRegion } from '@core/component/Toast/ToastRegion';
-import { ENABLE_ONBOARDING_V4_OVERRIDE } from '@core/constant/featureFlags';
+import { enableOnboardingV4 } from '@core/constant/featureFlags';
 import { ChannelsContextProvider } from '@core/context/channels';
 import { EmailLinksContextProvider } from '@core/context/emailLinks';
 import { QuickAccessProvider } from '@core/context/quickAccess';
@@ -496,7 +496,7 @@ function InitialInteractiveOnboardingModal() {
     // `just run_local` sets VITE_ENABLE_ONBOARDING_V4=false; without this the
     // v4-off fallback would still open this legacy modal. Opt in with
     // `just run_local --enable-onboarding`.
-    ENABLE_ONBOARDING_V4_OVERRIDE !== false &&
+    enableOnboardingV4.override !== false &&
     // Onboarding-v4 replaces this modal on desktop; the Layout redirect
     // sends first-time users to /onboarding instead. Desktop waits for the
     // flag to resolve so this doesn't flash before that redirect fires.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches many product gates (inbox, notifications, CRM, onboarding) across the app; behavior should be equivalent but any mismatch in env override or default semantics could silently flip features.
> 
> **Overview**
> **Centralizes feature gating** in `@core/constant/featureFlags` with `defineFlag()`, `RemoteFlag`/`EnvFlag` objects, and shared `isFeatureEnabled()` instead of per-flag `*_FLAG` / `*_OVERRIDE` pairs and `ENABLE_*()` helpers.
> 
> **Call sites** now pass flag objects into `useFeatureFlag(flag)` and `ShowFeatureFlag flag={…}`, and use `isFeatureEnabled(flag)` for imperative gates (reminders, CRM, GraphQL soup, calendar, snippets, etc.). Env-only toggles are expressed as `defineFlag({ env, default }).enabled`; composite helpers like `isCalendarSearchUiEnabled()` and `isAutoUpdateUiEnabled()` replace ad-hoc combinations. **`ENABLE_CALLS` is now a boolean constant** (`true`) rather than a PostHog-backed function.
> 
> **Tests** update mocks to stub `isFeatureEnabled` / flag objects (and add `localStorage` where module init needs it).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2ddde5c0539b466b4fb693cefd536f0e317bb24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->