### PR TITLE
feat(convert-service): dual-mount convert-service on the shared gateway

### DIFF
--- a/crates/macro_service_urls/src/lib.rs
+++ b/crates/macro_service_urls/src/lib.rs
@@ -512,6 +512,12 @@ service_url! {
             dev: "https://dev-gateway.macro.com/dss",
             prod: "https://gateway.macro.com/dss",
         },
+        /// Convert service API URL.
+        pub ConvertServiceUrl {
+            local: "http://localhost:8080",
+            dev: "https://dev-gateway.macro.com/convert",
+            prod: "https://gateway.macro.com/convert",
+        },
         /// Connection gateway HTTP API URL.
         pub ConnectionGatewayUrl {
             local: "http://localhost:8082",

--- a/crates/macro_service_urls/src/test.rs
+++ b/crates/macro_service_urls/src/test.rs
@@ -36,6 +36,23 @@ fn document_storage_service_url_parses() {
 }
 
 #[test]
+fn convert_service_url_parses() {
+    assert_parses_for_all_environments(ConvertServiceUrl::default_for_environment);
+}
+
+#[test]
+fn convert_service_url_has_no_trailing_slash() {
+    for environment in ENVS {
+        let url = ConvertServiceUrl::default_for_environment(environment);
+        assert!(
+            !url.as_ref().ends_with('/'),
+            "clients concatenate paths, so {} must not end with /",
+            url.as_ref()
+        );
+    }
+}
+
+#[test]
 fn connection_gateway_url_parses() {
     assert_parses_for_all_environments(ConnectionGatewayUrl::default_for_environment);
 }
@@ -244,6 +261,10 @@ fn exported_service_urls_match_local_values() {
         "http://localhost:8086",
     );
     assert_eq!(
+        service_urls.convert_service_url.as_ref(),
+        "http://localhost:8080",
+    );
+    assert_eq!(
         service_urls.connection_gateway_url.as_ref(),
         "http://localhost:8082",
     );
@@ -302,6 +323,10 @@ fn exported_service_urls_match_dev_values() {
         "https://dev-gateway.macro.com/dss",
     );
     assert_eq!(
+        service_urls.convert_service_url.as_ref(),
+        "https://dev-gateway.macro.com/convert",
+    );
+    assert_eq!(
         service_urls.connection_gateway_url.as_ref(),
         "https://connection-gateway-dev.macro.com",
     );
@@ -355,6 +380,10 @@ fn exported_service_urls_match_prod_values() {
     assert_eq!(
         service_urls.document_storage_service_url.as_ref(),
         "https://gateway.macro.com/dss",
+    );
+    assert_eq!(
+        service_urls.convert_service_url.as_ref(),
+        "https://gateway.macro.com/convert",
     );
     assert_eq!(
         service_urls.connection_gateway_url.as_ref(),
@@ -411,6 +440,10 @@ fn exported_service_url_override_names_are_derived_from_env_var_names() {
     assert_eq!(
         DocumentStorageServiceUrl::local().override_env_var_name(),
         "OVERRIDE_DOCUMENT_STORAGE_SERVICE_URL",
+    );
+    assert_eq!(
+        ConvertServiceUrl::local().override_env_var_name(),
+        "OVERRIDE_CONVERT_SERVICE_URL",
     );
     assert_eq!(
         ConnectionGatewayUrl::local().override_env_var_name(),

--- a/infra/packages/shared/src/gateway_priorities.ts
+++ b/infra/packages/shared/src/gateway_priorities.ts
@@ -5,6 +5,7 @@
 export enum GatewayService {
   DOCUMENT_STORAGE_SERVICE = 'DOCUMENT_STORAGE_SERVICE',
   UNFURL_SERVICE = 'UNFURL_SERVICE',
+  CONVERT_SERVICE = 'CONVERT_SERVICE',
 }
 
 /**
@@ -19,6 +20,7 @@ type GatewayPriorityMap = { [K in GatewayService]: number };
 export const GATEWAY_PRIORITIES: GatewayPriorityMap = {
   [GatewayService.DOCUMENT_STORAGE_SERVICE]: 10,
   [GatewayService.UNFURL_SERVICE]: 20,
+  [GatewayService.CONVERT_SERVICE]: 3000,
 };
 
 const assigned = Object.values(GATEWAY_PRIORITIES);

--- a/infra/packages/shared/src/index.ts
+++ b/infra/packages/shared/src/index.ts
@@ -41,15 +41,6 @@ export const DOCUMENT_STORAGE_GATEWAY_URL = `https://${
   stack === 'prod' ? '' : `${stack}-`
 }gateway.${BASE_DOMAIN}/dss`;
 
-/**
- * Public base URL for convert-service behind the shared gateway ALB, which
- * routes the `/convert` path prefix to the service. Callers append paths by
- * concatenation, so this must not end with a trailing slash.
- */
-export const CONVERT_SERVICE_GATEWAY_URL = `https://${
-  stack === 'prod' ? '' : `${stack}-`
-}gateway.${BASE_DOMAIN}/convert`;
-
 export const MACRO_SUBDOMAIN_CERT =
   'arn:aws:acm:us-east-1:569036502058:certificate/a75b1b07-534c-44e1-b59b-fa5f74fd8069';
 

--- a/infra/packages/shared/src/index.ts
+++ b/infra/packages/shared/src/index.ts
@@ -41,6 +41,15 @@ export const DOCUMENT_STORAGE_GATEWAY_URL = `https://${
   stack === 'prod' ? '' : `${stack}-`
 }gateway.${BASE_DOMAIN}/dss`;
 
+/**
+ * Public base URL for convert-service behind the shared gateway ALB, which
+ * routes the `/convert` path prefix to the service. Callers append paths by
+ * concatenation, so this must not end with a trailing slash.
+ */
+export const CONVERT_SERVICE_GATEWAY_URL = `https://${
+  stack === 'prod' ? '' : `${stack}-`
+}gateway.${BASE_DOMAIN}/convert`;
+
 export const MACRO_SUBDOMAIN_CERT =
   'arn:aws:acm:us-east-1:569036502058:certificate/a75b1b07-534c-44e1-b59b-fa5f74fd8069';
 

--- a/infra/stacks/convert-service/index.ts
+++ b/infra/stacks/convert-service/index.ts
@@ -1,6 +1,6 @@
 import * as pulumi from '@pulumi/pulumi';
 import { Queue } from '../../packages/resources';
-import { CONVERT_SERVICE_GATEWAY_URL, stack } from '../../packages/shared';
+import { BASE_DOMAIN, stack } from '../../packages/shared';
 import { get_coparse_api_vpc } from '../../packages/vpc';
 import { ConvertService } from './service';
 
@@ -83,7 +83,6 @@ const convertService = new ConvertService('convert-service', {
 });
 
 export const convertServiceRoleArn = pulumi.interpolate`${convertService.role.arn}`;
-// Consumers call the service through the shared gateway, not the legacy
-// per-service hostname. `convertService.domain` still names the dedicated
-// ALB and stays in place until that listener is retired.
-export const convertServiceUrl = CONVERT_SERVICE_GATEWAY_URL;
+export const convertServiceUrl = `https://${
+  stack === 'prod' ? '' : `${stack}-`
+}gateway.${BASE_DOMAIN}/convert`;

--- a/infra/stacks/convert-service/index.ts
+++ b/infra/stacks/convert-service/index.ts
@@ -1,6 +1,6 @@
 import * as pulumi from '@pulumi/pulumi';
 import { Queue } from '../../packages/resources';
-import { stack } from '../../packages/shared';
+import { CONVERT_SERVICE_GATEWAY_URL, stack } from '../../packages/shared';
 import { get_coparse_api_vpc } from '../../packages/vpc';
 import { ConvertService } from './service';
 
@@ -83,4 +83,7 @@ const convertService = new ConvertService('convert-service', {
 });
 
 export const convertServiceRoleArn = pulumi.interpolate`${convertService.role.arn}`;
-export const convertServiceUrl = pulumi.interpolate`${convertService.domain}`;
+// Consumers call the service through the shared gateway, not the legacy
+// per-service hostname. `convertService.domain` still names the dedicated
+// ALB and stays in place until that listener is retired.
+export const convertServiceUrl = CONVERT_SERVICE_GATEWAY_URL;

--- a/infra/stacks/convert-service/service.ts
+++ b/infra/stacks/convert-service/service.ts
@@ -306,7 +306,10 @@ export class ConvertService extends pulumi.ComponentResource {
     this.service = service;
 
     // auto-scaling and alarm notifications
-    this.setupAutoScaling();
+    this.setupAutoScaling({
+      gatewayAlbArnSuffix: gatewayLoadBalancer.albArnSuffix,
+      gatewayTargetGroup: gatewayTargetGroup.target_group,
+    });
     this.setupServiceAlarms();
 
     // DNS
@@ -431,7 +434,13 @@ export class ConvertService extends pulumi.ComponentResource {
     return { serviceAlbSg, serviceSg };
   }
 
-  setupAutoScaling() {
+  setupAutoScaling({
+    gatewayAlbArnSuffix,
+    gatewayTargetGroup,
+  }: {
+    gatewayAlbArnSuffix: pulumi.Output<string>;
+    gatewayTargetGroup: aws.lb.TargetGroup;
+  }) {
     if (!this.service) return;
 
     const serviceScalableTarget = new aws.appautoscaling.Target(
@@ -474,6 +483,31 @@ export class ConvertService extends pulumi.ComponentResource {
           predefinedMetricSpecification: {
             predefinedMetricType: 'ALBRequestCountPerTarget',
             resourceLabel,
+          },
+          scaleInCooldown: 60,
+          scaleOutCooldown: 120,
+        },
+      },
+      { parent: this }
+    );
+
+    // Gateway requests hit a different target group. A second policy is
+    // required because ALBRequestCountPerTarget is scoped to one
+    // load-balancer/target-group pair. Target tracking uses the higher
+    // desired count of the two.
+    const gatewayResourceLabel = pulumi.interpolate`${gatewayAlbArnSuffix}/${gatewayTargetGroup.arnSuffix}`;
+    new aws.appautoscaling.Policy(
+      `${BASE_NAME}-scaling-policy-gateway-request-count-${stack}`,
+      {
+        policyType: 'TargetTrackingScaling',
+        resourceId: serviceScalableTarget.resourceId,
+        scalableDimension: serviceScalableTarget.scalableDimension,
+        serviceNamespace: serviceScalableTarget.serviceNamespace,
+        targetTrackingScalingPolicyConfiguration: {
+          targetValue: 1000,
+          predefinedMetricSpecification: {
+            predefinedMetricType: 'ALBRequestCountPerTarget',
+            resourceLabel: gatewayResourceLabel,
           },
           scaleInCooldown: 60,
           scaleOutCooldown: 120,

--- a/infra/stacks/convert-service/service.ts
+++ b/infra/stacks/convert-service/service.ts
@@ -8,14 +8,19 @@ import {
   datadogAgentContainer,
   fargateLogRouterSidecarContainer,
   serviceLoadBalancer,
+  ServiceTargetGroup,
 } from '../../packages/resources';
 import { EcrImage } from '../../packages/service';
 import {
   BASE_DOMAIN,
   CLOUD_TRAIL_SNS_TOPIC_ARN,
   DopplerEcsEnvironment,
+  getGatewayAlb,
+  GatewayService,
   stack,
 } from '../../packages/shared';
+
+const gatewayLoadBalancer = getGatewayAlb();
 
 const BASE_NAME = pulumi.getProject();
 const REPO_ROOT = '../../..';
@@ -164,6 +169,22 @@ export class ConvertService extends pulumi.ComponentResource {
     this.serviceAlbSg = sg.serviceAlbSg;
     this.serviceSg = sg.serviceSg;
 
+    const gatewayTargetGroup = new ServiceTargetGroup(
+      `${stack}-${BASE_NAME}`,
+      {
+        tags: this.tags,
+        listenerArn: gatewayLoadBalancer.httpsListenerArn,
+        vpcId: vpc.vpcId,
+        containerPort: serviceContainerPort,
+        service: GatewayService.CONVERT_SERVICE,
+        healthCheckPath,
+        pathPatterns: ['/convert', '/convert/*'],
+        serviceSecurityGroupId: this.serviceSg.id,
+        albSecurityGroupId: gatewayLoadBalancer.albSecurityGroupId,
+      },
+      { parent: this }
+    );
+
     // Load balancer
     const { targetGroup, lb, listener } = serviceLoadBalancer(this, {
       serviceName: BASE_NAME, // service name
@@ -199,6 +220,23 @@ export class ConvertService extends pulumi.ComponentResource {
           enable: true,
           rollback: true,
         },
+        // Register tasks in both the legacy ALB's target group and the gateway
+        // target group while we migrate to the gateway. An explicit
+        // `loadBalancers` replaces the list awsx derives from
+        // `portMappings.targetGroup`, so the legacy entry must be listed here
+        // too.
+        loadBalancers: [
+          {
+            targetGroupArn: targetGroup.arn,
+            containerName: 'service',
+            containerPort: serviceContainerPort,
+          },
+          {
+            targetGroupArn: gatewayTargetGroup.target_group.arn,
+            containerName: 'service',
+            containerPort: serviceContainerPort,
+          },
+        ],
         taskDefinitionArgs: {
           taskRole: {
             roleArn: this.role.arn,
@@ -259,6 +297,10 @@ export class ConvertService extends pulumi.ComponentResource {
       },
       {
         parent: this,
+        // ECS refuses a service whose target group is not yet associated with
+        // a load balancer; it is the listener rule that creates that
+        // association
+        dependsOn: [gatewayTargetGroup.listener_rule],
       }
     );
     this.service = service;

--- a/infra/stacks/convert-service/service.ts
+++ b/infra/stacks/convert-service/service.ts
@@ -456,21 +456,8 @@ export class ConvertService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    const lbPortion: pulumi.Output<string> = this.lb.arn.apply((arn) => {
-      const parts = arn.split(':loadbalancer/');
-      return parts[1];
-    });
+    const resourceLabel = pulumi.interpolate`${gatewayAlbArnSuffix}/${gatewayTargetGroup.arnSuffix}`;
 
-    const tgPortion: pulumi.Output<string> = this.targetGroup.arn.apply(
-      (arn) => {
-        const parts = arn.split(':');
-        return parts[parts.length - 1];
-      }
-    );
-
-    const resourceLabel = pulumi.interpolate`${lbPortion}/${tgPortion}`;
-
-    // Create an Auto Scaling policy for request count.
     new aws.appautoscaling.Policy(
       `${BASE_NAME}-scaling-policy-request-count-${stack}`,
       {
@@ -483,31 +470,6 @@ export class ConvertService extends pulumi.ComponentResource {
           predefinedMetricSpecification: {
             predefinedMetricType: 'ALBRequestCountPerTarget',
             resourceLabel,
-          },
-          scaleInCooldown: 60,
-          scaleOutCooldown: 120,
-        },
-      },
-      { parent: this }
-    );
-
-    // Gateway requests hit a different target group. A second policy is
-    // required because ALBRequestCountPerTarget is scoped to one
-    // load-balancer/target-group pair. Target tracking uses the higher
-    // desired count of the two.
-    const gatewayResourceLabel = pulumi.interpolate`${gatewayAlbArnSuffix}/${gatewayTargetGroup.arnSuffix}`;
-    new aws.appautoscaling.Policy(
-      `${BASE_NAME}-scaling-policy-gateway-request-count-${stack}`,
-      {
-        policyType: 'TargetTrackingScaling',
-        resourceId: serviceScalableTarget.resourceId,
-        scalableDimension: serviceScalableTarget.scalableDimension,
-        serviceNamespace: serviceScalableTarget.serviceNamespace,
-        targetTrackingScalingPolicyConfiguration: {
-          targetValue: 1000,
-          predefinedMetricSpecification: {
-            predefinedMetricType: 'ALBRequestCountPerTarget',
-            resourceLabel: gatewayResourceLabel,
           },
           scaleInCooldown: 60,
           scaleOutCooldown: 120,

--- a/services/convert_service/helpers/README.md
+++ b/services/convert_service/helpers/README.md
@@ -10,7 +10,7 @@ The backfill script is used to backfill the Convert Service with docx files.
 
 To run the backfill script, you need to provide the following environment variables:
 
-- `BASE_URL`: The base URL of the Convert Service.
+- `BASE_URL`: Convert service origin with no trailing slash. On the gateway that is `https://dev-gateway.macro.com/convert` or `https://gateway.macro.com/convert`. The legacy host still works during cutover.
 - `INTERNAL_API_KEY`: The internal API key for the Convert Service.
 - `LIMIT`: The maximum number of documents to backfill.
 - `OFFSET`: The offset to start backfilling from.

--- a/services/convert_service/load-test/artillery.yml
+++ b/services/convert_service/load-test/artillery.yml
@@ -1,5 +1,5 @@
 config:
-  target: "https://convert-service-dev.macro.com"
+  target: "https://dev-gateway.macro.com"
   processor: "./artillery-function.js"
   phases:
     - duration: 10
@@ -18,7 +18,7 @@ scenarios:
     flow:
       - function: "generateRandomData"
       - post:
-          url: "/internal/convert"
+          url: "/convert/internal/convert"
           json:
             from_bucket: "doc-storage-dev"
             to_bucket: "doc-storage-dev"

--- a/services/convert_service/src/api.rs
+++ b/services/convert_service/src/api.rs
@@ -16,18 +16,30 @@ mod health;
 // Misc
 mod swagger;
 
+#[cfg(test)]
+mod test;
+
+/// Path prefix the shared gateway ALB forwards unmodified. Dual-mounted
+/// alongside `/` so the dedicated ALB keeps working during cutover.
+const GATEWAY_PATH_PREFIX: &str = "/convert";
+
 pub async fn setup_and_serve(state: ApiContext) -> anyhow::Result<()> {
     let cors = macro_cors::cors_layer();
 
     let port = state.config.port;
     let env = state.config.environment;
-    let app = api_router()
+    let traced_api = api_router()
         .with_state(state)
         .layer(cors.clone())
-        .layer(ServiceBuilder::new().layer(TraceLayer::new_for_http()))
-        // The health router is attached here so we don't attach the logging middleware to it
-        .merge(health::router().layer(cors))
-        .merge(SwaggerUi::new("/docs").url("/api-doc/openapi.json", swagger::ApiDoc::openapi()));
+        .layer(ServiceBuilder::new().layer(TraceLayer::new_for_http()));
+    // Health stays outside TraceLayer so the probe does not generate request logs.
+    let health = health::router().layer(cors);
+    let app = mount_at_root_and_prefix(traced_api.merge(health))
+        .merge(SwaggerUi::new("/docs").url("/api-doc/openapi.json", swagger::ApiDoc::openapi()))
+        .merge(
+            SwaggerUi::new("/convert/docs")
+                .url("/convert/api-doc/openapi.json", swagger::ApiDoc::openapi()),
+        );
 
     let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", port))
         .await
@@ -40,6 +52,12 @@ pub async fn setup_and_serve(state: ApiContext) -> anyhow::Result<()> {
     axum::serve(listener, app.into_make_service())
         .await
         .context("error starting service")
+}
+
+fn mount_at_root_and_prefix(inner: Router) -> Router {
+    Router::new()
+        .merge(inner.clone())
+        .nest(GATEWAY_PATH_PREFIX, inner)
 }
 
 fn api_router() -> Router<ApiContext> {

--- a/services/convert_service/src/api/test.rs
+++ b/services/convert_service/src/api/test.rs
@@ -1,0 +1,40 @@
+use super::{health, mount_at_root_and_prefix};
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn health_is_reachable_at_root_and_gateway_prefix() {
+    for path in ["/health", "/convert/health"] {
+        let response = mount_at_root_and_prefix(health::router())
+            .oneshot(
+                Request::builder()
+                    .uri(path)
+                    .method("GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK, "{path}");
+    }
+}
+
+#[tokio::test]
+async fn unprefixed_unknown_path_is_not_rewritten_onto_the_prefix() {
+    let response = mount_at_root_and_prefix(health::router())
+        .oneshot(
+            Request::builder()
+                .uri("/missing")
+                .method("GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
Serve the existing router at / and /convert so the gateway ALB can forward the prefix unmodified. Attach a ServiceTargetGroup at priority 20, register tasks in both target groups, and point clients at gateway.macro.com/convert with no trailing slash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dual ALB registration and routing changes affect production traffic and autoscaling; misconfigured listener rules or path prefix could break convert calls until cutover is complete.
> 
> **Overview**
> Moves **convert-service** onto the shared gateway at **`/convert`** while keeping the dedicated ALB hostname working during cutover.
> 
> **Application:** The Axum app is mounted at both `/` and `/convert` (including Swagger at `/convert/docs`). Health checks stay reachable at `/health` and `/convert/health`; new tests cover those paths and that unprefixed 404s are not rewritten onto the prefix.
> 
> **Infrastructure:** Pulumi adds a gateway `ServiceTargetGroup` with listener rules for `/convert` and `/convert/*`, registers ECS tasks in **both** the legacy and gateway target groups, and switches request-count autoscaling to the gateway ALB/target group. Stack output **`convertServiceUrl`** is now `https://{dev-}gateway.macro.com/convert` (no trailing slash). **`GATEWAY_PRIORITIES`** gains **`CONVERT_SERVICE`** at priority **3000**.
> 
> **Clients & ops:** **`ConvertServiceUrl`** is added to **`macro_service_urls`** (local/dev/prod, env override `OVERRIDE_CONVERT_SERVICE_URL`) with tests. Load-test Artillery config and backfill README point at the gateway base URL and `/convert/...` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b024e7bc91df254a0eb7a9077ae03513551dbeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->