### PR TITLE
refactor(ci): use determinator for affected packages

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@
 # `cargo x <subcommand>` runs xtask from anywhere in the repository:
 #   cargo x workflows [--check]      # regenerate / verify .github/workflows
 #   cargo x deps [--check]           # regenerate / verify workspace-hack + dep closures
-#   cargo x nextest-filter <file>    # nextest rdeps filter for changed files
+#   cargo x nextest-filter <file> <base-revision> # affected packages for changed files
 #   cargo x doppler-bins <file>      # Doppler config-validation bins affected by changed files
 #   cargo x graphql-soup-schema <file> # export GraphQL Soup SDL to a file
 #   cargo x cache-wasm [--force]     # build the browser cache wasm package

--- a/.github/workflows/code_check_cloud_storage.yml
+++ b/.github/workflows/code_check_cloud_storage.yml
@@ -70,6 +70,10 @@ jobs:
       run: |
         set -euo pipefail
 
+        # Compare against the merge-base so a deleted file still appears. `--no-renames`
+        # turns a rename into a delete+add pair so the old path is attributed to its
+        # package (otherwise git reports only the new name).
+
         if [ -z "${GITHUB_BASE_REF:-}" ]; then
           compare_rev="$(git rev-parse HEAD~1)"
         else
@@ -81,7 +85,8 @@ jobs:
           fi
         fi
 
-        git diff --name-only "$compare_rev" "$GITHUB_SHA" > /tmp/changed-files
+        printf '%s\n' "$compare_rev" > /tmp/base-revision
+        git diff --name-only --no-renames "$compare_rev" "$GITHUB_SHA" > /tmp/changed-files
       shell: bash
     - id: doppler-bins
       name: compute affected Doppler config bins
@@ -109,7 +114,8 @@ jobs:
         # live Postgres (SQLX_OFFLINE is unset there), so `.sqlx` contents cannot change
         # test outcomes, and a query change always comes with a source change in the
         # owning crate, which the package filter below already maps.
-        if grep -qE '^(Cargo\.(toml|lock)|rust-toolchain\.toml|Cross\.toml|clippy\.toml|deny\.toml|\.cargo/.*|\.config/.*|flake\.nix|flake\.lock|\.github/actions/(setup-rust|setup-nix|setup-nix-dev-shell|setup-sccache)/.*|\.github/workflows/code_check_cloud_storage\.yml)$' /tmp/changed-files; then
+        # Cargo.lock is omitted: determinator compares the old and new Cargo graphs.
+        if grep -qE '^(Cargo\.toml|rust-toolchain\.toml|Cross\.toml|clippy\.toml|deny\.toml|\.cargo/.*|\.config/.*|flake\.nix|flake\.lock|\.github/actions/(setup-rust|setup-nix|setup-nix-dev-shell|setup-sccache)/.*|\.github/workflows/code_check_cloud_storage\.yml)$' /tmp/changed-files; then
           echo "Workspace-level change detected; running all tests"
           echo "nextest_filter=" >> "$GITHUB_OUTPUT"
           exit 0
@@ -125,13 +131,35 @@ jobs:
           exit 0
         fi
 
-        filterset="$(cargo run --manifest-path tooling/xtask/Cargo.toml -- nextest-filter /tmp/changed-files)"
-
-        if [ -z "$filterset" ]; then
-          echo "No package-specific Rust changes detected; running all tests"
-        else
-          echo "nextest filter: $filterset"
+        if [ ! -s /tmp/changed-files ] || [ ! -s /tmp/base-revision ]; then
+          echo "Unknown or empty change set; running all tests"
+          echo "nextest_filter=" >> "$GITHUB_OUTPUT"
+          exit 0
         fi
+
+        packages="$(cargo run --manifest-path tooling/xtask/Cargo.toml -- nextest-filter /tmp/changed-files "$(< /tmp/base-revision)")"
+
+        # Keep the current nextest filterset contract so this PR can land without the
+        # `-p` runner rewrite. `all` / empty / `none` still mean "run the full suite"
+        # here; a follow-up can switch bash to `rust_packages` and treat `none` as skip.
+        if [ -z "$packages" ] || [ "$packages" = "all" ] || [ "$packages" = "none" ]; then
+          echo "No package-specific Rust changes detected; running all tests"
+          echo "nextest_filter=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        filterset=""
+        for package in $packages; do
+          escaped="${package//\\/\\\\}"
+          escaped="${escaped//)/\\)}"
+          escaped="${escaped//,/\\,}"
+          if [ -n "$filterset" ]; then
+            filterset="${filterset}|"
+          fi
+          filterset="${filterset}rdeps(=${escaped})"
+        done
+
+        echo "nextest filter: $filterset"
         echo "nextest_filter=$filterset" >> "$GITHUB_OUTPUT"
       shell: bash
   check:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4925,6 +4925,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "determinator"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf14b901cdfba3f731d01c4c184100e85f586a272d38874824175b845dbaeaf9"
