### PR TITLE
Fix duplicate messages in agent sessions on first open

### DIFF
--- a/apps/web/src/lib/queries/agent-session/session-fold.test.ts
+++ b/apps/web/src/lib/queries/agent-session/session-fold.test.ts
@@ -82,6 +82,10 @@ describe('buffer overlap', () => {
 
 describe('shared session folds', () => {
   it('buffers realtime overlap while fetching and replays only its suffix', async () => {
+    // This test verifies that buffered entries are replayed during opening.
+    // Sinks are registered AFTER getting the snapshot to prevent duplicate
+    // notifications: replayed entries update the worker but don't notify sinks,
+    // then the caller receives the full snapshot (including replayed messages).
     let resolveFetch!: (
       value: Result<AgentSessionLogResponse, unknown>
     ) => void;

--- a/apps/web/src/lib/queries/agent-session/session-fold.ts
+++ b/apps/web/src/lib/queries/agent-session/session-fold.ts
@@ -80,8 +80,6 @@ export async function acquireAgentSessionFold(args: {
     references: 0,
   };
   state.references += 1;
-  if (onChange) state.foldedSinks.add(onChange);
-  if (onMetadata) state.metadataSinks.add(onMetadata);
   sessions.set(agentSessionId, state);
 
   let released = false;
@@ -100,6 +98,14 @@ export async function acquireAgentSessionFold(args: {
     const snapshot = await sessionMessages(agentSessionId);
     const bot = state.bot;
     if (!bot) throw new Error(`agent session ${agentSessionId} has no bot`);
+
+    // Add sinks after getting the initial snapshot to avoid duplicate
+    // notifications: buffered entries replayed during opening would otherwise
+    // notify the sinks, and then the caller would also process the snapshot
+    // (which includes those same messages).
+    if (onChange) state.foldedSinks.add(onChange);
+    if (onMetadata) state.metadataSinks.add(onMetadata);
+
     return {
       bot,
       messages: snapshot.messages,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When an agent session is created and opened, the user's message appears twice in the agent session UI. Refreshing the page fixes the issue, but this is a poor user experience.

## Root Cause

The bug was in the `acquireAgentSessionFold` function in `session-fold.ts`. The sequence of events that caused duplicates:

1. `onChange` callback is registered as a sink **before** opening starts
2. During `open()`, if any realtime entries arrive and get buffered, they're replayed via `push()` which calls all registered sinks
3. The `onChange` callback receives those messages and inserts them into the UI
4. Then `sessionMessages()` returns a snapshot with ALL messages (including the buffered ones just pushed)
5. The caller processes the snapshot again, causing duplicate messages in the UI

## Solution

Moved sink registration to **after** the fold opening completes and the snapshot is retrieved. Now the flow is:

1. Opening starts with no sinks registered
2. Buffered entries update the worker machine but don't notify any sinks (none registered yet)
3. Snapshot is retrieved (includes all messages including replayed ones)
4. Sinks are registered for future updates
5. Snapshot is returned to caller - messages appear exactly once

## Changes

- **Modified** `apps/web/src/lib/queries/agent-session/session-fold.ts`:
  - Moved sink registration (`foldedSinks.add()` and `metadataSinks.add()`) to after snapshot retrieval
  - Added comment explaining why this prevents duplicates

- **Updated** `apps/web/src/lib/queries/agent-session/session-fold.test.ts`:
  - Added comment documenting how the fix prevents duplicate notifications

## Testing

### Existing Tests
All existing tests should continue to pass:
- Buffered entry replay still works (worker machine is updated)
- Live updates still notify sinks (registered before returning from acquisition)
- Concurrent acquisitions still share state correctly

### Manual Testing Required
To fully verify the fix:
1. Create a new agent session by mentioning an agent in a channel
2. Verify the user's message appears **only once** (not twice)
3. Send another message and verify it appears correctly
4. Verify the agent's response appears correctly
5. Verify subsequent live updates continue to work

## Impact

- **Affects**: First-time loading of agent sessions
- **Fixes**: Duplicate message display bug
- **Preserves**: All existing concurrent acquisition behavior
- **No breaking changes**: External API unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6898adcf-ca35-421e-a01b-c83239f468c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6898adcf-ca35-421e-a01b-c83239f468c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

