### PR TITLE
feat(unfurl): migrate unfurl-service onto the shared gateway

### DIFF
--- a/apps/web/scripts/services.ts
+++ b/apps/web/scripts/services.ts
@@ -82,8 +82,8 @@ export const services: Service[] = [
 	},
 	{
 		name: "unfurl-service",
-		dev: "https://unfurl-service-dev.macro.com/api-doc/openapi.json",
-		prod: "https://unfurl-service.macro.com/api-doc/openapi.json",
+		dev: "https://dev-gateway.macro.com/unfurl/api-doc/openapi.json",
+		prod: "https://gateway.macro.com/unfurl/api-doc/openapi.json",
 		local: "http://localhost:8095/api-doc/openapi.json",
 		output: "../src/lib/service-clients/service-unfurl/",
 		orvalKey: "unfurlService",

--- a/apps/web/src/lib/core/constant/servers.ts
+++ b/apps/web/src/lib/core/constant/servers.ts
@@ -18,9 +18,9 @@ const serverHostLocal: Servers = {
 
 const devServerSuffix = import.meta.env.MODE === 'development' ? '-dev' : '';
 
-// The shared gateway ALB fronts DSS under a `/dss` path prefix. Unlike the
-// other services it is named with a `dev-` prefix rather than a `-dev` suffix,
-// so it cannot reuse `devServerSuffix`.
+// The shared gateway ALB fronts DSS (`/dss`) and unfurl (`/unfurl`). Unlike
+// the other services it is named with a `dev-` prefix rather than a `-dev`
+// suffix, so it cannot reuse `devServerSuffix`.
 const gatewayHost =
   import.meta.env.MODE === 'development'
     ? 'https://dev-gateway.macro.com'
@@ -41,7 +41,7 @@ const serverHostRemote = {
   'connection-gateway': `wss://connection-gateway${devServerSuffix}.macro.com`,
   'notification-service': `https://notifications${devServerSuffix}.macro.com`,
   'static-file': `https://static-file-service${devServerSuffix}.macro.com`,
-  'unfurl-service': `https://unfurl-service${devServerSuffix}.macro.com`,
+  'unfurl-service': `${gatewayHost}/unfurl`,
   contacts: `https://contacts${devServerSuffix}.macro.com`,
   'email-service': `https://email-service${devServerSuffix}.macro.com`,
   'image-proxy-service': `https://image-proxy${devServerSuffix}.macro.com`,

--- a/crates/macro_service_urls/src/lib.rs
+++ b/crates/macro_service_urls/src/lib.rs
@@ -546,8 +546,8 @@ service_url! {
         /// Link unfurl service API URL.
         pub UnfurlServiceUrl {
             local: "http://localhost:8095",
-            dev: "https://unfurl-service-dev.macro.com",
-            prod: "https://unfurl-service.macro.com",
+            dev: "https://dev-gateway.macro.com/unfurl",
+            prod: "https://gateway.macro.com/unfurl",
         },
         /// Contacts service API URL.
         pub ContactsServiceUrl {

--- a/crates/macro_service_urls/src/test.rs
+++ b/crates/macro_service_urls/src/test.rs
@@ -319,7 +319,7 @@ fn exported_service_urls_match_dev_values() {
     );
     assert_eq!(
         service_urls.unfurl_service_url.as_ref(),
-        "https://unfurl-service-dev.macro.com",
+        "https://dev-gateway.macro.com/unfurl",
     );
     assert_eq!(
         service_urls.contacts_service_url.as_ref(),
@@ -374,7 +374,7 @@ fn exported_service_urls_match_prod_values() {
     );
     assert_eq!(
         service_urls.unfurl_service_url.as_ref(),
-        "https://unfurl-service.macro.com",
+        "https://gateway.macro.com/unfurl",
     );
     assert_eq!(
         service_urls.contacts_service_url.as_ref(),

--- a/docs/AGENT_GUIDE/observability.md
+++ b/docs/AGENT_GUIDE/observability.md
@@ -32,13 +32,14 @@ attribute.
   separate tiny traces for the same path — prefer the trace whose root is `web-app`.
 
 URL prefix → service mapping: `/dss/*` → document_storage_service,
-`/cognition/*` → document_cognition_service, `/auth/*` → authentication_service,
-`/email/*` → email_service. Frontend OTel exports to `/i/otlp/v1/{traces,logs}`.
+`/unfurl/*` → unfurl_service, `/cognition/*` → document_cognition_service,
+`/auth/*` → authentication_service, `/email/*` → email_service. Frontend OTel
+exports to `/i/otlp/v1/{traces,logs}`.
 
 The local Caddy proxy strips these prefixes before forwarding, so `span.url.path` is
-unprefixed locally. The deployed gateway ALB does **not** strip `/dss` — DSS serves the
-same routes at both `/` and `/dss` — so in dev and prod `span.url.path` includes the
-prefix. Query both forms when a search comes back empty.
+unprefixed locally. The deployed gateway ALB does **not** strip `/dss` or `/unfurl` —
+those services serve the same routes at both `/` and the prefix — so in dev and prod
+`span.url.path` includes the prefix. Query both forms when a search comes back empty.
 
 ## Logs (Loki)
 

--- a/infra/packages/shared/src/gateway_priorities.ts
+++ b/infra/packages/shared/src/gateway_priorities.ts
@@ -4,6 +4,7 @@
  */
 export enum GatewayService {
   DOCUMENT_STORAGE_SERVICE = 'DOCUMENT_STORAGE_SERVICE',
+  UNFURL_SERVICE = 'UNFURL_SERVICE',
 }
 
 /**
@@ -17,6 +18,7 @@ type GatewayPriorityMap = { [K in GatewayService]: number };
  */
 export const GATEWAY_PRIORITIES: GatewayPriorityMap = {
   [GatewayService.DOCUMENT_STORAGE_SERVICE]: 10,
+  [GatewayService.UNFURL_SERVICE]: 20,
 };
 
 const assigned = Object.values(GATEWAY_PRIORITIES);

--- a/infra/packages/shared/src/index.ts
+++ b/infra/packages/shared/src/index.ts
@@ -41,6 +41,15 @@ export const DOCUMENT_STORAGE_GATEWAY_URL = `https://${
   stack === 'prod' ? '' : `${stack}-`
 }gateway.${BASE_DOMAIN}/dss`;
 
+/**
+ * Public base URL for unfurl-service behind the shared gateway ALB, which
+ * routes the `/unfurl` path prefix to the service. Callers append paths by
+ * concatenation, so this must not end with a trailing slash.
+ */
+export const UNFURL_SERVICE_GATEWAY_URL = `https://${
+  stack === 'prod' ? '' : `${stack}-`
+}gateway.${BASE_DOMAIN}/unfurl`;
+
 export const MACRO_SUBDOMAIN_CERT =
   'arn:aws:acm:us-east-1:569036502058:certificate/a75b1b07-534c-44e1-b59b-fa5f74fd8069';
 

--- a/infra/packages/shared/src/index.ts
+++ b/infra/packages/shared/src/index.ts
@@ -41,15 +41,6 @@ export const DOCUMENT_STORAGE_GATEWAY_URL = `https://${
   stack === 'prod' ? '' : `${stack}-`
 }gateway.${BASE_DOMAIN}/dss`;
 
-/**
- * Public base URL for unfurl-service behind the shared gateway ALB, which
- * routes the `/unfurl` path prefix to the service. Callers append paths by
- * concatenation, so this must not end with a trailing slash.
- */
-export const UNFURL_SERVICE_GATEWAY_URL = `https://${
-  stack === 'prod' ? '' : `${stack}-`
-}gateway.${BASE_DOMAIN}/unfurl`;
-
 export const MACRO_SUBDOMAIN_CERT =
   'arn:aws:acm:us-east-1:569036502058:certificate/a75b1b07-534c-44e1-b59b-fa5f74fd8069';
 

--- a/infra/packages/shared/src/service_urls.ts
+++ b/infra/packages/shared/src/service_urls.ts
@@ -13,6 +13,7 @@ export enum ServiceUrl {
   CONNECTION_GATEWAY_URL = 'CONNECTION_GATEWAY_URL',
   DOCUMENT_COGNITION_SERVICE_URL = 'DOCUMENT_COGNITION_SERVICE_URL',
   LEXICAL_SERVICE_URL = 'LEXICAL_SERVICE_URL',
+  UNFURL_SERVICE_URL = 'UNFURL_SERVICE_URL',
 }
 
 /**
@@ -41,6 +42,7 @@ const DEV_SERVICE_URLS: ServiceUrlMap = {
     'https://document-cognition-dev.macro.com',
   [ServiceUrl.LEXICAL_SERVICE_URL]:
     'https://lexical-service-dev.macroverse.workers.dev',
+  [ServiceUrl.UNFURL_SERVICE_URL]: 'https://dev-gateway.macro.com/unfurl',
 };
 
 /**
@@ -59,6 +61,7 @@ const PROD_SERVICE_URLS: ServiceUrlMap = {
     'https://document-cognition.macro.com',
   [ServiceUrl.LEXICAL_SERVICE_URL]:
     'https://lexical-service-prod.macroverse.workers.dev',
+  [ServiceUrl.UNFURL_SERVICE_URL]: 'https://gateway.macro.com/unfurl',
 };
 
 /**

--- a/infra/stacks/unfurl-service/index.ts
+++ b/infra/stacks/unfurl-service/index.ts
@@ -1,5 +1,9 @@
 import * as pulumi from '@pulumi/pulumi';
-import { stack, UNFURL_SERVICE_GATEWAY_URL } from '../../packages/shared';
+import {
+  getServiceUrl,
+  ServiceUrl,
+  stack,
+} from '../../packages/shared';
 import { get_coparse_api_vpc } from '../../packages/vpc';
 import { UnfurlService } from './unfurl-service';
 
@@ -54,4 +58,4 @@ const unfurlService = new UnfurlService(`unfurl-service-${stack}`, {
 
 export const unfurlServiceSgId = unfurlService.serviceSg.id;
 export const unfurlServiceAlbSgId = unfurlService.serviceAlbSg.id;
-export const unfurlServiceUrl = UNFURL_SERVICE_GATEWAY_URL;
+export const unfurlServiceUrl = getServiceUrl(ServiceUrl.UNFURL_SERVICE_URL);

--- a/infra/stacks/unfurl-service/index.ts
+++ b/infra/stacks/unfurl-service/index.ts
@@ -1,5 +1,5 @@
 import * as pulumi from '@pulumi/pulumi';
-import { stack } from '../../packages/shared';
+import { stack, UNFURL_SERVICE_GATEWAY_URL } from '../../packages/shared';
 import { get_coparse_api_vpc } from '../../packages/vpc';
 import { UnfurlService } from './unfurl-service';
 
@@ -54,4 +54,4 @@ const unfurlService = new UnfurlService(`unfurl-service-${stack}`, {
 
 export const unfurlServiceSgId = unfurlService.serviceSg.id;
 export const unfurlServiceAlbSgId = unfurlService.serviceAlbSg.id;
-export const unfurlServiceUrl = pulumi.interpolate`${unfurlService.domain}`;
+export const unfurlServiceUrl = UNFURL_SERVICE_GATEWAY_URL;

--- a/infra/stacks/unfurl-service/index.ts
+++ b/infra/stacks/unfurl-service/index.ts
@@ -1,9 +1,5 @@
 import * as pulumi from '@pulumi/pulumi';
-import {
-  getServiceUrl,
-  ServiceUrl,
-  stack,
-} from '../../packages/shared';
+import { getServiceUrl, ServiceUrl, stack } from '../../packages/shared';
 import { get_coparse_api_vpc } from '../../packages/vpc';
 import { UnfurlService } from './unfurl-service';
 

--- a/infra/stacks/unfurl-service/unfurl-service.ts
+++ b/infra/stacks/unfurl-service/unfurl-service.ts
@@ -8,14 +8,19 @@ import {
   datadogAgentContainer,
   fargateLogRouterSidecarContainer,
   serviceLoadBalancer,
+  ServiceTargetGroup,
 } from '../../packages/resources';
 import { EcrImage } from '../../packages/service';
 import {
   BASE_DOMAIN,
   CLOUD_TRAIL_SNS_TOPIC_ARN,
   DopplerEcsEnvironment,
+  getGatewayAlb,
+  GatewayService,
   stack,
 } from '../../packages/shared';
+
+const gatewayLoadBalancer = getGatewayAlb();
 
 const BASE_NAME = pulumi.getProject();
 const REPO_ROOT = '../../..';
@@ -100,6 +105,22 @@ export class UnfurlService extends pulumi.ComponentResource {
     this.serviceAlbSg = sg.serviceAlbSg;
     this.serviceSg = sg.serviceSg;
 
+    const gatewayTargetGroup = new ServiceTargetGroup(
+      `${stack}-${BASE_NAME}`,
+      {
+        tags: this.tags,
+        listenerArn: gatewayLoadBalancer.httpsListenerArn,
+        vpcId: vpc.vpcId,
+        containerPort: serviceContainerPort,
+        service: GatewayService.UNFURL_SERVICE,
+        healthCheckPath,
+        pathPatterns: ['/unfurl', '/unfurl/*'],
+        serviceSecurityGroupId: this.serviceSg.id,
+        albSecurityGroupId: gatewayLoadBalancer.albSecurityGroupId,
+      },
+      { parent: this }
+    );
+
     // lb
     const { targetGroup, lb, listener } = serviceLoadBalancer(this, {
       serviceName: BASE_NAME, // service name
@@ -159,6 +180,18 @@ export class UnfurlService extends pulumi.ComponentResource {
           enable: true,
           rollback: true,
         },
+        loadBalancers: [
+          {
+            targetGroupArn: targetGroup.arn,
+            containerName: 'service',
+            containerPort: serviceContainerPort,
+          },
+          {
+            targetGroupArn: gatewayTargetGroup.target_group.arn,
+            containerName: 'service',
+            containerPort: serviceContainerPort,
+          },
+        ],
         taskDefinitionArgs: {
           taskRole: {
             roleArn: this.role.arn,
@@ -214,6 +247,7 @@ export class UnfurlService extends pulumi.ComponentResource {
       },
       {
         parent: this,
+        dependsOn: [gatewayTargetGroup.listener_rule],
       }
     );
 

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -37,7 +37,7 @@ export const HOSTS: Record<Env, Record<ServiceName, string>> = {
     'static-files': 'https://static-file-service-dev.macro.com',
     connection: 'https://connection-gateway-dev.macro.com',
     contacts: 'https://contacts-dev.macro.com',
-    unfurl: 'https://unfurl-service-dev.macro.com',
+    unfurl: 'https://dev-gateway.macro.com/unfurl',
   },
   prod: {
     'agent-harness': 'https://agent-harness.macro.com',
@@ -52,7 +52,7 @@ export const HOSTS: Record<Env, Record<ServiceName, string>> = {
     'static-files': 'https://static-file-service.macro.com',
     connection: 'https://connection-gateway.macro.com',
     contacts: 'https://contacts.macro.com',
-    unfurl: 'https://unfurl-service.macro.com',
+    unfurl: 'https://gateway.macro.com/unfurl',
   },
   local: {
     'agent-harness': 'http://localhost:8101',

--- a/services/notification_service/examples/send_push_notification.rs
+++ b/services/notification_service/examples/send_push_notification.rs
@@ -1,9 +1,7 @@
 use anyhow::Context;
-use aws_sdk_sns::types::MessageAttributeValue;
 use macro_entrypoint::MacroEntrypoint;
 use serde::Serialize;
 use sns_client::{APNSPushNotification, Alert, AlertDictionary, Aps, MessageAttributes, SnsTarget};
-use std::collections::HashMap;
 
 /// Sends a push notification to the provided ENDPOINT_ARN environment variable
 #[tokio::main]

--- a/services/unfurl_service/src/api.rs
+++ b/services/unfurl_service/src/api.rs
@@ -26,11 +26,13 @@ where
     let cors = macro_cors::cors_layer();
 
     let env = state.environment;
-    let app = api_router(unfurl_state)
-        .with_state(state)
-        .merge(health::router())
+    let app = app_router(state, unfurl_state)
         .layer(cors)
-        .merge(SwaggerUi::new("/docs").url("/api-doc/openapi.json", swagger::ApiDoc::openapi()));
+        .merge(SwaggerUi::new("/docs").url("/api-doc/openapi.json", swagger::ApiDoc::openapi()))
+        .merge(
+            SwaggerUi::new("/unfurl/docs")
+                .url("/unfurl/api-doc/openapi.json", swagger::ApiDoc::openapi()),
+        );
 
     let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", port))
         .await
@@ -55,6 +57,17 @@ where
     Router::new()
         .nest("/unfurl", unfurl::router(unfurl_state))
         .nest("/proxy", proxy::router())
+}
+
+fn app_router<F>(state: ApiContext, unfurl_state: UnfurlRouterState<UnfurlServiceImpl<F>>) -> Router
+where
+    F: UnfurlFetcher,
+    anyhow::Error: From<F::Err>,
+{
+    let inner = api_router(unfurl_state)
+        .with_state(state)
+        .merge(health::router());
+    Router::new().merge(inner.clone()).nest("/unfurl", inner)
 }
 
 #[cfg(test)]
@@ -103,6 +116,63 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
         let body = response.into_body().collect().await.unwrap().to_bytes();
         assert!(body.is_empty());
+    }
+
+    async fn health_body(app: Router, uri: &str) -> (StatusCode, String) {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .method("GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = String::from_utf8(
+            response
+                .into_body()
+                .collect()
+                .await
+                .unwrap()
+                .to_bytes()
+                .to_vec(),
+        )
+        .unwrap();
+        (status, body)
+    }
+
+    #[tokio::test]
+    async fn test_health_is_served_at_root_and_gateway_prefix() {
+        let (root_status, root_body) =
+            health_body(app_router(test_state(), test_unfurl_state()), "/health").await;
+        assert_eq!(root_status, StatusCode::OK);
+        assert_eq!(root_body, "healthy");
+
+        let (prefixed_status, prefixed_body) = health_body(
+            app_router(test_state(), test_unfurl_state()),
+            "/unfurl/health",
+        )
+        .await;
+        assert_eq!(prefixed_status, StatusCode::OK);
+        assert_eq!(prefixed_body, "healthy");
+    }
+
+    #[tokio::test]
+    async fn test_gateway_prefixed_unfurl_path_is_reachable() {
+        let api = app_router(test_state(), test_unfurl_state());
+
+        let response = api
+            .oneshot(
+                Request::builder()
+                    .uri("/unfurl/unfurl?url=https://doesnotexist.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Dual-mount the HTTP router at / and /unfurl so the gateway ALB can forward the prefix unmodified while the legacy hostname stays reachable. Attach the ECS service to both target groups and point clients at https://{dev-}gateway.macro.com/unfurl.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Routing and dual ALB attachment affect all unfurl traffic in dev/prod; misconfigured listener rules or path mounting could break link previews until rolled back, though the legacy hostname ALB remains in place.
> 
> **Overview**
> Routes **unfurl** through the shared gateway at `https://{dev-}gateway.macro.com/unfurl` instead of dedicated `unfurl-service*.macro.com` hosts. Web app server config, Orval OpenAPI URLs, SDK, Rust `macro_service_urls`, and infra `ServiceUrl` maps are updated to match; local URLs stay on `localhost:8095`.
> 
> **Infra** registers `UNFURL_SERVICE` on the gateway ALB (listener priority 20, paths `/unfurl` and `/unfurl/*`), attaches a second target group to the ECS service alongside the existing service ALB, and exports stack URL via `getServiceUrl`.
> 
> **unfurl_service** dual-mounts the app at `/` and under `/unfurl` (same pattern as DSS), adds gateway-prefixed Swagger/OpenAPI paths, and adds tests for health and prefixed routes. Observability docs note `/unfurl/*` → `unfurl_service` and that the ALB does not strip the prefix in dev/prod.
> 
> Unrelated cleanup: unused imports removed from a notification service example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a14cd40174a23b59d2fda14d0fde1b6b4805debe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->