### PR TITLE
fix(split-layout): hold last layout when the resize zone measures zero

### DIFF
--- a/apps/web/src/lib/core/component/Resize/solver.test.ts
+++ b/apps/web/src/lib/core/component/Resize/solver.test.ts
@@ -711,6 +711,34 @@ describe('createResizeSolver', () => {
 
       dispose();
     });
+
+    it('holds a single split at full width when the zone measures zero', async () => {
+      const [size, setSize] = createSignal(1000);
+      const { solver, dispose } = createRoot((dispose) => ({
+        dispose,
+        solver: createResizeSolver({
+          direction: 'horizontal',
+          gutter: () => 0,
+          size,
+          panels: [],
+        }),
+      }));
+
+      await Promise.resolve();
+
+      solver.addPanel({ id: 'A', minSize: 400 });
+      expect(solver.solve().sizes.get('A')).toBe(1000);
+
+      // Zone momentarily reports 0 (unmeasured / hidden under a popover).
+      setSize(0);
+      expect(solver.solve().sizes.get('A')).toBe(1000);
+
+      // A real measurement still re-solves normally.
+      setSize(800);
+      expect(solver.solve().sizes.get('A')).toBe(800);
+
+      dispose();
+    });
   });
 
   describe('canFitPanel', () => {

--- a/apps/web/src/lib/core/component/Resize/solver.ts
+++ b/apps/web/src/lib/core/component/Resize/solver.ts
@@ -382,18 +382,25 @@ export function createResizeSolver(params: {
   // Preview Pair would keep its crushed proportions after space frees up).
   createEffect(() => {
     const ps = panelsInOrder();
+    const zoneSize = params.size();
+    const gutter = params.gutter();
+
+    // A zero (or negative) zone size means it's unmeasured or hidden. Solving
+    // against it collapses every panel to zero, and since the observer may not
+    // fire again that sticks. Keep the last good layout, and leave the pending
+    // solve kind untouched so it still applies on the next real solve.
+    if (zoneSize <= 0) return;
+
     const solveKind = nextSolveKind;
     nextSolveKind = 'automatic';
 
-    const usable = getUsable(ps.length, params.size(), params.gutter());
+    const usable = getUsable(ps.length, zoneSize, gutter);
     const solvePanels =
       solveKind === 'automatic'
         ? applyRedistributionPreferences(ps, usable)
         : ps;
 
-    setLayout(
-      computeFractionalShares(solvePanels, params.size(), params.gutter())
-    );
+    setLayout(computeFractionalShares(solvePanels, zoneSize, gutter));
   });
 
   function addPanel(panel: PanelConfig, ndx?: number) {


### PR DESCRIPTION
Opening the task-compose popover over a freshly-loaded single-split view could blank the split behind it: the resize solver ran against a stale ResizeObserver measurement of 0 for the zone, collapsed the only panel to width 0, and with no further measurement it stuck. The solver now keeps the last good layout until the zone reports a real size again. The mention in the title is a red herring — the trigger is the popover mounting on a cold load.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized guard in the resize solver’s reactive solve path; behavior change only when zone size is zero or negative, with test coverage.
> 
> **Overview**
> Fixes split panes going to **zero width** when the resize zone briefly reports size `0` (unmeasured `ResizeObserver` / hidden under a popover on cold load). A solve against zero collapsed panels and could stick if no further measurement fired.
> 
> The layout **`createEffect` in `solver.ts` now bails out when `zoneSize <= 0`**, skipping `setLayout` so the **last good pixel layout** is kept. **`nextSolveKind` is not consumed** on that path, so the next real measurement still runs the pending automatic or manual solve.
> 
> Adds a regression test: a single panel stays at full width through `setSize(0)` and re-solves when a real size returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1e4000421f78e82faae7b59ef8a2f842889d936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->