### PR TITLE
perf(cache): reduce unnecessary cache revision work

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -126,7 +126,7 @@
     "nanoid": "^3.3.7",
     "neverthrow": "^8.2.0",
     "pdfjs-dist": "github:macro-inc/pdf.js#v2.16.52-web",
-    "posthog-js": "^1.387.0",
+    "posthog-js": "^1.424.0",
     "quill": "^2.0.3",
     "short-uuid": "^5.2.0",
     "signature_pad": "^5.0.10",

--- a/apps/web/src/lib/graphql-cache/exchange/normalized-cache-exchange.test.ts
+++ b/apps/web/src/lib/graphql-cache/exchange/normalized-cache-exchange.test.ts
@@ -289,6 +289,7 @@ function makeFakeHost(): FakeHost {
       host.cacheActions.push({ kind: 'write', value: args.data });
       return {
         revision: INITIAL_CACHE_REVISION,
+        revisionAdvanced: true,
         changed: [],
         affectedOps: [],
         reset: false,
@@ -318,6 +319,7 @@ function makeFakeHost(): FakeHost {
       return {
         transactionId,
         revision: INITIAL_CACHE_REVISION,
+        revisionAdvanced: true,
         changed: [],
         affectedOps: [],
         reset: false,
@@ -363,6 +365,7 @@ function makeFakeHost(): FakeHost {
       return {
         kind: 'committed',
         revision: INITIAL_CACHE_REVISION,
+        revisionAdvanced: true,
         changed: [],
         affectedOps: [],
         reset: false,
@@ -374,6 +377,7 @@ function makeFakeHost(): FakeHost {
       return {
         kind: 'rolled-back' as const,
         revision: INITIAL_CACHE_REVISION,
+        revisionAdvanced: true,
         changed: [],
         affectedOps: [],
         reset: false,
@@ -721,6 +725,7 @@ describe('normalizedCacheExchange', () => {
       cacheContainsDocument = true;
       return {
         revision: INITIAL_CACHE_REVISION,
+        revisionAdvanced: true,
         changed: [],
         affectedOps: [],
         reset: false,
@@ -1361,6 +1366,7 @@ describe('normalizedCacheExchange', () => {
       cached = args.data;
       return {
         revision: INITIAL_CACHE_REVISION,
+        revisionAdvanced: true,
         changed: [],
         affectedOps: [],
         reset: false,

--- a/apps/web/src/lib/graphql-cache/exchange/normalized-cache-exchange.test.ts
+++ b/apps/web/src/lib/graphql-cache/exchange/normalized-cache-exchange.test.ts
@@ -2038,6 +2038,68 @@ describe('normalizedCacheExchange', () => {
       expect(results[0]?.data).toBe(data);
     });
 
+    it('skips stale explicit effects and revalidations for a superseded commit', async () => {
+      const deletion = {
+        __typename: 'GraphqlCacheDeletion',
+        graphqlTypeName: 'GraphqlSoupDocument',
+        entityId: 'document-1',
+      };
+      const update = {
+        __typename: 'SoupUpdated',
+        item: {
+          __typename: 'GraphqlSoupDocument',
+          id: 'document-1',
+          displayName: 'Stale rename',
+        },
+      };
+      const data = {
+        renameEntities: {
+          results: [
+            {
+              __typename: 'GraphqlMutationSuccess',
+              effects: [deletion, update],
+            },
+          ],
+        },
+      };
+      const commit = host.commitOptimisticWrite.bind(host);
+      host.commitOptimisticWrite = async (transactionId, claim, args) => ({
+        ...(await commit(transactionId, claim, args)),
+        kind: 'committed-superseded',
+        replacementTransactionId: 'txn-2',
+        revalidations: [
+          {
+            query: stringifyDocument(QUERY),
+            operationName: 'Soup',
+            variablesJson: '{"input":{"limit":2}}',
+          },
+        ],
+      });
+      const base = makeRenameMutationOp(11);
+      const operation = makeOperation(base.kind, base, {
+        ...base.context,
+        normalizedCacheOptimistic: {
+          uuid: crypto.randomUUID(),
+          optimisticResponse: { renameEntities: { results: [] } },
+        },
+      });
+      const { ops, results, client } = harness(host, (op) =>
+        op.kind === 'mutation' ? { data } : {}
+      );
+
+      ops.next(operation);
+      await tick();
+
+      expect(host.commits).toHaveLength(1);
+      expect(host.cacheActions).toEqual([]);
+      expect(vi.mocked(client.query)).not.toHaveBeenCalled();
+      expect(results[0]?.data).toBeUndefined();
+      expect(optimisticMutationDispositionOf(results[0])).toEqual({
+        kind: 'queued',
+        transactionId: 'txn-2',
+      });
+    });
+
     it('fires commit revalidations with network-only policy', async () => {
       const commit = host.commitOptimisticWrite.bind(host);
       host.commitOptimisticWrite = async (transactionId, claim, args) => ({

--- a/apps/web/src/lib/graphql-cache/exchange/normalized-cache-exchange.ts
+++ b/apps/web/src/lib/graphql-cache/exchange/normalized-cache-exchange.ts
@@ -1259,18 +1259,18 @@ export function normalizedCacheExchange(
                     data: result.data,
                   }
                 );
-                const effects = operationCacheEffects(result.data);
-                if (effects.some((effect) => effect.kind === 'delete')) {
-                  // Commit already normalized the complete result. Replay only
-                  // mixed explicit effects so their final write/delete order is
-                  // identical to a non-optimistic operation.
-                  await applyOperationCacheEffects(op, effects);
-                }
-                revalidateAfterCommit(committed.revalidations ?? [], op);
                 if (committed.kind === 'committed-superseded') {
                   replacementTransactionId = committed.replacementTransactionId;
                   disposition = 'superseded';
                 } else {
+                  const effects = operationCacheEffects(result.data);
+                  if (effects.some((effect) => effect.kind === 'delete')) {
+                    // Commit already normalized the complete result. Replay only
+                    // mixed explicit effects so their final write/delete order is
+                    // identical to a non-optimistic operation.
+                    await applyOperationCacheEffects(op, effects);
+                  }
+                  revalidateAfterCommit(committed.revalidations ?? [], op);
                   disposition = 'committed';
                 }
               }

--- a/apps/web/src/lib/graphql-cache/host/noop-host.ts
+++ b/apps/web/src/lib/graphql-cache/host/noop-host.ts
@@ -9,6 +9,7 @@ import type { CacheHost } from './types';
 
 const emptyWriteResult = (): WriteResult => ({
   revision: INITIAL_CACHE_REVISION,
+  revisionAdvanced: false,
   changed: [],
   affectedOps: [],
   reset: false,

--- a/apps/web/src/lib/graphql-cache/host/worker-host.test.ts
+++ b/apps/web/src/lib/graphql-cache/host/worker-host.test.ts
@@ -23,6 +23,7 @@ import { createWorkerCacheHost } from './worker-host';
 const CLIENT_ID = '00000000-0000-4000-8000-000000000007';
 const EMPTY_WRITE: WriteResult = {
   revision: INITIAL_CACHE_REVISION,
+  revisionAdvanced: true,
   changed: [],
   affectedOps: [],
   reset: false,

--- a/apps/web/src/lib/graphql-cache/host/worker-host.test.ts
+++ b/apps/web/src/lib/graphql-cache/host/worker-host.test.ts
@@ -23,7 +23,7 @@ import { createWorkerCacheHost } from './worker-host';
 const CLIENT_ID = '00000000-0000-4000-8000-000000000007';
 const EMPTY_WRITE: WriteResult = {
   revision: INITIAL_CACHE_REVISION,
-  revisionAdvanced: true,
+  revisionAdvanced: false,
   changed: [],
   affectedOps: [],
   reset: false,

--- a/apps/web/src/lib/graphql-cache/protocol.ts
+++ b/apps/web/src/lib/graphql-cache/protocol.ts
@@ -305,6 +305,8 @@ export type HydrationResult =
 export type WriteResult = {
   /** Effective-view revision installed by this logical mutation. */
   revision: CacheRevision;
+  /** Whether this write advanced `revision`. */
+  revisionAdvanced: boolean;
   /** Entity keys whose records changed. */
   changed: string[];
   /** Registered operation ids affected by the change (origin excluded). */

--- a/apps/web/src/lib/graphql-cache/worker/worker-core.test.ts
+++ b/apps/web/src/lib/graphql-cache/worker/worker-core.test.ts
@@ -839,6 +839,7 @@ describe('CacheWorkerCore', () => {
   it('pushes cache changes even without affected operations', async () => {
     const writeResult = {
       revision: INITIAL_CACHE_REVISION,
+      revisionAdvanced: true,
       changed: ['GraphqlSoupDocument:doc-1'],
       affectedOps: [],
       reset: false,
@@ -881,6 +882,42 @@ describe('CacheWorkerCore', () => {
       undefined
     );
     expect(messages).toContainEqual({
+      kind: 'cache-changed',
+      revision: INITIAL_CACHE_REVISION,
+    });
+  });
+
+  it('does not push cache changes for no-op writes', async () => {
+    const writeResult = {
+      revision: INITIAL_CACHE_REVISION,
+      revisionAdvanced: false,
+      changed: [],
+      affectedOps: [],
+      reset: false,
+    };
+    loadCacheWasmMock.mockResolvedValue({
+      openCache: vi.fn().mockResolvedValue({
+        writeQuery: vi.fn().mockResolvedValue(writeResult),
+      }),
+    });
+    const messages: unknown[] = [];
+    const port = { postMessage: (message: unknown) => messages.push(message) };
+    const core = new CacheWorkerCore();
+    core.addPort(port);
+
+    await core.handleRequest(port, {
+      id: 1,
+      kind: 'init',
+      scope: 'scope-1',
+    });
+    await core.handleRequest(port, {
+      id: 2,
+      kind: 'write',
+      query: 'subscription { soupUpdates { __typename } }',
+      data: { soupUpdates: [] },
+    });
+
+    expect(messages).not.toContainEqual({
       kind: 'cache-changed',
       revision: INITIAL_CACHE_REVISION,
     });

--- a/apps/web/src/lib/graphql-cache/worker/worker-core.ts
+++ b/apps/web/src/lib/graphql-cache/worker/worker-core.ts
@@ -207,7 +207,12 @@ export class CacheWorkerCore {
       const result = await this.enqueue(request);
       const durationMs = this.now() - startedAt;
       const revisionCategory = revisionAdvancementCategory(request);
-      if (revisionCategory !== undefined) {
+      const revisionAdvanced =
+        typeof result !== 'object' ||
+        result === null ||
+        !('revisionAdvanced' in result) ||
+        result.revisionAdvanced !== false;
+      if (revisionCategory !== undefined && revisionAdvanced) {
         this.telemetry.record({
           name: 'graphql_cache.revision_advance',
           operationCategory: category,
@@ -639,6 +644,7 @@ export class CacheWorkerCore {
         this.fanOut(
           {
             revision: result.revision,
+            revisionAdvanced: true,
             changed: request.keys,
             affectedOps: result.affectedOps,
             reset: false,
@@ -657,6 +663,7 @@ export class CacheWorkerCore {
         this.fanOut(
           {
             revision: result.revision,
+            revisionAdvanced: true,
             changed: request.keys,
             affectedOps: result.affectedOps,
             reset: false,
@@ -918,7 +925,7 @@ export class CacheWorkerCore {
         keys: result.changed,
       });
     }
-    if (cacheChanged) {
+    if (cacheChanged && result.revisionAdvanced) {
       this.push({ kind: 'cache-changed', revision: result.revision });
     }
   }

--- a/apps/web/src/lib/queries/properties/graphql/entity.test.ts
+++ b/apps/web/src/lib/queries/properties/graphql/entity.test.ts
@@ -262,7 +262,7 @@ describe('GraphQL entity property mutations', () => {
     );
   });
 
-  it('durably queues optimistic saves', async () => {
+  it('returns optimistic data for saves queued behind a replacement', async () => {
     const property = {
       propertyId: 'assignment-1',
       propertyDefinitionId: 'definition-1',
@@ -283,11 +283,12 @@ describe('GraphQL entity property mutations', () => {
             kind: 'mutation',
             context,
           } as Operation,
-          data: { setEntityProperty: { id: 'assignment-1' } },
+          data: undefined,
           extensions: {
             normalizedCacheMutationDisposition: {
-              kind: 'queued',
+              kind: 'superseded',
               transactionId: 'transaction-1',
+              replacementTransactionId: 'transaction-2',
             },
           },
           stale: false,
@@ -317,10 +318,14 @@ describe('GraphQL entity property mutations', () => {
         ],
       })
     ).resolves.toMatchObject({
+      data: {
+        setEntityProperty: expect.objectContaining({ id: 'assignment-1' }),
+      },
       extensions: {
         normalizedCacheMutationDisposition: {
-          kind: 'queued',
+          kind: 'superseded',
           transactionId: 'transaction-1',
+          replacementTransactionId: 'transaction-2',
         },
       },
     });

--- a/apps/web/src/lib/queries/properties/graphql/entity.ts
+++ b/apps/web/src/lib/queries/properties/graphql/entity.ts
@@ -384,6 +384,17 @@ const executeGraphqlEntityPropertyMutation: UrqlMutationExecutor<
       ).toPromise()
     : client.mutation(mutation, variables, context).toPromise());
   const disposition = mutationDisposition(mutationResult);
+  if (
+    disposition.kind === 'queued' &&
+    mutationResult.data == null &&
+    args.optimisticProperty
+  ) {
+    return {
+      ...mutationResult,
+      data: { setEntityProperty: args.optimisticProperty },
+      error: undefined,
+    };
+  }
   if (disposition.kind !== 'permanently-failed' || mutationResult.error) {
     return mutationResult;
   }

--- a/apps/web/src/lib/queries/soup/graphql/items.test.ts
+++ b/apps/web/src/lib/queries/soup/graphql/items.test.ts
@@ -332,7 +332,7 @@ describe('createGraphqlSoupAstItemsQuery', () => {
       const names =
         currentRevision === REVISION_2
           ? ['Network item', 'Realtime item']
-          : currentRevision === '5'
+          : currentRevision === '6'
             ? ['Latest local item']
             : ['Replacement durable item'];
       return {
@@ -347,7 +347,7 @@ describe('createGraphqlSoupAstItemsQuery', () => {
         const names =
           currentRevision === REVISION_2
             ? ['Network item', 'Realtime item']
-            : currentRevision === '5'
+            : currentRevision === '6'
               ? ['Latest local item']
               : ['Replacement durable item'];
         return {
@@ -411,21 +411,25 @@ describe('createGraphqlSoupAstItemsQuery', () => {
     await vi.waitFor(() => expect(entityFilterMock).toHaveBeenCalledTimes(2));
     currentRevision = '5';
     notifyCacheChanged('5');
-    await vi.waitFor(() => {
-      expect(query.data()?.entities.map((item) => item.name)).toEqual([
-        'Latest local item',
-      ]);
-    });
+    currentRevision = '6';
+    notifyCacheChanged('6');
+    await Promise.resolve();
+    expect(entityFilterMock).toHaveBeenCalledTimes(2);
+    expect(query.data()?.entities.map((item) => item.name)).toEqual([
+      'New network item',
+    ]);
     resolveRevision4({
       kind: 'complete',
       revision: '4',
       keys: ['GraphqlSoupDocument:stale'],
       optimistic: false,
     });
-    await Promise.resolve();
-    expect(query.data()?.entities.map((item) => item.name)).toEqual([
-      'Latest local item',
-    ]);
+    await vi.waitFor(() => {
+      expect(entityFilterMock).toHaveBeenCalledTimes(3);
+      expect(query.data()?.entities.map((item) => item.name)).toEqual([
+        'Latest local item',
+      ]);
+    });
 
     currentRevision = REVISION_0;
     notifyGenerationChanged();

--- a/apps/web/src/lib/queries/soup/graphql/items.ts
+++ b/apps/web/src/lib/queries/soup/graphql/items.ts
@@ -106,8 +106,11 @@ export function createGraphqlSoupAstItemsQuery(
   const [localProjection, setLocalProjection] = createSignal<
     LocalProjection | undefined
   >();
+  const [localEvaluationTrigger, setLocalEvaluationTrigger] = createSignal(0);
   const soupItemSelection = selectRecords(SoupItemFieldsFragmentDoc);
   let localRequest = 0;
+  let localEvaluationRunning = false;
+  let localEvaluationPending = false;
   let cacheGeneration = 0;
   let resetContinuationPages: (() => void) | undefined;
   let previousInitialInput: GraphqlSoupInput | undefined;
@@ -177,6 +180,7 @@ export function createGraphqlSoupAstItemsQuery(
   });
 
   createEffect(() => {
+    localEvaluationTrigger();
     const revision = currentCacheRevision();
     const input = firstPageInput();
     const queryOptions = options();
@@ -195,15 +199,29 @@ export function createGraphqlSoupAstItemsQuery(
       !host ||
       !('initial' in input)
     ) {
+      localEvaluationPending = false;
       return;
     }
     const initial = input.initial;
-    if (!initial) return;
+    if (!initial) {
+      localEvaluationPending = false;
+      return;
+    }
     const filters = initial.filters ?? {};
     const sortMethod = initial.sortMethod;
-    if (!sortMethod || sortMethod === 'VIEWED_AT') return;
+    if (!sortMethod || sortMethod === 'VIEWED_AT') {
+      localEvaluationPending = false;
+      return;
+    }
     const sortDirection = initial.sortDirection ?? 'DESC';
     const limit = initial.limit ?? 20;
+
+    if (localEvaluationRunning) {
+      localEvaluationPending = true;
+      return;
+    }
+    localEvaluationRunning = true;
+    localEvaluationPending = false;
 
     void (async () => {
       const span = Telemetry.span('graphql_cache.soup_local_evaluation');
@@ -281,6 +299,11 @@ export function createGraphqlSoupAstItemsQuery(
         span.setAttr('evaluation.retry_count', retryCount);
         span.setAttr('evaluation.discarded', discarded);
         span.end();
+        localEvaluationRunning = false;
+        if (localEvaluationPending) {
+          localEvaluationPending = false;
+          setLocalEvaluationTrigger((trigger) => trigger + 1);
+        }
       }
     })();
   });

--- a/apps/web/tauri/graphql_cache_plugin/src/commands.rs
+++ b/apps/web/tauri/graphql_cache_plugin/src/commands.rs
@@ -371,7 +371,9 @@ pub async fn graphql_cache_defer_optimistic_write<R: Runtime>(
     } = &result
     {
         emit_ops_affected(&app, &write_result.affected_ops, &write_result.changed);
-        emit_cache_changed(&app, &write_result.revision);
+        if write_result.revision_advanced {
+            emit_cache_changed(&app, &write_result.revision);
+        }
         emit_mutation_settled(
             &app,
             settlement_transaction_id,
@@ -415,11 +417,7 @@ pub async fn graphql_cache_commit_optimistic_write<R: Runtime>(
             result,
         } => (result, Some(replacement_transaction_id.clone())),
     };
-    emit_ops_affected(
-        &app,
-        &write_result.affected_ops,
-        &write_result.changed,
-    );
+    emit_ops_affected(&app, &write_result.affected_ops, &write_result.changed);
     if write_result.revision_advanced {
         emit_cache_changed(&app, &write_result.revision);
     }

--- a/apps/web/tauri/graphql_cache_plugin/src/commands.rs
+++ b/apps/web/tauri/graphql_cache_plugin/src/commands.rs
@@ -169,7 +169,9 @@ pub async fn graphql_cache_write<R: Runtime>(
         })
         .await?;
     emit_ops_affected(&app, &result.affected_ops, &result.changed);
-    emit_cache_changed(&app, &result.revision);
+    if result.revision_advanced {
+        emit_cache_changed(&app, &result.revision);
+    }
     Ok(result)
 }
 
@@ -217,7 +219,9 @@ pub async fn graphql_cache_hydrate<R: Runtime>(
         &result.write_result.affected_ops,
         &result.write_result.changed,
     );
-    emit_cache_changed(&app, &result.write_result.revision);
+    if result.write_result.revision_advanced {
+        emit_cache_changed(&app, &result.write_result.revision);
+    }
     Ok(match result.data {
         Some(data) => HydrationResultWire::Data {
             data,
@@ -266,7 +270,9 @@ pub async fn graphql_cache_enqueue_optimistic_mutation<R: Runtime>(
         )
         .await?;
     emit_ops_affected(&app, &result.result.affected_ops, &result.result.changed);
-    emit_cache_changed(&app, &result.result.revision);
+    if result.result.revision_advanced {
+        emit_cache_changed(&app, &result.result.revision);
+    }
     if let MutationUpsertKindWire::ReplacedPending {
         removed_transaction_id,
     } = &result.upsert_kind
@@ -414,7 +420,9 @@ pub async fn graphql_cache_commit_optimistic_write<R: Runtime>(
         &write_result.affected_ops,
         &write_result.changed,
     );
-    emit_cache_changed(&app, &write_result.revision);
+    if write_result.revision_advanced {
+        emit_cache_changed(&app, &write_result.revision);
+    }
     emit_mutation_settled(
         &app,
         settlement_transaction_id,
@@ -448,7 +456,9 @@ pub async fn graphql_cache_rollback_optimistic_write<R: Runtime>(
             result: write_result,
         } => {
             emit_ops_affected(&app, &write_result.affected_ops, &write_result.changed);
-            emit_cache_changed(&app, &write_result.revision);
+            if write_result.revision_advanced {
+                emit_cache_changed(&app, &write_result.revision);
+            }
             emit_mutation_settled(
                 &app,
                 settlement_transaction_id,
@@ -462,7 +472,9 @@ pub async fn graphql_cache_rollback_optimistic_write<R: Runtime>(
             result: write_result,
         } => {
             emit_ops_affected(&app, &write_result.affected_ops, &write_result.changed);
-            emit_cache_changed(&app, &write_result.revision);
+            if write_result.revision_advanced {
+                emit_cache_changed(&app, &write_result.revision);
+            }
             emit_mutation_settled(
                 &app,
                 settlement_transaction_id,

--- a/apps/web/tauri/graphql_cache_plugin/src/engine.rs
+++ b/apps/web/tauri/graphql_cache_plugin/src/engine.rs
@@ -52,6 +52,8 @@ pub enum ReadResultWire {
 pub struct WriteResultWire {
     /// Effective-view revision installed by this logical mutation.
     pub revision: String,
+    /// Whether this write advanced `revision`.
+    pub revision_advanced: bool,
     /// Entity keys whose records changed.
     pub changed: Vec<String>,
     /// Registered operation ids affected by the change (origin excluded).
@@ -352,6 +354,7 @@ pub struct EngineHandle {
 fn wire_write_result(ops: &OpInterner, result: WriteResult) -> WriteResultWire {
     WriteResultWire {
         revision: result.revision.to_string(),
+        revision_advanced: result.revision_advanced,
         changed: result
             .changed
             .into_iter()

--- a/apps/web/tauri/graphql_cache_plugin/src/engine/test.rs
+++ b/apps/web/tauri/graphql_cache_plugin/src/engine/test.rs
@@ -71,6 +71,7 @@ fn read(handle: &EngineHandle, op_id: Option<&str>) -> ReadResultWire {
 fn empty_write_result() -> WriteResultWire {
     WriteResultWire {
         revision: "0".to_string(),
+        revision_advanced: false,
         changed: Vec::new(),
         affected_ops: Vec::new(),
         reset: false,

--- a/bun.lock
+++ b/bun.lock
@@ -101,7 +101,7 @@
         "nanoid": "^3.3.7",
         "neverthrow": "^8.2.0",
         "pdfjs-dist": "github:macro-inc/pdf.js#v2.16.52-web",
-        "posthog-js": "^1.387.0",
+        "posthog-js": "^1.424.0",
         "quill": "^2.0.3",
         "short-uuid": "^5.2.0",
         "signature_pad": "^5.0.10",
@@ -1295,11 +1295,11 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
-    "@posthog/browser-common": ["@posthog/browser-common@0.2.4", "", { "dependencies": { "@posthog/core": "^1.45.1", "@posthog/types": "^1.398.0" } }, "sha512-/xI4sIVNiZMJButhNdQFdCHtOcB6v8xM8vtJKznqqB7SMbpYwUNok68iPxGNZHPDwUYM6GAqM/AbMiS80UNyMw=="],
+    "@posthog/browser-common": ["@posthog/browser-common@0.7.1", "", { "dependencies": { "@posthog/core": "^1.50.0", "@posthog/types": "^1.407.1" } }, "sha512-JO/5dIVx3NTrbg0W2VciDDmmizsvwaYYHE5cnJE1Gra+UqBnEuVGH9DTE/kBFgVMp+08z5uj/aAprsYD2WG/QQ=="],
 
-    "@posthog/core": ["@posthog/core@1.45.2", "", { "dependencies": { "@posthog/types": "^1.398.0" } }, "sha512-OhEHkojFkqEFbtm/wUtLYgomN1gFNU9IyufvNsuZvpIOh8TZ9tnAvI81Sej/2zu+vyDExs9JroQB5SW3y5QyOw=="],
+    "@posthog/core": ["@posthog/core@1.50.1", "", { "dependencies": { "@posthog/types": "^1.407.1" } }, "sha512-REG9hSmWdQhPvXJfZuH0cwvveq5lS3wAluNSav7mqiaZszALRL4+4qS5FFO2gpgvV5D7OIhkJFB4ZKFbzqbviA=="],
 
-    "@posthog/types": ["@posthog/types@1.398.0", "", {}, "sha512-sJMkl4k+u8yS/0fjHsKqE9xTdsAh30a2WvgChiptellnVoE0e8QJKFgqOMD2sk8FaEArPdeFklAhXvmENAt3Sg=="],
+    "@posthog/types": ["@posthog/types@1.407.1", "", {}, "sha512-WhbkXPC2rgylXqmxHqv70ffI3k+KxyR6s7DBIfr5NvIqHkxp6v0pk31D/jbz0DNVbzwkLjyll2pxr4FNbJiYzg=="],
 
     "@preact/signals-core": ["@preact/signals-core@1.14.4", "", {}, "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA=="],
 
@@ -2021,7 +2021,7 @@
 
     "dommatrix": ["dommatrix@1.0.3", "", {}, "sha512-l32Xp/TLgWb8ReqbVJAFIvXmY7go4nTxxlWiAFyhoQw9RKEOHBZNnyGvJWqDVSPmq3Y9HlM4npqF/T6VMOXhww=="],
 
-    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
+    "dompurify": ["dompurify@3.4.14", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
@@ -2813,7 +2813,7 @@
 
     "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
 
-    "posthog-js": ["posthog-js@1.407.8", "", { "dependencies": { "@posthog/browser-common": "^0.2.4", "@posthog/core": "^1.45.2", "@posthog/types": "^1.398.0", "core-js": "^3.49.0", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.29.3", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0" } }, "sha512-I3rE1WQI9by/RrtgoE34opVmEsnCyUui5EkD3VYJWRiBIkglcn7A3Ixk7tniPEOfGMiDZFETX8ORAQBt47Z0VA=="],
+    "posthog-js": ["posthog-js@1.424.0", "", { "dependencies": { "@posthog/browser-common": "^0.7.1", "@posthog/core": "^1.50.1", "@posthog/types": "^1.407.1", "core-js": "^3.49.0", "dompurify": "^3.4.13", "fflate": "^0.4.8", "preact": "^10.29.3", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^6.2.1", "web-vitals-soft-navs": "npm:web-vitals@6.2.1" }, "peerDependencies": { "@types/react": ">=16.8.0", "react": ">=16.8.0" }, "optionalPeers": ["@types/react", "react"] }, "sha512-owEiZm26dJe7THtRvgMuKRJ0RS7GhZieL42PVcDN8IWzHdDL2VMEIX6bcIN8+HmK9Jleih7cyhPjw8o3GxRC3w=="],
 
     "preact": ["preact@10.12.1", "", {}, "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg=="],
 
@@ -3307,7 +3307,9 @@
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
-    "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
+    "web-vitals": ["web-vitals@6.2.1", "", {}, "sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw=="],
+
+    "web-vitals-soft-navs": ["web-vitals@6.2.1", "", {}, "sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw=="],
 
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 

--- a/crates/client/cache-core/src/engine.rs
+++ b/crates/client/cache-core/src/engine.rs
@@ -134,6 +134,8 @@ pub struct QueryRegistration<'a> {
 pub struct WriteResult {
     /// Revision installed after this logical cache mutation.
     pub revision: CacheRevision,
+    /// Whether this write advanced [`Self::revision`].
+    pub revision_advanced: bool,
     /// Records whose contents changed.
     pub changed: BTreeSet<EntityKey<'static>>,
     /// Active operations depending on changed records (host re-executes
@@ -395,6 +397,7 @@ impl<S: Storage> Engine<S> {
         let revision = self.advance_revision()?;
         Ok(WriteResult {
             revision,
+            revision_advanced: true,
             changed,
             affected_ops,
             reset: false,
@@ -1101,7 +1104,12 @@ impl<S: Storage> Engine<S> {
         candidates.extend(updates.keys().cloned());
         let bases_before = self.load_bases(&candidates).await?;
         let before = effective_records(&bases_before, &self.optimistic, &candidates);
-        let (changed, revision) = self.persist_updates(updates, projections).await?;
+        let (changed, mut revision, mut revision_advanced) =
+            self.persist_updates(updates, projections).await?;
+        if reset && !revision_advanced {
+            revision = self.advance_revision()?;
+            revision_advanced = true;
+        }
 
         if !self.optimistic.is_empty() {
             let queued = self
@@ -1140,6 +1148,7 @@ impl<S: Storage> Engine<S> {
         }
         Ok(WriteResult {
             revision,
+            revision_advanced,
             changed,
             affected_ops,
             reset,
@@ -1219,7 +1228,7 @@ impl<S: Storage> Engine<S> {
         &mut self,
         updates: RecordUpdates,
         projections: Vec<ProjectionMutation>,
-    ) -> Result<(BTreeSet<EntityKey<'static>>, CacheRevision), EngineError<S::Error>> {
+    ) -> Result<(BTreeSet<EntityKey<'static>>, CacheRevision, bool), EngineError<S::Error>> {
         // Load current values (hot tier, then storage) so merges detect real
         // changes. Merges are staged in a plain map, NOT the LRU: a batch
         // larger than the hot capacity would otherwise evict its own
@@ -1271,13 +1280,87 @@ impl<S: Storage> Engine<S> {
         // Persist every touched record (idempotent for unchanged ones —
         // keeps storage authoritative even if the hot tier evicted them
         // between loads).
+        let revision_advanced = if changed.is_empty() {
+            self.projection_mutations_change(&projections).await?
+        } else {
+            true
+        };
         self.storage
             .put_batch_with_projections(to_persist.clone(), projections)
             .await
             .map_err(EngineError::Storage)?;
-        let revision = self.advance_revision()?;
+        let revision = if revision_advanced {
+            self.advance_revision()?
+        } else {
+            self.revision
+        };
         self.update_loaded_search_catalogs(&to_persist);
-        Ok((changed, revision))
+        Ok((changed, revision, revision_advanced))
+    }
+
+    async fn projection_mutations_change(
+        &self,
+        mutations: &[ProjectionMutation],
+    ) -> Result<bool, EngineError<S::Error>> {
+        if mutations.is_empty() {
+            return Ok(false);
+        }
+        let keys = mutations
+            .iter()
+            .map(ProjectionMutation::record_key)
+            .cloned()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let states = self
+            .storage
+            .load_projection_states(&keys)
+            .await
+            .map_err(EngineError::Storage)?;
+        let mut projected = keys.iter().cloned().zip(states).collect::<HashMap<_, _>>();
+        let before = projected.clone();
+
+        for mutation in mutations {
+            let key = mutation.record_key().clone();
+            let state = match mutation {
+                ProjectionMutation::Replace(document) => {
+                    let mut document = document.clone();
+                    document.canonicalize();
+                    Some(ProjectionState::Complete(document))
+                }
+                ProjectionMutation::Patch {
+                    record_key,
+                    profile,
+                    partition,
+                    exact,
+                    integers,
+                    sorts,
+                } => Some(apply_authoritative_projection_patch(
+                    projected.get(record_key).and_then(Option::as_ref),
+                    record_key,
+                    profile,
+                    partition,
+                    exact,
+                    integers,
+                    sorts,
+                )),
+                ProjectionMutation::MarkIncomplete {
+                    record_key,
+                    profile,
+                    partition,
+                    kind,
+                } => Some(ProjectionState::Incomplete {
+                    record_key: record_key.clone(),
+                    profile: profile.clone(),
+                    partition: partition.clone(),
+                    kind: *kind,
+                }),
+                ProjectionMutation::Delete(_) => None,
+            };
+            projected.insert(key, state);
+        }
+
+        Ok(projected != before)
     }
 
     /// Atomically enqueues a mutation together with its optimistic layer.
@@ -1514,6 +1597,7 @@ impl<S: Storage> Engine<S> {
             upsert_kind: upsert.kind,
             write_result: WriteResult {
                 revision,
+                revision_advanced: true,
                 changed,
                 affected_ops,
                 reset: false,
@@ -1923,6 +2007,7 @@ impl<S: Storage> Engine<S> {
         let affected_ops = self.deps.ops_for_keys(visible_changed.iter());
         Ok(WriteResult {
             revision,
+            revision_advanced: true,
             changed: durable_changed,
             affected_ops,
             reset: false,
@@ -2008,6 +2093,7 @@ impl<S: Storage> Engine<S> {
         let affected_ops = self.deps.ops_for_keys(visible_changed.iter());
         Ok(WriteResult {
             revision,
+            revision_advanced: true,
             changed: BTreeSet::new(),
             affected_ops,
             reset: false,
@@ -2295,13 +2381,15 @@ impl<S: PredicateIndexStorage> Engine<S> {
         for (key, record) in entries {
             updates.entry(key).or_default().merge(record);
         }
-        let (changed, revision) = self.persist_updates(updates, projections).await?;
+        let (changed, revision, revision_advanced) =
+            self.persist_updates(updates, projections).await?;
         let mut affected_ops = self.deps.ops_for_keys(changed.iter());
         if let Some(origin_op) = origin_op {
             affected_ops.remove(&origin_op);
         }
         Ok(WriteResult {
             revision,
+            revision_advanced,
             changed,
             affected_ops,
             reset: false,

--- a/crates/client/cache-core/src/engine.rs
+++ b/crates/client/cache-core/src/engine.rs
@@ -24,7 +24,8 @@ use crate::predicate::{
     OptimisticShadowReconciliation, OptimisticUpsertReconciliation, PredicateIndexStorage,
     PredicateQueryResult, ProjectionMutation, ProjectionMutationLayer, ProjectionState,
     StagedOptimisticProjection, StagedOptimisticProjectionOwner,
-    apply_authoritative_projection_patch, compose_effective_optimistic_projection,
+    apply_authoritative_projection_mutations, apply_authoritative_projection_patch,
+    compose_effective_optimistic_projection,
 };
 use crate::query_inspection::{
     CachedQueryInstance, CachedQueryVariant, OwnerResolution, QueryInspection,
@@ -1317,49 +1318,13 @@ impl<S: Storage> Engine<S> {
             .load_projection_states(&keys)
             .await
             .map_err(EngineError::Storage)?;
-        let mut projected = keys.iter().cloned().zip(states).collect::<HashMap<_, _>>();
+        let mut projected = keys
+            .into_iter()
+            .zip(states)
+            .filter_map(|(key, state)| state.map(|state| (key, state)))
+            .collect::<HashMap<_, _>>();
         let before = projected.clone();
-
-        for mutation in mutations {
-            let key = mutation.record_key().clone();
-            let state = match mutation {
-                ProjectionMutation::Replace(document) => {
-                    let mut document = document.clone();
-                    document.canonicalize();
-                    Some(ProjectionState::Complete(document))
-                }
-                ProjectionMutation::Patch {
-                    record_key,
-                    profile,
-                    partition,
-                    exact,
-                    integers,
-                    sorts,
-                } => Some(apply_authoritative_projection_patch(
-                    projected.get(record_key).and_then(Option::as_ref),
-                    record_key,
-                    profile,
-                    partition,
-                    exact,
-                    integers,
-                    sorts,
-                )),
-                ProjectionMutation::MarkIncomplete {
-                    record_key,
-                    profile,
-                    partition,
-                    kind,
-                } => Some(ProjectionState::Incomplete {
-                    record_key: record_key.clone(),
-                    profile: profile.clone(),
-                    partition: partition.clone(),
-                    kind: *kind,
-                }),
-                ProjectionMutation::Delete(_) => None,
-            };
-            projected.insert(key, state);
-        }
-
+        apply_authoritative_projection_mutations(&mut projected, mutations);
         Ok(projected != before)
     }
 

--- a/crates/client/cache-core/src/predicate.rs
+++ b/crates/client/cache-core/src/predicate.rs
@@ -13,7 +13,7 @@ use predicate_index::{
     PendingOptimisticProjection, Profile, RecordKey, Token, ValidatedIndexQuery, ValidationError,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use thiserror::Error;
 
 /// Persisted projection state for one supported normalized record.
@@ -567,6 +567,60 @@ impl ProjectionMutation {
             Self::Patch { record_key, .. }
             | Self::MarkIncomplete { record_key, .. }
             | Self::Delete(record_key) => record_key,
+        }
+    }
+}
+
+/// Apply authoritative projection mutations to materialized projection states.
+///
+/// Replacement documents are canonicalized before becoming authoritative so
+/// no-op detection and every storage implementation compare and persist the
+/// same value.
+pub fn apply_authoritative_projection_mutations(
+    states: &mut HashMap<RecordKey, ProjectionState>,
+    mutations: &[ProjectionMutation],
+) {
+    for mutation in mutations {
+        let key = mutation.record_key().clone();
+        let state = match mutation {
+            ProjectionMutation::Replace(document) => {
+                let mut document = document.clone();
+                document.canonicalize();
+                Some(ProjectionState::Complete(document))
+            }
+            ProjectionMutation::Patch {
+                record_key,
+                profile,
+                partition,
+                exact,
+                integers,
+                sorts,
+            } => Some(apply_authoritative_projection_patch(
+                states.get(record_key),
+                record_key,
+                profile,
+                partition,
+                exact,
+                integers,
+                sorts,
+            )),
+            ProjectionMutation::MarkIncomplete {
+                record_key,
+                profile,
+                partition,
+                kind,
+            } => Some(ProjectionState::Incomplete {
+                record_key: record_key.clone(),
+                profile: profile.clone(),
+                partition: partition.clone(),
+                kind: *kind,
+            }),
+            ProjectionMutation::Delete(_) => None,
+        };
+        if let Some(state) = state {
+            states.insert(key, state);
+        } else {
+            states.remove(&key);
         }
     }
 }

--- a/crates/client/cache-core/src/store.rs
+++ b/crates/client/cache-core/src/store.rs
@@ -9,7 +9,7 @@
 use crate::predicate::{
     OptimisticShadowReconciliation, OptimisticUpsertReconciliation, PredicateIndexStorage,
     PredicateQueryResult, ProjectionMutation, ProjectionState, StagedOptimisticProjection,
-    StagedOptimisticProjectionOwner, apply_authoritative_projection_patch,
+    StagedOptimisticProjectionOwner, apply_authoritative_projection_mutations,
 };
 use crate::queue::{
     ClaimedMutation, MutationClaimRequest, MutationClaimToken, MutationId, MutationQueueSnapshot,
@@ -835,54 +835,7 @@ fn apply_in_memory_projection_mutations(
     projections: &mut HashMap<PredicateRecordKey, ProjectionState>,
     mutations: Vec<ProjectionMutation>,
 ) {
-    for mutation in mutations {
-        match mutation {
-            ProjectionMutation::Replace(document) => {
-                projections.insert(
-                    document.record_key.clone(),
-                    ProjectionState::Complete(document),
-                );
-            }
-            ProjectionMutation::Patch {
-                record_key,
-                profile,
-                partition,
-                exact,
-                integers,
-                sorts,
-            } => {
-                let state = apply_authoritative_projection_patch(
-                    projections.get(&record_key),
-                    &record_key,
-                    &profile,
-                    &partition,
-                    &exact,
-                    &integers,
-                    &sorts,
-                );
-                projections.insert(record_key, state);
-            }
-            ProjectionMutation::MarkIncomplete {
-                record_key,
-                profile,
-                partition,
-                kind,
-            } => {
-                projections.insert(
-                    record_key.clone(),
-                    ProjectionState::Incomplete {
-                        record_key,
-                        profile,
-                        partition,
-                        kind,
-                    },
-                );
-            }
-            ProjectionMutation::Delete(record_key) => {
-                projections.remove(&record_key);
-            }
-        }
-    }
+    apply_authoritative_projection_mutations(projections, &mutations);
 }
 
 fn claim_matches(mutation: &crate::queue::StoredMutation, claim: &MutationClaimToken) -> bool {

--- a/crates/client/cache-core/tests/engine.rs
+++ b/crates/client/cache-core/tests/engine.rs
@@ -143,6 +143,7 @@ fn revision_tracks_logical_mutations_only_within_one_engine_generation() {
             .await
             .unwrap();
         assert_eq!(first.revision.to_string(), "1");
+        assert!(first.revision_advanced);
         assert_eq!(engine.current_revision(), first.revision);
 
         engine
@@ -151,14 +152,14 @@ fn revision_tracks_logical_mutations_only_within_one_engine_generation() {
             .unwrap();
         assert_eq!(engine.current_revision(), first.revision);
 
-        // Conservative advancement: an idempotent logical write still makes
-        // older observations stale.
+        // An idempotent authoritative write preserves existing observations.
         let second = engine
             .write_query(None, QUERY, Some("Soup"), &vars(10), &data, None)
             .await
             .unwrap();
         assert!(second.changed.is_empty());
-        assert_eq!(second.revision.to_string(), "2");
+        assert!(!second.revision_advanced);
+        assert_eq!(second.revision, first.revision);
 
         let storage = engine.storage().clone();
         let mut replacement = Engine::new(storage);

--- a/crates/client/cache-core/tests/predicate.rs
+++ b/crates/client/cache-core/tests/predicate.rs
@@ -150,6 +150,48 @@ async fn begin_with_projection(
 }
 
 #[test]
+fn authoritative_projection_no_op_does_not_advance_revision() {
+    pollster::block_on(async {
+        let mut engine = Engine::new(InMemoryStorage::new());
+        let entity_key = EntityKey::entity("GraphqlSoupDocument", &["doc-1"]);
+        let first = engine
+            .put_records_with_projections(
+                None,
+                vec![(entity_key.clone(), Record::default())],
+                vec![ProjectionMutation::Replace(projection("owner-1"))],
+            )
+            .await
+            .unwrap();
+        assert!(first.revision_advanced);
+        assert_eq!(first.revision.to_string(), "1");
+
+        let unchanged = engine
+            .put_records_with_projections(
+                None,
+                vec![(entity_key.clone(), Record::default())],
+                vec![ProjectionMutation::Replace(projection("owner-1"))],
+            )
+            .await
+            .unwrap();
+        assert!(unchanged.changed.is_empty());
+        assert!(!unchanged.revision_advanced);
+        assert_eq!(unchanged.revision, first.revision);
+
+        let projection_only = engine
+            .put_records_with_projections(
+                None,
+                vec![(entity_key, Record::default())],
+                vec![ProjectionMutation::Replace(projection("owner-2"))],
+            )
+            .await
+            .unwrap();
+        assert!(projection_only.changed.is_empty());
+        assert!(projection_only.revision_advanced);
+        assert_eq!(projection_only.revision.to_string(), "2");
+    });
+}
+
+#[test]
 fn replacement_removes_stale_facts_and_incomplete_states_fall_back() {
     pollster::block_on(async {
         let mut engine = Engine::new(InMemoryStorage::new());

--- a/crates/client/cache-core/tests/predicate.rs
+++ b/crates/client/cache-core/tests/predicate.rs
@@ -192,6 +192,52 @@ fn authoritative_projection_no_op_does_not_advance_revision() {
 }
 
 #[test]
+fn authoritative_projection_no_op_uses_the_canonical_persisted_value() {
+    pollster::block_on(async {
+        let mut engine = Engine::new(InMemoryStorage::new());
+        let entity_key = EntityKey::entity("GraphqlSoupDocument", &["doc-1"]);
+        let mut replacement = projection("owner-1");
+        replacement.exact_facts.push(ExactFact {
+            attribute: token("category"),
+            value: ExactValue::utf8("report").unwrap(),
+        });
+        let mut canonical = replacement.clone();
+        canonical.canonicalize();
+        assert_ne!(replacement, canonical, "fixture must be non-canonical");
+
+        let first = engine
+            .put_records_with_projections(
+                None,
+                vec![(entity_key.clone(), Record::default())],
+                vec![ProjectionMutation::Replace(replacement.clone())],
+            )
+            .await
+            .unwrap();
+        assert!(first.revision_advanced);
+        assert_eq!(
+            engine
+                .storage()
+                .load_projection_states(&[record_key()])
+                .await
+                .unwrap(),
+            vec![Some(ProjectionState::Complete(canonical))]
+        );
+
+        let unchanged = engine
+            .put_records_with_projections(
+                None,
+                vec![(entity_key, Record::default())],
+                vec![ProjectionMutation::Replace(replacement)],
+            )
+            .await
+            .unwrap();
+        assert!(unchanged.changed.is_empty());
+        assert!(!unchanged.revision_advanced);
+        assert_eq!(unchanged.revision, first.revision);
+    });
+}
+
+#[test]
 fn replacement_removes_stale_facts_and_incomplete_states_fall_back() {
     pollster::block_on(async {
         let mut engine = Engine::new(InMemoryStorage::new());

--- a/crates/client/cache-turso/src/storage.rs
+++ b/crates/client/cache-turso/src/storage.rs
@@ -7,7 +7,7 @@ use cache_core::codec::{
 use cache_core::predicate::{
     OptimisticShadowReconciliation, OptimisticUpsertReconciliation, PredicateIndexStorage,
     PredicateQueryResult, ProjectionIncompleteKind, ProjectionMutation, ProjectionState,
-    StagedOptimisticProjectionOwner, apply_authoritative_projection_patch,
+    StagedOptimisticProjectionOwner, apply_authoritative_projection_mutations,
 };
 use cache_core::queue::{
     ClaimedMutation, MutationClaimRequest, MutationClaimToken, MutationId, MutationQueueSnapshot,
@@ -1723,125 +1723,112 @@ fn optimistic_projection_state_code(state: &OptimisticProjectionState) -> (i64, 
 
 fn write_projection_mutations(
     connection: &Arc<Connection>,
-    projections: Vec<ProjectionMutation>,
+    mutations: Vec<ProjectionMutation>,
 ) -> Result<(), TursoStorageError> {
-    for mutation in projections {
-        match mutation {
-            ProjectionMutation::Replace(document) => {
-                document.validate().map_err(|_| invariant())?;
-                let document_id = upsert_index_document(
-                    connection,
-                    &document.record_key,
-                    &document.profile,
-                    &document.partition,
-                    0,
+    let keys = mutations
+        .iter()
+        .map(ProjectionMutation::record_key)
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let mut states = keys
+        .iter()
+        .cloned()
+        .zip(load_projection_states(connection, &keys)?)
+        .filter_map(|(key, state)| state.map(|state| (key, state)))
+        .collect::<HashMap<_, _>>();
+
+    for mutation in &mutations {
+        let key = mutation.record_key().clone();
+        apply_authoritative_projection_mutations(&mut states, std::slice::from_ref(mutation));
+        write_projection_state(connection, &key, states.get(&key))?;
+    }
+    Ok(())
+}
+
+fn write_projection_state(
+    connection: &Arc<Connection>,
+    record_key: &PredicateRecordKey,
+    state: Option<&ProjectionState>,
+) -> Result<(), TursoStorageError> {
+    match state {
+        Some(ProjectionState::Complete(document)) => {
+            document.validate().map_err(|_| invariant())?;
+            let document_id = upsert_index_document(
+                connection,
+                &document.record_key,
+                &document.profile,
+                &document.partition,
+                0,
+            )?;
+            delete_index_facts(connection, document_id)?;
+            for fact in &document.exact_facts {
+                require_changed(
+                    driver::execute(
+                        connection,
+                        EXACT_FACT_INSERT,
+                        vec![
+                            Value::from_i64(document_id),
+                            text(fact.attribute.as_str()),
+                            Value::from_blob(fact.value.as_bytes().to_vec()),
+                        ],
+                    )?,
+                    1,
                 )?;
-                delete_index_facts(connection, document_id)?;
-                for fact in document.exact_facts {
-                    require_changed(
-                        driver::execute(
-                            connection,
-                            EXACT_FACT_INSERT,
-                            vec![
-                                Value::from_i64(document_id),
-                                text(fact.attribute.as_str()),
-                                Value::from_blob(fact.value.as_bytes().to_vec()),
-                            ],
-                        )?,
-                        1,
-                    )?;
-                }
-                for fact in document.integer_facts {
-                    require_changed(
-                        driver::execute(
-                            connection,
-                            INTEGER_FACT_INSERT,
-                            vec![
-                                Value::from_i64(document_id),
-                                text(fact.attribute.as_str()),
-                                Value::from_i64(fact.value),
-                            ],
-                        )?,
-                        1,
-                    )?;
-                }
-                for fact in document.sort_facts {
-                    require_changed(
-                        driver::execute(
-                            connection,
-                            SORT_FACT_INSERT,
-                            vec![
-                                Value::from_i64(document_id),
-                                text(fact.attribute.as_str()),
-                                Value::from_i64(fact.value),
-                            ],
-                        )?,
-                        1,
-                    )?;
-                }
             }
-            ProjectionMutation::Patch {
+            for fact in &document.integer_facts {
+                require_changed(
+                    driver::execute(
+                        connection,
+                        INTEGER_FACT_INSERT,
+                        vec![
+                            Value::from_i64(document_id),
+                            text(fact.attribute.as_str()),
+                            Value::from_i64(fact.value),
+                        ],
+                    )?,
+                    1,
+                )?;
+            }
+            for fact in &document.sort_facts {
+                require_changed(
+                    driver::execute(
+                        connection,
+                        SORT_FACT_INSERT,
+                        vec![
+                            Value::from_i64(document_id),
+                            text(fact.attribute.as_str()),
+                            Value::from_i64(fact.value),
+                        ],
+                    )?,
+                    1,
+                )?;
+            }
+        }
+        Some(ProjectionState::Incomplete {
+            profile,
+            partition,
+            kind,
+            ..
+        }) => {
+            let document_id = upsert_index_document(
+                connection,
                 record_key,
                 profile,
                 partition,
-                exact,
-                integers,
-                sorts,
-            } => {
-                let current =
-                    load_projection_states(connection, std::slice::from_ref(&record_key))?
-                        .into_iter()
-                        .next()
-                        .flatten();
-                let state = apply_authoritative_projection_patch(
-                    current.as_ref(),
-                    &record_key,
-                    &profile,
-                    &partition,
-                    &exact,
-                    &integers,
-                    &sorts,
-                );
-                let resolved = match state {
-                    ProjectionState::Complete(document) => ProjectionMutation::Replace(document),
-                    ProjectionState::Incomplete {
-                        record_key,
-                        profile,
-                        partition,
-                        kind,
-                    } => ProjectionMutation::MarkIncomplete {
-                        record_key,
-                        profile,
-                        partition,
-                        kind,
-                    },
-                };
-                write_projection_mutations(connection, vec![resolved])?;
-            }
-            ProjectionMutation::MarkIncomplete {
-                record_key,
-                profile,
-                partition,
-                kind,
-            } => {
-                let document_id = upsert_index_document(
-                    connection,
-                    &record_key,
-                    &profile,
-                    &partition,
-                    projection_state_code(kind),
-                )?;
-                delete_index_facts(connection, document_id)?;
-            }
-            ProjectionMutation::Delete(record_key) => {
-                let changed = driver::execute(
-                    connection,
-                    INDEX_DOCUMENT_DELETE,
-                    vec![text(record_key.as_str())],
-                )?;
-                if !(0..=1).contains(&changed) {
-                    return Err(invariant());
-                }
+                projection_state_code(*kind),
+            )?;
+            delete_index_facts(connection, document_id)?;
+        }
+        None => {
+            let changed = driver::execute(
+                connection,
+                INDEX_DOCUMENT_DELETE,
+                vec![text(record_key.as_str())],
+            )?;
+            if !(0..=1).contains(&changed) {
+                return Err(invariant());
             }
         }
     }
@@ -2266,7 +2253,8 @@ fn load_index_documents(
             });
     }
 
-    for document in documents.values() {
+    for document in documents.values_mut() {
+        document.canonicalize();
         document.validate().map_err(|_| invariant())?;
     }
     Ok(keys.iter().map(|key| documents.get(key).cloned()).collect())

--- a/crates/client/cache-wasm/src/shell.rs
+++ b/crates/client/cache-wasm/src/shell.rs
@@ -144,6 +144,7 @@ struct JsQueryRegistration {
 #[serde(rename_all = "camelCase")]
 struct JsWriteResult {
     revision: String,
+    revision_advanced: bool,
     changed: Vec<String>,
     affected_ops: Vec<String>,
     reset: bool,
@@ -154,6 +155,7 @@ struct JsWriteResult {
 #[serde(rename_all = "camelCase")]
 struct JsHydrationWriteResult {
     revision: String,
+    revision_advanced: bool,
     changed: Vec<String>,
     affected_ops: Vec<String>,
     reset: bool,
@@ -172,6 +174,7 @@ struct JsEnqueueOptimisticMutationResult {
     transaction_id: String,
     upsert_kind: JsMutationUpsertKind,
     revision: String,
+    revision_advanced: bool,
     changed: Vec<String>,
     affected_ops: Vec<String>,
     reset: bool,
@@ -389,6 +392,7 @@ enum JsRollbackOptimisticWriteResult {
 fn js_write_result(result: WriteResult, ops: &OpInterner) -> JsWriteResult {
     JsWriteResult {
         revision: result.revision.to_string(),
+        revision_advanced: result.revision_advanced,
         changed: result
             .changed
             .into_iter()
@@ -1113,6 +1117,7 @@ impl CacheEngine {
             let result = state.engine_result(result)?;
             to_js(&JsHydrationWriteResult {
                 revision: result.write_result.revision.to_string(),
+                revision_advanced: result.write_result.revision_advanced,
                 changed: result
                     .write_result
                     .changed
@@ -1202,6 +1207,7 @@ impl CacheEngine {
                 transaction_id: result.transaction_id.to_string(),
                 upsert_kind: result.upsert_kind.into(),
                 revision: result.write_result.revision.to_string(),
+                revision_advanced: result.write_result.revision_advanced,
                 changed: result
                     .write_result
                     .changed

--- a/nix-support/node_modules-hashes.json
+++ b/nix-support/node_modules-hashes.json
@@ -1,6 +1,6 @@
 {
   "nodeModules": {
-    "aarch64-darwin": "sha256-iPpZ7oaorFe423fnfFl7t0WhJYlAXU9w7tU2D/kAUPk=",
-    "x86_64-linux": "sha256-sHJyjMTBdvttX2Yu5BaxbPjyNaB5/+uhOdQZ21uNTbM="
+    "aarch64-darwin": "sha256-NXjiNsnz379tBD66IOcU8Mp01Aq/lVPTPfVsg2Yfmlk=",
+    "x86_64-linux": "sha256-OtORVfsX/AToOwqELPlXFtsfH51Styrf0LiX1Ehe3cA="
   }
 }


### PR DESCRIPTION
This PR addresses some low hanging performance improvments with the cache revisions which reduces unecessary extra work from noisy cache revisions. We also bump posthog to a version which patches the memory leak issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cache revision semantics and optimistic mutation settlement across JS, Rust engine, and Tauri—incorrect `revisionAdvanced` handling could leave UIs stale or skip needed revalidations.
> 
> **Overview**
> Reduces **noisy cache revision notifications** by introducing `revisionAdvanced` on write results: idempotent authoritative writes (same normalized data or canonical projection) no longer bump revision or emit `cache-changed` through the worker, Tauri plugin, or WASM shell. Projection-only updates still advance revision when facts actually change.
> 
> **Optimistic mutation correctness:** commits that land as `committed-superseded` no longer replay explicit cache effects or commit revalidations. Property saves queued behind a replacement still return **optimistic `data`** when the network disposition is queued with null data. Soup list local projection evaluation is **serialized** (pending re-run after in-flight work) so stale revision notifications don’t thrash filters.
> 
> Also bumps **posthog-js** to ^1.424.0 (lockfile includes related PostHog and web-vitals updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77279d609500b1db3fcd38d953f4698f88cc25a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->