### PR TITLE
feat(infra): add typed shared-gateway listener priorities

### DIFF
--- a/infra/packages/resources/src/resources/service_target_group.ts
+++ b/infra/packages/resources/src/resources/service_target_group.ts
@@ -23,10 +23,7 @@ type ServiceTargetGroupArgs = {
   // whole hostname on a shared listener.
   hostHeaders?: string[];
   // Shared-gateway tenant. Priority comes from GATEWAY_PRIORITIES.
-  // Exactly one of service and priority must be set.
-  service?: GatewayService;
-  // Dedicated-ALB rule priority. Do not use on the shared gateway.
-  priority?: number;
+  service: GatewayService;
   // Health check
   healthCheck?: Partial<aws.types.input.lb.TargetGroupHealthCheck>;
   // Deregistration delay
@@ -59,16 +56,6 @@ export class ServiceTargetGroup extends pulumi.ComponentResource {
       );
     }
 
-    if (!args.service === !args.priority) {
-      throw new Error(
-        `${name}: exactly one of service and priority must be set`
-      );
-    }
-
-    const priority = args.service
-      ? GATEWAY_PRIORITIES[args.service]
-      : args.priority;
-
     this.target_group = new aws.lb.TargetGroup(
       `${name}-target-group`,
       {
@@ -99,7 +86,7 @@ export class ServiceTargetGroup extends pulumi.ComponentResource {
       `${name}-listener-rule`,
       {
         listenerArn: args.listenerArn,
-        priority,
+        priority: GATEWAY_PRIORITIES[args.service],
 
         conditions: [
           args.pathPatterns

--- a/infra/packages/resources/src/resources/service_target_group.ts
+++ b/infra/packages/resources/src/resources/service_target_group.ts
@@ -23,7 +23,10 @@ type ServiceTargetGroupArgs = {
   // whole hostname on a shared listener.
   hostHeaders?: string[];
   // Shared-gateway tenant. Priority comes from GATEWAY_PRIORITIES.
-  service: GatewayService;
+  // Exactly one of service and priority must be set.
+  service?: GatewayService;
+  // Dedicated-ALB rule priority. Do not use on the shared gateway.
+  priority?: number;
   // Health check
   healthCheck?: Partial<aws.types.input.lb.TargetGroupHealthCheck>;
   // Deregistration delay
@@ -56,6 +59,16 @@ export class ServiceTargetGroup extends pulumi.ComponentResource {
       );
     }
 
+    if (!args.service === !args.priority) {
+      throw new Error(
+        `${name}: exactly one of service and priority must be set`
+      );
+    }
+
+    const priority = args.service
+      ? GATEWAY_PRIORITIES[args.service]
+      : args.priority;
+
     this.target_group = new aws.lb.TargetGroup(
       `${name}-target-group`,
       {
@@ -86,7 +99,7 @@ export class ServiceTargetGroup extends pulumi.ComponentResource {
       `${name}-listener-rule`,
       {
         listenerArn: args.listenerArn,
-        priority: GATEWAY_PRIORITIES[args.service],
+        priority,
 
         conditions: [
           args.pathPatterns

--- a/infra/packages/resources/src/resources/service_target_group.ts
+++ b/infra/packages/resources/src/resources/service_target_group.ts
@@ -21,7 +21,7 @@ type ServiceTargetGroupArgs = {
   // Host headers to match instead of paths, for a target group that owns a
   // whole hostname on a shared listener.
   hostHeaders?: string[];
-  // Priority **MUST BE UNIQUE**
+  // Must be unique on the listener. Shared-gateway stacks use GATEWAY_PRIORITIES.
   priority: number;
   // Health check
   healthCheck?: Partial<aws.types.input.lb.TargetGroupHealthCheck>;

--- a/infra/packages/resources/src/resources/service_target_group.ts
+++ b/infra/packages/resources/src/resources/service_target_group.ts
@@ -1,5 +1,6 @@
 import * as aws from '@pulumi/aws';
 import * as pulumi from '@pulumi/pulumi';
+import { GATEWAY_PRIORITIES, type GatewayService } from '../../../shared';
 import {
   DEFAULT_DEREGISTRATION_DELAY_SECONDS,
   DEFAULT_TARGET_GROUP_HEALTH_CHECK,
@@ -21,8 +22,11 @@ type ServiceTargetGroupArgs = {
   // Host headers to match instead of paths, for a target group that owns a
   // whole hostname on a shared listener.
   hostHeaders?: string[];
-  // Must be unique on the listener. Shared-gateway stacks use GATEWAY_PRIORITIES.
-  priority: number;
+  // Shared-gateway tenant. Priority comes from GATEWAY_PRIORITIES.
+  // Exactly one of service and priority must be set.
+  service?: GatewayService;
+  // Dedicated-ALB rule priority. Do not use on the shared gateway.
+  priority?: number;
   // Health check
   healthCheck?: Partial<aws.types.input.lb.TargetGroupHealthCheck>;
   // Deregistration delay
@@ -55,6 +59,16 @@ export class ServiceTargetGroup extends pulumi.ComponentResource {
       );
     }
 
+    if (!args.service === !args.priority) {
+      throw new Error(
+        `${name}: exactly one of service and priority must be set`
+      );
+    }
+
+    const priority = args.service
+      ? GATEWAY_PRIORITIES[args.service]
+      : args.priority;
+
     this.target_group = new aws.lb.TargetGroup(
       `${name}-target-group`,
       {
@@ -85,7 +99,7 @@ export class ServiceTargetGroup extends pulumi.ComponentResource {
       `${name}-listener-rule`,
       {
         listenerArn: args.listenerArn,
-        priority: args.priority,
+        priority,
 
         conditions: [
           args.pathPatterns

--- a/infra/packages/shared/src/gateway_priorities.ts
+++ b/infra/packages/shared/src/gateway_priorities.ts
@@ -1,0 +1,25 @@
+/**
+ * Services attached to the shared gateway ALB listener.
+ * Add a member when a service migrates onto the gateway.
+ */
+export enum GatewayService {
+  DOCUMENT_STORAGE_SERVICE = 'DOCUMENT_STORAGE_SERVICE',
+}
+
+/**
+ * Listener-rule priority for every gateway tenant.
+ */
+type GatewayPriorityMap = { [K in GatewayService]: number };
+
+/**
+ * Source of truth for shared-gateway ALB listener-rule priorities.
+ * Values on this listener must be unique. A missing key is a compile error.
+ */
+export const GATEWAY_PRIORITIES: GatewayPriorityMap = {
+  [GatewayService.DOCUMENT_STORAGE_SERVICE]: 10,
+};
+
+const assigned = Object.values(GATEWAY_PRIORITIES);
+if (new Set(assigned).size !== assigned.length) {
+  throw new Error('GATEWAY_PRIORITIES values must be unique');
+}

--- a/infra/packages/shared/src/index.ts
+++ b/infra/packages/shared/src/index.ts
@@ -66,5 +66,6 @@ export {
 } from './ai_tools';
 export { getKafkaClusterPolicy } from './kafka_cluster_policy';
 export { getGatewayAlb, type GatewayAlb } from './gateway';
+export { GATEWAY_PRIORITIES, GatewayService } from './gateway_priorities';
 
 export * from './service_urls';

--- a/infra/stacks/agent-harness-service/agent_harness_service.ts
+++ b/infra/stacks/agent-harness-service/agent_harness_service.ts
@@ -4,8 +4,9 @@ import * as pulumi from '@pulumi/pulumi';
 import {
   DATADOG_API_KEY,
   DEFAULT_CONTINUE_BEFORE_STEADY_STATE,
+  DEFAULT_DEREGISTRATION_DELAY_SECONDS,
+  DEFAULT_TARGET_GROUP_HEALTH_CHECK,
   EcsDeploymentFailureAlarm,
-  ServiceTargetGroup,
   datadogAgentContainer,
   fargateLogRouterSidecarContainer,
   serviceLoadBalancer,
@@ -285,7 +286,7 @@ export class AgentHarnessService extends pulumi.ComponentResource {
     // ALB-to-service holes for the egress port.
     // Not `${BASE_NAME}-egress`: with the helper's `-tg` suffix that is 36
     // chars, and target group names cap at 32.
-    const egress = new ServiceTargetGroup(
+    const egress = new DedicatedListenerTargetGroup(
       `agent-harness-egress-${stack}`,
       {
         listenerArn: listener.arn,
@@ -592,6 +593,95 @@ export class AgentHarnessService extends pulumi.ComponentResource {
         },
         alarmActions: [CLOUD_TRAIL_SNS_TOPIC_ARN],
         tags: this.tags,
+      },
+      { parent: this }
+    );
+  }
+}
+
+type DedicatedListenerTargetGroupArgs = {
+  tags: { [key: string]: string };
+  listenerArn: pulumi.Output<string>;
+  vpcId: pulumi.Output<string> | string;
+  containerPort: number;
+  healthCheckPath: string;
+  hostHeaders: string[];
+  priority: number;
+  serviceSecurityGroupId: pulumi.Output<string>;
+  albSecurityGroupId: pulumi.Output<string>;
+};
+
+class DedicatedListenerTargetGroup extends pulumi.ComponentResource {
+  public readonly target_group: aws.lb.TargetGroup;
+
+  constructor(
+    name: string,
+    args: DedicatedListenerTargetGroupArgs,
+    opts?: pulumi.ComponentResourceOptions
+  ) {
+    // Keep the ServiceTargetGroup type token so Pulumi does not replace the live egress rule.
+    super('my:components:ServiceTargetGroup', name, {}, opts);
+
+    this.target_group = new aws.lb.TargetGroup(
+      `${name}-target-group`,
+      {
+        name: `${name}-tg`,
+        port: args.containerPort,
+        protocol: 'HTTP',
+        targetType: 'ip',
+        vpcId: args.vpcId,
+        deregistrationDelay: DEFAULT_DEREGISTRATION_DELAY_SECONDS,
+        healthCheck: {
+          path: args.healthCheckPath,
+          protocol: 'HTTP',
+          ...DEFAULT_TARGET_GROUP_HEALTH_CHECK,
+        },
+        tags: args.tags,
+      },
+      { parent: this }
+    );
+
+    new aws.lb.ListenerRule(
+      `${name}-listener-rule`,
+      {
+        listenerArn: args.listenerArn,
+        priority: args.priority,
+        conditions: [{ hostHeader: { values: args.hostHeaders } }],
+        actions: [
+          {
+            type: 'forward',
+            targetGroupArn: this.target_group.arn,
+          },
+        ],
+        tags: args.tags,
+      },
+      { parent: this }
+    );
+
+    new aws.vpc.SecurityGroupIngressRule(
+      `${name}-security-group-ingress-service-to-alb`,
+      {
+        securityGroupId: args.serviceSecurityGroupId,
+        description: 'Allow inbound traffic from ALB',
+        referencedSecurityGroupId: args.albSecurityGroupId,
+        fromPort: args.containerPort,
+        toPort: args.containerPort,
+        ipProtocol: 'tcp',
+        tags: args.tags,
+      },
+      { parent: this }
+    );
+
+    new aws.vpc.SecurityGroupEgressRule(
+      `${name}-security-group-egress-alb-to-service`,
+      {
+        description: `Allow traffic to ${name}`,
+        securityGroupId: args.albSecurityGroupId,
+        referencedSecurityGroupId: args.serviceSecurityGroupId,
+        fromPort: args.containerPort,
+        ipProtocol: 'tcp',
+        toPort: args.containerPort,
+        tags: args.tags,
       },
       { parent: this }
     );

--- a/infra/stacks/agent-harness-service/agent_harness_service.ts
+++ b/infra/stacks/agent-harness-service/agent_harness_service.ts
@@ -4,9 +4,8 @@ import * as pulumi from '@pulumi/pulumi';
 import {
   DATADOG_API_KEY,
   DEFAULT_CONTINUE_BEFORE_STEADY_STATE,
-  DEFAULT_DEREGISTRATION_DELAY_SECONDS,
-  DEFAULT_TARGET_GROUP_HEALTH_CHECK,
   EcsDeploymentFailureAlarm,
+  ServiceTargetGroup,
   datadogAgentContainer,
   fargateLogRouterSidecarContainer,
   serviceLoadBalancer,
@@ -286,7 +285,7 @@ export class AgentHarnessService extends pulumi.ComponentResource {
     // ALB-to-service holes for the egress port.
     // Not `${BASE_NAME}-egress`: with the helper's `-tg` suffix that is 36
     // chars, and target group names cap at 32.
-    const egress = new DedicatedListenerTargetGroup(
+    const egress = new ServiceTargetGroup(
       `agent-harness-egress-${stack}`,
       {
         listenerArn: listener.arn,
@@ -593,95 +592,6 @@ export class AgentHarnessService extends pulumi.ComponentResource {
         },
         alarmActions: [CLOUD_TRAIL_SNS_TOPIC_ARN],
         tags: this.tags,
-      },
-      { parent: this }
-    );
-  }
-}
-
-type DedicatedListenerTargetGroupArgs = {
-  tags: { [key: string]: string };
-  listenerArn: pulumi.Output<string>;
-  vpcId: pulumi.Output<string> | string;
-  containerPort: number;
-  healthCheckPath: string;
-  hostHeaders: string[];
-  priority: number;
-  serviceSecurityGroupId: pulumi.Output<string>;
-  albSecurityGroupId: pulumi.Output<string>;
-};
-
-class DedicatedListenerTargetGroup extends pulumi.ComponentResource {
-  public readonly target_group: aws.lb.TargetGroup;
-
-  constructor(
-    name: string,
-    args: DedicatedListenerTargetGroupArgs,
-    opts?: pulumi.ComponentResourceOptions
-  ) {
-    // Keep the ServiceTargetGroup type token so Pulumi does not replace the live egress rule.
-    super('my:components:ServiceTargetGroup', name, {}, opts);
-
-    this.target_group = new aws.lb.TargetGroup(
-      `${name}-target-group`,
-      {
-        name: `${name}-tg`,
-        port: args.containerPort,
-        protocol: 'HTTP',
-        targetType: 'ip',
-        vpcId: args.vpcId,
-        deregistrationDelay: DEFAULT_DEREGISTRATION_DELAY_SECONDS,
-        healthCheck: {
-          path: args.healthCheckPath,
-          protocol: 'HTTP',
-          ...DEFAULT_TARGET_GROUP_HEALTH_CHECK,
-        },
-        tags: args.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.lb.ListenerRule(
-      `${name}-listener-rule`,
-      {
-        listenerArn: args.listenerArn,
-        priority: args.priority,
-        conditions: [{ hostHeader: { values: args.hostHeaders } }],
-        actions: [
-          {
-            type: 'forward',
-            targetGroupArn: this.target_group.arn,
-          },
-        ],
-        tags: args.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${name}-security-group-ingress-service-to-alb`,
-      {
-        securityGroupId: args.serviceSecurityGroupId,
-        description: 'Allow inbound traffic from ALB',
-        referencedSecurityGroupId: args.albSecurityGroupId,
-        fromPort: args.containerPort,
-        toPort: args.containerPort,
-        ipProtocol: 'tcp',
-        tags: args.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupEgressRule(
-      `${name}-security-group-egress-alb-to-service`,
-      {
-        description: `Allow traffic to ${name}`,
-        securityGroupId: args.albSecurityGroupId,
-        referencedSecurityGroupId: args.serviceSecurityGroupId,
-        fromPort: args.containerPort,
-        ipProtocol: 'tcp',
-        toPort: args.containerPort,
-        tags: args.tags,
       },
       { parent: this }
     );

--- a/infra/stacks/cloud-storage-service/cloud-storage-service.ts
+++ b/infra/stacks/cloud-storage-service/cloud-storage-service.ts
@@ -21,7 +21,6 @@ import {
   getKafkaClusterPolicy,
   stack,
   getGatewayAlb,
-  GATEWAY_PRIORITIES,
   GatewayService,
 } from '../../packages/shared';
 
@@ -317,7 +316,7 @@ export class CloudStorageService extends pulumi.ComponentResource {
         listenerArn: gatewayLoadBalancer.httpsListenerArn,
         vpcId: vpc.vpcId,
         containerPort: serviceContainerPort,
-        priority: GATEWAY_PRIORITIES[GatewayService.DOCUMENT_STORAGE_SERVICE],
+        service: GatewayService.DOCUMENT_STORAGE_SERVICE,
         healthCheckPath,
         pathPatterns: ['/dss', '/dss/*'],
         serviceSecurityGroupId: this.serviceSg.id,

--- a/infra/stacks/cloud-storage-service/cloud-storage-service.ts
+++ b/infra/stacks/cloud-storage-service/cloud-storage-service.ts
@@ -21,6 +21,8 @@ import {
   getKafkaClusterPolicy,
   stack,
   getGatewayAlb,
+  GATEWAY_PRIORITIES,
+  GatewayService,
 } from '../../packages/shared';
 
 const gatewayLoadBalancer = getGatewayAlb();
@@ -315,7 +317,7 @@ export class CloudStorageService extends pulumi.ComponentResource {
         listenerArn: gatewayLoadBalancer.httpsListenerArn,
         vpcId: vpc.vpcId,
         containerPort: serviceContainerPort,
-        priority: 10,
+        priority: GATEWAY_PRIORITIES[GatewayService.DOCUMENT_STORAGE_SERVICE],
         healthCheckPath,
         pathPatterns: ['/dss', '/dss/*'],
         serviceSecurityGroupId: this.serviceSg.id,


### PR DESCRIPTION
ALB listener-rule priorities on the shared gateway must be unique. A GatewayService enum and GATEWAY_PRIORITIES map replace the comment-enforced literal so a missing tenant is a compile error and duplicates live in one file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how shared-gateway listener priorities are assigned; a wrong or duplicate priority in `GATEWAY_PRIORITIES` could break ALB rule creation or routing on deploy, though the uniqueness guard and XOR validation reduce that risk.
> 
> **Overview**
> Centralizes **shared gateway ALB** listener-rule priorities in a new `GatewayService` enum and `GATEWAY_PRIORITIES` map (with a runtime uniqueness check), exported from shared infra packages.
> 
> **`ServiceTargetGroup`** now requires exactly one of `service` (gateway tenant → priority from the map) or `priority` (dedicated ALB rules). Cloud storage’s gateway target group switches from a hardcoded `priority: 10` to `service: GatewayService.DOCUMENT_STORAGE_SERVICE`, so new gateway tenants must register in the map and missing entries fail at compile time instead of relying on comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c52c77052f3382a9f3f334e66c6123b395ebc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->