+dependencies = [
+ "camino",
+ "globset",
+ "guppy",
+ "guppy-workspace-hack",
+ "once_cell",
+ "petgraph 0.6.5",
+ "rayon",
+ "serde",
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "device-info"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18702,8 +18719,11 @@ name = "xtask_nextest_filter"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "determinator",
  "guppy",
+ "tempfile",
  "xtask_graph",
+ "xtask_paths",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,7 @@ cron = "0.16.0"
 csv = "1"
 dashmap = "6.1.0"
 dateparser = "0.2.1"
+determinator = "0.12.0"
 dotenvy = "0.15.7"
 ego-tree = "0.6.2"
 either = "1"
@@ -284,6 +285,7 @@ sqlx = { version = "0.8.6", features = [
 ] }
 sqlx-core = { version = "0.8.6" }
 strum = { version = "0.27.1", features = ["derive"] }
+tempfile = "3"
 thiserror = "2.0.0"
 time = "0.3.37"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }

--- a/crates/client/cache-turso/Cargo.toml
+++ b/crates/client/cache-turso/Cargo.toml
@@ -26,7 +26,7 @@ pollster = { workspace = true }
 serde_json = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { workspace = true }

--- a/services/upload_extractor_lambda_handler/Cargo.toml
+++ b/services/upload_extractor_lambda_handler/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = { workspace = true }
 macro_service_urls = { path = "../../crates/macro_service_urls" }
 sha2 = { workspace = true }
 sqs_client = { path = "../../crates/sqs_client" }
-tempfile = "3.19.1"
+tempfile = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }

--- a/tooling/seed_cli/Cargo.toml
+++ b/tooling/seed_cli/Cargo.toml
@@ -51,4 +51,4 @@ uuid = { workspace = true }
 workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }

--- a/tooling/xtask/crates/xtask_graph/src/lib.rs
+++ b/tooling/xtask/crates/xtask_graph/src/lib.rs
@@ -5,6 +5,8 @@
 //! Anchors `cargo metadata` on the workspace root (from [`xtask_paths`]) so
 //! the task works from anywhere in the repo.
 
+use std::path::Path;
+
 use anyhow::{Context, Result};
 use guppy::MetadataCommand;
 use guppy::graph::PackageGraph;
