### PR TITLE
fix(web): show only the agent's latest chunk in the magic chip

### DIFF
--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -3,31 +3,25 @@ import {
   StaticMarkdownContext,
 } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
 import { channelTheme } from '@core/component/LexicalMarkdown/theme';
-import { type Component, Match, Show, Switch } from 'solid-js';
+import { type Component, Show } from 'solid-js';
 import type { MagicChipActivity, MagicChipPresentation } from './presentation';
 
-function working(presentation: MagicChipPresentation) {
-  return presentation.kind === 'working' ? presentation : undefined;
-}
-
-function answering(presentation: MagicChipPresentation) {
-  return presentation.kind === 'answering' ? presentation : undefined;
-}
-
-function settled(presentation: MagicChipPresentation) {
-  return presentation.kind === 'settled' ? presentation : undefined;
-}
-
-/** Fixed-height activity line — no box, just a shimmering label in the flow. */
+/**
+ * The whole chip while a turn runs: one line, always `h-6`, whatever the agent
+ * is doing.
+ *
+ * Both halves are held to that line. The label is short and never shrinks; the
+ * detail — a thought, a command, a sentence of narration — is arbitrarily long
+ * and gets the rest of the row, clipped with `min-w-0` so it can be narrower
+ * than its text and truncated at whatever width the message gives it.
+ */
 const ActivityLine: Component<{
-  agentSessionId: string;
   activity: MagicChipActivity;
   onOpen?: () => void;
 }> = (props) => (
   <button
     type="button"
-    class="flex h-6 w-full min-w-0 items-center gap-2 text-left"
-    data-magic-chip={props.agentSessionId}
+    class="flex h-6 w-full min-w-0 items-center gap-2 overflow-hidden text-left"
     disabled={!props.onOpen}
     onMouseDown={(event) => event.preventDefault()}
     onClick={props.onOpen}
@@ -44,7 +38,7 @@ const ActivityLine: Component<{
     </span>
     <Show when={props.activity.detail}>
       {(detail) => (
-        <span class="min-w-0 truncate text-xs text-ink-extra-muted">
+        <span class="min-w-0 flex-1 truncate text-xs text-ink-extra-muted">
           {detail()}
         </span>
       )}
@@ -52,100 +46,67 @@ const ActivityLine: Component<{
   </button>
 );
 
-/** The response, quoted as if the agent had answered inline. */
+/** The finished answer, quoted as if the agent had replied inline. */
 const AnswerBody: Component<{ markdown: string }> = (props) => (
-  <div class="w-full border-l-2 border-accent pl-3 text-left text-sm leading-6">
+  <div class="w-full min-w-0 border-l-2 border-accent pl-3 text-left text-sm leading-6">
     <StaticMarkdownContext theme={channelTheme}>
       <StaticMarkdown markdown={props.markdown} target="external" />
     </StaticMarkdownContext>
   </div>
 );
 
+/** Closes the settled chip where the activity line sat while the turn ran. */
+const OpenSessionLink: Component<{ onOpen?: () => void }> = (props) => (
+  <button
+    type="button"
+    class="mb-2 flex h-6 items-center text-xs text-ink-extra-muted hover:text-ink"
+    onMouseDown={(event) => event.preventDefault()}
+    onClick={props.onOpen}
+    disabled={!props.onOpen}
+  >
+    Open session
+  </button>
+);
+
 /**
- * The answer as it is being written, with the activity line beneath it.
+ * Render an already-derived Magic Chip presentation.
  *
- * The same quoted body the settled state uses, so the turn ending changes
- * only what is under the answer, not the answer itself — no reflow at the
- * moment the agent stops.
+ * A running turn is one `h-6` row and stays that height from the first event
+ * to the last, however much the agent narrates in between — the message below
+ * never moves while the agent works. Reaching the answer is the single moment
+ * the chip grows.
  */
-const StreamingAnswer: Component<{
-  agentSessionId: string;
-  markdown: string;
-  activity: MagicChipActivity;
-  onOpen?: () => void;
-}> = (props) => (
-  <div
-    class="grid w-full min-w-0 justify-items-start gap-1"
-    data-magic-chip={props.agentSessionId}
-  >
-    <AnswerBody markdown={props.markdown} />
-    <div class="w-full pl-3">
-      <ActivityLine
-        agentSessionId={props.agentSessionId}
-        activity={props.activity}
-        onOpen={props.onOpen}
-      />
-    </div>
-  </div>
-);
-
-/** The settled response, quoted as if the agent had answered inline. */
-const SettledAnswer: Component<{
-  agentSessionId: string;
-  markdown: string;
-  onOpen?: () => void;
-}> = (props) => (
-  <div
-    class="grid w-full min-w-0 justify-items-start gap-1"
-    data-magic-chip={props.agentSessionId}
-  >
-    <AnswerBody markdown={props.markdown} />
-    <button
-      type="button"
-      class="pl-3.5 mb-2 text-xs text-ink-extra-muted hover:text-ink"
-      onMouseDown={(event) => event.preventDefault()}
-      onClick={props.onOpen}
-      disabled={!props.onOpen}
-    >
-      Open session
-    </button>
-  </div>
-);
-
-/** Render an already-derived Magic Chip presentation. */
 export const MagicChipView: Component<{
   agentSessionId: string;
   presentation: MagicChipPresentation;
   onOpen?: () => void;
-}> = (props) => (
-  <Switch>
-    <Match when={working(props.presentation)}>
-      {(presentation) => (
-        <ActivityLine
-          agentSessionId={props.agentSessionId}
-          activity={presentation().activity}
-          onOpen={props.onOpen}
-        />
-      )}
-    </Match>
-    <Match when={answering(props.presentation)}>
-      {(presentation) => (
-        <StreamingAnswer
-          agentSessionId={props.agentSessionId}
-          markdown={presentation().markdown}
-          activity={presentation().activity}
-          onOpen={props.onOpen}
-        />
-      )}
-    </Match>
-    <Match when={settled(props.presentation)}>
-      {(presentation) => (
-        <SettledAnswer
-          agentSessionId={props.agentSessionId}
-          markdown={presentation().markdown}
-          onOpen={props.onOpen}
-        />
-      )}
-    </Match>
-  </Switch>
-);
+}> = (props) => {
+  // A settled turn is the only one with prose; an unsettled one is the only
+  // one guaranteed an activity. The footer takes whichever it gets.
+  const markdown = () =>
+    props.presentation.kind === 'settled'
+      ? props.presentation.markdown
+      : undefined;
+  const activity = () => props.presentation.activity;
+
+  return (
+    <div
+      class="grid w-full min-w-0 justify-items-start gap-1"
+      data-magic-chip={props.agentSessionId}
+    >
+      <Show when={markdown()}>
+        {(markdown) => <AnswerBody markdown={markdown()} />}
+      </Show>
+      <div class="w-full min-w-0 pl-3">
+        <Show
+          when={activity()}
+          fallback={<OpenSessionLink onOpen={props.onOpen} />}
+        >
+          {(activity) => (
+            <ActivityLine activity={activity()} onOpen={props.onOpen} />
+          )}
+        </Show>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.test.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.test.ts
@@ -122,22 +122,25 @@ describe('deriveMagicChipPresentation', () => {
     }
   );
 
-  it('shows the answer as it is written, before the turn ends', () => {
+  it('keeps prose to the activity line until the turn ends', () => {
     const presentation = deriveMagicChipPresentation({
       persistedStatus: 'acp_ready',
       response: response({ parts: [{ kind: 'text', text: 'Looking at t' }] }),
     });
 
     expect(presentation).toEqual({
-      kind: 'answering',
-      markdown: 'Looking at t',
-      activity: { label: 'Writing response', busy: false },
+      kind: 'working',
+      activity: {
+        label: 'Writing response',
+        detail: 'Looking at t',
+        busy: true,
+      },
     });
   });
 
-  it('keeps the answer visible while a tool runs mid-turn', () => {
-    // Prose, then a tool call: the text stays and the activity says what the
-    // agent moved on to, rather than the answer vanishing until it resumes.
+  it('drops narration the agent moved on from when a tool follows it', () => {
+    // Prose, then a tool call: the prose was a chunk, not the turn's answer,
+    // so the chip goes back to the activity line rather than holding it.
     const presentation = deriveMagicChipPresentation({
       persistedStatus: 'acp_ready',
       response: response({
@@ -162,9 +165,35 @@ describe('deriveMagicChipPresentation', () => {
     });
 
     expect(presentation).toEqual({
-      kind: 'answering',
-      markdown: 'Let me check the tests.',
+      kind: 'working',
       activity: { label: 'Running command', detail: 'cargo test', busy: true },
+    });
+  });
+
+  it('answers with the last chunk, not every chunk of the turn', () => {
+    const presentation = deriveMagicChipPresentation({
+      persistedStatus: 'acp_ready',
+      response: response({
+        parts: [
+          { kind: 'text', text: "I'll research frogs from a few angles." },
+          {
+            kind: 'tool_use',
+            rawInput: null,
+            rawOutput: null,
+            id: 'search',
+            label: 'Search',
+            status: 'completed',
+            detail: { kind: 'search', paths: ['frogs'], output: null },
+          },
+          { kind: 'text', text: 'Frogs are amphibians.' },
+        ],
+        stop: { kind: 'end_turn' },
+      }),
+    });
+
+    expect(presentation).toEqual({
+      kind: 'settled',
+      markdown: 'Frogs are amphibians.',
     });
   });
 
@@ -178,7 +207,7 @@ describe('deriveMagicChipPresentation', () => {
     });
 
     expect(presentation).toEqual({
-      kind: 'answering',
+      kind: 'settled',
       markdown: 'Half an ans',
       activity: { label: 'Stopped', busy: false },
     });

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.ts
@@ -14,14 +14,19 @@ export type MagicChipActivity = {
 /**
  * The one state the chip renders.
  *
- * Three, in the order a turn passes through them: an activity line while the
- * agent works with nothing to show, the answer as it is written with the
- * activity line still under it, and the answer alone once the turn ends.
+ * A running turn is always `working`: one fixed-height line, whatever the
+ * agent is doing — narration included, carried as the activity's detail. The
+ * chip only takes the height of real prose once the turn is over, so it never
+ * grows and shrinks under the message while the agent works.
  */
 export type MagicChipPresentation =
   | { kind: 'working'; activity: MagicChipActivity }
-  | { kind: 'answering'; markdown: string; activity: MagicChipActivity }
-  | { kind: 'settled'; markdown: string };
+  | {
+      kind: 'settled';
+      markdown: string;
+      /** How the turn ended, when it ended as anything but a clean answer. */
+      activity?: MagicChipActivity;
+    };
 
 export type MagicChipPresentationInput = {
   persistedStatus: MagicChipStatus;
@@ -84,7 +89,11 @@ function toolActivity(
 
 function partActivity(part: MessagePart): MagicChipActivity {
   return match(part)
-    .with({ kind: 'text' }, () => ({ label: 'Writing response', busy: false }))
+    .with({ kind: 'text' }, ({ text }) => ({
+      label: 'Writing response',
+      detail: text.trim() || undefined,
+      busy: true,
+    }))
     .with({ kind: 'thought' }, ({ text }) => ({
       label: 'Thinking',
       detail: text.trim() || undefined,
@@ -235,16 +244,18 @@ function liveEventActivity(
   return statusActivity(name);
 }
 
+/**
+ * The agent's latest prose, which is the trailing text part and only that.
+ *
+ * The fold coalesces streamed chunks into the trailing text part, so a text
+ * part that is no longer last is something the agent said and then moved on
+ * from — narration before a tool call, not the turn's answer. Only the last
+ * one is the answer, and only a finished turn has one.
+ */
 function answerMarkdown(response: FoldedMessage | undefined): string {
-  return (
-    response?.parts
-      .filter(
-        (part): part is Extract<MessagePart, { kind: 'text' }> =>
-          part.kind === 'text' && Boolean(part.text.trim())
-      )
-      .map((part) => part.text)
-      .join('\n\n') ?? ''
-  );
+  const latest = response?.parts.at(-1);
+  if (latest?.kind !== 'text' || !latest.text.trim()) return '';
+  return latest.text;
 }
 
 /** Project fold and lifecycle facts into the one state the view renders. */
@@ -253,9 +264,18 @@ export function deriveMagicChipPresentation(
 ): MagicChipPresentation {
   const { response, prompt, latestEvent, persistedStatus } = input;
 
+  // Only a finished turn earns the chip's full height, and every ending
+  // qualifies: a turn cut short still leaves prose worth reading, with the
+  // reason it stopped kept underneath.
   const markdown = answerMarkdown(response);
-  if (response?.stop?.kind === 'end_turn' && markdown) {
-    return { kind: 'settled', markdown };
+  if (response?.stop && markdown) {
+    return {
+      kind: 'settled',
+      markdown,
+      ...(response.stop.kind === 'end_turn'
+        ? {}
+        : { activity: turnEndedActivity(response) }),
+    };
   }
 
   // Best available answer first: how the turn ended, then what it is doing,
@@ -268,12 +288,6 @@ export function deriveMagicChipPresentation(
     (prompt ? { label: 'Waiting for agent', busy: true } : undefined) ??
     liveEventActivity(latestEvent, 'acp_ready') ??
     statusActivity(persistedStatus);
-
-  // Prose the turn has not closed on yet. The fold appends into the trailing
-  // text part as chunks land, so this is the answer being written, and the
-  // activity stays alongside it to say what the agent is doing between
-  // sentences.
-  if (markdown) return { kind: 'answering', markdown, activity };
 
   return { kind: 'working', activity };
 }


### PR DESCRIPTION
## Problem

Two things, both visible on any Cursor session that narrates between tool calls:

1. **The chip stacked the whole turn's commentary.** `answerMarkdown` joined *every* text part of the folded turn, so what you read was the sum of all chunks up to that point rather than the agent's reply.
2. **The chip grew and shrank while the agent worked**, and a long `Thinking` detail could extend well past the right edge of the message it sits in.

## Fix

**Only the last chunk is the answer.** The fold coalesces streamed chunks into the trailing text part ([`agent_fold` `append_text`](../blob/main/crates/agent_fold/src/domain/fold.rs#L1048)), so a text part that is no longer last is exactly a chunk the agent moved on from. The answer is the trailing text part and only that.

**One fixed row until the answer.** Mid-turn prose now rides the activity line as its `detail` rather than rendering as a block, so a running turn is one `h-6` row from the first event to the last. The message below never shifts while the agent works, and an arbitrarily long thought truncates at whatever width the message gives it. The chip takes real height at exactly one moment — when the turn ends.

`MagicChipPresentation` drops from three states to two (`working` | `settled`) as a result. Any ending settles now, not just `end_turn`, so a cancelled or failed turn still shows the prose it managed with the reason underneath.

## Verification

Driven against a live local stack with real Cursor turns.

**Height, sampled every 250ms across an 87-second turn** — 348 in-flight samples, one distinct height, zero horizontal escapes:

```
inFlightHeights: [[24, 348]]     // 24px, every sample
overflowEscapes: []              // nothing ever wider than the chip
```

```
t=0.0   Waiting for agent   h=24
t=1.3   Thinking            h=24
t=5.0   Writing response    h=24
t=7.3   web_search          h=24
...     (13 transitions)    h=24
t=87.3  Open session        h=2161   <- the one moment it grows
```

**Content** — settled on a single 5.5k-char answer opening *"Octopuses are the closest thing the ocean has to an alien neighbor"*, with none of the four narration chunks from that turn leaking in.

`bun run check` (tsc + biome) clean; 13 tests pass.

## Note for review

If a turn ends on a *tool call* after its last prose, the chip shows "Agent finished without a response" rather than that earlier prose. Consistent with the rule above and Cursor normally ends turns with prose, but it is a live behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Lexical Magic Chip UI and presentation derivation; behavior changes for edge cases (e.g. turn ending on a tool after prose) but no auth, data, or API surface changes.
> 
> **Overview**
> Fixes Magic Chip layout and content during agent turns: **mid-turn narration no longer stacks or expands the chip**, and **settled answers use only the final text chunk**, not every narration segment in the turn.
> 
> **Presentation model** drops the `answering` state (`working` | `settled` only). `answerMarkdown` now reads only the **trailing** text part (aligned with fold coalescing); streaming prose appears on the activity line as `detail` with “Writing response”. Turns that end with prose settle for any `stop` kind, with optional footer activity for non–`end_turn` endings (e.g. cancelled).
> 
> **`MagicChipView`** uses one grid: quoted markdown when settled, then either the fixed **`h-6`** activity row or “Open session”. Activity line gets `overflow-hidden`, `flex-1`, and truncation so long thoughts/commands stay within the message width.
> 
> Tests in `presentation.test.ts` cover the new derivation rules (including last-chunk answer and narration dropped after a tool).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d959700d39dfb72c22e7f9db95248b5cdb834a13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->