### PR TITLE
fix(email): order thread messages null-safe so previews resolve the subject

### DIFF
--- a/.sqlx/query-773d0b6612870f6750de395ca225fb4d180682d34c80b269bf53edba5a93e3a3.json
+++ b/.sqlx/query-773d0b6612870f6750de395ca225fb4d180682d34c80b269bf53edba5a93e3a3.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id, provider_id, thread_id, provider_thread_id, replying_to_id,\n            global_id, link_id, provider_history_id, internal_date_ts, snippet,\n            size_estimate, subject, sent_at, has_attachments, is_read, is_starred,\n            is_sent, is_draft, body_text, body_html_sanitized, body_macro,\n            headers_jsonb, created_at, updated_at\n        FROM email_messages\n        WHERE thread_id = $1\n        ORDER BY internal_date_ts DESC\n        LIMIT $2 OFFSET $3\n        ",
+  "query": "\n        SELECT\n            id, provider_id, thread_id, provider_thread_id, replying_to_id,\n            global_id, link_id, provider_history_id, internal_date_ts, snippet,\n            size_estimate, subject, sent_at, has_attachments, is_read, is_starred,\n            is_sent, is_draft, body_text, body_html_sanitized, body_macro,\n            headers_jsonb, created_at, updated_at\n        FROM email_messages\n        WHERE thread_id = $1\n        ORDER BY COALESCE(internal_date_ts, sent_at, created_at) DESC, id DESC\n        LIMIT $2 OFFSET $3\n        ",
   "describe": {
     "columns": [
       {
@@ -158,5 +158,5 @@
       false
     ]
   },
-  "hash": "f95b295c9ffa7b96a7907c43c0557d60af3f02fc72c3f541bc94c903034a6748"
+  "hash": "773d0b6612870f6750de395ca225fb4d180682d34c80b269bf53edba5a93e3a3"
 }

--- a/crates/email/fixtures/email_thread.sql
+++ b/crates/email/fixtures/email_thread.sql
@@ -38,3 +38,20 @@ INSERT INTO email_messages (id, provider_id, thread_id, link_id, internal_date_t
 VALUES
     ('22222222-aaaa-0001-aaaa-222222222222', 'msg-2-only', '22222222-2222-2222-2222-222222222222', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
      '2025-02-01 12:00:00+00', 'Thread 2 message', 'Different thread', true, false, false, false, '2025-02-01 12:00:00+00', '2025-02-01 12:00:00+00');
+
+-- Thread 4: a dateless, subjectless message alongside the real subject-bearing
+-- message. Under a bare `ORDER BY internal_date_ts DESC` the NULL date sorts first,
+-- so a limit-1 fetch returns the subjectless message instead of the newest real one.
+INSERT INTO email_threads (id, provider_id, link_id, inbox_visible, is_read, latest_inbound_message_ts, latest_non_spam_message_ts, created_at, updated_at)
+VALUES
+    ('44444444-4444-4444-4444-444444444444', 'provider-thread-4', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', true, false,
+     '2025-03-02 09:00:00+00', '2025-03-02 09:00:00+00', '2025-03-01 00:00:00+00', '2025-03-02 09:00:00+00');
+
+INSERT INTO email_messages (id, provider_id, thread_id, link_id, internal_date_ts, sent_at, snippet, subject, is_read, is_sent, is_draft, has_attachments, created_at, updated_at)
+VALUES
+    -- Real latest message: has a date and the thread's subject.
+    ('44444444-aaaa-0001-aaaa-444444444444', 'msg-4-real', '44444444-4444-4444-4444-444444444444', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+     '2025-03-02 09:00:00+00', NULL, 'Latest reply', 'Change workspace name and emails', false, false, false, false, '2025-03-02 09:00:00+00', '2025-03-02 09:00:00+00'),
+    -- Dateless, subjectless message created earlier: NULL internal_date_ts sorts first under a bare DESC.
+    ('44444444-aaaa-0002-aaaa-444444444444', 'msg-4-dateless', '44444444-4444-4444-4444-444444444444', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+     NULL, NULL, 'Dateless message', NULL, true, false, false, false, '2025-03-01 08:00:00+00', '2025-03-01 08:00:00+00');

--- a/crates/email/src/outbound/email_pg_repo/test/thread.rs
+++ b/crates/email/src/outbound/email_pg_repo/test/thread.rs
@@ -253,6 +253,42 @@ async fn test_messages_by_thread_id_paginated_fields_populated(
     migrator = "MACRO_DB_MIGRATIONS",
     fixtures(path = "../../../../fixtures", scripts("email_thread"))
 )]
