### PR TITLE
fix(soup): publish realtime updates for channel-shared entities

### DIFF
--- a/crates/soup_realtime/src/inbound/kafka_consumer.rs
+++ b/crates/soup_realtime/src/inbound/kafka_consumer.rs
@@ -14,7 +14,10 @@ use crate::domain::{
     ports::SoupRealtimeService,
     service::SoupRealtimeServiceImpl,
 };
-use channels::domain::broker_events::{ChannelMacroEvent, ChannelTopicEvent};
+use channels::domain::{
+    broker_events::{ChannelMacroEvent, ChannelTopicEvent},
+    models::ReferencedShareItemType,
+};
 use chat::domain::events::{ChatMacroEvent, ChatTopicEvent};
 use documents::domain::events::{DocumentMacroEvent, DocumentTopicEvent, InteractionReason};
 use email::domain::events::{EmailMacroEvent, EmailTopicEvent};
@@ -63,13 +66,22 @@ fn delete(entity_type: EntityType, entity_id: impl ToString) -> SoupRealtimePatc
     SoupRealtimePatch::for_entity(Patch::Deleted(entity(entity_type, entity_id)))
 }
 
-fn push_unique_patch(patches: &mut Vec<SoupRealtimePatch>, patch: Patch<Entity<'static>>) {
+fn push_unique_patch_with_access_source(
+    patches: &mut Vec<SoupRealtimePatch>,
+    patch: Patch<Entity<'static>>,
+    access_source: Entity<'static>,
+) {
     if patch.value().entity_id.is_empty()
         || patches.iter().any(|candidate| candidate.patch == patch)
     {
         return;
     }
-    patches.push(SoupRealtimePatch::for_entity(patch));
+    patches.push(SoupRealtimePatch::new(patch, access_source));
+}
+
+fn push_unique_patch(patches: &mut Vec<SoupRealtimePatch>, patch: Patch<Entity<'static>>) {
+    let access_source = patch.value().clone();
+    push_unique_patch_with_access_source(patches, patch, access_source);
 }
 
 fn push_unique_update(
@@ -296,16 +308,54 @@ fn channel_and_thread_entities(
     ]
 }
 
+fn soup_entity_type_from_channel_reference(entity_type: &str) -> Option<EntityType> {
+    match ReferencedShareItemType::from_raw(entity_type)? {
+        ReferencedShareItemType::Document => Some(EntityType::Document),
+        ReferencedShareItemType::Chat => Some(EntityType::Chat),
+        ReferencedShareItemType::Project => Some(EntityType::Project),
+        ReferencedShareItemType::EmailThread => Some(EntityType::EmailThread),
+        ReferencedShareItemType::Call => Some(EntityType::Call),
+    }
+}
+
+fn push_channel_reference_update(
+    patches: &mut Vec<SoupRealtimePatch>,
+    channel: &Entity<'static>,
+    entity_type: &str,
+    entity_id: &str,
+) {
+    let Some(entity_type) = soup_entity_type_from_channel_reference(entity_type) else {
+        return;
+    };
+    push_unique_patch_with_access_source(
+        patches,
+        Patch::Updated(entity(entity_type, entity_id)),
+        channel.clone(),
+    );
+}
+
 fn patches_from_channel_event(event: &ChannelTopicEvent) -> Vec<SoupRealtimePatch> {
     match event {
         ChannelTopicEvent::Updated(metadata) => {
             vec![update(EntityType::Channel, metadata.channel_id)]
         }
-        ChannelTopicEvent::MessagePosted(metadata) => channel_and_thread_entities(
-            metadata.channel_id,
-            metadata.message_id,
-            metadata.thread_id,
-        ),
+        ChannelTopicEvent::MessagePosted(metadata) => {
+            let mut patches = channel_and_thread_entities(
+                metadata.channel_id,
+                metadata.message_id,
+                metadata.thread_id,
+            );
+            let channel = entity(EntityType::Channel, metadata.channel_id);
+            for mention in &metadata.mentions {
+                push_channel_reference_update(
+                    &mut patches,
+                    &channel,
+                    &mention.entity_type,
+                    &mention.entity_id,
+                );
+            }
+            patches
+        }
         ChannelTopicEvent::MessagePatched(metadata) => channel_and_thread_entities(
             metadata.channel_id,
             metadata.message_id,
@@ -323,7 +373,19 @@ fn patches_from_channel_event(event: &ChannelTopicEvent) -> Vec<SoupRealtimePatc
             ]
         }
         ChannelTopicEvent::MessageAttachmentCreated(metadata) => {
-            vec![update(EntityType::Channel, metadata.channel_id)]
+            let channel = entity(EntityType::Channel, metadata.channel_id);
+            let mut patches = vec![SoupRealtimePatch::for_entity(Patch::Updated(
+                channel.clone(),
+            ))];
+            for attachment in &metadata.attachments {
+                push_channel_reference_update(
+                    &mut patches,
+                    &channel,
+                    &attachment.entity_type,
+                    &attachment.entity_id,
+                );
+            }
+            patches
         }
         ChannelTopicEvent::MessageAttachmentRemoved(metadata) => {
             vec![update(EntityType::Channel, metadata.channel_id)]

--- a/crates/soup_realtime/src/inbound/kafka_consumer/test.rs
+++ b/crates/soup_realtime/src/inbound/kafka_consumer/test.rs
@@ -3,9 +3,10 @@ use std::sync::{Arc, Mutex};
 
 use channels::domain::{
     broker_events::{
-        ChannelMessageAttachmentCreatedMetadata, ChannelMessageDeletedMetadata, ChannelTopicEvent,
+        ChannelEventAttachment, ChannelMessageAttachmentCreatedMetadata,
+        ChannelMessageDeletedMetadata, ChannelMessagePostedMetadata, ChannelTopicEvent,
     },
-    models::ChannelSender,
+    models::{ChannelSender, ChannelType, SimpleMention},
 };
 use chat::domain::events::{ChatMessageDeletedMetadata, ChatTopicEvent, ChatUpdatedMetadata};
 use chrono::Utc;
@@ -475,20 +476,56 @@ fn new_email_events_map_to_realtime_thread_patches() {
 }
 
 #[test]
-fn attachment_events_use_only_metadata_available_on_the_existing_event() {
+fn attachment_events_update_referenced_documents_for_channel_members() {
     let channel_id = Uuid::now_v7();
     let event =
         ChannelTopicEvent::MessageAttachmentCreated(ChannelMessageAttachmentCreatedMetadata {
             channel_id,
             message_id: Uuid::now_v7(),
             actor: ChannelSender::new_from_user(user()),
-            attachments: Vec::new(),
+            attachments: vec![ChannelEventAttachment {
+                attachment_id: Uuid::now_v7(),
+                entity_type: "document".to_string(),
+                entity_id: DOCUMENT_ID.to_string(),
+                created_at: Utc::now(),
+            }],
         });
 
     let patches = patches_from_channel_event(&event);
-    assert_eq!(patches.len(), 1);
+    assert_eq!(patches.len(), 2);
     assert_eq!(patch_entity(&patches[0]).entity_type, EntityType::Channel);
     assert_eq!(patch_entity(&patches[0]).entity_id, channel_id.to_string());
+    assert_eq!(patch_entity(&patches[1]).entity_type, EntityType::Document);
+    assert_eq!(patch_entity(&patches[1]).entity_id, DOCUMENT_ID);
+    assert_eq!(patches[1].access_source.entity_type, EntityType::Channel);
+    assert_eq!(patches[1].access_source.entity_id, channel_id.to_string());
+}
+
+#[test]
+fn posted_message_mentions_update_referenced_documents_for_channel_members() {
+    let channel_id = Uuid::now_v7();
+    let event = ChannelTopicEvent::MessagePosted(ChannelMessagePostedMetadata {
+        channel_id,
+        message_id: Uuid::now_v7(),
+        thread_id: None,
+        sender: ChannelSender::new_from_user(user()),
+        triggered_by: None,
+        channel_type: ChannelType::Private,
+        content: "shared a document".to_string(),
+        mentions: vec![SimpleMention {
+            entity_type: "document".to_string(),
+            entity_id: DOCUMENT_ID.to_string(),
+        }],
+        attachments: Vec::new(),
+        created_at: Utc::now(),
+    });
+
+    let patches = patches_from_channel_event(&event);
+    assert_eq!(patches.len(), 3);
+    assert_eq!(patch_entity(&patches[2]).entity_type, EntityType::Document);
+    assert_eq!(patch_entity(&patches[2]).entity_id, DOCUMENT_ID);
+    assert_eq!(patches[2].access_source.entity_type, EntityType::Channel);
+    assert_eq!(patches[2].access_source.entity_id, channel_id.to_string());
 }
 
 #[test]


### PR DESCRIPTION
Currently sharing a channel message with an attached document does not produce a kafka event for the document which is now accessible to members of the channel. This PR changes the soup realtime consumer to produce an event for the newly visible document

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes realtime notification fan-out for channel shares; wrong `access_source` or entity mapping could over- or under-notify users, but scope is limited to the soup realtime Kafka consumer.
> 
> **Overview**
> Channel **message posted** and **attachment created** events now emit extra Soup realtime patches for referenced entities (documents, chats, projects, email threads, calls), not only channel/thread updates.
> 
> Those patches set **`access_source` to the channel** so fan-out targets channel members who newly gain visibility via the share, instead of using the referenced entity alone.
> 
> Patch building adds reference-type mapping (`ReferencedShareItemType`), `push_unique_patch_with_access_source`, and tests for attachment and mention flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fdbf867050e0b262232012210f8e86adf179d62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->