### PR TITLE
Seanaye/fix/thread content backfill

### DIFF
--- a/apps/web/src/lib/graphql-cache/host/types.ts
+++ b/apps/web/src/lib/graphql-cache/host/types.ts
@@ -102,7 +102,11 @@ export interface CacheHost {
   /** Evaluates an exact initial Soup filter page over complete local projections. */
   entityFilter(args: EntityFilterCacheArgs): Promise<EntityFilterCacheResult>;
   writeQuery(args: CacheWriteArgs): Promise<WriteResult>;
-  /** Stores a query response and returns only fields not marked `@cacheOnly`. */
+  /**
+   * Stores a background query response and returns only fields not marked
+   * `@cacheOnly`. Advances the internal revision for coherent reads without
+   * notifying foreground subscribers unless the write resets cache identity.
+   */
   hydrateQuery(args: Omit<CacheWriteArgs, 'opKey'>): Promise<HydrationResult>;
   /** Durably queues an optimistic mutation and claims the strict head. */
   enqueueOptimisticMutation(

--- a/apps/web/src/lib/graphql-cache/lifecycle.test.ts
+++ b/apps/web/src/lib/graphql-cache/lifecycle.test.ts
@@ -16,8 +16,11 @@ describe('clearRegisteredCaches', () => {
     vi.unstubAllGlobals();
   });
 
-  it('preserves the scope when every cache clears', async () => {
+  it('preserves the scope and clears external cursors when every cache clears', async () => {
     localStorage.setItem('graphql-cache:scope', 'current-scope');
+    localStorage.setItem('graphql-soup-backfill:v6:user-1:core', '{}');
+    localStorage.setItem('graphql-soup-backfill:v7:user-1:email', '{}');
+    localStorage.setItem('unrelated', 'keep');
     const clear = vi.fn().mockResolvedValue(undefined);
     const { clearRegisteredCaches, registerCacheHost } = await import(
       './lifecycle'
@@ -28,6 +31,13 @@ describe('clearRegisteredCaches', () => {
 
     expect(clear).toHaveBeenCalledOnce();
     expect(localStorage.getItem('graphql-cache:scope')).toBe('current-scope');
+    expect(localStorage.getItem('graphql-soup-backfill:v6:user-1:core')).toBe(
+      null
+    );
+    expect(localStorage.getItem('graphql-soup-backfill:v7:user-1:email')).toBe(
+      null
+    );
+    expect(localStorage.getItem('unrelated')).toBe('keep');
   });
 
   it('awaits the serialized scope rotation before logout clearing resolves', async () => {

--- a/apps/web/src/lib/graphql-cache/lifecycle.ts
+++ b/apps/web/src/lib/graphql-cache/lifecycle.ts
@@ -3,6 +3,19 @@ import { rotateCacheScope } from './scope';
 
 const hosts = new Set<CacheHost>();
 
+function clearExternalCacheState(): void {
+  try {
+    for (let index = localStorage.length - 1; index >= 0; index -= 1) {
+      const key = localStorage.key(index);
+      if (key?.startsWith('graphql-soup-backfill:')) {
+        localStorage.removeItem(key);
+      }
+    }
+  } catch {
+    // Storage can be unavailable in restricted browser contexts.
+  }
+}
+
 /** Registers a cache host for account-lifecycle clearing. */
 export function registerCacheHost(host: CacheHost): () => void {
   hosts.add(host);
@@ -11,6 +24,9 @@ export function registerCacheHost(host: CacheHost): () => void {
 
 /** Best-effort reset of each active cache database during logout. */
 export async function clearRegisteredCaches(): Promise<void> {
+  // Soup cursors live outside the normalized cache. Reset them in the same
+  // lifecycle operation so no later login resumes past records wiped below.
+  clearExternalCacheState();
   const results = await Promise.allSettled(
     [...hosts].map((host) => host.clear())
   );

--- a/apps/web/src/lib/graphql-cache/protocol.ts
+++ b/apps/web/src/lib/graphql-cache/protocol.ts
@@ -440,6 +440,7 @@ export type CacheRequest = { id: number } & (
       identity?: string;
     }
   | {
+      /** Background cache warming; ordinary writes do not publish pushes. */
       kind: 'hydrate';
       query: string;
       operationName?: string;

--- a/apps/web/src/lib/graphql-cache/worker/worker-core.test.ts
+++ b/apps/web/src/lib/graphql-cache/worker/worker-core.test.ts
@@ -923,6 +923,53 @@ describe('CacheWorkerCore', () => {
     });
   });
 
+  it('keeps revision-advancing background hydration silent', async () => {
+    const hydrateQuery = vi.fn().mockResolvedValue({
+      revision: INITIAL_CACHE_REVISION,
+      revisionAdvanced: true,
+      changed: ['GraphqlSoupDocument:doc-1'],
+      affectedOps: ['client:7'],
+      reset: false,
+      data: { cursor: 'next' },
+    });
+    loadCacheWasmMock.mockResolvedValue({
+      openCache: vi.fn().mockResolvedValue({ hydrateQuery }),
+    });
+    const messages: unknown[] = [];
+    const port = { postMessage: (message: unknown) => messages.push(message) };
+    const core = new CacheWorkerCore();
+    core.addPort(port);
+
+    await core.handleRequest(port, {
+      id: 1,
+      kind: 'init',
+      scope: 'scope-1',
+    });
+    await core.handleRequest(port, {
+      id: 2,
+      kind: 'hydrate',
+      query: 'query Backfill { cursor }',
+      data: { cursor: 'next' },
+    });
+
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({ kind: 'ops-affected' })
+    );
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({ kind: 'cache-changed' })
+    );
+    expect(messages.at(-1)).toEqual({
+      id: 2,
+      ok: true,
+      result: {
+        kind: 'data',
+        data: { cursor: 'next' },
+        revision: INITIAL_CACHE_REVISION,
+        reset: false,
+      },
+    });
+  });
+
   it('drains earlier request responses before consuming close and rejects later admission', async () => {
     const order: string[] = [];
     let releaseRead!: () => void;
@@ -1351,11 +1398,12 @@ describe('CacheWorkerCore', () => {
     expect(onStorageResetRequired).not.toHaveBeenCalled();
   });
 
-  it('records an identity-changing hydration as a logical reset', async () => {
+  it('records and broadcasts identity-changing hydration as a logical reset', async () => {
     const hydrateQuery = vi.fn().mockResolvedValue({
       revision: INITIAL_CACHE_REVISION,
-      changed: [],
-      affectedOps: [],
+      revisionAdvanced: true,
+      changed: ['GraphqlUser:user-1'],
+      affectedOps: ['client:7'],
       reset: true,
       data: { cursor: 'next' },
     });
@@ -1370,6 +1418,7 @@ describe('CacheWorkerCore', () => {
         flush: vi.fn(),
       },
     });
+    core.addPort(port);
     await core.handleRequest(port, { id: 1, kind: 'init', scope: 'scope-1' });
 
     await core.handleRequest(port, {
@@ -1386,6 +1435,15 @@ describe('CacheWorkerCore', () => {
         resetReason: 'identity-change',
       })
     );
+    expect(port.postMessage).toHaveBeenCalledWith({
+      kind: 'ops-affected',
+      opIds: ['client:7'],
+      keys: ['GraphqlUser:user-1'],
+    });
+    expect(port.postMessage).toHaveBeenCalledWith({
+      kind: 'cache-changed',
+      revision: INITIAL_CACHE_REVISION,
+    });
     expect(port.postMessage).toHaveBeenLastCalledWith({
       id: 2,
       ok: true,

--- a/apps/web/src/lib/graphql-cache/worker/worker-core.ts
+++ b/apps/web/src/lib/graphql-cache/worker/worker-core.ts
@@ -490,7 +490,11 @@ export class CacheWorkerCore {
           request.identity
         );
         result.revision = parseCacheRevision(result.revision);
-        this.fanOut(result, true);
+        // Hydration is background cache warming. Keep its revision advancement
+        // for coherent reads, but do not publish foreground invalidations that
+        // would make mounted Soup views switch authority mid-backfill. An
+        // identity change is a real cache reset and must still be broadcast.
+        if (result.reset) this.fanOut(result, true);
         const hydration: HydrationResult & Pick<WriteResult, 'reset'> =
           result.data === null
             ? { kind: 'void', revision: result.revision, reset: result.reset }

--- a/apps/web/src/lib/queries/soup/backfill.test.tsx
+++ b/apps/web/src/lib/queries/soup/backfill.test.tsx
@@ -27,6 +27,14 @@ const telemetryMocks = vi.hoisted(() => ({
   anonymousSpan: vi.fn(),
 }));
 
+const cacheGenerationCallbacks = new Set<() => void>();
+const mockCacheHost = {
+  onCacheGenerationChanged: vi.fn((callback: () => void) => {
+    cacheGenerationCallbacks.add(callback);
+    return () => cacheGenerationCallbacks.delete(callback);
+  }),
+};
+
 vi.mock('@app/lib/analytics/posthog', () => ({
   useFeatureFlag: featureFlagMocks.useFeatureFlag,
 }));
@@ -78,7 +86,11 @@ describe('runSoupBackfills', () => {
     featureFlagMocks.useFeatureFlag
       .mockReset()
       .mockReturnValue(() => ({ enabled: true, payload: undefined }));
-    graphqlMocks.getGraphqlSoupCacheHost.mockReset().mockReturnValue({});
+    cacheGenerationCallbacks.clear();
+    mockCacheHost.onCacheGenerationChanged.mockClear();
+    graphqlMocks.getGraphqlSoupCacheHost
+      .mockReset()
+      .mockReturnValue(mockCacheHost);
     graphqlMocks.hydrateGraphqlSoup.mockReset();
     leaderMocks.createTabLeaderSignal.mockReset().mockReturnValue(() => true);
     telemetryMocks.anonymousSpan.mockReset().mockImplementation(() => ({
@@ -129,6 +141,53 @@ describe('runSoupBackfills', () => {
     expect(loadSoupBackfillCheckpoint('user-1', 'second-lane').completed).toBe(
       true
     );
+  });
+
+  it('immediately catches up email changes that moved ahead of the initial cursor', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2026-09-02T12:00:00.000Z');
+    const fetchPage = vi.fn(
+      async (
+        _input: Parameters<NonNullable<SoupBackfillParams['fetchPage']>>[0]
+      ) => {
+        if (fetchPage.mock.calls.length === 1) {
+          vi.setSystemTime('2026-09-02T12:01:00.000Z');
+        }
+        return { nextCursor: null };
+      }
+    );
+
+    await Effect.runPromise(
+      runSoupBackfill('user-1', {
+        ...lane('email-thread-pages', fetchPage),
+        catchUpAfterInitialPass: true,
+      })
+    );
+
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+    expect(fetchPage.mock.calls[0]?.[0]).toMatchObject({
+      initial: { sortMethod: 'VIEWED_UPDATED' },
+    });
+    expect(fetchPage.mock.calls[1]?.[0]).toMatchObject({
+      initial: {
+        filters: {
+          emailFilter: {
+            tree: {
+              literal: {
+                updatedAt: { gte: '2026-09-02T12:00:00.000Z' },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(
+      loadSoupBackfillCheckpoint('user-1', 'email-thread-pages')
+    ).toMatchObject({
+      completed: true,
+      scanStartedAt: null,
+      updatedSince: '2026-09-02T12:01:00.000Z',
+    });
   });
 
   it('does not checkpoint a page whose required v2 capsule ingestion fails', async () => {
@@ -215,7 +274,7 @@ describe('runSoupBackfills', () => {
 
   it('starts when only the cache host becomes available', async () => {
     vi.useFakeTimers();
-    let cacheHost: object | undefined;
+    let cacheHost: typeof mockCacheHost | undefined;
     graphqlMocks.getGraphqlSoupCacheHost.mockImplementation(() => cacheHost);
     graphqlMocks.hydrateGraphqlSoup.mockResolvedValue({ nextCursor: null });
 
@@ -223,11 +282,67 @@ describe('runSoupBackfills', () => {
     expect(graphqlMocks.getGraphqlSoupCacheHost).toHaveBeenCalledOnce();
     expect(graphqlMocks.hydrateGraphqlSoup).not.toHaveBeenCalled();
 
-    cacheHost = {};
+    cacheHost = mockCacheHost;
     await vi.advanceTimersByTimeAsync(100);
 
     expect(graphqlMocks.getGraphqlSoupCacheHost).toHaveBeenCalledTimes(2);
     expect(graphqlMocks.hydrateGraphqlSoup).toHaveBeenCalled();
+    rendered.unmount();
+  });
+
+  it('restarts from the beginning when the cache generation is replaced', async () => {
+    localStorage.setItem(
+      'graphql-soup-backfill:v7:user-1:core-entities',
+      JSON.stringify({
+        userId: 'user-1',
+        nextCursor: 'stale-cursor',
+        pagesFetched: 12,
+        completed: false,
+        scanStartedAt: '2026-09-01T00:00:00.000Z',
+        updatedSince: null,
+        completedAt: null,
+      })
+    );
+    const fetchInputs: unknown[] = [];
+    const fetchSignals: AbortSignal[] = [];
+    graphqlMocks.hydrateGraphqlSoup.mockImplementation(
+      (
+        _document,
+        variables: { input: unknown },
+        options: { signal: AbortSignal }
+      ) =>
+        new Promise((_resolve, reject) => {
+          fetchInputs.push(variables.input);
+          fetchSignals.push(options.signal);
+          options.signal.addEventListener(
+            'abort',
+            () => reject(options.signal.reason),
+            { once: true }
+          );
+        })
+    );
+
+    const rendered = render(() => <BackfillRunner userId="user-1" />);
+    await vi.waitFor(() =>
+      expect(graphqlMocks.hydrateGraphqlSoup).toHaveBeenCalledOnce()
+    );
+    expect(fetchInputs[0]).toMatchObject({
+      continuation: { cursor: 'stale-cursor' },
+    });
+
+    for (const callback of cacheGenerationCallbacks) callback();
+
+    await vi.waitFor(() =>
+      expect(graphqlMocks.hydrateGraphqlSoup).toHaveBeenCalledTimes(2)
+    );
+    expect(fetchSignals[0]?.aborted).toBe(true);
+    expect(fetchInputs[1]).toMatchObject({ initial: { limit: 100 } });
+    expect(loadSoupBackfillCheckpoint('user-1', 'core-entities')).toMatchObject(
+      {
+        nextCursor: null,
+        pagesFetched: 0,
+      }
+    );
     rendered.unmount();
   });
 

--- a/apps/web/src/lib/queries/soup/backfill.test.tsx
+++ b/apps/web/src/lib/queries/soup/backfill.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@solidjs/testing-library';
 import * as Effect from 'effect/Effect';
+import * as Fiber from 'effect/Fiber';
 import { createSignal, Show } from 'solid-js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -184,6 +185,89 @@ describe('runSoupBackfills', () => {
     expect(
       loadSoupBackfillCheckpoint('user-1', 'email-thread-pages')
     ).toMatchObject({
+      completed: true,
+      scanStartedAt: null,
+      updatedSince: '2026-09-02T12:01:00.000Z',
+    });
+  });
+
+  it('atomically checkpoints and resumes an interrupted email catch-up pass', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2026-09-02T12:00:00.000Z');
+    let holdCatchUp = true;
+    let markCatchUpStarted!: () => void;
+    const catchUpStarted = new Promise<void>((resolve) => {
+      markCatchUpStarted = resolve;
+    });
+    const fetchPage = vi.fn(
+      (
+        _input: Parameters<NonNullable<SoupBackfillParams['fetchPage']>>[0],
+        options: Parameters<NonNullable<SoupBackfillParams['fetchPage']>>[1]
+      ) => {
+        if (fetchPage.mock.calls.length === 1) {
+          vi.setSystemTime('2026-09-02T12:01:00.000Z');
+          return Promise.resolve({ nextCursor: null });
+        }
+        if (holdCatchUp) {
+          markCatchUpStarted();
+          const signal = options?.signal;
+          if (!signal) throw new Error('expected a backfill abort signal');
+          return new Promise<{ nextCursor: string | null }>(
+            (_resolve, reject) =>
+              signal.addEventListener(
+                'abort',
+                () =>
+                  reject(
+                    signal.reason ?? new DOMException('Aborted', 'AbortError')
+                  ),
+                { once: true }
+              )
+          );
+        }
+        return Promise.resolve({ nextCursor: null });
+      }
+    );
+    const params = {
+      ...lane('email-thread-pages', fetchPage),
+      catchUpAfterInitialPass: true,
+    };
+
+    const fiber = Effect.runFork(runSoupBackfill('user-1', params));
+    await catchUpStarted;
+
+    expect(
+      loadSoupBackfillCheckpoint('user-1', 'email-thread-pages')
+    ).toMatchObject({
+      nextCursor: null,
+      pagesFetched: 1,
+      completed: false,
+      completedAt: null,
+      scanStartedAt: '2026-09-02T12:01:00.000Z',
+      updatedSince: '2026-09-02T12:00:00.000Z',
+    });
+
+    await Effect.runPromise(Fiber.interrupt(fiber));
+    holdCatchUp = false;
+    await Effect.runPromise(runSoupBackfill('user-1', params));
+
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+    expect(fetchPage.mock.calls[2]?.[0]).toMatchObject({
+      initial: {
+        filters: {
+          emailFilter: {
+            tree: {
+              literal: {
+                updatedAt: { gte: '2026-09-02T12:00:00.000Z' },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(
+      loadSoupBackfillCheckpoint('user-1', 'email-thread-pages')
+    ).toMatchObject({
+      pagesFetched: 2,
       completed: true,
       scanStartedAt: null,
       updatedSince: '2026-09-02T12:01:00.000Z',

--- a/apps/web/src/lib/queries/soup/backfill.ts
+++ b/apps/web/src/lib/queries/soup/backfill.ts
@@ -380,39 +380,50 @@ export const runSoupBackfill = Effect.fn('runSoupBackfill')(function* (
         fetchPage(input, { signal })
       );
 
-      const completed = page.nextCursor == null;
+      const passCompleted = page.nextCursor == null;
+      const transitionToCatchUp = passCompleted && catchUpPassPending;
+      const passCompletedAt = passCompleted ? new Date().toISOString() : null;
       checkpoint = {
         ...checkpoint,
         nextCursor: page.nextCursor ?? null,
         pagesFetched: checkpoint.pagesFetched + 1,
-        completed,
-        ...(completed
-          ? {
-              // Use the pass start rather than its completion time so updates
-              // made while this pass was running are included by the catch-up.
-              updatedSince: checkpoint.scanStartedAt ?? checkpoint.updatedSince,
-              completedAt: new Date().toISOString(),
-              scanStartedAt: null,
-            }
+        // Atomically persist the required catch-up as in progress instead of
+        // exposing a completed lane between the two passes.
+        completed: passCompleted && !transitionToCatchUp,
+        ...(passCompleted
+          ? transitionToCatchUp
+            ? {
+                // Filter from the full pass start, while using its completion
+                // as the resumable catch-up pass watermark.
+                updatedSince:
+                  checkpoint.scanStartedAt ?? checkpoint.updatedSince,
+                completedAt: null,
+                scanStartedAt: passCompletedAt,
+              }
+            : {
+                // Use the pass start rather than its completion time so updates
+                // made while this pass was running are included next time.
+                updatedSince:
+                  checkpoint.scanStartedAt ?? checkpoint.updatedSince,
+                completedAt: passCompletedAt,
+                scanStartedAt: null,
+              }
           : {}),
       };
+      if (transitionToCatchUp) catchUpPassPending = false;
       yield* Effect.sync(() => {
         saveSoupBackfillCheckpoint(checkpoint, params.checkpointId);
         onCheckpoint?.(checkpoint);
       });
 
-      if (checkpoint.completed) break;
+      if (passCompleted) break;
 
       yield* Effect.sleep(params.pageDelayMs ?? PAGE_DELAY_MS);
     }
 
-    if (!catchUpPassPending) return;
-
-    catchUpPassPending = false;
-    // Do not expose the initial cursor exhaustion as lane completion. Start
-    // the narrowed pass immediately so entities that moved ahead of the
-    // VIEWED_UPDATED cursor are hydrated in this invocation.
-    yield* Effect.sync(startPass);
+    if (checkpoint.completed) return;
+    // The only incomplete terminal-page state is the atomic transition above.
+    // Continue directly into its narrowed catch-up pass.
   }
 });
 

--- a/apps/web/src/lib/queries/soup/backfill.ts
+++ b/apps/web/src/lib/queries/soup/backfill.ts
@@ -5,6 +5,7 @@ import {
   ENABLE_GRAPHQL_SOUP_OVERRIDE,
 } from '@core/constant/featureFlags';
 import { createTabLeaderSignal } from '@core/cross-tab/tab-leader';
+import type { CacheHost } from '@graphql-cache/host/types';
 import { Telemetry } from '@macro-inc/observability';
 import { SoupBackfillDocument } from '@service-storage/graphql/generated/graphql';
 import {
@@ -18,11 +19,11 @@ import {
 import * as Effect from 'effect/Effect';
 import * as Fiber from 'effect/Fiber';
 import * as Schedule from 'effect/Schedule';
-import { createEffect, onCleanup } from 'solid-js';
+import { createEffect, createSignal, onCleanup } from 'solid-js';
 
-// Bump when a default backfill input changes so persisted opaque cursors
-// cannot retain the previous server-side filters.
-const BACKFILL_VERSION = 6;
+// Bump when a default backfill input or completion guarantee changes so
+// persisted cursors cannot retain an older hydration contract.
+const BACKFILL_VERSION = 7;
 const PAGE_LIMIT = 100;
 // Five threads × twenty messages reaches the backend's 100-message cap.
 const EMAIL_CONTENT_PAGE_LIMIT = 5;
@@ -54,6 +55,8 @@ export type SoupBackfillParams = {
   input: GraphqlSoupInitialInput;
   /** Delay between successful pages. Defaults to two seconds. */
   pageDelayMs?: number;
+  /** Immediately follows the initial full scan with its watermark pass. */
+  catchUpAfterInitialPass?: boolean;
 };
 
 /** Backfills the entities used most often by Quick Access and primary views. */
@@ -80,9 +83,12 @@ export const CORE_SOUP_BACKFILL_LANE: SoupBackfillParams = {
  * while excluding every other entity variant with an impossible id filter.
  */
 export const EMAIL_SOUP_BACKFILL_LANE: SoupBackfillParams = {
-  // Restart completed legacy newest-message checkpoints with the new shape.
   checkpointId: 'email-thread-pages',
   fetchPage: fetchEmailContentPage,
+  // A long full scan can skip threads created, viewed, or updated after its
+  // VIEWED_UPDATED cursor has passed them. Consume the recorded watermark
+  // before reporting this lane complete.
+  catchUpAfterInitialPass: true,
   input: {
     limit: EMAIL_CONTENT_PAGE_LIMIT,
     expand: true,
@@ -243,6 +249,12 @@ export function resetSoupBackfillCheckpoint(
   }
 }
 
+function resetDefaultSoupBackfillCheckpoints(userId: string): void {
+  for (const lane of DEFAULT_SOUP_BACKFILL_LANES) {
+    resetSoupBackfillCheckpoint(userId, lane.checkpointId);
+  }
+}
+
 type SoupBackfillTelemetryState =
   | 'started'
   | 'progress'
@@ -326,66 +338,81 @@ export const runSoupBackfill = Effect.fn('runSoupBackfill')(function* (
   let checkpoint = yield* Effect.sync(() =>
     loadSoupBackfillCheckpoint(userId, params.checkpointId)
   );
+  // Only a never-completed full scan needs the additional watermark pass. An
+  // interrupted catch-up already has updatedSince and resumes normally.
+  let catchUpPassPending =
+    params.catchUpAfterInitialPass === true && checkpoint.updatedSince === null;
 
-  // `completed` only marks the end of one pass. A later invocation resets
-  // pagination so it can run another pass narrowed by the stored updatedSince.
-  // An unfinished checkpoint without scanStartedAt keeps its cursor and only
-  // initializes the timestamp needed for the next watermark.
-  if (checkpoint.completed || checkpoint.scanStartedAt === null) {
+  const startPass = () => {
     checkpoint = {
       ...checkpoint,
       nextCursor: checkpoint.completed ? null : checkpoint.nextCursor,
       completed: false,
       scanStartedAt: new Date().toISOString(),
     };
-    yield* Effect.sync(() =>
-      saveSoupBackfillCheckpoint(checkpoint, params.checkpointId)
-    );
+    saveSoupBackfillCheckpoint(checkpoint, params.checkpointId);
+  };
+
+  // `completed` marks the end of one pass. Start a fresh pass from its stored
+  // watermark, while an unfinished checkpoint keeps its cursor.
+  if (checkpoint.completed || checkpoint.scanStartedAt === null) {
+    yield* Effect.sync(startPass);
   }
 
-  const passInput = withUpdatedSince(params.input, checkpoint.updatedSince);
   const fetchPage = params.fetchPage ?? fetchSoupPage;
 
   while (true) {
-    const input: GraphqlSoupInput = checkpoint.nextCursor
-      ? {
-          continuation: {
-            cursor: checkpoint.nextCursor,
-            expand: passInput.expand,
-            emailView: passInput.emailView,
-          },
-        }
-      : { initial: passInput };
-    // Hydration returns only the cursor projection. Cache-only entity payloads
-    // are persisted without being materialized back into this page.
-    const page = yield* Effect.tryPromise((signal) =>
-      fetchPage(input, { signal })
-    );
+    const passInput = withUpdatedSince(params.input, checkpoint.updatedSince);
 
-    const completed = page.nextCursor == null;
-    checkpoint = {
-      ...checkpoint,
-      nextCursor: page.nextCursor ?? null,
-      pagesFetched: checkpoint.pagesFetched + 1,
-      completed,
-      ...(completed
+    while (true) {
+      const input: GraphqlSoupInput = checkpoint.nextCursor
         ? {
-            // Use the pass start rather than its completion time so updates
-            // made while this pass was running are included next time.
-            updatedSince: checkpoint.scanStartedAt ?? checkpoint.updatedSince,
-            completedAt: new Date().toISOString(),
-            scanStartedAt: null,
+            continuation: {
+              cursor: checkpoint.nextCursor,
+              expand: passInput.expand,
+              emailView: passInput.emailView,
+            },
           }
-        : {}),
-    };
-    yield* Effect.sync(() => {
-      saveSoupBackfillCheckpoint(checkpoint, params.checkpointId);
-      onCheckpoint?.(checkpoint);
-    });
+        : { initial: passInput };
+      // Hydration returns only the cursor projection. Cache-only entity
+      // payloads are persisted without being materialized back into this page.
+      const page = yield* Effect.tryPromise((signal) =>
+        fetchPage(input, { signal })
+      );
 
-    if (checkpoint.completed) return;
+      const completed = page.nextCursor == null;
+      checkpoint = {
+        ...checkpoint,
+        nextCursor: page.nextCursor ?? null,
+        pagesFetched: checkpoint.pagesFetched + 1,
+        completed,
+        ...(completed
+          ? {
+              // Use the pass start rather than its completion time so updates
+              // made while this pass was running are included by the catch-up.
+              updatedSince: checkpoint.scanStartedAt ?? checkpoint.updatedSince,
+              completedAt: new Date().toISOString(),
+              scanStartedAt: null,
+            }
+          : {}),
+      };
+      yield* Effect.sync(() => {
+        saveSoupBackfillCheckpoint(checkpoint, params.checkpointId);
+        onCheckpoint?.(checkpoint);
+      });
 
-    yield* Effect.sleep(params.pageDelayMs ?? PAGE_DELAY_MS);
+      if (checkpoint.completed) break;
+
+      yield* Effect.sleep(params.pageDelayMs ?? PAGE_DELAY_MS);
+    }
+
+    if (!catchUpPassPending) return;
+
+    catchUpPassPending = false;
+    // Do not expose the initial cursor exhaustion as lane completion. Start
+    // the narrowed pass immediately so entities that moved ahead of the
+    // VIEWED_UPDATED cursor are hydrated in this invocation.
+    yield* Effect.sync(startPass);
   }
 });
 
@@ -471,11 +498,12 @@ export const runSoupBackfills = Effect.fn('runSoupBackfills')(function* (
   );
 });
 
-const waitForGraphqlSoupCacheHost = Effect.suspend(() =>
-  getGraphqlSoupCacheHost() === undefined
+const waitForGraphqlSoupCacheHost = Effect.suspend(() => {
+  const host = getGraphqlSoupCacheHost();
+  return host === undefined
     ? Effect.fail('cache-host-unavailable' as const)
-    : Effect.void
-).pipe(
+    : Effect.succeed(host);
+}).pipe(
   Effect.retry({
     times: CACHE_HOST_RETRY_COUNT,
     schedule: CACHE_HOST_RETRY_SCHEDULE,
@@ -485,7 +513,8 @@ const waitForGraphqlSoupCacheHost = Effect.suspend(() =>
 /**
  * Runs the checkpointed backfill Effect while this tab owns leadership.
  * Interrupting the fiber cancels cache readiness waits, active fetches, and
- * inter-page sleeps.
+ * inter-page sleeps. A replacement cache generation resets the external
+ * cursors before restarting so they can never point past wiped cache data.
  */
 export function useSoupBackfills(userId: string): void {
   const graphqlSoupFlag = useFeatureFlag(ENABLE_GRAPHQL_SOUP_FLAG, {
@@ -494,18 +523,42 @@ export function useSoupBackfills(userId: string): void {
   const isLeader = createTabLeaderSignal(
     `graphql-soup-backfill:v${BACKFILL_VERSION}:coordinator`
   );
+  const [cacheHost, setCacheHost] = createSignal<CacheHost>();
+  const [cacheGeneration, setCacheGeneration] = createSignal(0);
 
   createEffect(() => {
     if (!ENABLE_GRAPHQL_BACKFILL || !graphqlSoupFlag().enabled || !isLeader()) {
+      setCacheHost(undefined);
       return;
     }
 
     const fiber = Effect.runFork(
       waitForGraphqlSoupCacheHost.pipe(
-        Effect.flatMap(() => runSoupBackfills(userId)),
+        Effect.tap((host) => Effect.sync(() => setCacheHost(host))),
         Effect.ignore
       )
     );
+    onCleanup(() => {
+      Effect.runFork(Fiber.interrupt(fiber));
+    });
+  });
+
+  createEffect(() => {
+    const host = cacheHost();
+    if (!host) return;
+
+    const unsubscribe = host.onCacheGenerationChanged(() => {
+      resetDefaultSoupBackfillCheckpoints(userId);
+      setCacheGeneration((generation) => generation + 1);
+    });
+    onCleanup(unsubscribe);
+  });
+
+  createEffect(() => {
+    if (!cacheHost()) return;
+    cacheGeneration();
+
+    const fiber = Effect.runFork(runSoupBackfills(userId).pipe(Effect.ignore));
     onCleanup(() => {
       Effect.runFork(Fiber.interrupt(fiber));
     });

--- a/apps/web/tauri/graphql_cache_plugin/src/commands.rs
+++ b/apps/web/tauri/graphql_cache_plugin/src/commands.rs
@@ -193,8 +193,9 @@ pub enum HydrationResultWire {
     },
 }
 
-/// Normalizes and stores a network response, broadcasts affected operations,
-/// and returns only fields not marked `@cacheOnly`.
+/// Normalizes and stores a background hydration response and returns only
+/// fields not marked `@cacheOnly`. Ordinary hydration remains silent to
+/// foreground subscribers; identity-changing resets are still broadcast.
 #[tauri::command]
 pub async fn graphql_cache_hydrate<R: Runtime>(
     app: AppHandle<R>,
@@ -214,13 +215,15 @@ pub async fn graphql_cache_hydrate<R: Runtime>(
             identity,
         )
         .await?;
-    emit_ops_affected(
-        &app,
-        &result.write_result.affected_ops,
-        &result.write_result.changed,
-    );
-    if result.write_result.revision_advanced {
-        emit_cache_changed(&app, &result.write_result.revision);
+    if result.write_result.reset {
+        emit_ops_affected(
+            &app,
+            &result.write_result.affected_ops,
+            &result.write_result.changed,
+        );
+        if result.write_result.revision_advanced {
+            emit_cache_changed(&app, &result.write_result.revision);
+        }
     }
     Ok(match result.data {
         Some(data) => HydrationResultWire::Data {

--- a/crates/soup_realtime/src/inbound/kafka_consumer.rs
+++ b/crates/soup_realtime/src/inbound/kafka_consumer.rs
@@ -14,7 +14,10 @@ use crate::domain::{
     ports::SoupRealtimeService,
     service::SoupRealtimeServiceImpl,
 };
-use channels::domain::broker_events::{ChannelMacroEvent, ChannelTopicEvent};
+use channels::domain::{
+    broker_events::{ChannelMacroEvent, ChannelTopicEvent},
+    models::ReferencedShareItemType,
+};
 use chat::domain::events::{ChatMacroEvent, ChatTopicEvent};
 use documents::domain::events::{DocumentMacroEvent, DocumentTopicEvent, InteractionReason};
 use email::domain::events::{EmailMacroEvent, EmailTopicEvent};
@@ -63,13 +66,22 @@ fn delete(entity_type: EntityType, entity_id: impl ToString) -> SoupRealtimePatc
     SoupRealtimePatch::for_entity(Patch::Deleted(entity(entity_type, entity_id)))
 }
 
-fn push_unique_patch(patches: &mut Vec<SoupRealtimePatch>, patch: Patch<Entity<'static>>) {
+fn push_unique_patch_with_access_source(
+    patches: &mut Vec<SoupRealtimePatch>,
+    patch: Patch<Entity<'static>>,
+    access_source: Entity<'static>,
+) {
     if patch.value().entity_id.is_empty()
         || patches.iter().any(|candidate| candidate.patch == patch)
     {
         return;
     }
-    patches.push(SoupRealtimePatch::for_entity(patch));
+    patches.push(SoupRealtimePatch::new(patch, access_source));
+}
+
+fn push_unique_patch(patches: &mut Vec<SoupRealtimePatch>, patch: Patch<Entity<'static>>) {
+    let access_source = patch.value().clone();
+    push_unique_patch_with_access_source(patches, patch, access_source);
 }
 
 fn push_unique_update(
@@ -296,16 +308,54 @@ fn channel_and_thread_entities(
     ]
 }
 
+fn soup_entity_type_from_channel_reference(entity_type: &str) -> Option<EntityType> {
+    match ReferencedShareItemType::from_raw(entity_type)? {
+        ReferencedShareItemType::Document => Some(EntityType::Document),
+        ReferencedShareItemType::Chat => Some(EntityType::Chat),
+        ReferencedShareItemType::Project => Some(EntityType::Project),
+        ReferencedShareItemType::EmailThread => Some(EntityType::EmailThread),
+        ReferencedShareItemType::Call => Some(EntityType::Call),
+    }
+}
+
+fn push_channel_reference_update(
+    patches: &mut Vec<SoupRealtimePatch>,
+    channel: &Entity<'static>,
+    entity_type: &str,
+    entity_id: &str,
+) {
+    let Some(entity_type) = soup_entity_type_from_channel_reference(entity_type) else {
+        return;
+    };
+    push_unique_patch_with_access_source(
+        patches,
+        Patch::Updated(entity(entity_type, entity_id)),
+        channel.clone(),
+    );
+}
+
 fn patches_from_channel_event(event: &ChannelTopicEvent) -> Vec<SoupRealtimePatch> {
     match event {
         ChannelTopicEvent::Updated(metadata) => {
             vec![update(EntityType::Channel, metadata.channel_id)]
         }
-        ChannelTopicEvent::MessagePosted(metadata) => channel_and_thread_entities(
-            metadata.channel_id,
-            metadata.message_id,
-            metadata.thread_id,
-        ),
+        ChannelTopicEvent::MessagePosted(metadata) => {
+            let mut patches = channel_and_thread_entities(
+                metadata.channel_id,
+                metadata.message_id,
+                metadata.thread_id,
+            );
+            let channel = entity(EntityType::Channel, metadata.channel_id);
+            for mention in &metadata.mentions {
+                push_channel_reference_update(
+                    &mut patches,
+                    &channel,
+                    &mention.entity_type,
+                    &mention.entity_id,
+                );
+            }
+            patches
+        }
         ChannelTopicEvent::MessagePatched(metadata) => channel_and_thread_entities(
             metadata.channel_id,
             metadata.message_id,
@@ -323,7 +373,19 @@ fn patches_from_channel_event(event: &ChannelTopicEvent) -> Vec<SoupRealtimePatc
             ]
         }
         ChannelTopicEvent::MessageAttachmentCreated(metadata) => {
-            vec![update(EntityType::Channel, metadata.channel_id)]
+            let channel = entity(EntityType::Channel, metadata.channel_id);
+            let mut patches = vec![SoupRealtimePatch::for_entity(Patch::Updated(
+                channel.clone(),
+            ))];
+            for attachment in &metadata.attachments {
+                push_channel_reference_update(
+                    &mut patches,
+                    &channel,
+                    &attachment.entity_type,
+                    &attachment.entity_id,
+                );
+            }
+            patches
         }
         ChannelTopicEvent::MessageAttachmentRemoved(metadata) => {
             vec![update(EntityType::Channel, metadata.channel_id)]

--- a/crates/soup_realtime/src/inbound/kafka_consumer/test.rs
+++ b/crates/soup_realtime/src/inbound/kafka_consumer/test.rs
@@ -3,9 +3,10 @@ use std::sync::{Arc, Mutex};
 
 use channels::domain::{
     broker_events::{
-        ChannelMessageAttachmentCreatedMetadata, ChannelMessageDeletedMetadata, ChannelTopicEvent,
+        ChannelEventAttachment, ChannelMessageAttachmentCreatedMetadata,
+        ChannelMessageDeletedMetadata, ChannelMessagePostedMetadata, ChannelTopicEvent,
     },
-    models::ChannelSender,
+    models::{ChannelSender, ChannelType, SimpleMention},
 };
 use chat::domain::events::{ChatMessageDeletedMetadata, ChatTopicEvent, ChatUpdatedMetadata};
 use chrono::Utc;
@@ -475,20 +476,56 @@ fn new_email_events_map_to_realtime_thread_patches() {
 }
 
 #[test]
-fn attachment_events_use_only_metadata_available_on_the_existing_event() {
+fn attachment_events_update_referenced_documents_for_channel_members() {
     let channel_id = Uuid::now_v7();
     let event =
         ChannelTopicEvent::MessageAttachmentCreated(ChannelMessageAttachmentCreatedMetadata {
             channel_id,
             message_id: Uuid::now_v7(),
             actor: ChannelSender::new_from_user(user()),
-            attachments: Vec::new(),
+            attachments: vec![ChannelEventAttachment {
+                attachment_id: Uuid::now_v7(),
+                entity_type: "document".to_string(),
+                entity_id: DOCUMENT_ID.to_string(),
+                created_at: Utc::now(),
+            }],
         });
 
     let patches = patches_from_channel_event(&event);
-    assert_eq!(patches.len(), 1);
+    assert_eq!(patches.len(), 2);
     assert_eq!(patch_entity(&patches[0]).entity_type, EntityType::Channel);
     assert_eq!(patch_entity(&patches[0]).entity_id, channel_id.to_string());
+    assert_eq!(patch_entity(&patches[1]).entity_type, EntityType::Document);
+    assert_eq!(patch_entity(&patches[1]).entity_id, DOCUMENT_ID);
+    assert_eq!(patches[1].access_source.entity_type, EntityType::Channel);
+    assert_eq!(patches[1].access_source.entity_id, channel_id.to_string());
+}
+
+#[test]
+fn posted_message_mentions_update_referenced_documents_for_channel_members() {
+    let channel_id = Uuid::now_v7();
+    let event = ChannelTopicEvent::MessagePosted(ChannelMessagePostedMetadata {
+        channel_id,
+        message_id: Uuid::now_v7(),
+        thread_id: None,
+        sender: ChannelSender::new_from_user(user()),
+        triggered_by: None,
+        channel_type: ChannelType::Private,
+        content: "shared a document".to_string(),
+        mentions: vec![SimpleMention {
+            entity_type: "document".to_string(),
+            entity_id: DOCUMENT_ID.to_string(),
+        }],
+        attachments: Vec::new(),
+        created_at: Utc::now(),
+    });
+
+    let patches = patches_from_channel_event(&event);
+    assert_eq!(patches.len(), 3);
+    assert_eq!(patch_entity(&patches[2]).entity_type, EntityType::Document);
+    assert_eq!(patch_entity(&patches[2]).entity_id, DOCUMENT_ID);
+    assert_eq!(patches[2].access_source.entity_type, EntityType::Channel);
+    assert_eq!(patches[2].access_source.entity_id, channel_id.to_string());
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes 2 issues: 1. the backfill had the potential to skip over the lane which hydrates email content, leaving the metadata for the email in the cache but not the full content. 2. backfill was incrementing the cache revision which caused soup views to swap onto local authoritative views when they shouldn't

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache invalidation semantics and backfill lifecycle (easy to miss stale UI or incomplete hydration); email catch-up and logout cursor clearing affect data completeness on login/logout.
> 
> **Overview**
> Fixes Soup backfill gaps and stops background hydration from flipping mounted Soup views to local authority mid-backfill.
> 
> **GraphQL cache:** `hydrate` / `hydrateQuery` still advances revision for coherent reads, but **only broadcasts** `ops-affected` and `cache-changed` when the write is a real **identity reset** (`reset: true`). Same behavior in the web worker and Tauri plugin. Logout cache clearing also wipes **`graphql-soup-backfill:`** localStorage cursors so a new session cannot resume past wiped data.
> 
> **Soup backfill (v7):** The email content lane gets **`catchUpAfterInitialPass`**—after the full `VIEWED_UPDATED` scan it runs a narrowed **`updatedAt` watermark** pass so threads that moved ahead of the cursor are not skipped. Checkpoints transition atomically between the two passes (including resume after interrupt). **`useSoupBackfills`** subscribes to **`onCacheGenerationChanged`**, clears default lane checkpoints, aborts in-flight work, and restarts from the initial page.
> 
> **Realtime:** Channel **message posted** (mentions) and **attachment created** events now emit Soup patches for referenced entities (document, chat, project, etc.) with **access source** set to the channel so members see updates on shared items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90a5117578e372fe555a658da57a1397f7cdd73f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->