### PR TITLE
chore(service_url): remove unused and dead service urls

### DIFF
--- a/crates/macro_service_urls/src/lib.rs
+++ b/crates/macro_service_urls/src/lib.rs
@@ -506,43 +506,17 @@ service_url! {
             dev: "https://auth-service-dev.macro.com",
             prod: "https://auth-service.macro.com",
         },
-        /// PDF rendering service API URL.
-        pub PdfServiceUrl {
-            local: "http://localhost:4567",
-            dev: "https://pdf-service-dev.macro.com",
-            prod: "https://pdf-service.macro.com",
-        },
         /// Document storage service API URL.
         pub DocumentStorageServiceUrl {
             local: "http://localhost:8086",
             dev: "https://dev-gateway.macro.com/dss",
             prod: "https://gateway.macro.com/dss",
         },
-        /// WebSocket service URL.
-        pub WebsocketServiceUrl {
-            local: "ws://localhost:6969",
-            dev: "wss://services-dev.macro.com",
-            prod: "wss://services.macro.com",
-        },
         /// Connection gateway HTTP API URL.
         pub ConnectionGatewayUrl {
             local: "http://localhost:8082",
             dev: "https://connection-gateway-dev.macro.com",
             prod: "https://connection-gateway.macro.com",
-        },
-        /// Connection gateway WebSocket URL.
-        pub ConnectionGatewayWebsocketUrl {
-            local: "ws://localhost:8082",
-            dev: "wss://connection-gateway-dev.macro.com",
-            prod: "wss://connection-gateway.macro.com",
-        },
-        /// Agent proxy WebSocket URL (the shared runtime endpoint external
-        /// agent runtimes dial). Unused: its service is gone, and the URL
-        /// stays only until the deployed stack behind it is torn down.
-        pub AgentProxyWebsocketUrl {
-            local: "ws://localhost:8091",
-            dev: "wss://agent-proxy-dev.macro.com",
-            prod: "wss://agent-proxy.macro.com",
         },
         /// Document cognition service API URL.
         pub DocumentCognitionServiceUrl {

--- a/crates/macro_service_urls/src/test.rs
+++ b/crates/macro_service_urls/src/test.rs
@@ -31,28 +31,13 @@ fn auth_service_url_parses() {
 }
 
 #[test]
-fn pdf_service_url_parses() {
-    assert_parses_for_all_environments(PdfServiceUrl::default_for_environment);
-}
-
-#[test]
 fn document_storage_service_url_parses() {
     assert_parses_for_all_environments(DocumentStorageServiceUrl::default_for_environment);
 }
 
 #[test]
-fn websocket_service_url_parses() {
-    assert_parses_for_all_environments(WebsocketServiceUrl::default_for_environment);
-}
-
-#[test]
 fn connection_gateway_url_parses() {
     assert_parses_for_all_environments(ConnectionGatewayUrl::default_for_environment);
-}
-
-#[test]
-fn connection_gateway_websocket_url_parses() {
-    assert_parses_for_all_environments(ConnectionGatewayWebsocketUrl::default_for_environment);
 }
 
 #[test]
@@ -255,24 +240,12 @@ fn exported_service_urls_match_local_values() {
         "http://localhost:8080"
     );
     assert_eq!(
-        service_urls.pdf_service_url.as_ref(),
-        "http://localhost:4567"
-    );
-    assert_eq!(
         service_urls.document_storage_service_url.as_ref(),
         "http://localhost:8086",
     );
     assert_eq!(
-        service_urls.websocket_service_url.as_ref(),
-        "ws://localhost:6969"
-    );
-    assert_eq!(
         service_urls.connection_gateway_url.as_ref(),
         "http://localhost:8082",
-    );
-    assert_eq!(
-        service_urls.connection_gateway_websocket_url.as_ref(),
-        "ws://localhost:8082",
     );
     assert_eq!(
         service_urls.document_cognition_service_url.as_ref(),
@@ -325,24 +298,12 @@ fn exported_service_urls_match_dev_values() {
         "https://auth-service-dev.macro.com",
     );
     assert_eq!(
-        service_urls.pdf_service_url.as_ref(),
-        "https://pdf-service-dev.macro.com",
-    );
-    assert_eq!(
         service_urls.document_storage_service_url.as_ref(),
         "https://dev-gateway.macro.com/dss",
     );
     assert_eq!(
-        service_urls.websocket_service_url.as_ref(),
-        "wss://services-dev.macro.com",
-    );
-    assert_eq!(
         service_urls.connection_gateway_url.as_ref(),
         "https://connection-gateway-dev.macro.com",
-    );
-    assert_eq!(
-        service_urls.connection_gateway_websocket_url.as_ref(),
-        "wss://connection-gateway-dev.macro.com",
     );
     assert_eq!(
         service_urls.document_cognition_service_url.as_ref(),
@@ -392,24 +353,12 @@ fn exported_service_urls_match_prod_values() {
         "https://auth-service.macro.com",
     );
     assert_eq!(
-        service_urls.pdf_service_url.as_ref(),
-        "https://pdf-service.macro.com",
-    );
-    assert_eq!(
         service_urls.document_storage_service_url.as_ref(),
         "https://gateway.macro.com/dss",
     );
     assert_eq!(
-        service_urls.websocket_service_url.as_ref(),
-        "wss://services.macro.com",
-    );
-    assert_eq!(
         service_urls.connection_gateway_url.as_ref(),
         "https://connection-gateway.macro.com",
-    );
-    assert_eq!(
-        service_urls.connection_gateway_websocket_url.as_ref(),
-        "wss://connection-gateway.macro.com",
     );
     assert_eq!(
         service_urls.document_cognition_service_url.as_ref(),
@@ -460,24 +409,12 @@ fn exported_service_url_override_names_are_derived_from_env_var_names() {
         "OVERRIDE_AUTH_SERVICE_URL",
     );
     assert_eq!(
-        PdfServiceUrl::local().override_env_var_name(),
-        "OVERRIDE_PDF_SERVICE_URL",
-    );
-    assert_eq!(
         DocumentStorageServiceUrl::local().override_env_var_name(),
         "OVERRIDE_DOCUMENT_STORAGE_SERVICE_URL",
     );
     assert_eq!(
-        WebsocketServiceUrl::local().override_env_var_name(),
-        "OVERRIDE_WEBSOCKET_SERVICE_URL",
-    );
-    assert_eq!(
         ConnectionGatewayUrl::local().override_env_var_name(),
         "OVERRIDE_CONNECTION_GATEWAY_URL",
-    );
-    assert_eq!(
-        ConnectionGatewayWebsocketUrl::local().override_env_var_name(),
-        "OVERRIDE_CONNECTION_GATEWAY_WEBSOCKET_URL",
     );
     assert_eq!(
         DocumentCognitionServiceUrl::local().override_env_var_name(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dead-code removal in a URL registry with no remaining references; only risk is if external crates or deploy configs still relied on the removed override env vars.
> 
> **Overview**
> Removes **five** typed service URL entries from the `ServiceUrls` macro in `macro_service_urls`: PDF (`PdfServiceUrl`), generic websocket (`WebsocketServiceUrl`), connection-gateway websocket (`ConnectionGatewayWebsocketUrl`), and agent-proxy websocket (`AgentProxyWebsocketUrl`), along with their local/dev/prod defaults and override env var names.
> 
> Tests are updated in parallel—parse tests, per-environment default assertions, and override-name checks no longer cover those removed types. Remaining `ServiceUrls` entries (app, auth, DSS, connection gateway HTTP, etc.) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e08b57496a6616dda2cd1aa240553007293ef7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->