### PR TITLE
feat(observability): correlate WAF logs with traces

### DIFF
--- a/apps/web/src/lib/core/util/safeFetch.spec.ts
+++ b/apps/web/src/lib/core/util/safeFetch.spec.ts
@@ -4,6 +4,89 @@
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+const telemetryRecorder = vi.hoisted(() => {
+  let activeSpan: TestSpan | undefined;
+
+  class TestSpan {
+    readonly attributes: Record<string, unknown> = {};
+    readonly errors: unknown[] = [];
+    ended = false;
+
+    constructor(
+      readonly name: string,
+      readonly parent?: TestSpan
+    ) {}
+
+    setAttr(name: string, value: unknown) {
+      this.attributes[name] = value;
+    }
+
+    injectTraceHeaders(headers: Record<string, string>) {
+      headers.traceparent = 'test-traceparent';
+    }
+
+    error(error: unknown) {
+      this.errors.push(error);
+    }
+
+    run<T>(operation: () => T): T {
+      const previous = activeSpan;
+      activeSpan = this;
+      try {
+        const result = operation();
+        if (result instanceof Promise) {
+          return result.finally(() => {
+            activeSpan = previous;
+          }) as T;
+        }
+        activeSpan = previous;
+        return result;
+      } catch (error) {
+        activeSpan = previous;
+        throw error;
+      }
+    }
+
+    end() {
+      this.ended = true;
+    }
+  }
+
+  const spans: TestSpan[] = [];
+  const startSpan = (name: string) => {
+    const span = new TestSpan(name, activeSpan);
+    spans.push(span);
+    return span;
+  };
+
+  return {
+    spans,
+    reset() {
+      spans.length = 0;
+      activeSpan = undefined;
+    },
+    span: (name: string, operation?: (span: TestSpan) => Promise<unknown>) => {
+      const span = startSpan(name);
+      if (!operation) return span;
+      return span.run(async () => {
+        try {
+          return await operation(span);
+        } finally {
+          span.end();
+        }
+      });
+    },
+    clientSpan: (name: string) => startSpan(name),
+  };
+});
+
+vi.mock('@macro-inc/observability', () => ({
+  Telemetry: {
+    span: telemetryRecorder.span,
+    clientSpan: telemetryRecorder.clientSpan,
+  },
+}));
+
 import { type BaseFetchErrorCode, safeFetch } from './safeFetch';
 
 let originalFetch = global.fetch;
