### PR TITLE
fix(email): preserve UTF-8 in misdeclared Gmail bodies

### DIFF
--- a/crates/email_api_client/src/outbound/gmail/convert/payload.rs
+++ b/crates/email_api_client/src/outbound/gmail/convert/payload.rs
@@ -144,16 +144,24 @@ fn parse_part(part: &MessagePart, message_id: &str, parsed: &mut ParsedGmailPayl
     }
 }
 
-/// Decodes part bytes honoring the part's declared `charset`, so non-UTF-8
-/// bodies (e.g. ISO-8859-1, Windows-1252, Shift_JIS) are not mangled by a
-/// blind lossy UTF-8 conversion. Unknown or missing charsets fall back to
-/// lossy UTF-8.
+/// Decodes part bytes using UTF-8 when valid, otherwise honoring the part's
+/// declared `charset`.
+///
+/// Some senders emit UTF-8 bytes while incorrectly declaring a legacy
+/// single-byte charset. Trusting that declaration turns a bullet (`•`) into
+/// mojibake (`â€¢`). Valid UTF-8 is therefore preferred over a conflicting
+/// single-byte declaration. Multi-byte encodings still take precedence, and
+/// unknown or missing charsets fall back to lossy UTF-8.
 fn decode_part_text(bytes: &[u8], part: &MessagePart) -> String {
     let encoding = find_header(&part.headers, "Content-Type")
         .and_then(content_type_charset)
         .and_then(|label| encoding_rs::Encoding::for_label(label.as_bytes()));
 
     match encoding {
+        Some(encoding) if encoding.is_single_byte() => match str::from_utf8(bytes) {
+            Ok(text) => text.to_owned(),
+            Err(_) => encoding.decode(bytes).0.into_owned(),
+        },
         Some(encoding) => encoding.decode(bytes).0.into_owned(),
         None => String::from_utf8_lossy(bytes).into_owned(),
     }

--- a/crates/email_api_client/src/outbound/gmail/convert/payload/test.rs
+++ b/crates/email_api_client/src/outbound/gmail/convert/payload/test.rs
@@ -79,6 +79,23 @@ fn honors_declared_non_utf8_charsets() {
 }
 
 #[test]
+fn prefers_valid_utf8_over_a_misdeclared_single_byte_charset() {
+    let body = "<p>• A dedicated Macro product walkthrough</p>";
+    let encoded = URL_SAFE.encode(body);
+    let mut part = payload("text/html", &encoded);
+    part.headers.push(Header {
+        name: "Content-Type".into(),
+        value: "text/html; charset=Windows-1252".into(),
+    });
+
+    let parsed = parse_gmail_payload(&part, "message").unwrap();
+    let html = parsed.body_html_sanitized.unwrap();
+
+    assert!(html.contains("• A dedicated Macro product walkthrough"));
+    assert!(!html.contains("â€¢"));
+}
+
+#[test]
 fn unknown_charsets_fall_back_to_lossy_utf8() {
     let encoded = URL_SAFE.encode("Hello");
     let mut part = payload("text/plain", &encoded);


### PR DESCRIPTION
## Summary

- prefer valid UTF-8 body bytes over conflicting legacy single-byte charset declarations
- retain declared charset decoding when the body is not valid UTF-8
- add a regression test for Windows-1252-labeled HTML that previously rendered bullets as mojibake

## Root cause

Some Gmail message parts contain valid UTF-8 bytes while declaring a legacy single-byte charset. The payload converter always trusted that declaration, so the UTF-8 bytes for a bullet were decoded as Windows-1252 and rendered as `â€¢`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to Gmail payload text decoding with a targeted regression test; no auth, persistence, or API contract changes.
> 
> **Overview**
> Fixes mojibake in Gmail HTML/plain bodies when senders ship **valid UTF-8** but label the part with a legacy single-byte charset (e.g. Windows-1252), which previously turned bullets like `•` into `â€¢`.
> 
> **`decode_part_text`** now treats declared **single-byte** charsets specially: if the raw bytes are valid UTF-8, it uses UTF-8; otherwise it still decodes with the declared encoding. Multi-byte declared encodings and the lossy UTF-8 fallback for unknown charsets are unchanged.
> 
> Adds a regression test for Windows-1252-labeled HTML that must keep the bullet character after parse/sanitize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45006bd789cd16ce95f3a9e0117fdba2910ef134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->