### PR TITLE
feat(ui): kill bento

### DIFF
--- a/apps/web/src/components/app/split-layout/SplitLayout.tsx
+++ b/apps/web/src/components/app/split-layout/SplitLayout.tsx
@@ -116,8 +116,11 @@ export function SplitLayoutContainer(props: SplitLayoutContainerProps) {
   return (
     <SplitLayoutContext.Provider value={{ manager: splitManager }}>
       <div
-        class={cn('size-full p-2 touch:p-0', {
-          'pl-0': isSidebarVisible() && !sidebar.isCollapsed(),
+        class={cn('size-full', {
+          // A hairline separates the docked sidebar from the splits; the slim
+          // sidebar floats as an overlay and needs none.
+          'border-l border-edge-muted touch:border-l-0':
+            isSidebarVisible() && !sidebar.isCollapsed(),
         })}
       >
         <Show
@@ -126,7 +129,7 @@ export function SplitLayoutContainer(props: SplitLayoutContainerProps) {
             // Desktop: side-by-side resizable splits.
             <Resize.Zone
               direction="horizontal"
-              gutter={8}
+              gutter={0}
               captureResizeCtx={splitManager.setResizeContext}
             >
               <For each={ids()}>

--- a/apps/web/src/components/app/split-layout/components/SplitDrawer.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitDrawer.tsx
@@ -69,16 +69,16 @@ export function SplitDrawer(
     let positionClasses = '';
     switch (props.side) {
       case 'top':
-        positionClasses = 'left-px right-px border-b';
+        positionClasses = 'left-0 right-0 border-b';
         break;
       case 'bottom':
-        positionClasses = 'top-unset left-px right-px bottom-px border-t';
+        positionClasses = 'top-unset left-0 right-0 bottom-0 border-t';
         break;
       case 'left':
-        positionClasses = 'bottom-px left-px border-r border-t';
+        positionClasses = 'bottom-0 left-0 border-r border-t';
         break;
       case 'right':
-        positionClasses = 'bottom-px right-px border-l border-t';
+        positionClasses = 'bottom-0 right-0 border-l border-t';
         break;
       default:
         break;
@@ -124,7 +124,7 @@ export function SplitDrawer(
       <ScopedPortal scope="split">
         <Layer depth={2}>
           <div
-            class="inset-px bg-modal-overlay absolute"
+            class="inset-0 bg-modal-overlay absolute"
             style={{ top: `${contentOffsetTop()}px` }}
             onClick={drawerControl.close}
           />

--- a/apps/web/src/components/app/split-layout/components/SplitDrawer.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitDrawer.tsx
@@ -2,8 +2,9 @@ import { ScopedPortal } from '@core/component/ScopedPortal';
 import { registerHotkey } from '@core/hotkey/hotkeys';
 import { TOKENS } from '@core/hotkey/tokens';
 import CloseIcon from '@phosphor/x.svg';
-import { Button, Layer } from '@ui';
+import { Button, cn, Layer } from '@ui';
 import { type JSX, type ParentProps, Show } from 'solid-js';
+import { match, P } from 'ts-pattern';
 import { useSplitPanel } from '../layoutUtils';
 import { useDrawerControl, useDrawerGroup } from './SplitDrawerContext';
 
@@ -64,28 +65,16 @@ export function SplitDrawer(
     return `${constrainedSize}px`;
   };
 
-  const getPositionClasses = () => {
-    const baseClasses = `absolute bg-surface border-edge-muted z-annotation-layer flex flex-col`;
-    let positionClasses = '';
-    switch (props.side) {
-      case 'top':
-        positionClasses = 'left-0 right-0 border-b';
-        break;
-      case 'bottom':
-        positionClasses = 'top-unset left-0 right-0 bottom-0 border-t';
-        break;
-      case 'left':
-        positionClasses = 'bottom-0 left-0 border-r border-t';
-        break;
-      case 'right':
-        positionClasses = 'bottom-0 right-0 border-l border-t';
-        break;
-      default:
-        break;
-    }
-
-    return `${baseClasses} ${positionClasses}`;
-  };
+  const getPositionClasses = () =>
+    cn(
+      'absolute bg-surface border-edge-muted z-annotation-layer flex flex-col',
+      match(props.side)
+        .with('top', () => 'left-0 right-0 border-b')
+        .with('bottom', () => 'top-unset left-0 right-0 bottom-0 border-t')
+        .with('left', () => 'bottom-0 left-0 border-r border-t')
+        .with('right', () => 'bottom-0 right-0 border-l border-t')
+        .exhaustive()
+    );
 
   const getSizeStyle = () => {
     const constrainedSize = getConstrainedSize();
@@ -103,21 +92,27 @@ export function SplitDrawer(
     }
   };
 
-  const getGradientMaskClasses = () => {
-    const baseClasses = 'absolute pattern-panel pattern-diagonal-4 opacity-100';
-    switch (props.side) {
-      case 'left':
-        return `${baseClasses} h-full w-4 left-0 top-0 -translate-x-[calc(100%+1px)] mask-l-from-0`;
-      case 'right':
-        return `${baseClasses} h-full w-4 left-0 top-0 -translate-x-[calc(100%+1px)] mask-l-from-0`;
-      case 'top':
-        return `${baseClasses} w-full h-4 left-0 top-0 -translate-y-[calc(100%+1px)] mask-t-from-0`;
-      case 'bottom':
-        return `${baseClasses} w-full h-4 left-0 bottom-0 translate-y-[calc(100%+1px)] mask-b-from-0`;
-      default:
-        return baseClasses;
-    }
-  };
+  const getGradientMaskClasses = () =>
+    cn(
+      'absolute pattern-panel pattern-diagonal-4 opacity-100',
+      match(props.side)
+        .with(
+          P.union('left', 'right'),
+          () =>
+            'h-full w-4 left-0 top-0 -translate-x-[calc(100%+1px)] mask-l-from-0'
+        )
+        .with(
+          'top',
+          () =>
+            'w-full h-4 left-0 top-0 -translate-y-[calc(100%+1px)] mask-t-from-0'
+        )
+        .with(
+          'bottom',
+          () =>
+            'w-full h-4 left-0 bottom-0 translate-y-[calc(100%+1px)] mask-b-from-0'
+        )
+        .exhaustive()
+    );
 
   return (
     <Show when={drawerControl.isOpen()}>

--- a/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitHeader.tsx
@@ -527,7 +527,7 @@ export function SplitHeader(props: {
             <Portal mount={panelRef()}>
               <Show when={isEntityDraggingOver()}>
                 <div
-                  class="pointer-events-none absolute inset-0 rounded-xl z-modal-overlay bg-modal-overlay pattern-diagonal-4 pattern-edge-muted flex items-center justify-center"
+                  class="pointer-events-none absolute inset-0 z-modal-overlay bg-modal-overlay pattern-diagonal-4 pattern-edge-muted flex items-center justify-center"
                   data-split-header-drop-overlay
                 >
                   <div class="max-w-[min(28rem,calc(100%-3rem))] min-w-0 bg-surface border border-edge rounded-lg shadow-lg shadow-drop-shadow px-4 py-3 flex items-center gap-2 text-sm text-ink">

--- a/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitPanel.tsx
@@ -168,12 +168,6 @@ export function SplitPanel(props: SplitPanelProps) {
   // floating filter-pill strip (see MobileSoupViewTabs).
   const shouldHideSplitHeader = createMemo(() => isSoloSettings());
 
-  const splitFocusStyling = () =>
-    !isTouchDevice() &&
-    props.active &&
-    multipleSplits() &&
-    !props.handle.isSpotLight();
-
   const splitUnfocusedStyling = () =>
     !isTouchDevice() && !props.active && multipleSplits();
 
@@ -194,21 +188,8 @@ export function SplitPanel(props: SplitPanelProps) {
   });
 
   /**
-   * This split is a preview controller with its viewer tucked flush against
-   * its right edge: paint above the viewer so the controller's card and
-   * shadow read as being in front.
-   */
-  const hasTuckedViewer = createMemo(() => {
-    return (
-      !isTouchDevice() &&
-      !props.handle.isSpotLight() &&
-      props.handle.isControllerSplit()
-    );
-  });
-
-  /**
-   * When either member of a tucked Preview Pair is active, the active member
-   * stays solid and its partner is dashed. Both retain the standard edge color.
+   * Either member of a tucked Preview Pair is active: the seam between the
+   * two is drawn dashed so they read as one unit.
    */
   const previewPairFocusStyling = createMemo(() => {
     const manager = globalSplitManager();
@@ -343,24 +324,21 @@ export function SplitPanel(props: SplitPanelProps) {
           >
             <Panel
               class={cn(
-                'rounded-xl touch:rounded-none touch:after:hidden touch:border-0! bg-panel',
+                'rounded-none bg-panel',
                 splitUnfocusedStyling() && 'split-panel-inactive',
-                {
-                  'shadow-sm shadow-drop-shadow/50': splitUnfocusedStyling(),
-                  'shadow-2xl shadow-drop-shadow': splitFocusStyling(),
-                  'border-solid!': previewPairFocusStyling() && props.active,
-                  'border-dashed!': previewPairFocusStyling() && !props.active,
-                  // Drawer look: both members square their seam corners. The
-                  // seam border always belongs to the Controller — the
-                  // Viewer's seam edge stays borderless so the line never
-                  // doubles, and keeping it on one fixed member regardless
-                  // of focus means switching focus can't shift layout by the
-                  // border width (the ! beats Surface's inline border
-                  // shorthand).
-                  'rounded-l-none border-l-0!': tuckedBehindController(),
-                  'rounded-r-none': hasTuckedViewer(),
-                }
+                // Splits sit flush; the only chrome between them is a hairline
+                // on the left edge of every split after the first. The line
+                // lives on the split rather than the (zero-width) gutter so a
+                // tucked Viewer carries the seam with it when it slides across.
+                props.index > 0 &&
+                  'border-l border-edge-muted touch:border-l-0',
+                // An engaged Preview Pair dashes its seam so the two members
+                // read as one unit.
+                previewPairFocusStyling() &&
+                  tuckedBehindController() &&
+                  'border-dashed'
               )}
+              hideBorder
               depth={isTouchDevice() ? 0 : 1}
             >
               <Show
@@ -369,7 +347,7 @@ export function SplitPanel(props: SplitPanelProps) {
                   <>
                     <Panel.Header
                       class={cn(
-                        'relative block min-h-10.25 touch:min-h-11.25 p-0 overflow-visible border-b-0!',
+                        'relative block min-h-10.25 touch:min-h-11.25 p-0 overflow-visible',
                         'z-split-panel-chrome',
                         // On mobile/tablet the header collapses to a zero-height grid row;
                         // SplitHeader overlays the body as floating islands.

--- a/apps/web/src/features/settings/Settings.tsx
+++ b/apps/web/src/features/settings/Settings.tsx
@@ -310,7 +310,7 @@ export function SettingsPanel(props: SettingsPanelProps) {
         <Show when={!isTouchDevice() && !compact()}>
           <SideNav
             class={cn(
-              'w-[clamp(208px,20%,248px)] gap-3',
+              'w-[clamp(208px,20%,248px)] gap-3 border-r border-edge-muted',
               narrow() ? 'pr-1' : 'pr-2'
             )}
           >
@@ -353,19 +353,11 @@ export function SettingsPanel(props: SettingsPanelProps) {
           </SideNav>
         </Show>
 
-        {/* Content sits in its own subtly-raised, rounded card. The gutter
-            around it tightens as the panel narrows, and goes uniform once the
-            sidebar collapses. Full-bleed on mobile. */}
-        <div
-          class="flex-1 min-w-0 overflow-hidden touch:p-0"
-          classList={{
-            'py-2 pr-2 pl-0': !compact() && !narrow(),
-            'py-1 pr-1 pl-0': !compact() && narrow(),
-            'p-1': compact(),
-          }}
-        >
+        {/* Content sits flush against the sidebar's hairline, matching the
+            split chrome. Full-bleed on mobile. */}
+        <div class="flex-1 min-w-0 overflow-hidden">
           <Layer depth={1}>
-            <div class="relative flex size-full flex-col overflow-hidden rounded-xl border border-ink/[0.06] bg-surface shadow-menu touch:rounded-none touch:border-0 touch:bg-transparent">
+            <div class="relative flex size-full flex-col overflow-hidden bg-surface touch:bg-transparent">
               {/* Compact full-screen chrome: no split header to host the tabs,
                   so the sidebar collapses into a top bar here — back / tab
                   dropdown / move-to-split. (Split mode puts the tabs in its

--- a/apps/web/src/lib/core/component/Resize/Resize.tsx
+++ b/apps/web/src/lib/core/component/Resize/Resize.tsx
@@ -520,6 +520,16 @@ function Gutter(props: GutterProps) {
       onPointerDown={onPointerDown}
       onKeyDown={onKeyDown}
     >
+      {/* Drag hit-area independent of the gutter width, so a zero-width
+          gutter (flush panels) stays grabbable. */}
+      <div
+        class={cn(
+          'absolute',
+          ctx.direction() === 'horizontal'
+            ? 'inset-y-0 -inset-x-1'
+            : 'inset-x-0 -inset-y-1'
+        )}
+      />
       <div
         class={cn(
           'bg-accent absolute opacity-0 group-focus:opacity-100 rounded-[1px]',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Visual and layout-only changes to split/settings chrome; resize behavior is preserved via a wider gutter hit area.
> 
> **Overview**
> Removes the **bento** look (outer padding, rounded cards, drop shadows, 8px resize gutters) in favor of **edge-to-edge splits** separated by **`border-edge-muted` hairlines**.
> 
> **Split layout:** `SplitLayout` drops `p-2` and uses a left border when the docked sidebar is open; desktop `Resize.Zone` **gutter goes 0**. **`SplitPanel`** panels are square (`rounded-none`), use **`hideBorder`** on `Panel`, and draw the seam on **`border-l`** for every split after the first (including dashed seams for active preview pairs); focus/tucked-corner shadow logic is removed. **`SplitDrawer`** and header drop overlays align to **`inset-0`** / flush edges; drawer positioning classes are refactored with **`ts-pattern`**.
> 
> **Settings** matches the same chrome: sidebar **`border-r`**, content no longer sits in a padded rounded card.
> 
> **Resize:** adds an expanded invisible hit target on gutters so **zero-width** seams stay draggable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6faa24a72ab8b663020db5501c4ba8dfb7826d28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->