@@ -19,6 +102,7 @@ describe('safeFetch', () => {
   });
 
   beforeEach(() => {
+    telemetryRecorder.reset();
     global.fetch = mockFetch as typeof fetch;
     global.setTimeout = ((fn: (...args: any[]) => any) => {
       fn();
@@ -62,6 +146,13 @@ describe('safeFetch', () => {
       const [{ code }] = result.error;
       expect(code).toBe('NETWORK_ERROR');
     }
+    const [parent, attempt] = telemetryRecorder.spans;
+    expect(parent?.attributes['safe_fetch.error.code']).toBe('NETWORK_ERROR');
+    expect(attempt?.attributes).toMatchObject({
+      'error.type': 'chromium_failed_to_fetch',
+      'network.error.kind': 'chromium_failed_to_fetch',
+      'safe_fetch.response.visible': false,
+    });
   });
 
   test('retry on network errors when configured', async () => {
@@ -87,6 +178,203 @@ describe('safeFetch', () => {
       expect(data).toEqual({ data: 'retry success' });
     }
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('creates one parent with child spans and fresh request IDs per attempt', async () => {
+    const callerHeaders = new Headers({ Authorization: 'Bearer token' });
+    mockFetch
+      .mockRejectedValueOnce(
+        new TypeError('NetworkError when attempting to fetch resource.')
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: 'retry success' }), {
+          headers: {
+            'Content-Length': '24',
+            'Content-Type': 'application/json',
+          },
+        })
+      );
+
+    const result = await safeFetch<{ data: string }>(
+      `${window.location.origin}/users/2e4d2c15-4f8c-478b-a157-78fd126ba539`,
+      {
+        method: 'POST',
+        body: '{"query":"safe"}',
+        headers: callerHeaders,
+        retry: { maxTries: 2, delay: 0 },
+        trace: { route: '/users/{userId}' },
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    const [parent, firstAttempt, secondAttempt] = telemetryRecorder.spans;
+    expect(parent?.name).toBe('safeFetch POST /users/{userId}');
+    expect(firstAttempt?.name).toBe('HTTP POST /users/{userId}');
+    expect(secondAttempt?.name).toBe('HTTP POST /users/{userId}');
+    expect(firstAttempt?.parent).toBe(parent);
+    expect(secondAttempt?.parent).toBe(parent);
+    expect(firstAttempt?.attributes).toMatchObject({
+      'http.request.method': 'POST',
+      'http.request.body.size': 16,
+      'safe_fetch.retry.attempt': 1,
+      'safe_fetch.retry.max_tries': 2,
+      'safe_fetch.response.visible': false,
+      'network.error.kind': 'firefox_network_error',
+    });
+    expect(secondAttempt?.attributes).toMatchObject({
+      'http.response.status_code': 200,
+      'http.response.body.size': 24,
+      'safe_fetch.retry.attempt': 2,
+      'safe_fetch.response.visible': true,
+    });
+
+    const firstHeaders = mockFetch.mock.calls[0]?.[1]?.headers as Record<
+      string,
+      string
+    >;
+    const secondHeaders = mockFetch.mock.calls[1]?.[1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(firstHeaders['x-request-id']).toBeTruthy();
+    expect(secondHeaders['x-request-id']).toBeTruthy();
+    expect(firstHeaders['x-request-id']).not.toBe(
+      secondHeaders['x-request-id']
+    );
+    expect(firstHeaders.authorization).toBe('Bearer token');
+    expect(callerHeaders.has('x-request-id')).toBe(false);
+  });
+
+  test('does not add request IDs to untraced third-party origins', async () => {
+    await safeFetch<{ data: string }>('https://example.com/data');
+
+    const headers = mockFetch.mock.calls[0]?.[1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(headers['x-request-id']).toBeUndefined();
+  });
+
+  test('retries Request bodies with a fresh clone and honors header replacement', async () => {
+    const consumedBodies: string[] = [];
+    mockFetch
+      .mockImplementationOnce(async (input) => {
+        consumedBodies.push(await (input as Request).text());
+        throw new TypeError('Failed to fetch');
+      })
+      .mockImplementationOnce(async (input, init) => {
+        consumedBodies.push(await (input as Request).text());
+        const headers = new Headers(init?.headers);
+        expect(headers.has('authorization')).toBe(false);
+        expect(headers.get('x-test')).toBe('replacement');
+        return new Response(JSON.stringify({ data: 'ok' }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+
+    const request = new Request(`${window.location.origin}/data`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer original' },
+      body: '{"value":1}',
+    });
+    const result = await safeFetch<{ data: string }>(request, {
+      headers: { 'x-test': 'replacement' },
+      retry: { maxTries: 2, delay: 0 },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(consumedBodies).toEqual(['{"value":1}', '{"value":1}']);
+  });
+
+  test('consumes the original Request when retries are disabled', async () => {
+    const request = new Request(`${window.location.origin}/data`, {
+      method: 'POST',
+      body: '{"value":1}',
+    });
+    mockFetch.mockImplementationOnce(async (input) => {
+      expect(input).toBe(request);
+      expect(await (input as Request).text()).toBe('{"value":1}');
+      return new Response(JSON.stringify({ data: 'ok' }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const result = await safeFetch<{ data: string }>(request);
+
+    expect(result.isOk()).toBe(true);
+    expect(request.bodyUsed).toBe(true);
+  });
+
+  test('tees RequestInit streams for retries', async () => {
+    const consumedBodies: string[] = [];
+    mockFetch
+      .mockImplementationOnce(async (_input, init) => {
+        consumedBodies.push(await new Response(init?.body).text());
+        throw new TypeError('Failed to fetch');
+      })
+      .mockImplementationOnce(async (_input, init) => {
+        consumedBodies.push(await new Response(init?.body).text());
+        return new Response(JSON.stringify({ data: 'ok' }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"value":1}'));
+        controller.close();
+      },
+    });
+
+    const result = await safeFetch<{ data: string }>(
+      `${window.location.origin}/data`,
+      {
+        method: 'POST',
+        body,
+        retry: { maxTries: 2, delay: 0 },
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(consumedBodies).toEqual(['{"value":1}', '{"value":1}']);
+  });
+
+  test('uses the final network outcome instead of a stale retry status', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(null, { status: 500, statusText: 'Server Error' })
+      )
+      .mockRejectedValueOnce(new TypeError('Load failed'));
+
+    const result = await safeFetch<{ data: string }>(
+      `${window.location.origin}/data`,
+      {
+        retry: { maxTries: 2, delay: 0 },
+        trace: { expectedStatusCodes: [500] },
+      }
+    );
+
+    expect(result).toMatchObject({
+      error: [{ code: 'NETWORK_ERROR' }],
+    });
+    const parent = telemetryRecorder.spans[0];
+    const finalAttempt = telemetryRecorder.spans[2];
+    expect(parent?.attributes['safe_fetch.response.visible']).toBe(false);
+    expect(parent?.attributes['http.response.status_code']).toBeUndefined();
+    expect(parent?.errors).toHaveLength(1);
+    expect(finalAttempt?.attributes['network.error.kind']).toBe(
+      'safari_load_failed'
+    );
+  });
+
+  test('normalizes identifier path segments in fallback span names', async () => {
+    await safeFetch<{ data: string }>(
+      'https://localhost/documents/2e4d2c15-4f8c-478b-a157-78fd126ba539'
+    );
+
+    expect(telemetryRecorder.spans.map((span) => span.name)).toEqual([
+      'safeFetch GET /documents/{id}',
+      'HTTP GET /documents/{id}',
+    ]);
   });
 
   test('handle invalid JSON', async () => {

--- a/apps/web/src/lib/core/util/safeFetch.ts
+++ b/apps/web/src/lib/core/util/safeFetch.ts
@@ -35,25 +35,212 @@ function requestUrl(input: RequestInfo): URL | undefined {
   }
 }
 
+const UUID_PATH_SEGMENT =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const OPAQUE_PATH_SEGMENT = /^(?:\d+|[0-9a-f]{16,}|[A-Za-z0-9_-]{24,})$/;
+
+function traceRoute(url: URL, route?: string): string {
+  const configuredRoute = route?.split(/[?#]/, 1)[0];
+  const pathname = configuredRoute || url.pathname || '/';
+  const segments = pathname.split('/');
+  const normalized = pathname
+    .split('/')
+    .map((segment, index) => {
+      if (
+        UUID_PATH_SEGMENT.test(segment) ||
+        OPAQUE_PATH_SEGMENT.test(segment)
+      ) {
+        return '{id}';
+      }
+      if (configuredRoute || index <= 1 || segment === '') return segment;
+      return '{path}';
+    })
+    .join('/');
+  if (!configuredRoute && segments.length > 2) {
+    return normalized.replace(/(?:\/\{path\})+$/, '/{path}');
+  }
+  return normalized.startsWith('/') ? normalized : `/${normalized}`;
+}
+
+function requestMethod(input: RequestInfo, init: RequestInit): string {
+  return (
+    init.method ??
+    (typeof input === 'string' ? undefined : input.method) ??
+    'GET'
+  ).toUpperCase();
+}
+
+function requestBodySize(
+  body: BodyInit | null | undefined
+): number | undefined {
+  if (typeof body === 'string')
+    return new TextEncoder().encode(body).byteLength;
+  if (body instanceof URLSearchParams) {
+    return new TextEncoder().encode(body.toString()).byteLength;
+  }
+  if (body instanceof Blob) return body.size;
+  if (body instanceof ArrayBuffer) return body.byteLength;
+  if (ArrayBuffer.isView(body)) return body.byteLength;
+  return undefined;
+}
+
+function retryBodyStream(
+  body: BodyInit | null | undefined,
+  maxTries: number
+):
+  | {
+      next(attempt: number): BodyInit;
+      cancel(): Promise<void>;
+    }
+  | undefined {
+  if (
+    maxTries <= 1 ||
+    typeof ReadableStream === 'undefined' ||
+    !(body instanceof ReadableStream)
+  ) {
+    return undefined;
+  }
+
+  let remaining: ReadableStream | undefined = body;
+  return {
+    next(attempt) {
+      if (!remaining) throw new Error('Request body stream already consumed');
+      if (attempt === maxTries) {
+        const current = remaining;
+        remaining = undefined;
+        return current;
+      }
+      const [current, next] = remaining.tee();
+      remaining = next;
+      return current;
+    },
+    async cancel() {
+      await remaining?.cancel();
+      remaining = undefined;
+    },
+  };
+}
+
+function declaredBodySize(response: Response): number | undefined {
+  const value = response.headers?.get('content-length') ?? null;
+  if (value === null || !/^\d+$/.test(value)) return undefined;
+  const size = Number(value);
+  return Number.isSafeInteger(size) ? size : undefined;
+}
+
+function networkErrorKind(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined;
+  if (
+    error instanceof TypeError &&
+    /^Failed to fetch\.?$/i.test(error.message)
+  ) {
+    return 'chromium_failed_to_fetch';
+  }
+  if (error.name === 'NetworkError' || /NetworkError/i.test(error.message)) {
+    return 'firefox_network_error';
+  }
+  if (error instanceof TypeError && /^Load failed\.?$/i.test(error.message)) {
+    return 'safari_load_failed';
+  }
+  return undefined;
+}
+
+function newRequestId(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+  const bytes = new Uint8Array(16);
+  if (globalThis.crypto?.getRandomValues) {
+    globalThis.crypto.getRandomValues(bytes);
+  } else {
+    for (let index = 0; index < bytes.length; index++) {
+      bytes[index] = Math.floor(Math.random() * 256);
+    }
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0'));
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10).join('')}`;
+}
+
+function attemptHeaders(
+  input: RequestInfo,
+  init: RequestInit,
+  method: string,
+  requestId: string,
+  includeRequestId: boolean
+): Record<string, string> {
+  const headers = new Headers(
+    init.headers ?? (typeof input === 'string' ? undefined : input.headers)
+  );
+  if (
+    method !== 'GET' &&
+    method !== 'HEAD' &&
+    !(init.body instanceof FormData) &&
+    !headers.has('content-type')
+  ) {
+    headers.set('content-type', 'application/json');
+  }
+  if (includeRequestId) headers.set('x-request-id', requestId);
+  return Object.fromEntries(headers.entries());
+}
+
 function tracedFetch(
   input: RequestInfo,
-  init: RequestInit & { headers: Record<string, string> },
-  traceOptions?: SafeFetchTraceOptions
+  init: RequestInit,
+  context: {
+    attempt: number;
+    maxTries: number;
+    method: string;
+    requestId: string;
+    route: string;
+    traceOptions?: SafeFetchTraceOptions;
+  }
 ): Promise<Response> {
   const url = requestUrl(input);
-  if (!url) return platformFetch(input, init);
-  const method = (init.method ?? 'GET').toUpperCase();
-  const span = Telemetry.clientSpan(`http ${method} ${url.pathname}`);
+  const { attempt, maxTries, method, requestId, route, traceOptions } = context;
+  const tracedOrigin = url ? isTracedOrigin(url) : false;
+  const headers = attemptHeaders(input, init, method, requestId, tracedOrigin);
+  const attemptInput =
+    typeof input !== 'string' && maxTries > 1 && init.body === undefined
+      ? input.clone()
+      : input;
+  if (!url) return platformFetch(attemptInput, { ...init, headers });
+  const span = Telemetry.clientSpan(`HTTP ${method} ${route}`);
+  span.setAttr('http.request.method', method);
   span.setAttr('http.method', method);
-  // Path only: query strings can carry tokens.
-  span.setAttr('http.url', `${url.origin}${url.pathname}`);
+  span.setAttr('http.route', route);
+  span.setAttr('url.scheme', url.protocol.slice(0, -1));
+  span.setAttr('server.address', url.hostname);
+  if (url.port) span.setAttr('server.port', Number(url.port));
+  span.setAttr('url.path', route);
+  // Use the normalized route: query strings and path segments can carry tokens.
+  const sanitizedUrl = `${url.origin}${route}`;
+  span.setAttr('url.full', sanitizedUrl);
+  span.setAttr('http.url', sanitizedUrl);
+  span.setAttr('request.id', requestId);
+  span.setAttr('http.request.resend_count', attempt - 1);
+  span.setAttr('safe_fetch.retry.attempt', attempt);
+  span.setAttr('safe_fetch.retry.max_tries', maxTries);
+  span.setAttr('safe_fetch.response.visible', false);
+  const bodySize = requestBodySize(init.body);
+  if (bodySize !== undefined) span.setAttr('http.request.body.size', bodySize);
   return span.run(async () => {
     try {
-      if (isTracedOrigin(url)) {
-        span.injectTraceHeaders(init.headers);
+      if (tracedOrigin) {
+        span.injectTraceHeaders(headers);
       }
-      const response = await platformFetch(input, init);
+      const response = await platformFetch(attemptInput, { ...init, headers });
+      span.setAttr('safe_fetch.response.visible', true);
+      span.setAttr('http.response.status_code', response.status);
       span.setAttr('http.status_code', response.status);
+      const responseSize = declaredBodySize(response);
+      if (responseSize !== undefined) {
+        span.setAttr('http.response.body.size', responseSize);
+      }
+      const contentType = response.headers?.get('content-type');
+      if (contentType)
+        span.setAttr('http.response.body.content_type', contentType);
       if (!response.ok) {
         const expected = traceOptions?.expectedStatusCodes?.includes(
           response.status
@@ -62,7 +249,8 @@ function tracedFetch(
           span.setAttr('http.expected_status', true);
           return response;
         }
-        const message = `HTTP ${response.status} for ${method} ${url.pathname}`;
+        span.setAttr('error.type', String(response.status));
+        const message = `HTTP ${response.status} for ${method} ${route}`;
         span.error({
           name: 'HttpError',
           message,
@@ -71,6 +259,11 @@ function tracedFetch(
       }
       return response;
     } catch (error) {
+      const kind = networkErrorKind(error);
+      if (kind) {
+        span.setAttr('error.type', kind);
+        span.setAttr('network.error.kind', kind);
+      }
       span.error(error);
       throw error;
     } finally {
@@ -139,6 +332,8 @@ export interface RetryConfig {
 
 /** Trace-only classification for responses that are expected by the caller. */
 export interface SafeFetchTraceOptions {
+  /** Low-cardinality route template used in span names, for example `/users/{id}`. */
+  route?: string;
   /** Non-OK responses that should not mark the HTTP span as failed. */
   expectedStatusCodes?: readonly number[];
 }
@@ -246,119 +441,171 @@ export async function safeFetch<
   const { retry, trace, ...fetchInit } = init || {};
   const maxTries = retry?.maxTries ?? 1;
   const delay = retry?.delay ?? 0;
-  type ErrorCode = BaseFetchErrorCode | CustomErrorCode;
-  const fetchErr = (errors: ResultError<ErrorCode>[]) =>
-    err<T, ResultError<ErrorCode>[]>(errors);
-  let lastError: Result<T, ResultError<ErrorCode>[]> | undefined;
+  const method = requestMethod(input, fetchInit);
+  const url = requestUrl(input);
+  const route = url ? traceRoute(url, trace?.route) : '/unknown';
 
-  for (let attempt = 1; attempt <= maxTries; attempt++) {
-    try {
-      const response = await tracedFetch(
-        input,
-        {
-          ...fetchInit,
-          headers: {
-            ...(fetchInit?.method !== 'GET' &&
-              fetchInit?.method !== 'HEAD' &&
-              !(fetchInit?.body instanceof FormData) && {
-                'Content-Type':
-                  (fetchInit?.headers as Record<string, string> | undefined)?.[
-                    'Content-Type'
-                  ] ?? 'application/json',
-              }),
-            ...fetchInit?.headers,
-          } as Record<string, string>,
-        },
-        trace
-      );
+  return Telemetry.span(`safeFetch ${method} ${route}`, async (parentSpan) => {
+    parentSpan.setAttr('http.request.method', method);
+    parentSpan.setAttr('http.method', method);
+    parentSpan.setAttr('http.route', route);
+    parentSpan.setAttr('safe_fetch.retry.max_tries', maxTries);
+    const bodySize = requestBodySize(fetchInit.body);
+    if (bodySize !== undefined) {
+      parentSpan.setAttr('http.request.body.size', bodySize);
+    }
 
-      if (!response.ok) {
-        if (errorResponseHandler) {
-          const customError = await errorResponseHandler(response);
-          return fetchErr(customError ? [customError] : []);
-        }
+    type ErrorCode = BaseFetchErrorCode | CustomErrorCode;
+    const fetchErr = (errors: ResultError<ErrorCode>[]) =>
+      err<T, ResultError<ErrorCode>[]>(errors);
+    let lastError: Result<T, ResultError<ErrorCode>[]> | undefined;
+    let lastResponseStatus: number | undefined;
+    let attempts = 0;
+    const retryBody = retryBodyStream(fetchInit.body, maxTries);
+    const retryRequest =
+      typeof input !== 'string' && maxTries > 1 && fetchInit.body === undefined
+        ? input
+        : undefined;
 
-        switch (response.status) {
-          case 404:
-            return fetchErr([
-              { code: 'NOT_FOUND', message: 'Resource not found' },
-            ]);
-          case 401:
-            return fetchErr([
-              { code: 'UNAUTHORIZED', message: 'Unauthorized access' },
-            ]);
-          case 403:
-            return fetchErr([{ code: 'FORBIDDEN', message: 'Forbidden' }]);
-          case 409:
-            return fetchErr([
-              { code: 'CONFLICT', message: 'Resource conflict' },
-            ]);
-          case 410:
-            return fetchErr([{ code: 'GONE', message: 'Resource deleted' }]);
-          case 500:
+    const result = await (async () => {
+      for (let attempt = 1; attempt <= maxTries; attempt++) {
+        attempts = attempt;
+        lastResponseStatus = undefined;
+        try {
+          const attemptInit = retryBody
+            ? { ...fetchInit, body: retryBody.next(attempt) }
+            : fetchInit;
+          const response = await tracedFetch(input, attemptInit, {
+            attempt,
+            maxTries,
+            method,
+            requestId: newRequestId(),
+            route,
+            traceOptions: trace,
+          });
+          lastResponseStatus = response.status;
+
+          if (!response.ok) {
+            if (errorResponseHandler) {
+              const customError = await errorResponseHandler(response);
+              return fetchErr(customError ? [customError] : []);
+            }
+
+            switch (response.status) {
+              case 404:
+                return fetchErr([
+                  { code: 'NOT_FOUND', message: 'Resource not found' },
+                ]);
+              case 401:
+                return fetchErr([
+                  { code: 'UNAUTHORIZED', message: 'Unauthorized access' },
+                ]);
+              case 403:
+                return fetchErr([{ code: 'FORBIDDEN', message: 'Forbidden' }]);
+              case 409:
+                return fetchErr([
+                  { code: 'CONFLICT', message: 'Resource conflict' },
+                ]);
+              case 410:
+                return fetchErr([
+                  { code: 'GONE', message: 'Resource deleted' },
+                ]);
+              case 500:
+                lastError = fetchErr([
+                  {
+                    code: 'SERVER_ERROR',
+                    message: 'Internal server error',
+                  },
+                ]);
+                break;
+              default:
+                return fetchErr([
+                  {
+                    code: 'HTTP_ERROR',
+                    message: `HTTP error! status: ${response.status}`,
+                  },
+                ]);
+            }
+          } else {
+            if (method === 'HEAD') return ok({} as T);
+
+            const contentType = response.headers.get('Content-Type');
+            if (!contentType) return ok({} as T);
+
+            if (contentType.includes('text/plain')) {
+              const text = await response.text();
+              return ok({ contentType, body: text } as T);
+            }
+
+            if (contentType.includes('application/octet-stream')) {
+              return ok(new Uint8Array(await response.arrayBuffer()) as T);
+            }
+
+            const data = await response.json();
+            return ok(data as T);
+          }
+        } catch (error) {
+          if (networkErrorKind(error)) {
             lastError = fetchErr([
-              { code: 'SERVER_ERROR', message: 'Internal server error' },
+              { code: 'NETWORK_ERROR', message: 'Network error occurred' },
             ]);
-            break;
-          default:
+          } else if (error instanceof SyntaxError) {
+            return fetchErr([
+              { code: 'INVALID_JSON', message: 'Invalid JSON in response' },
+            ]);
+          } else {
             return fetchErr([
               {
-                code: 'HTTP_ERROR',
-                message: `HTTP error! status: ${response.status}`,
+                code: 'UNKNOWN_ERROR',
+                message: `An unknown error occurred: ${error}`,
               },
             ]);
-        }
-      } else {
-        if (fetchInit.method === 'HEAD') return ok({} as T);
-
-        const contentType = response.headers.get('Content-Type');
-        if (!contentType) return ok({} as T);
-
-        if (contentType.includes('text/plain')) {
-          const text = await response.text();
-          return ok({ contentType, body: text } as T);
+          }
         }
 
-        if (contentType.includes('application/octet-stream')) {
-          return ok(new Uint8Array(await response.arrayBuffer()) as T);
+        if (attempt < maxTries) {
+          await sleep(calculateDelay(delay, attempt));
         }
-
-        const data = await response.json();
-        return ok(data as T);
       }
-    } catch (error) {
-      if (error instanceof TypeError && error.message === 'Failed to fetch') {
-        lastError = fetchErr([
-          { code: 'NETWORK_ERROR', message: 'Network error occurred' },
-        ]);
-      } else if (error instanceof SyntaxError) {
-        return fetchErr([
-          { code: 'INVALID_JSON', message: 'Invalid JSON in response' },
-        ]);
-      } else {
-        return fetchErr([
+
+      return (
+        lastError ??
+        fetchErr([
           {
             code: 'UNKNOWN_ERROR',
-            message: `An unknown error occurred: ${error}`,
+            message: 'Retry failed for an unknown reason',
           },
-        ]);
+        ])
+      );
+    })();
+
+    try {
+      await retryBody?.cancel();
+    } catch {}
+    try {
+      await retryRequest?.body?.cancel();
+    } catch {}
+    parentSpan.setAttr('safe_fetch.retry.attempts', attempts);
+    parentSpan.setAttr(
+      'safe_fetch.response.visible',
+      lastResponseStatus !== undefined
+    );
+    if (lastResponseStatus !== undefined) {
+      parentSpan.setAttr('http.response.status_code', lastResponseStatus);
+      parentSpan.setAttr('http.status_code', lastResponseStatus);
+    }
+    if (result.isErr()) {
+      const code = result.error[0]?.code ?? 'UNKNOWN_ERROR';
+      parentSpan.setAttr('safe_fetch.error.code', code);
+      const expectedResponse =
+        lastResponseStatus !== undefined &&
+        trace?.expectedStatusCodes?.includes(lastResponseStatus);
+      if (!expectedResponse) {
+        parentSpan.error({ name: 'SafeFetchError', message: code });
       }
     }
-
-    if (attempt < maxTries) {
-      await sleep(calculateDelay(delay, attempt));
-    }
-  }
-
-  return (
-    lastError ??
-    fetchErr([
-      {
-        code: 'UNKNOWN_ERROR',
-        message: 'Retry failed for an unknown reason',
-      },
-    ])
-  );
+    return result;
+  });
 }
 function calculateDelay(
   delay: 'exponential' | number,

--- a/crates/macro_cors/src/lib.rs
+++ b/crates/macro_cors/src/lib.rs
@@ -23,11 +23,24 @@ static ALLOWED_ORIGINS: [&str; 11] = [
     "https://apollo-testing.macro.com",
 ];
 
-static EXTRA_HEADERS: [&str; 4] = [
+const REQUEST_ID_HEADER: &str = "x-request-id";
+
+static EXTRA_HEADERS: [&str; 5] = [
     "x-permissions-token",
     "traceparent",
     "tracestate",
     "x-email-link-id",
+    REQUEST_ID_HEADER,
+];
+static EXPOSED_HEADERS: [&str; 1] = [REQUEST_ID_HEADER];
+static ALLOWED_METHODS: [Method; 7] = [
+    Method::GET,
+    Method::HEAD,
+    Method::POST,
+    Method::PUT,
+    Method::PATCH,
+    Method::DELETE,
+    Method::OPTIONS,
 ];
 
 fn get_allowed_origins() -> Vec<Cow<'static, str>> {
@@ -88,14 +101,8 @@ pub fn cors_layer_with_headers(additional_headers: Vec<HeaderName>) -> CorsLayer
     CorsLayer::new()
         .allow_credentials(true)
         .allow_headers(headers)
-        .allow_methods(vec![
-            Method::GET,
-            Method::POST,
-            Method::PUT,
-            Method::PATCH,
-            Method::DELETE,
-            Method::OPTIONS,
-        ])
+        .expose_headers(EXPOSED_HEADERS.map(HeaderName::from_static))
+        .allow_methods(ALLOWED_METHODS.to_vec())
         .allow_origin(AllowOrigin::predicate(
             |origin: &HeaderValue, _request_parts| {
                 origin.to_str().map(is_allowed_origin).unwrap_or(false)

--- a/crates/macro_cors/src/test.rs
+++ b/crates/macro_cors/src/test.rs
@@ -33,3 +33,18 @@ fn allows_static_origins() {
     assert!(is_allowed_origin("https://macro.com"));
     assert!(is_allowed_origin("tauri://localhost"));
 }
+
+#[test]
+fn allows_request_id_header() {
+    assert!(EXTRA_HEADERS.contains(&REQUEST_ID_HEADER));
+}
+
+#[test]
+fn exposes_request_id_header() {
+    assert!(EXPOSED_HEADERS.contains(&REQUEST_ID_HEADER));
+}
+
+#[test]
+fn allows_head_requests() {
+    assert!(ALLOWED_METHODS.contains(&Method::HEAD));
+}

--- a/crates/macro_tower_layers/src/test.rs
+++ b/crates/macro_tower_layers/src/test.rs
@@ -165,6 +165,76 @@ async fn request_span_records_the_matched_route() {
     );
 }
 
+#[tokio::test]
+async fn generated_request_id_is_recorded_on_span_and_propagated_to_response() {
+    let (subscriber, captured) = TracingCapture::new();
+    let _guard = set_default(subscriber);
+    let app = Router::new()
+        .route("/documents", get(|| async {}))
+        .layer(MacroRequestIdAndTracingLayer::new(Duration::from_millis(200)).into_inner());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/documents")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let request_id = response
+        .headers()
+        .get("x-request-id")
+        .expect("generated request ID should be propagated to the response")
+        .to_str()
+        .unwrap();
+    assert!(!request_id.is_empty());
+    assert_eq!(
+        captured
+            .initial_span_fields
+            .lock()
+            .unwrap()
+            .get("request.id")
+            .unwrap(),
+        &format!("\"{request_id}\"")
+    );
+}
+
+#[tokio::test]
+async fn incoming_request_id_is_preserved_on_span_and_response() {
+    let (subscriber, captured) = TracingCapture::new();
+    let _guard = set_default(subscriber);
+    let app = Router::new()
+        .route("/documents", get(|| async {}))
+        .layer(MacroRequestIdAndTracingLayer::new(Duration::from_millis(200)).into_inner());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/documents")
+                .header("x-request-id", "request-42")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.headers().get("x-request-id").unwrap(),
+        "request-42"
+    );
+    assert_eq!(
+        captured
+            .initial_span_fields
+            .lock()
+            .unwrap()
+            .get("request.id")
+            .unwrap(),
+        "\"request-42\""
+    );
+}
+
 #[test]
 fn successful_response_records_telemetry_without_completion_event() {
     let (subscriber, captured) = TracingCapture::new();

--- a/infra/stacks/cloud-storage-service/Pulumi.prod.yaml
+++ b/infra/stacks/cloud-storage-service/Pulumi.prod.yaml
@@ -1,6 +1,7 @@
 config:
   aws-native:region: us-east-1
   aws:region: us-east-1
+  datadog:apiUrl: https://api.us5.datadoghq.com/
   cloud-storage-service:macro_db_secret_key: macro-db-prod
   cloud-storage-service:macro_db_proxy_secret_key: macrodb-rds-proxy-prod
   cloud-storage-service:macro_db_readonly_secret_key: macro-db-readonly-prod

--- a/infra/stacks/cloud-storage-service/WAF_RUNBOOK.md
+++ b/infra/stacks/cloud-storage-service/WAF_RUNBOOK.md
@@ -1,0 +1,26 @@
+# Cloud Storage WAF Adoption
+
+The production WAF component adopts the existing Web ACL, ALB association, CloudWatch log group, and WAF logging configuration through Pulumi resource `import` options. These resources are also protected. The existing ALB is already managed by the cloud-storage-service stack, and the existing Datadog Forwarder and `ip_safety` rule group are referenced by ARN rather than duplicated.
+
+## First Deployment
+
+1. Run `pulumi preview --stack prod` from `infra/stacks/cloud-storage-service` with AWS account `569036502058` and Datadog US5 credentials.
+2. Confirm the Web ACL, association, log group, and logging configuration are imports followed only by in-place updates. Do not proceed if Pulumi proposes a replacement or deletion for any of them.
+3. Confirm the ALB ARN is `arn:aws:elasticloadbalancing:us-east-1:569036502058:loadbalancer/app/cloud-storage-service-alb-prod/d451a7c4e101c61d`.
+4. Confirm the existing Lambda policy has no statement named `AllowCloudWatchLogsAwsWafProd`. If it does, import that permission before deployment or rename the statement only after determining ownership.
+5. Confirm the log group has capacity for another subscription filter and no existing filter already sends these events to the same Forwarder. CloudWatch subscriptions process only events written after the filter is created; this configuration does not replay retained logs.
+6. Review the intended in-place policy changes explicitly: sensitive headers, query strings, URI paths, bodies, and SQL/XSS match details become protected; sampled requests are disabled; Bot Control HTTP-library exceptions become non-terminating counts; and `SQLi_BODY` becomes a label that is blocked everywhere except the exact channel-message POST route. Non-body SQLi rules remain active on that route.
+
+Do not run a separate `pulumi import`: the fixed import IDs in `waf-observability.ts` perform adoption on the first update and remain harmless after the resources are in stack state.
+
+## Datadog Pipeline Order
+
+`LogsPipelineOrder` represents the complete organization-global pipeline order. The stack reads the current order during deployment, removes any existing occurrence of this pipeline, and prepends it. This preserves unrelated pipeline IDs while ensuring its trace, span, and service remappers run before other matching pipelines.
+
+Before the first deployment, confirm no other Pulumi stack manages the singleton Datadog pipeline-order resource. Then:
+
+1. Verify that Datadog placed `Macro Cloud Storage AWS WAF` first in the pipeline order and that matching sample logs are processed.
+2. Verify all pre-existing pipeline IDs remain in their original relative order.
+3. Coordinate pipeline-order deployments because the Datadog API exposes one organization-global order; concurrent external edits can race an update.
+
+The pipeline filter includes the production Web ACL name so it does not remap unrelated WAF logs. It parses WAF JSON, extracts W3C `traceparent` IDs as lowercase 32-character trace IDs and 16-character span IDs, and uses the trace, span, and service remappers supported by the installed Datadog provider.

--- a/infra/stacks/cloud-storage-service/index.ts
+++ b/infra/stacks/cloud-storage-service/index.ts
@@ -25,6 +25,7 @@ import {
 } from './document-upload-finalizer-lambda';
 import { CalendarReminderDispatchQueue } from './calendar-reminder-dispatch-queue';
 import { ReminderDispatchQueue } from './reminder-dispatch-queue';
+import { WafObservability } from './waf-observability';
 
 const tags = {
   environment: stack,
@@ -327,6 +328,14 @@ const cloudStorageService = new CloudStorageService(
     tags,
   }
 );
+
+if (stack === 'prod') {
+  new WafObservability(
+    'cloud-storage-service-prod',
+    { albArn: cloudStorageService.lb.arn },
+    { protect: true }
+  );
+}
 
 export const cloudStorageServiceRoleArn = cloudStorageService.role.arn;
 export const cloudStorageServiceSgId = cloudStorageService.serviceSg.id;

--- a/infra/stacks/cloud-storage-service/waf-observability.ts
+++ b/infra/stacks/cloud-storage-service/waf-observability.ts
@@ -1,0 +1,544 @@
+import * as aws from '@pulumi/aws';
+import * as datadog from '@pulumi/datadog';
+import * as pulumi from '@pulumi/pulumi';
+
+const ACCOUNT_ID = '569036502058';
+const REGION = 'us-east-1';
+const WEB_ACL_NAME = 'macro-cloud-storage-prod';
+const WEB_ACL_ID = '0f1059a5-1ee4-4b57-a429-88df830d5091';
+const WEB_ACL_ARN = `arn:aws:wafv2:${REGION}:${ACCOUNT_ID}:regional/webacl/${WEB_ACL_NAME}/${WEB_ACL_ID}`;
+const ALB_ARN = `arn:aws:elasticloadbalancing:${REGION}:${ACCOUNT_ID}:loadbalancer/app/cloud-storage-service-alb-prod/d451a7c4e101c61d`;
+const IP_SAFETY_RULE_GROUP_ARN = `arn:aws:wafv2:${REGION}:${ACCOUNT_ID}:regional/rulegroup/ip_safety/0a1bfeec-4d6c-4afe-bf35-b93e06c65f9b`;
+const WAF_LOG_GROUP_NAME = 'aws-waf-logs-macro-cloud-storage-prod';
+const DATADOG_FORWARDER_ARN = `arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:DatadogIntegration-ForwarderStack-BS3QDP-Forwarder-O0hyWQ9Yq4uQ`;
+const SENSITIVE_HEADERS = [
+  'authorization',
+  'cookie',
+  'x-api-key',
+  'x-cal-signature-256',
+  'x-document-storage-service-auth-key',
+  'x-document-storage-service-session-id',
+  'x-document-storage-service-user-id',
+  'x-email-link-id',
+  'x-hub-signature-256',
+  'x-internal-auth-key',
+  'x-internal-fusionauth-user-id',
+  'x-internal-macro-user-id',
+  'x-internal-macro-organization-id',
+  'x-macro-bot-token',
+  'x-macro-channel-bot-token',
+  'x-macro-bot-for-fusionauth-user-id',
+  'x-macro-bot-for-macro-user-id',
+  'x-macro-bot-for-organization-id',
+  'x-macro-internal-call',
+  'x-macro-signature',
+  'x-macro-user-api-key',
+  'x-permissions-token',
+] as const;
+
+interface WafObservabilityArgs {
+  albArn: pulumi.Input<string>;
+}
+
+const visibilityConfig = (metricName: string) => ({
+  cloudwatchMetricsEnabled: true,
+  metricName,
+  sampledRequestsEnabled: false,
+});
+
+const managedRule = (
+  name: string,
+  priority: number,
+  managedRuleGroupStatement: aws.types.input.wafv2.WebAclRuleStatementManagedRuleGroupStatement
+): aws.types.input.wafv2.WebAclRule => ({
+  name,
+  priority,
+  overrideAction: { none: {} },
+  statement: { managedRuleGroupStatement },
+  visibilityConfig: visibilityConfig(name),
+});
+
+const messagePostStatement = (
+  regexPatternSetArn: pulumi.Input<string>
+): aws.types.input.wafv2.WebAclRuleStatement => ({
+  andStatement: {
+    statements: [
+      {
+        byteMatchStatement: {
+          fieldToMatch: { method: {} },
+          positionalConstraint: 'EXACTLY',
+          searchString: 'POST',
+          textTransformations: [{ priority: 0, type: 'NONE' }],
+        },
+      },
+      {
+        regexPatternSetReferenceStatement: {
+          arn: regexPatternSetArn,
+          fieldToMatch: { uriPath: {} },
+          textTransformations: [{ priority: 0, type: 'NONE' }],
+        },
+      },
+    ],
+  },
+});
+
+export class WafObservability extends pulumi.ComponentResource {
+  constructor(
+    name: string,
+    args: WafObservabilityArgs,
+    opts?: pulumi.ComponentResourceOptions
+  ) {
+    super('macro:cloud-storage:WafObservability', name, args, opts);
+
+    const childOptions = { parent: this, protect: true };
+    const adoptedOptions = {
+      parent: this,
+      protect: true,
+    };
+
+    const messagePostPaths = new aws.wafv2.RegexPatternSet(
+      `${name}-message-post-paths`,
+      {
+        name: 'cloud-storage-message-post-prod',
+        description: 'Exact channel message creation URI paths',
+        scope: 'REGIONAL',
+        regularExpressions: [
+          {
+            regexString:
+              '^/channels/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[89AaBb][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}/message$',
+          },
+        ],
+      },
+      childOptions
+    );
+
+    const webAcl = new aws.wafv2.WebAcl(
+      `${name}-web-acl`,
+      {
+        name: WEB_ACL_NAME,
+        description: 'Cloud Storage WAF for production resources',
+        scope: 'REGIONAL',
+        defaultAction: { allow: {} },
+        dataProtectionConfig: {
+          dataProtections: [
+            {
+              action: 'SUBSTITUTION',
+              field: { fieldType: 'BODY' },
+            },
+            {
+              action: 'SUBSTITUTION',
+              field: {
+                fieldType: 'SINGLE_HEADER',
+                fieldKeys: [...SENSITIVE_HEADERS],
+              },
+            },
+            {
+              action: 'SUBSTITUTION',
+              field: { fieldType: 'QUERY_STRING' },
+            },
+          ],
+        },
+        rules: [
+          managedRule('AWS-AWSManagedRulesAmazonIpReputationList', 0, {
+            name: 'AWSManagedRulesAmazonIpReputationList',
+            vendorName: 'AWS',
+          }),
+          managedRule('AWS-AWSManagedRulesBotControlRuleSet', 1, {
+            name: 'AWSManagedRulesBotControlRuleSet',
+            vendorName: 'AWS',
+            managedRuleGroupConfigs: [
+              {
+                awsManagedRulesBotControlRuleSet: {
+                  inspectionLevel: 'COMMON',
+                },
+              },
+            ],
+            ruleActionOverrides: [
+              {
+                name: 'SignalNonBrowserUserAgent',
+                actionToUse: { count: {} },
+              },
+              {
+                name: 'CategoryHttpLibrary',
+                actionToUse: { count: {} },
+              },
+            ],
+          }),
+          managedRule('AWS-AWSManagedRulesKnownBadInputsRuleSet', 2, {
+            name: 'AWSManagedRulesKnownBadInputsRuleSet',
+            vendorName: 'AWS',
+          }),
+          managedRule('AWS-AWSManagedRulesSQLiRuleSet', 3, {
+            name: 'AWSManagedRulesSQLiRuleSet',
+            vendorName: 'AWS',
+            ruleActionOverrides: [
+              {
+                name: 'SQLi_BODY',
+                actionToUse: { count: {} },
+              },
+            ],
+          }),
+          {
+            name: 'BlockSQLiBody',
+            priority: 4,
+            action: { block: {} },
+            statement: {
+              andStatement: {
+                statements: [
+                  {
+                    labelMatchStatement: {
+                      key: 'awswaf:managed:aws:sql-database:SQLi_Body',
+                      scope: 'LABEL',
+                    },
+                  },
+                  {
+                    notStatement: {
+                      statement: messagePostStatement(messagePostPaths.arn),
+                    },
+                  },
+                ],
+              },
+            },
+            visibilityConfig: visibilityConfig('BlockSQLiBody'),
+          },
+          {
+            name: 'ip_safety',
+            priority: 5,
+            overrideAction: { none: {} },
+            statement: {
+              ruleGroupReferenceStatement: {
+                arn: IP_SAFETY_RULE_GROUP_ARN,
+              },
+            },
+            visibilityConfig: visibilityConfig('ip_safety'),
+          },
+        ],
+        visibilityConfig: visibilityConfig(WEB_ACL_NAME),
+      },
+      {
+        ...adoptedOptions,
+        import: `${WEB_ACL_ID}/${WEB_ACL_NAME}/REGIONAL`,
+      }
+    );
+
+    new aws.wafv2.WebAclAssociation(
+      `${name}-web-acl-association`,
+      {
+        resourceArn: args.albArn,
+        webAclArn: webAcl.arn,
+      },
+      {
+        ...adoptedOptions,
+        import: `${WEB_ACL_ARN},${ALB_ARN}`,
+      }
+    );
+
+    const logGroup = new aws.cloudwatch.LogGroup(
+      `${name}-log-group`,
+      {
+        name: WAF_LOG_GROUP_NAME,
+        retentionInDays: 7,
+      },
+      {
+        ...adoptedOptions,
+        import: WAF_LOG_GROUP_NAME,
+      }
+    );
+
+    const loggingConfiguration = new aws.wafv2.WebAclLoggingConfiguration(
+      `${name}-logging`,
+      {
+        resourceArn: webAcl.arn,
+        logDestinationConfigs: [logGroup.arn],
+        loggingFilter: {
+          defaultBehavior: 'DROP',
+          filters: [
+            {
+              behavior: 'KEEP',
+              requirement: 'MEETS_ANY',
+              conditions: [
+                { actionCondition: { action: 'BLOCK' } },
+                { actionCondition: { action: 'CHALLENGE' } },
+              ],
+            },
+          ],
+        },
+        redactedFields: [
+          ...SENSITIVE_HEADERS.map((name) => ({ singleHeader: { name } })),
+          { queryString: {} },
+          { uriPath: {} },
+        ],
+      },
+      {
+        ...adoptedOptions,
+        import: WEB_ACL_ARN,
+      }
+    );
+
+    const forwarderPermission = new aws.lambda.Permission(
+      `${name}-forwarder-permission`,
+      {
+        statementId: 'AllowCloudWatchLogsAwsWafProd',
+        action: 'lambda:InvokeFunction',
+        function: DATADOG_FORWARDER_ARN,
+        principal: `logs.${REGION}.amazonaws.com`,
+        sourceAccount: ACCOUNT_ID,
+        sourceArn: pulumi.interpolate`${logGroup.arn}:*`,
+      },
+      childOptions
+    );
+
+    new aws.cloudwatch.LogSubscriptionFilter(
+      `${name}-forwarder-subscription`,
+      {
+        name: 'datadog-forwarder',
+        destinationArn: DATADOG_FORWARDER_ARN,
+        filterPattern: '{ ($.action = "BLOCK") || ($.action = "CHALLENGE") }',
+        logGroup: logGroup.name,
+      },
+      {
+        ...childOptions,
+        dependsOn: [forwarderPermission, loggingConfiguration],
+      }
+    );
+
+    const datadogPipeline = new datadog.LogsCustomPipeline(
+      `${name}-datadog-pipeline`,
+      {
+        name: 'Macro Cloud Storage AWS WAF',
+        description:
+          'Parses and normalizes blocked or challenged AWS WAF requests for cloud-storage-service.',
+        isEnabled: true,
+        filters: [
+          {
+            query: '"macro-cloud-storage-prod"',
+          },
+        ],
+        tags: ['env:prod', 'service:cloud-storage-service', 'source:waf'],
+        processors: [
+          {
+            grokParser: {
+              name: 'Parse AWS WAF JSON',
+              isEnabled: true,
+              source: 'message',
+              samples: [
+                '{"timestamp":0,"webaclId":"arn:aws:wafv2:us-east-1:569036502058:regional/webacl/macro-cloud-storage-prod/0f1059a5-1ee4-4b57-a429-88df830d5091","action":"BLOCK","httpRequest":{"clientIp":"192.0.2.1","uri":"/","httpMethod":"GET"}}',
+              ],
+              grok: {
+                matchRules: 'waf_json %{data::json}',
+                supportRules: '',
+              },
+            },
+          },
+          {
+            grokParser: {
+              name: 'Parse W3C traceparent',
+              isEnabled: true,
+              source: 'message',
+              samples: [
+                '{"httpRequest":{"headers":[{"name":"traceparent","value":"00-4BF92F3577B34DA6A3CE929D0E0E4736-00F067AA0BA902B7-01"}]}}',
+              ],
+              grok: {
+                matchRules:
+                  'traceparent %{traceparentPrefix}%{regex("[0-9A-Fa-f]{32}"):waf.trace_id:lowercase}-%{regex("[0-9A-Fa-f]{16}"):waf.span_id:lowercase}-%{regex("[0-9A-Fa-f]{2}")}%{data}',
+                supportRules:
+                  'traceparentPrefix .*"name"\\s*:\\s*"[Tt][Rr][Aa][Cc][Ee][Pp][Aa][Rr][Ee][Nn][Tt]"\\s*,\\s*"value"\\s*:\\s*"00-',
+              },
+            },
+          },
+          {
+            attributeRemapper: {
+              name: 'Normalize WAF web ACL ARN',
+              isEnabled: true,
+              sources: ['webaclId'],
+              sourceType: 'attribute',
+              target: 'waf.web_acl_arn',
+              targetType: 'attribute',
+              preserveSource: true,
+              overrideOnConflict: false,
+            },
+          },
+          {
+            attributeRemapper: {
+              name: 'Normalize WAF request ID',
+              isEnabled: true,
+              sources: ['httpRequest.requestId'],
+              sourceType: 'attribute',
+              target: 'waf.request_id',
+              targetType: 'attribute',
+              preserveSource: true,
+              overrideOnConflict: false,
+            },
+          },
+          {
+            attributeRemapper: {
+              name: 'Normalize WAF rule ID',
+              isEnabled: true,
+              sources: ['terminatingRuleId'],
+              sourceType: 'attribute',
+              target: 'waf.rule_id',
+              targetType: 'attribute',
+              preserveSource: true,
+              overrideOnConflict: false,
+            },
+          },
+          {
+            attributeRemapper: {
+              name: 'Normalize WAF action',
+              isEnabled: true,
+              sources: ['action'],
+              sourceType: 'attribute',
+              target: 'waf.action',
+              targetType: 'attribute',
+              preserveSource: true,
+              overrideOnConflict: false,
+            },
+          },
+          {
+            attributeRemapper: {
+              name: 'Normalize client IP',
+              isEnabled: true,
+              sources: ['httpRequest.clientIp'],
+              sourceType: 'attribute',
+              target: 'network.client.ip',
+              targetType: 'attribute',
+              preserveSource: true,
+              overrideOnConflict: false,
+            },
+          },
+          {
+            attributeRemapper: {
+              name: 'Normalize HTTP method',
+              isEnabled: true,
+              sources: ['httpRequest.httpMethod'],
+              sourceType: 'attribute',
+              target: 'http.method',
+              targetType: 'attribute',
+              preserveSource: true,
+              overrideOnConflict: false,
+            },
+          },
+          {
+            attributeRemapper: {
+              name: 'Normalize HTTP version',
+              isEnabled: true,
+              sources: ['httpRequest.httpVersion'],
+              sourceType: 'attribute',
+              target: 'http.version',
+              targetType: 'attribute',
+              preserveSource: true,
+              overrideOnConflict: false,
+            },
+          },
+          {
+            geoIpParser: {
+              name: 'Enrich client IP',
+              isEnabled: true,
+              sources: ['network.client.ip'],
+              target: 'network.client.geoip',
+            },
+          },
+          {
+            dateRemapper: {
+              name: 'Use WAF event time',
+              isEnabled: true,
+              sources: ['timestamp'],
+            },
+          },
+          {
+            stringBuilderProcessor: {
+              name: 'Set service',
+              isEnabled: true,
+              target: 'waf.service',
+              template: 'cloud-storage-service',
+              isReplaceMissing: true,
+            },
+          },
+          {
+            categoryProcessor: {
+              name: 'Set WAF response status',
+              isEnabled: true,
+              target: 'http.response.status_code',
+              categories: [
+                {
+                  name: '403',
+                  filter: { query: '@action:BLOCK' },
+                },
+                {
+                  name: '202',
+                  filter: { query: '@action:CHALLENGE' },
+                },
+              ],
+            },
+          },
+          {
+            stringBuilderProcessor: {
+              name: 'Set environment',
+              isEnabled: true,
+              target: 'env',
+              template: 'prod',
+              isReplaceMissing: true,
+            },
+          },
+          {
+            stringBuilderProcessor: {
+              name: 'Set source',
+              isEnabled: true,
+              target: 'source',
+              template: 'waf',
+              isReplaceMissing: true,
+            },
+          },
+          {
+            traceIdRemapper: {
+              name: 'Remap trace ID',
+              isEnabled: true,
+              sources: ['waf.trace_id'],
+            },
+          },
+          {
+            spanIdRemapper: {
+              name: 'Remap span ID',
+              isEnabled: true,
+              sources: ['waf.span_id'],
+            },
+          },
+          {
+            serviceRemapper: {
+              name: 'Remap service',
+              isEnabled: true,
+              sources: ['waf.service'],
+            },
+          },
+        ],
+      },
+      {
+        parent: this,
+        protect: true,
+      }
+    );
+
+    const currentPipelineOrder = datadog.getLogsPipelinesOrderOutput();
+    new datadog.LogsPipelineOrder(
+      `${name}-datadog-pipeline-order`,
+      {
+        name: 'macro-cloud-storage-waf-pipeline-order',
+        pipelines: pulumi
+          .all([currentPipelineOrder.pipelineIds, datadogPipeline.id])
+          .apply(([pipelineIds, pipelineId]) => [
+            pipelineId,
+            ...pipelineIds.filter((id) => id !== pipelineId),
+          ]),
+      },
+      {
+        parent: this,
+        protect: true,
+      }
+    );
+
+    this.registerOutputs({
+      webAclArn: webAcl.arn,
+      logGroupName: logGroup.name,
+    });
+  }
+}

--- a/services/sync-service/src/durable_object.rs
+++ b/services/sync-service/src/durable_object.rs
@@ -1242,7 +1242,7 @@ pub fn cors(request_origin: Option<&str>) -> Cors {
 
     Cors::new()
         .with_credentials(true)
-        // `traceparent`/`tracestate` are injected by the web client's traced
+        // Trace and request IDs are injected by the web client's traced
         // fetch wrapper (see `safeFetch`), so they must be preflight-allowed or
         // the browser blocks every instrumented call. Kept in sync with
         // `macro_cors::EXTRA_HEADERS`, which the axum services use; this worker
@@ -1252,9 +1252,11 @@ pub fn cors(request_origin: Option<&str>) -> Cors {
             "content-type",
             "traceparent",
             "tracestate",
+            "x-request-id",
         ])
         .with_methods(vec![
             Method::Get,
+            Method::Head,
             Method::Post,
             Method::Put,
             Method::Patch,

--- a/services/sync-service/tests/cors.test.ts
+++ b/services/sync-service/tests/cors.test.ts
@@ -59,7 +59,8 @@ describe('CORS middleware tests', async () => {
         headers: {
           Origin: 'https://dev.macro.com',
           'Access-Control-Request-Method': 'GET',
-          'Access-Control-Request-Headers': 'authorization, content-type',
+          'Access-Control-Request-Headers':
+            'authorization, content-type, x-request-id',
         },
       }
     );
@@ -87,6 +88,9 @@ describe('CORS middleware tests', async () => {
     );
     expect(response.headers.get('Access-Control-Allow-Headers')).toContain(
       'content-type'
+    );
+    expect(response.headers.get('Access-Control-Allow-Headers')).toContain(
+      'x-request-id'
     );
   });
 
@@ -121,7 +125,7 @@ describe('CORS middleware tests', async () => {
   });
 
   test('should allow all HTTP methods for whitelisted origins', async () => {
-    const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
+    const methods = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'];
     const origin = 'https://dev.macro.com';
 
     for (const method of methods) {
@@ -152,7 +156,7 @@ describe('CORS middleware tests', async () => {
         headers: {
           Origin: 'https://dev.macro.com',
           'Access-Control-Request-Method': 'GET',
-          'Access-Control-Request-Headers': 'authorization',
+          'Access-Control-Request-Headers': 'authorization,x-request-id',
         },
       }
     );
@@ -161,6 +165,7 @@ describe('CORS middleware tests', async () => {
     const allowedHeaders = response.headers.get('Access-Control-Allow-Headers');
     expect(allowedHeaders).toContain('authorization');
     expect(allowedHeaders).toContain('content-type');
+    expect(allowedHeaders).toContain('x-request-id');
   });
 
   // The web client's traced fetch wrapper injects W3C trace context on every
@@ -175,7 +180,8 @@ describe('CORS middleware tests', async () => {
         headers: {
           Origin: 'https://dev.macro.com',
           'Access-Control-Request-Method': 'GET',
-          'Access-Control-Request-Headers': 'authorization,traceparent',
+          'Access-Control-Request-Headers':
+            'authorization,traceparent,x-request-id',
         },
       }
     );
@@ -184,6 +190,7 @@ describe('CORS middleware tests', async () => {
     const allowedHeaders = response.headers.get('Access-Control-Allow-Headers');
     expect(allowedHeaders).toContain('traceparent');
     expect(allowedHeaders).toContain('tracestate');
+    expect(allowedHeaders).toContain('x-request-id');
   });
 
   test('should work with actual API requests after CORS validation', async () => {


### PR DESCRIPTION
## Summary
- adopt and protect the production WAF, ALB association, logging configuration, and log group in Pulumi
- redact request bodies, query strings, paths, credentials, and identity headers before forwarding blocked/challenged WAF events to Datadog
- correlate WAF events with browser traces and request IDs, including retry-attempt spans and safe route normalization
- allow and expose `x-request-id` through shared Axum and sync-worker CORS

## WAF policy
- replace the broad legacy `/comms/channels` SQLi bypass with an exact channel-message `POST` exception for `SQLi_BODY` only
- retain non-body SQLi protection on that route
- convert Bot Control HTTP-library exceptions to non-terminating counts
- prepend the WAF pipeline so trace/span/service remappers run before other matching Datadog pipelines while preserving existing relative order

## Verification
- `bun run check` in `infra`
- Biome checks for affected infra and web files
- web TypeScript type-check
- `bunx vitest run src/lib/core/util/safeFetch.spec.ts` (19 passed)
- `cargo fmt --check`
- `cargo test -p macro_cors -p macro_tower_layers` (20 passed)
- sync-worker CORS assertions pass after `just worker-build`; full focused file is 8/9 because the existing `tests/utils.ts` fixture sends obsolete `PeerUpdate { update }` instead of the current `PeerUpdate { updates, id }`
- independent final review: no findings
- `git diff --check`

## Deployment warning
A read-only `pulumi preview --stack macro-inc/prod --diff --non-interactive` was run and no `pulumi up` was executed. It compiles and begins constructing/importing the protected WAF resources, but cannot complete in this environment because the Datadog provider requires production API/app credentials. Before deployment, rerun the preview with Datadog US5 credentials and follow `infra/stacks/cloud-storage-service/WAF_RUNBOOK.md`; do not proceed if any adopted resource is replaced or deleted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches production WAF policy and protected Pulumi imports, org-global Datadog pipeline order, and the shared fetch path used by the web client—misconfiguration could block legitimate traffic or break CORS on instrumented APIs.
> 
> **Overview**
> Adds **end-to-end request correlation** so production WAF blocks/challenges can be tied to browser traces: the web **`safeFetch`** wrapper now runs under a parent telemetry span with per-retry child HTTP spans, normalized low-cardinality routes (optional `trace.route`), sanitized URL attributes, browser-specific network error kinds, and a fresh **`x-request-id`** on each attempt for same-origin/traced calls (not third-party URLs). Retries are made safe for **`Request`** clones, header replacement, and **`ReadableStream`** bodies via teeing.
> 
> **CORS** is updated in shared Axum (`macro_cors`) and the sync worker to allow **`HEAD`**, permit **`x-request-id`** on preflight, and expose it to the client—matching what traced fetches send.
> 
> For **prod cloud-storage**, Pulumi adopts/protects the existing WAF, ALB association, logging, and CloudWatch → Datadog forwarding, with redaction of sensitive headers/bodies/paths and a new Datadog pipeline (prepended org-wide) that parses WAF JSON and remaps W3C **`traceparent`** / request IDs. WAF rule tweaks narrow the SQLi body exception to exact channel-message **`POST`** paths, count Bot Control HTTP-library signals instead of blocking, and add a dedicated block rule for SQLi body elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d719c816880e394215b17abe8d2ad42aa5c4bc14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->