### PR TITLE
feat(calendar): manage calendar accounts from the calendar view

### DIFF
--- a/apps/web/src/features/auth/EmailAuth.tsx
+++ b/apps/web/src/features/auth/EmailAuth.tsx
@@ -185,7 +185,7 @@ function EmailLinkCallback(props: Pick<EmailAuthParams, 'successPath'>) {
         // callback so the inbox panel shows it immediately on return rather
         // than flashing a stale list until its own refetch lands.
         await query.refetch();
-        toast.success('Inbox connected');
+        toast.success('Account connected');
         navigateAfterLink(linkId);
       },
       async (err) => {

--- a/apps/web/src/features/calendar/components/CalendarSettingsDropdown.tsx
+++ b/apps/web/src/features/calendar/components/CalendarSettingsDropdown.tsx
@@ -9,6 +9,7 @@ import GearIcon from '@phosphor/gear.svg';
 import PlusIcon from '@phosphor/plus.svg';
 import { Button, Checkbox, Dropdown } from '@ui';
 import { createMemo, createSignal, For, Show } from 'solid-js';
+import { match } from 'ts-pattern';
 import {
   type CalendarAccount,
   useCalendarAccounts,
@@ -93,14 +94,17 @@ function createCalendarSettingsControls(isNarrow: () => boolean) {
   // turn off opens the confirmation, which lives outside the closing menu.
   const runAccountAction = (account: CalendarAccount) => {
     calendarView.closeEventDetails();
-    if (account.action === 'enable') {
-      startAddInbox({ scopes: 'calendar' });
-      return;
-    }
-    setTurnOffTarget({
-      linkId: account.linkId,
-      emailAddress: account.emailAddress,
-    });
+    match(account.action)
+      .with('enable', () => {
+        startAddInbox({ scopes: 'calendar' });
+      })
+      .with('turnOff', () => {
+        setTurnOffTarget({
+          linkId: account.linkId,
+          emailAddress: account.emailAddress,
+        });
+      })
+      .exhaustive();
   };
 
   // A brand-new account needs the mailbox scopes alongside calendar.

--- a/apps/web/src/features/calendar/components/CalendarSettingsDropdown.tsx
+++ b/apps/web/src/features/calendar/components/CalendarSettingsDropdown.tsx
@@ -1,11 +1,18 @@
+import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { MobileDrawer } from '@components/app/mobile/MobileDrawer';
+import { ENABLE_MULTI_INBOX_OVERRIDE } from '@core/constant/featureFlags';
+import { useAddInboxFlow } from '@core/email-link';
 import { isMobile } from '@core/mobile/isMobile';
 import CaretRightIcon from '@phosphor/caret-right.svg';
 import CheckIcon from '@phosphor/check.svg';
 import GearIcon from '@phosphor/gear.svg';
+import PlusIcon from '@phosphor/plus.svg';
 import { Button, Checkbox, Dropdown } from '@ui';
 import { createMemo, createSignal, For, Show } from 'solid-js';
-import { useCalendarConnectedInboxes } from '../hooks/use-calendar-connected-inboxes';
+import {
+  type CalendarAccount,
+  useCalendarAccounts,
+} from '../hooks/use-calendar-accounts';
 import type { CalendarTimeFormat, CalendarWeekStart } from '../types';
 import { useCalendarView } from './CalendarViewContext';
 import { MobilePeriodControls } from './PeriodSelector';
@@ -32,7 +39,11 @@ const TIME_FORMAT_OPTIONS: Array<{
 
 function createCalendarSettingsControls(isNarrow: () => boolean) {
   const calendarView = useCalendarView();
-  const connectedInboxes = useCalendarConnectedInboxes();
+  const accounts = useCalendarAccounts();
+  const startAddInbox = useAddInboxFlow();
+  const multiInboxFlag = useFeatureFlag('enable-multi-inbox', {
+    enabledOverride: ENABLE_MULTI_INBOX_OVERRIDE,
+  });
   const [turnOffTarget, setTurnOffTarget] =
     createSignal<TurnOffCalendarTarget | null>(null);
 
@@ -73,23 +84,29 @@ function createCalendarSettingsControls(isNarrow: () => boolean) {
     calendarView.setTimeFormat(timeFormat);
   };
 
-  // Only ever the viewer's own connected inboxes, so a delegate can never turn
-  // off (and delete) the owner's calendar from here. The address is shown only
-  // when more than one inbox could be meant.
-  const turnOffItems = createMemo(() => {
-    const inboxes = connectedInboxes();
-    return inboxes.map((link) => ({
-      target: { linkId: link.id, emailAddress: link.email_address },
-      label:
-        inboxes.length > 1
-          ? `Turn off calendar for ${link.email_address}`
-          : 'Turn off calendar',
-    }));
-  });
+  // The add-inbox flow is entitlement-gated by the backend (402 -> paywall), so
+  // "Connect another account" follows the multi-inbox flag like the email
+  // inbox selector rather than mirroring that rule on the client.
+  const showConnectAccount = () => multiInboxFlag().enabled;
 
-  const startTurnOff = (target: TurnOffCalendarTarget) => {
+  // Enable re-runs Google consent for calendar on an already-connected inbox;
+  // turn off opens the confirmation, which lives outside the closing menu.
+  const runAccountAction = (account: CalendarAccount) => {
     calendarView.closeEventDetails();
-    setTurnOffTarget(target);
+    if (account.action === 'enable') {
+      startAddInbox({ scopes: 'calendar' });
+      return;
+    }
+    setTurnOffTarget({
+      linkId: account.linkId,
+      emailAddress: account.emailAddress,
+    });
+  };
+
+  // A brand-new account needs the mailbox scopes alongside calendar.
+  const connectAnotherAccount = () => {
+    calendarView.closeEventDetails();
+    startAddInbox({ scopes: 'gmail_and_calendar' });
   };
 
   return {
@@ -101,9 +118,11 @@ function createCalendarSettingsControls(isNarrow: () => boolean) {
     changeShowWeekends,
     changeWeekStartsOn,
     changeTimeFormat,
-    turnOffItems,
+    accounts,
+    showConnectAccount,
+    runAccountAction,
+    connectAnotherAccount,
     turnOffTarget,
-    startTurnOff,
     clearTurnOffTarget: () => setTurnOffTarget(null),
   };
 }
@@ -235,20 +254,43 @@ function DesktopCalendarSettings(props: {
           </Dropdown.Sub>
         </Dropdown.Group>
 
-        <Show when={controls.turnOffItems().length > 0}>
+        <Show
+          when={controls.accounts().length > 0 || controls.showConnectAccount()}
+        >
           <Dropdown.Group>
-            <Dropdown.GroupLabel>Calendar access</Dropdown.GroupLabel>
-            <For each={controls.turnOffItems()}>
-              {(item) => (
+            <Dropdown.GroupLabel>Accounts</Dropdown.GroupLabel>
+            <For each={controls.accounts()}>
+              {(account) => (
                 <Dropdown.Item
                   closeOnSelect
-                  class="text-failure"
-                  onSelect={() => controls.startTurnOff(item.target)}
+                  onSelect={() => controls.runAccountAction(account)}
                 >
-                  <span class="min-w-0 flex-1 truncate">{item.label}</span>
+                  <span class="min-w-0 flex-1 truncate">
+                    {account.emailAddress}
+                  </span>
+                  <span
+                    class="shrink-0 text-xs font-medium"
+                    classList={{
+                      'text-accent': account.action === 'enable',
+                      'text-failure': account.action === 'turnOff',
+                    }}
+                  >
+                    {account.action === 'enable' ? 'Enable' : 'Turn off'}
+                  </span>
                 </Dropdown.Item>
               )}
             </For>
+            <Show when={controls.showConnectAccount()}>
+              <Dropdown.Item
+                closeOnSelect
+                onSelect={controls.connectAnotherAccount}
+              >
+                <PlusIcon class="size-3.5 shrink-0 text-ink-muted" />
+                <span class="min-w-0 flex-1 truncate">
+                  Connect another account
+                </span>
+              </Dropdown.Item>
+            </Show>
           </Dropdown.Group>
         </Show>
       </Dropdown.Content>
@@ -385,27 +427,53 @@ function MobileCalendarSettings(props: { controls: CalendarSettingsControls }) {
             </For>
           </MobileDrawer.Section>
 
-          <Show when={controls.turnOffItems().length > 0}>
-            <MobileDrawer.Label class="pt-4">
-              Calendar access
-            </MobileDrawer.Label>
+          <Show
+            when={
+              controls.accounts().length > 0 || controls.showConnectAccount()
+            }
+          >
+            <MobileDrawer.Label class="pt-4">Accounts</MobileDrawer.Label>
             <MobileDrawer.Section class="mb-3 flex shrink-0 flex-col">
-              <For each={controls.turnOffItems()}>
-                {(item) => (
+              <For each={controls.accounts()}>
+                {(account) => (
                   <button
                     type="button"
                     class={DRAWER_ROW_CLASS}
                     onClick={() => {
                       setOpen(false);
-                      controls.startTurnOff(item.target);
+                      controls.runAccountAction(account);
                     }}
                   >
-                    <span class="min-w-0 flex-1 truncate text-failure">
-                      {item.label}
+                    <span class="min-w-0 flex-1 truncate">
+                      {account.emailAddress}
+                    </span>
+                    <span
+                      class="shrink-0 text-xs font-medium"
+                      classList={{
+                        'text-accent': account.action === 'enable',
+                        'text-failure': account.action === 'turnOff',
+                      }}
+                    >
+                      {account.action === 'enable' ? 'Enable' : 'Turn off'}
                     </span>
                   </button>
                 )}
               </For>
+              <Show when={controls.showConnectAccount()}>
+                <button
+                  type="button"
+                  class={DRAWER_ROW_CLASS}
+                  onClick={() => {
+                    setOpen(false);
+                    controls.connectAnotherAccount();
+                  }}
+                >
+                  <PlusIcon class="size-4 shrink-0 text-ink-muted" />
+                  <span class="min-w-0 flex-1 truncate">
+                    Connect another account
+                  </span>
+                </button>
+              </Show>
             </MobileDrawer.Section>
           </Show>
         </MobileDrawer.Content>

--- a/apps/web/src/features/calendar/hooks/use-calendar-accounts.test.ts
+++ b/apps/web/src/features/calendar/hooks/use-calendar-accounts.test.ts
@@ -1,0 +1,66 @@
+import type { Link as EmailLink } from '@service-email/generated/schemas';
+import { describe, expect, it } from 'vitest';
+import { toCalendarAccounts } from './use-calendar-accounts';
+
+const link = (id: string, overrides: Partial<EmailLink> = {}): EmailLink =>
+  ({
+    id,
+    macro_id: 'macro|self',
+    email_address: `${id}@example.com`,
+    needs_calendar_permission: false,
+    calendar_disabled: false,
+    has_calendar_data: true,
+    is_primary: false,
+    ...overrides,
+  }) as unknown as EmailLink;
+
+describe('toCalendarAccounts', () => {
+  it('offers turn-off for an inbox that already has calendar', () => {
+    expect(toCalendarAccounts([link('a')], 'macro|self')).toEqual([
+      { linkId: 'a', emailAddress: 'a@example.com', action: 'turnOff' },
+    ]);
+  });
+
+  it('offers enable for an inbox missing calendar permission', () => {
+    const links = [link('a', { needs_calendar_permission: true })];
+    expect(toCalendarAccounts(links, 'macro|self')).toEqual([
+      { linkId: 'a', emailAddress: 'a@example.com', action: 'enable' },
+    ]);
+  });
+
+  it('offers enable for a turned-off inbox so it can be turned back on', () => {
+    const links = [
+      link('a', { needs_calendar_permission: true, calendar_disabled: true }),
+    ];
+    expect(toCalendarAccounts(links, 'macro|self')[0]?.action).toBe('enable');
+  });
+
+  it('offers enable — not turn-off — for a legacy inbox with stale data', () => {
+    const links = [
+      link('a', { needs_calendar_permission: true, has_calendar_data: true }),
+    ];
+    expect(toCalendarAccounts(links, 'macro|self')[0]?.action).toBe('enable');
+  });
+
+  it('sorts the primary inbox first and keeps the rest in order', () => {
+    const links = [
+      link('second'),
+      link('primary', { is_primary: true }),
+      link('third'),
+    ];
+    expect(
+      toCalendarAccounts(links, 'macro|self').map((a) => a.linkId)
+    ).toEqual(['primary', 'second', 'third']);
+  });
+
+  it('drops delegated inboxes the viewer does not own', () => {
+    const links = [link('own'), link('shared', { macro_id: 'macro|other' })];
+    expect(toCalendarAccounts(links, 'macro|self')).toEqual([
+      { linkId: 'own', emailAddress: 'own@example.com', action: 'turnOff' },
+    ]);
+  });
+
+  it('is empty when the user id is not yet known', () => {
+    expect(toCalendarAccounts([link('a')], undefined)).toEqual([]);
+  });
+});

--- a/apps/web/src/features/calendar/hooks/use-calendar-accounts.ts
+++ b/apps/web/src/features/calendar/hooks/use-calendar-accounts.ts
@@ -1,0 +1,49 @@
+import { useUserId } from '@core/context/user';
+import { useEmailLinksQuery } from '@queries/email/link';
+import type { Link as EmailLink } from '@service-email/generated/schemas';
+import { createMemo } from 'solid-js';
+
+/** The one calendar action a connected account offers from the calendar view. */
+type CalendarAccountAction = 'enable' | 'turnOff';
+
+/** A viewer-owned inbox rendered as a manageable calendar account. */
+export interface CalendarAccount {
+  linkId: string;
+  emailAddress: string;
+  action: CalendarAccountAction;
+}
+
+/**
+ * Classifies the viewer's own inboxes into one calendar action each. An inbox
+ * whose Google grant is missing calendar access — never granted, declined, or
+ * turned off — offers `enable`; one that already has it offers `turnOff`. A
+ * legacy inbox that still has data but no longer satisfies the capability check
+ * also reads as `enable`: re-granting resumes it, and removing the stale data
+ * stays available from connection settings.
+ *
+ * Delegated inboxes are dropped: the viewer reads the owner's calendar but must
+ * not enable or delete the owner's calendar from here. The viewer's primary
+ * inbox sorts first; the rest keep the links list's order.
+ */
+export function toCalendarAccounts(
+  links: readonly EmailLink[],
+  userId: string | undefined
+): CalendarAccount[] {
+  return links
+    .filter((link) => link.macro_id === userId)
+    .sort((a, b) => Number(b.is_primary) - Number(a.is_primary))
+    .map((link) => ({
+      linkId: link.id,
+      emailAddress: link.email_address,
+      action: link.needs_calendar_permission ? 'enable' : 'turnOff',
+    }));
+}
+
+/** Reactive {@link toCalendarAccounts} over the current email links. */
+export function useCalendarAccounts() {
+  const linksQuery = useEmailLinksQuery();
+  const userId = useUserId();
+  return createMemo<CalendarAccount[]>(() =>
+    toCalendarAccounts(linksQuery.data?.links ?? [], userId())
+  );
+}

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/inbox-selector.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/inbox-selector.tsx
@@ -1,9 +1,8 @@
-import { openAddInboxDialog } from '@app/features/inbox/AddInboxDialog';
 import { useSoupView } from '@app/features/next-soup/soup-view/soup-view-context';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { CollapsibleHeaderItem } from '@components/app/split-layout/components/CollapsibleItem';
 import { ENABLE_MULTI_INBOX_OVERRIDE } from '@core/constant/featureFlags';
-import { useSettingsState } from '@core/constant/SettingsState';
+import { useAddInboxFlow } from '@core/email-link';
 import { Combobox } from '@kobalte/core/combobox';
 import CaretDownIcon from '@phosphor/caret-down.svg';
 import PlusIcon from '@phosphor/plus.svg';
@@ -18,7 +17,7 @@ import { SearchableMultiSelect } from './searchable-multi-select';
  * default = all (no clause). Shown whenever the multi-inbox flag is on (or
  * the user already has multiple inboxes). With exactly one inbox connected
  * there is nothing to filter, so the dropdown is replaced by a "Connect
- * another email" button that jumps straight into the add-inbox flow.
+ * another account" button that jumps straight into the add-inbox flow.
  * Selection is held in soup-view's `inboxFilter` and compiled into `Owner`
  * email literals.
  */
@@ -31,12 +30,7 @@ export function InboxSelector() {
   const multiInboxFlag = useFeatureFlag('enable-multi-inbox', {
     enabledOverride: ENABLE_MULTI_INBOX_OVERRIDE,
   });
-  const { openSettings } = useSettingsState();
-
-  const startAddInboxFlow = () => {
-    openSettings('Connected');
-    openAddInboxDialog();
-  };
+  const addInbox = useAddInboxFlow();
 
   const label = () => {
     const ids = inboxFilter();
@@ -58,9 +52,9 @@ export function InboxSelector() {
       action={
         multiInboxFlag().enabled
           ? {
-              label: 'Add inbox',
+              label: 'Connect another account',
               icon: () => <PlusIcon class="size-4" />,
-              onSelect: startAddInboxFlow,
+              onSelect: () => addInbox(),
             }
           : undefined
       }
@@ -85,19 +79,19 @@ export function InboxSelector() {
     </SearchableMultiSelect>
   );
 
-  const ConnectAnotherEmail = (buttonProps: { hideLabel?: boolean }) => (
+  const ConnectAnotherAccount = (buttonProps: { hideLabel?: boolean }) => (
     <Button
       variant="outline"
       size="sm"
       depth={2}
-      aria-label={buttonProps.hideLabel ? 'Connect another email' : undefined}
-      tooltip={buttonProps.hideLabel ? 'Connect another email' : undefined}
+      aria-label={buttonProps.hideLabel ? 'Connect another account' : undefined}
+      tooltip={buttonProps.hideLabel ? 'Connect another account' : undefined}
       class={cn('bg-surface gap-1', buttonProps.hideLabel && 'px-1')}
-      onClick={startAddInboxFlow}
+      onClick={() => addInbox()}
     >
       <TrayIcon />
       <Show when={!buttonProps.hideLabel}>
-        <span class="truncate">Connect another email</span>
+        <span class="truncate">Connect another account</span>
       </Show>
     </Button>
   );
@@ -117,7 +111,7 @@ export function InboxSelector() {
             when={showConnectButton()}
             fallback={<Selector hideLabel={isCollapsed()} />}
           >
-            <ConnectAnotherEmail hideLabel={isCollapsed()} />
+            <ConnectAnotherAccount hideLabel={isCollapsed()} />
           </Show>
         )}
       </CollapsibleHeaderItem>

--- a/apps/web/src/features/next-soup/soup-view/filters-bar/mobile-filter-drawer.tsx
+++ b/apps/web/src/features/next-soup/soup-view/filters-bar/mobile-filter-drawer.tsx
@@ -140,8 +140,9 @@ export const MobileFilterDrawer = (props: {
   });
   const addInbox = useAddInboxFlow();
 
-  // Mirrors the desktop InboxSelector's visibility rule so the "Add inbox"
-  // action stays discoverable with zero or one inbox connected. Also stays
+  // Mirrors the desktop InboxSelector's visibility rule so the "Connect
+  // another account" action stays discoverable with zero or one inbox
+  // connected. Also stays
   // visible while a scope is active so it can be reset even if the linked
   // inboxes drop to one.
   const showInboxSection = () =>
@@ -520,7 +521,9 @@ export const MobileFilterDrawer = (props: {
                             <span class="size-4 flex items-center justify-center shrink-0">
                               <PlusIcon class="size-4 text-ink-muted" />
                             </span>
-                            <span class="flex-1 truncate">Add inbox</span>
+                            <span class="flex-1 truncate">
+                              Connect another account
+                            </span>
                           </button>
                         </Show>
                       </Accordion.Content>

--- a/apps/web/src/lib/core/email-link/index.ts
+++ b/apps/web/src/lib/core/email-link/index.ts
@@ -242,7 +242,7 @@ export function useAddInboxFlow() {
     await initEmailLink({ linkId, forceShare }).match(
       async () => {
         await query.refetch();
-        toast.success('Inbox connected');
+        toast.success('Account connected');
       },
       async (error) => {
         if (error.tag === 'AlreadyInitialized') {

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -30,7 +30,10 @@ tags, updated time. Clicking a row opens the doc.
 
 Week view with `New event`, `Choose calendar view` menu, prev/next week, `Search events`,
 `Calendar settings`, and a mini month picker in the side panel. Events require connecting a
-Google account (`Connect calendar`).
+Google account (`Connect calendar`). The `Calendar settings` (gear) menu has an `Accounts`
+section listing each connected account with a per-account `Enable` (grant calendar) or
+`Turn off` action, plus `Connect another account` to connect a new Google account
+(email + calendar).
 
 ## Calls — `/app/component/calls`
 


### PR DESCRIPTION
Adds an Accounts section to the calendar view's settings menu — enable or turn off calendar per connected account (primary first) and connect another account — so calendar access isn't only manageable from email settings. Also renames the inbox selector's connect action to "Connect another account" (going straight to consent, dropping the settings/dialog detour) and updates the add-inbox success toast to "Account connected".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth entry points and calendar enable/disable UX across calendar and mail; scope selection for existing vs new accounts affects consent behavior but stays in established `useAddInboxFlow` paths.
> 
> **Overview**
> Calendar settings (desktop dropdown and mobile drawer) now include an **Accounts** section instead of only “turn off calendar” links. Each viewer-owned inbox shows **Enable** (re-run Google consent for calendar) or **Turn off**, with primary sorted first; delegated inboxes stay excluded. **Connect another account** appears when the multi-inbox flag is on and starts `useAddInboxFlow` with full Gmail+calendar scopes, while per-account enable uses calendar-only scopes.
> 
> Mail surfaces align on the same connect path: inbox selector and mobile filters rename **Add inbox** / **Connect another email** to **Connect another account** and call `useAddInboxFlow()` directly instead of opening Connected settings plus `AddInboxDialog`. Success toasts after linking now say **Account connected**.
> 
> New `use-calendar-accounts` (with unit tests) drives the account list from `needs_calendar_permission`. Agent guide docs note the Accounts section in calendar settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a50896e1cb5a478a241f67c14ee7de35105ff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->