+async fn test_messages_by_thread_id_paginated_dateless_message_not_page_head(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    // Thread 4 has a real dated message carrying the subject and an earlier dateless,
+    // subjectless one. A single-row fetch must return the subject-bearing message, not
+    // the dateless one that a bare `internal_date_ts DESC` floats to the top on NULL.
+    let repo = EmailPgRepo::new(pool);
+
+    let thread_id = Uuid::parse_str("44444444-4444-4444-4444-444444444444")?;
+
+    let preview = repo
+        .messages_by_thread_id_paginated(thread_id, 0, 1)
+        .await?;
+    assert_eq!(preview.len(), 1);
+    assert_eq!(preview[0].provider_id.as_deref(), Some("msg-4-real"));
+    assert_eq!(
+        preview[0].subject.as_deref(),
+        Some("Change workspace name and emails"),
+        "limit-1 fetch must return the subject-bearing message"
+    );
+
+    // The dateless message still comes back, ordered after the real one.
+    let all = repo
+        .messages_by_thread_id_paginated(thread_id, 0, 50)
+        .await?;
+    assert_eq!(all.len(), 2);
+    assert_eq!(all[0].provider_id.as_deref(), Some("msg-4-real"));
+    assert_eq!(all[1].provider_id.as_deref(), Some("msg-4-dateless"));
+
+    Ok(())
+}
+
+#[sqlx::test(
+    migrator = "MACRO_DB_MIGRATIONS",
+    fixtures(path = "../../../../fixtures", scripts("email_thread"))
+)]
 async fn test_latest_content_messages_are_batched_and_exclude_drafts(
     pool: Pool<Postgres>,
 ) -> anyhow::Result<()> {

--- a/crates/email/src/outbound/email_pg_repo/thread.rs
+++ b/crates/email/src/outbound/email_pg_repo/thread.rs
@@ -72,7 +72,7 @@ pub(super) async fn messages_by_thread_id_paginated(
             headers_jsonb, created_at, updated_at
         FROM email_messages
         WHERE thread_id = $1
-        ORDER BY internal_date_ts DESC
+        ORDER BY COALESCE(internal_date_ts, sent_at, created_at) DESC, id DESC
         LIMIT $2 OFFSET $3
         "#,
         thread_id,


### PR DESCRIPTION
Email mention previews re-resolve the subject via `getThread(limit:1)` and read `messages[0].subject`, but `messages_by_thread_id_paginated` ordered by a bare `internal_date_ts DESC` (NULLS FIRST, no tiebreaker), so a NULL-date message floated to the page head and a single-row fetch landed on it — rendering "No Subject" while opening the thread showed the real one. Reorders by `COALESCE(internal_date_ts, sent_at, created_at) DESC, id DESC` (matching `latest_content_message_rows`) so the page head is deterministic and null-safe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped read-path SQL ordering change with fixture coverage; no schema or write-path changes.
> 
> **Overview**
> Fixes **wrong thread subject in mention previews** when a thread includes a message with a NULL `internal_date_ts`. A `limit: 1` fetch used the first row from `messages_by_thread_id_paginated`, but ordering by bare `internal_date_ts DESC` put NULLs at the top, so previews showed **"No Subject"** even though the real latest message had a subject.
> 
> **`messages_by_thread_id_paginated`** now orders by `COALESCE(internal_date_ts, sent_at, created_at) DESC, id DESC`, matching **`latest_content_message_rows`** for a deterministic, null-safe “newest message” head. The sqlx offline query artifact is updated accordingly.
> 
> Adds **Thread 4** fixture data (dated subject-bearing message + earlier dateless/subjectless message) and an integration test asserting limit-1 returns the subject-bearing message and full pagination still returns both in the right order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aa3211668b2764b734182161cc53aaa204143a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->