@@ -16,8 +18,13 @@ use guppy::graph::PackageGraph;
 /// silently rewritten.
 pub fn build_graph(locked: bool) -> Result<PackageGraph> {
     let workspace_dir = xtask_paths::workspace_root();
+    build_graph_at(&workspace_dir, locked)
+}
+
+/// Build a [`PackageGraph`] for the workspace rooted at `workspace_dir`.
+pub fn build_graph_at(workspace_dir: &Path, locked: bool) -> Result<PackageGraph> {
     let mut cmd = MetadataCommand::new();
-    cmd.current_dir(&workspace_dir);
+    cmd.current_dir(workspace_dir);
     if locked {
         cmd.other_options(vec!["--locked".to_owned()]);
     }

--- a/tooling/xtask/crates/xtask_local/src/main.rs
+++ b/tooling/xtask/crates/xtask_local/src/main.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 
 /// The repo-automation verbs handled by the launcher. Shown alongside this
 /// crate's own clap usage when an unrecognized command reaches the parser.
-const LAUNCHER_USAGE: &str = "repo automation (from the repository root):\n  cargo x deps [--check]\n  cargo x nextest-filter <changed-files-path>\n  cargo x doppler-bins <changed-files-path>\n  cargo x graphql-soup-schema <output-path>\n  cargo x cache-wasm [--force]\n  cargo x kafka-topics [--check]\n  cargo x workflows [--check]";
+const LAUNCHER_USAGE: &str = "repo automation (from the repository root):\n  cargo x deps [--check]\n  cargo x nextest-filter <changed-files-path> <base-revision>\n  cargo x doppler-bins <changed-files-path>\n  cargo x graphql-soup-schema <output-path>\n  cargo x cache-wasm [--force]\n  cargo x kafka-topics [--check]\n  cargo x workflows [--check]";
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();

--- a/tooling/xtask/crates/xtask_nextest_filter/Cargo.toml
+++ b/tooling/xtask/crates/xtask_nextest_filter/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-description = "xtask nextest-filter: nextest rdeps package filter for a set of changed files"
+description = "xtask nextest-filter: affected Cargo packages for a set of changed files"
 edition = "2024"
 name = "xtask_nextest_filter"
 publish = false
@@ -11,5 +11,8 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+determinator = { workspace = true }
 guppy = { workspace = true }
+tempfile = { workspace = true }
 xtask_graph = { path = "../xtask_graph" }
+xtask_paths = { path = "../xtask_paths" }

--- a/tooling/xtask/crates/xtask_nextest_filter/determinator.toml
+++ b/tooling/xtask/crates/xtask_nextest_filter/determinator.toml
@@ -1,0 +1,12 @@
+use-default-rules = false
+
+[[path-rule]]
+globs = ["static_assets/**"]
+mark-changed = [
+  "cache-core",
+  "collab_surface",
+  "complete_graph",
+  "documents",
+  "seed_cli",
+  "xtask_workflows",
+]

--- a/tooling/xtask/crates/xtask_nextest_filter/src/main.rs
+++ b/tooling/xtask/crates/xtask_nextest_filter/src/main.rs
@@ -1,136 +1,223 @@
-//! `cargo x nextest-filter <changed-files-path>`
+//! `cargo x nextest-filter <changed-files-path> <base-revision>`
 //!
-//! Computes the cargo-nextest package filter for Rust CI.
+//! Computes the set of workspace packages cargo nextest / clippy should run
+//! for Rust CI using [`determinator`].
 //!
 //! Input is a newline-delimited file of paths relative to the repository root
-//! (typically `git diff --name-only ...`). For each changed path inside the
-//! Rust workspace, find the deepest workspace package containing that
-//! path using Cargo's own workspace metadata via guppy. Shared files that
-//! crates embed from outside their own directory are mapped through
-//! [`EMBEDDED_ASSET_PACKAGES`]. The resulting nextest expression runs tests
-//! for reverse dependencies of every changed package.
+//! (typically `git diff --name-only ...`) and a Git base revision. The command
+//! builds Cargo metadata for the base and current revisions, then lets
+//! determinator account for path, dependency, and feature changes. Shared
+//! inputs that Cargo does not know about are declared in `determinator.toml`.
+//!
+//! Stdout is one of:
+//! - `all` — every workspace package is affected.
+//! - `none` — no changed file mapped to a package (a top-level JSON, a Nix
+//!   shell tweak, docs, …). CI must not treat this as "run everything".
+//! - space-separated package names — pass each as `cargo nextest run -p` /
+//!   `cargo clippy -p`.
 
 use std::collections::BTreeSet;
+use std::fmt;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, bail};
-use guppy::graph::PackageGraph;
+use determinator::Determinator;
+use determinator::rules::{DeterminatorRules, PathMatch};
+use guppy::graph::{DependencyDirection, PackageGraph};
+use tempfile::TempDir;
+#[cfg(test)]
 use xtask_graph::build_graph;
+use xtask_graph::build_graph_at;
 
 #[cfg(test)]
 mod test;
 
-/// Workspace paths that crates consume at compile time from outside their own
-/// directory (`include_str!`/`include_bytes!` or `build.rs` reads), mapped to
-/// the consuming packages. Directory containment cannot attribute these, so
-/// without an entry here a change to such a file would select no tests
-/// whenever the PR also touches a package. The drift test in `test.rs` keeps
-/// this table in sync with the source tree, and every run validates the
-/// package names against the workspace so a rename fails loudly.
-const EMBEDDED_ASSET_PACKAGES: &[(&str, &[&str])] = &[(
-    "static_assets",
-    &[
-        "cache-core",
-        "collab_surface",
-        "complete_graph",
-        "documents",
-        "seed_cli",
-        "xtask_workflows",
-    ],
-)];
+const DETERMINATOR_RULES: &str = include_str!("../determinator.toml");
 
-fn main() -> Result<()> {
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    match args.iter().map(String::as_str).collect::<Vec<_>>()[..] {
-        [changed_files_path] => {
-            // Read-only: `--locked` so computing the filter never rewrites Cargo.lock.
-            let graph = build_graph(true)?;
-            run(&graph, Path::new(changed_files_path))
+/// Which workspace packages Rust CI should compile and test.
+///
+/// Stringified only at the CLI seam (`Display`) so bash can switch on `all`,
+/// `none`, or a space-separated package list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PackageSelection {
+    /// Every workspace package is affected.
+    All,
+    /// No changed file mapped to a package.
+    None,
+    /// Changed packages plus reverse dependencies.
+    Packages(BTreeSet<String>),
+}
+
+impl fmt::Display for PackageSelection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::All => f.write_str("all"),
+            Self::None => f.write_str("none"),
+            Self::Packages(packages) => {
+                let mut first = true;
+                for name in packages {
+                    if !first {
+                        f.write_str(" ")?;
+                    }
+                    first = false;
+                    f.write_str(name)?;
+                }
+                Ok(())
+            }
         }
-        _ => bail!("usage: cargo x nextest-filter <changed-files-path>"),
     }
 }
 
-fn run(graph: &PackageGraph, changed_files_path: &Path) -> Result<()> {
+#[cfg(test)]
+impl PackageSelection {
+    fn packages(&self) -> Option<&BTreeSet<String>> {
+        match self {
+            Self::Packages(packages) => Some(packages),
+            Self::All | Self::None => None,
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let args: Vec<_> = std::env::args_os().skip(1).collect();
+    match args.as_slice() {
+        [changed_files_path, base_revision] => {
+            let base_revision = base_revision
+                .to_str()
+                .context("base revision is not valid UTF-8")?;
+            run(Path::new(changed_files_path), base_revision)
+        }
+        _ => bail!("usage: cargo x nextest-filter <changed-files-path> <base-revision>"),
+    }
+}
+
+fn run(changed_files_path: &Path, base_revision: &str) -> Result<()> {
     let changed_files = std::fs::read_to_string(changed_files_path).with_context(|| {
         format!(
             "reading changed files from {}",
             changed_files_path.display()
         )
     })?;
+    let changed_files: Vec<PathBuf> = changed_files
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .collect();
 
-    let filter = compute_filter(graph, &changed_files)?;
-    println!("{filter}");
+    let workspace_dir = xtask_paths::workspace_root();
+    let base_worktree = BaseWorktree::new(&workspace_dir, base_revision)?;
+    let (old_graph, new_graph) = build_graphs(base_worktree.path(), &workspace_dir)?;
+    let packages = compute_packages(&old_graph, &new_graph, &changed_files)?;
+    println!("{packages}");
     Ok(())
 }
 
-/// Map each changed path to its owning workspace package (or embedded-asset
-/// consumers) and combine them into one nextest filterset expression. An
-/// empty result means no changed file mapped to a package; CI treats that as
-/// "run everything".
-fn compute_filter(graph: &PackageGraph, changed_files: &str) -> Result<String> {
-    let workspace = graph.workspace();
-    let ws_root = workspace.root();
-    let repo_root = ws_root;
+fn build_graphs(base_dir: &Path, current_dir: &Path) -> Result<(PackageGraph, PackageGraph)> {
+    Ok((
+        build_graph_at(base_dir, true)?,
+        build_graph_at(current_dir, true)?,
+    ))
+}
 
-    let packages = workspace
-        .iter()
-        .map(|package| {
-            let dir = package
-                .manifest_path()
-                .parent()
-                .with_context(|| format!("manifest {} has no parent", package.manifest_path()))?;
-            Ok((PathBuf::from(dir.as_std_path()), package.name().to_owned()))
-        })
-        .collect::<Result<Vec<_>>>()?;
+/// Use determinator to compare both Cargo graphs and return affected package
+/// names. Paths outside Cargo packages contribute nothing, preserving the CI
+/// behavior for Nix-only and other non-Rust changes.
+fn compute_packages(
+    old_graph: &PackageGraph,
+    new_graph: &PackageGraph,
+    changed_files: &[PathBuf],
+) -> Result<PackageSelection> {
+    let rules = DeterminatorRules::parse(DETERMINATOR_RULES)
+        .context("parsing nextest determinator rules")?;
+    let mut determinator = Determinator::new(old_graph, new_graph);
+    determinator
+        .set_rules(&rules)
+        .context("applying nextest determinator rules")?;
 
-    let package_names: BTreeSet<&str> = packages.iter().map(|(_, name)| name.as_str()).collect();
-    for (prefix, names) in EMBEDDED_ASSET_PACKAGES {
-        if let Some(name) = names.iter().find(|name| !package_names.contains(**name)) {
+    for changed_file in changed_files {
+        let changed_file = changed_file
+            .to_str()
+            .context("changed file path is not valid UTF-8")?;
+        if !matches!(
+            determinator.match_path(changed_file, |_| {}),
+            PathMatch::NoMatches
+        ) {
+            determinator.add_changed_paths([changed_file]);
+        }
+    }
+
+    let affected = determinator.compute().affected_set;
+    let packages: BTreeSet<_> = affected
+        .packages(DependencyDirection::Forward)
+        .filter(|package| package.in_workspace())
+        .map(|package| package.name().to_owned())
+        .collect();
+
+    if packages.is_empty() {
+        return Ok(PackageSelection::None);
+    }
+
+    if packages.len() == new_graph.workspace().iter().count() {
+        return Ok(PackageSelection::All);
+    }
+
+    Ok(PackageSelection::Packages(packages))
+}
+
+struct BaseWorktree {
+    repo_root: PathBuf,
+    path: PathBuf,
+    _temp_dir: TempDir,
+}
+
+impl BaseWorktree {
+    fn new(repo_root: &Path, revision: &str) -> Result<Self> {
+        let temp_dir = tempfile::Builder::new()
+            .prefix("nextest-determinator-")
+            .tempdir()
+            .context("creating temporary directory for base worktree")?;
+        let path = temp_dir.path().join("base");
+        let output = Command::new("git")
+            .current_dir(repo_root)
+            .args(["worktree", "add", "--detach"])
+            .arg(&path)
+            .arg(revision)
+            .output()
+            .context("creating base Git worktree")?;
+        if !output.status.success() {
             bail!(
-                "EMBEDDED_ASSET_PACKAGES maps `{prefix}` to `{name}`, which is not a \
-                 workspace package; update the table in {}",
-                file!()
+                "creating base Git worktree failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+
+        Ok(Self {
+            repo_root: repo_root.to_owned(),
+            path,
+            _temp_dir: temp_dir,
+        })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for BaseWorktree {
+    fn drop(&mut self) {
+        let result = Command::new("git")
+            .current_dir(&self.repo_root)
+            .args(["worktree", "remove", "--force"])
+            .arg(&self.path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        if !matches!(result, Ok(status) if status.success()) {
+            eprintln!(
+                "warning: failed to unregister temporary worktree {}",
+                self.path.display()
             );
         }
     }
-
-    let mut changed_packages = BTreeSet::new();
-    for changed_file in changed_files.lines().filter(|line| !line.is_empty()) {
-        for (prefix, names) in EMBEDDED_ASSET_PACKAGES {
-            if Path::new(changed_file).starts_with(prefix) {
-                changed_packages.extend(names.iter().map(|name| (*name).to_owned()));
-            }
-        }
-
-        let path = repo_root
-            .join(changed_file)
-            .canonicalize()
-            .unwrap_or_else(|_| repo_root.join(changed_file).into());
-        if path != ws_root.as_std_path() && !path.starts_with(ws_root.as_std_path()) {
-            continue;
-        }
-
-        let package = packages
-            .iter()
-            .filter(|(dir, _)| path == *dir || path.starts_with(dir))
-            .max_by_key(|(dir, _)| dir.components().count())
-            .map(|(_, name)| name);
-
-        if let Some(name) = package {
-            changed_packages.insert(name.clone());
-        }
-    }
-
-    Ok(changed_packages
-        .into_iter()
-        .map(|name| format!("rdeps(={})", escape_nextest_name(&name)))
-        .collect::<Vec<_>>()
-        .join("|"))
-}
-
-fn escape_nextest_name(name: &str) -> String {
-    name.replace('\\', "\\\\")
-        .replace(')', "\\)")
-        .replace(',', "\\,")
 }

--- a/tooling/xtask/crates/xtask_nextest_filter/src/test.rs
+++ b/tooling/xtask/crates/xtask_nextest_filter/src/test.rs
@@ -1,57 +1,131 @@
 use super::*;
 
-/// A change in a single crate selects only that crate's reverse dependencies.
+fn changed_files(paths: &[&str]) -> Vec<PathBuf> {
+    paths.iter().map(PathBuf::from).collect()
+}
+
+fn selected_packages(selection: &PackageSelection) -> &BTreeSet<String> {
+    selection
+        .packages()
+        .unwrap_or_else(|| panic!("expected targeted packages, got {selection:?}"))
+}
+
+/// The CLI prints `all` / `none` / space-separated names; bash switches on those
+/// tokens and must not see an empty string for an unmapped change.
+#[test]
+fn display_is_the_cli_seam() {
+    assert_eq!(PackageSelection::All.to_string(), "all");
+    assert_eq!(PackageSelection::None.to_string(), "none");
+    assert_eq!(
+        PackageSelection::Packages(BTreeSet::from([
+            "email_validator".to_owned(),
+            "webhook".to_owned(),
+        ]))
+        .to_string(),
+        "email_validator webhook"
+    );
+}
+
+/// A change in a single crate selects that crate and its reverse dependencies,
+/// never the whole workspace.
 #[test]
 fn crate_change_maps_to_rdeps_of_that_crate() {
     let graph = build_graph(false).expect("cargo metadata");
-    let filter = compute_filter(&graph, "crates/email_validator/src/lib.rs\n").unwrap();
-    assert_eq!(filter, "rdeps(=email_validator)");
+    let selection = compute_packages(
+        &graph,
+        &graph,
+        &changed_files(&["crates/email_validator/src/lib.rs"]),
+    )
+    .unwrap();
+    assert_ne!(selection, PackageSelection::None);
+    assert_ne!(selection, PackageSelection::All);
+    assert!(
+        selected_packages(&selection).contains("email_validator"),
+        "changed crate must be selected: {selection:?}"
+    );
 }
 
-/// Changed files inside the workspace that belong to no package (and are not
-/// embedded assets) contribute nothing, leaving the filter empty so CI falls
-/// back to the full suite.
+/// Top-level files that belong to no package — a JSON at the repo root, a
+/// README, a deleted misc file — must not select the full suite.
 #[test]
-fn unmapped_files_alone_yield_empty_filter() {
+fn unmapped_files_alone_yield_none() {
     let graph = build_graph(false).expect("cargo metadata");
-    let filter = compute_filter(&graph, "docs/README.md\njustfile\n").unwrap();
-    assert_eq!(filter, "");
+    let selection = compute_packages(
+        &graph,
+        &graph,
+        &changed_files(&["random.json", "package.json", "docs/README.md", "justfile"]),
+    )
+    .unwrap();
+    assert_eq!(selection, PackageSelection::None);
+}
+
+/// Package-local metadata files still select their package because some are
+/// compile-time inputs (for example, webhook embeds its README).
+#[test]
+fn package_readme_selects_its_package() {
+    let graph = build_graph(false).expect("cargo metadata");
+    let selection = compute_packages(
+        &graph,
+        &graph,
+        &changed_files(&["crates/webhook/README.md"]),
+    )
+    .unwrap();
+    assert!(
+        selected_packages(&selection).contains("webhook"),
+        "package README must select its owner: {selection:?}"
+    );
 }
 
 /// Shared assets embedded into crates from outside their directories select
-/// their consumers, including when the change list also contains ordinary
-/// package files (previously the asset change was silently dropped).
+/// their consumers (and those consumers' reverse deps).
 #[test]
 fn embedded_assets_select_their_consumers() {
     let graph = build_graph(false).expect("cargo metadata");
 
-    let filter = compute_filter(&graph, "static_assets/schema.graphql\n").unwrap();
-    assert_eq!(
-        filter,
-        "rdeps(=cache-core)|rdeps(=collab_surface)|rdeps(=complete_graph)|rdeps(=documents)|rdeps(=seed_cli)|rdeps(=xtask_workflows)"
-    );
-
-    let mixed = compute_filter(
+    let selection = compute_packages(
         &graph,
-        "crates/email_validator/src/lib.rs\nstatic_assets/markdown-golden.1.bin\n",
+        &graph,
+        &changed_files(&["static_assets/schema.graphql"]),
     )
     .unwrap();
-    assert_eq!(
-        mixed,
-        "rdeps(=cache-core)|rdeps(=collab_surface)|rdeps(=complete_graph)|rdeps(=documents)|rdeps(=email_validator)|rdeps(=seed_cli)|rdeps(=xtask_workflows)"
-    );
+    let set = selected_packages(&selection);
+    for expected in [
+        "cache-core",
+        "collab_surface",
+        "complete_graph",
+        "documents",
+        "seed_cli",
+        "xtask_workflows",
+    ] {
+        assert!(
+            set.contains(expected),
+            "embedded asset consumers must include {expected}: {selection:?}"
+        );
+    }
+
+    let mixed = compute_packages(
+        &graph,
+        &graph,
+        &changed_files(&[
+            "crates/email_validator/src/lib.rs",
+            "static_assets/markdown-golden.1.bin",
+        ]),
+    )
+    .unwrap();
+    let mixed_set = selected_packages(&mixed);
+    assert!(mixed_set.contains("email_validator"));
+    assert!(mixed_set.contains("documents"));
+    assert!(mixed_set.contains("collab_surface"));
 }
 
-/// Drift check: every workspace package whose Rust sources mention an
-/// [`EMBEDDED_ASSET_PACKAGES`] path prefix must be listed in the table (and
-/// vice versa), so new compile-time embeds of shared assets never silently
-/// escape the CI test filter. The scan is textual, so a doc-comment mention
-/// counts; listing such a package merely over-selects, which is the safe
-/// direction.
+/// Drift check: every workspace package whose Rust sources mention the shared
+/// asset path must be listed in the determinator rule (and vice versa). The
+/// scan is textual, so a doc-comment mention merely over-selects safely.
 #[test]
 fn embedded_asset_packages_match_source_references() {
     let graph = build_graph(false).expect("cargo metadata");
     let workspace = graph.workspace();
+    let prefix = "static_assets";
 
     let packages: Vec<(PathBuf, String)> = workspace
         .iter()
@@ -66,36 +140,44 @@ fn embedded_asset_packages_match_source_references() {
         collect_rust_files(dir, &mut rust_files);
     }
 
-    for (prefix, expected) in EMBEDDED_ASSET_PACKAGES {
-        let mut found = BTreeSet::new();
-        for file in &rust_files {
-            let content = std::fs::read_to_string(file).unwrap_or_default();
-            if !content.contains(prefix) {
-                continue;
-            }
-            // Attribute the file to its deepest containing package, mirroring
-            // compute_filter, so nested workspaces (tooling/xtask/crates/*)
-            // don't credit the parent package.
-            let owner = packages
-                .iter()
-                .filter(|(dir, _)| file.starts_with(dir))
-                .max_by_key(|(dir, _)| dir.components().count())
-                .map(|(_, name)| name.clone())
-                .expect("rust file collected from a package dir");
-            // This crate's own sources name the prefixes it maps.
-            if owner == env!("CARGO_PKG_NAME") {
-                continue;
-            }
+    let mut found = BTreeSet::new();
+    for file in &rust_files {
+        let content = std::fs::read_to_string(file).unwrap_or_default();
+        if !content.contains(prefix) {
+            continue;
+        }
+        // Attribute the file to its deepest containing package, mirroring
+        // determinator's nearest-package behavior for nested xtask crates.
+        let owner = packages
+            .iter()
+            .filter(|(dir, _)| file.starts_with(dir))
+            .max_by_key(|(dir, _)| dir.components().count())
+            .map(|(_, name)| name.clone())
+            .expect("rust file collected from a package dir");
+        if owner != env!("CARGO_PKG_NAME") {
             found.insert(owner);
         }
-
-        let expected: BTreeSet<String> = expected.iter().map(|name| (*name).to_owned()).collect();
-        assert_eq!(
-            found, expected,
-            "EMBEDDED_ASSET_PACKAGES entry for `{prefix}` is out of sync with the \
-             packages whose Rust sources reference it; update the table in main.rs"
-        );
     }
+
+    let rules = DeterminatorRules::parse(DETERMINATOR_RULES).expect("determinator rules");
+    let mut determinator = Determinator::new(&graph, &graph);
+    determinator.set_rules(&rules).expect("set rules");
+    let mut configured = BTreeSet::new();
+    determinator.match_path("static_assets/drift-check", |id| {
+        configured.insert(
+            graph
+                .metadata(id)
+                .expect("package metadata")
+                .name()
+                .to_owned(),
+        );
+    });
+
+    assert_eq!(
+        found, configured,
+        "determinator rule for `{prefix}` is out of sync with packages whose Rust sources \
+         reference it; update determinator.toml"
+    );
 }
 
 /// Recursively collect `.rs` files under `dir`, skipping hidden and build

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/code_check_cloud_storage.rs
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/code_check_cloud_storage.rs
@@ -181,8 +181,9 @@ fn compute_doppler_bins() -> Step<Run> {
 }
 
 /// Compute the cargo-nextest package filter from the changed files, via the
-/// `xtask nextest-filter` subcommand. Root cargo/toolchain/CI changes
-/// short-circuit to an empty filter (run the whole suite).
+/// `xtask nextest-filter` subcommand. Determinator compares the PR merge-base
+/// against HEAD; root cargo/toolchain/CI changes still short-circuit to an
+/// empty filter (run the whole suite).
 fn compute_nextest_filter() -> Step<Run> {
     Step::new("compute nextest package filter")
         .run(include_str!("scripts/compute_nextest_filter.sh"))

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/scripts/compute_changed_files.sh
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/scripts/compute_changed_files.sh
@@ -1,5 +1,9 @@
 set -euo pipefail
 
+# Compare against the merge-base so a deleted file still appears. `--no-renames`
+# turns a rename into a delete+add pair so the old path is attributed to its
+# package (otherwise git reports only the new name).
+
 if [ -z "${GITHUB_BASE_REF:-}" ]; then
   compare_rev="$(git rev-parse HEAD~1)"
 else
@@ -11,4 +15,5 @@ else
   fi
 fi
 
-git diff --name-only "$compare_rev" "$GITHUB_SHA" > /tmp/changed-files
+printf '%s\n' "$compare_rev" > /tmp/base-revision
+git diff --name-only --no-renames "$compare_rev" "$GITHUB_SHA" > /tmp/changed-files

--- a/tooling/xtask/crates/xtask_workflows/src/workflows/scripts/compute_nextest_filter.sh
+++ b/tooling/xtask/crates/xtask_workflows/src/workflows/scripts/compute_nextest_filter.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 # live Postgres (SQLX_OFFLINE is unset there), so `.sqlx` contents cannot change
 # test outcomes, and a query change always comes with a source change in the
 # owning crate, which the package filter below already maps.
-if grep -qE '^(Cargo\.(toml|lock)|rust-toolchain\.toml|Cross\.toml|clippy\.toml|deny\.toml|\.cargo/.*|\.config/.*|flake\.nix|flake\.lock|\.github/actions/(setup-rust|setup-nix|setup-nix-dev-shell|setup-sccache)/.*|\.github/workflows/code_check_cloud_storage\.yml)$' /tmp/changed-files; then
+# Cargo.lock is omitted: determinator compares the old and new Cargo graphs.
+if grep -qE '^(Cargo\.toml|rust-toolchain\.toml|Cross\.toml|clippy\.toml|deny\.toml|\.cargo/.*|\.config/.*|flake\.nix|flake\.lock|\.github/actions/(setup-rust|setup-nix|setup-nix-dev-shell|setup-sccache)/.*|\.github/workflows/code_check_cloud_storage\.yml)$' /tmp/changed-files; then
   echo "Workspace-level change detected; running all tests"
   echo "nextest_filter=" >> "$GITHUB_OUTPUT"
   exit 0
@@ -21,11 +22,33 @@ if [ -s /tmp/changed-files ] && ! grep -qvE '^\.sqlx/' /tmp/changed-files; then
   exit 0
 fi
 
-filterset="$(cargo run --manifest-path tooling/xtask/Cargo.toml -- nextest-filter /tmp/changed-files)"
-
-if [ -z "$filterset" ]; then
-  echo "No package-specific Rust changes detected; running all tests"
-else
-  echo "nextest filter: $filterset"
+if [ ! -s /tmp/changed-files ] || [ ! -s /tmp/base-revision ]; then
+  echo "Unknown or empty change set; running all tests"
+  echo "nextest_filter=" >> "$GITHUB_OUTPUT"
+  exit 0
 fi
+
+packages="$(cargo run --manifest-path tooling/xtask/Cargo.toml -- nextest-filter /tmp/changed-files "$(< /tmp/base-revision)")"
+
+# Keep the current nextest filterset contract so this PR can land without the
+# `-p` runner rewrite. `all` / empty / `none` still mean "run the full suite"
+# here; a follow-up can switch bash to `rust_packages` and treat `none` as skip.
+if [ -z "$packages" ] || [ "$packages" = "all" ] || [ "$packages" = "none" ]; then
+  echo "No package-specific Rust changes detected; running all tests"
+  echo "nextest_filter=" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+filterset=""
+for package in $packages; do
+  escaped="${package//\\/\\\\}"
+  escaped="${escaped//)/\\)}"
+  escaped="${escaped//,/\\,}"
+  if [ -n "$filterset" ]; then
+    filterset="${filterset}|"
+  fi
+  filterset="${filterset}rdeps(=${escaped})"
+done
+
+echo "nextest filter: $filterset"
 echo "nextest_filter=$filterset" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Extract the Determinator and path-typing work from #5802 into a smaller change that can land independently.

`cargo x nextest-filter` now compares old vs new Cargo graphs via determinator, types changed files as paths, and takes a base revision. Changed-file detection writes that revision and uses `--no-renames` so renames still attribute the old package path.

The CLI prints all/none/package names. Cloud-storage CI still consumes a nextest rdeps filterset so this can merge without the `-p` runner rewrite in #5802.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI test scope depends on determinator, git worktrees, and transitional bash that still runs the full suite for `none`/`all`; mis-selection could skip or over-run tests.
> 
> **Overview**
> **`cargo x nextest-filter`** now takes a **base revision** and uses **[determinator](https://github.com/facebookincubator/determinator)** to compare Cargo metadata at merge-base vs HEAD, so path, dependency, and feature changes drive affected packages. Shared **`static_assets`** embeds moved from a Rust table to **`determinator.toml`**.
> 
> Changed-file detection writes **`/tmp/base-revision`**, uses **`git diff --no-renames`**, and CI passes both files into the xtask. The tool prints **`all`**, **`none`**, or package names; the workflow still builds the existing **`rdeps(...)`** nextest filter from that list. **`Cargo.lock`** is no longer a workspace-wide “run everything” trigger because graph diffs handle lockfile changes.
> 
> Minor: workspace **`tempfile`**, **`xtask_graph::build_graph_at`**, and docs/usage strings updated for the new arity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9092c4a114e24edb23f908aa9f9b7b9456b61efb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->