### PR TITLE
fix(ios): text selection menu focus bug

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -103,3 +103,20 @@ The `import Worker from './w?worker'` import itself is harmless — only `new Wo
 6. **Cross-reference the last URL request with the stuck thread.** If the last `tauri://` request was `*-worker.js?worker_file&type=module` and a worker thread is in `loadModuleSynchronously`, you've confirmed which worker is the culprit. Then trace back to where it was constructed (`new Worker(...)` or a `?worker` default export being instantiated) and make that lazy.
 
 Don't get distracted by red herrings the logs will show: `NSKeyedArchiver` main-thread fault, IPC throttling warnings ("N pending incoming messages"), the bundle updater's failed `localhost:3001` request — all are downstream symptoms or unrelated noise.
+
+## iOS gotcha: a device tap fires `mousedown` even after `pointerdown.preventDefault()`
+On a physical iPhone, WKWebView still synthesises the compatibility `mousedown`/`mouseup` for a tap whose `pointerdown` was cancelled. The spec, Chrome, and the iOS Simulator all drop those events, so the difference only shows on real hardware. The synthetic `mousedown`'s default moves focus to the tapped element's nearest focusable ancestor — a `<button>` is not mouse-focusable on iOS, so focus lands on whatever container carries a `tabindex`, e.g. the block element a popup is portaled into. A focused contenteditable then fires `focusout`, the software keyboard hides, and anything keyed off editor focus (the md selection popup) closes. The DOM selection survives the blur, so actions that read it (Copy) keep working and mask the bug.
+
+**Rule:** UI that overlays an editor and must not steal its focus (toolbars, popups, paging chevrons) cancels both `pointerdown` and `mousedown`, on the container root rather than per button so dividers and gaps are covered too. See `keepEditorFocus` in `src/features/block-md/component/TouchSelectionToolbar.tsx`.
+
+**Symptom signature:** works in Chrome mobile emulation and in the iOS Simulator, fails every time on a physical iPhone regardless of tap accuracy; the keyboard dismisses on the tap.
+
+**How to diagnose this class of bug:**
+
+1. **Don't reason from finger precision.** A deterministic device-only failure is an event-model difference (compat mouse events, software keyboard), not a near miss.
+
+2. **Add a temporary window-level event trace.** Log `touchstart`, `touchend`, `pointerdown`, `pointerup`, `mousedown`, `mouseup`, `click`, `focusin`, `focusout` and `selectionchange` with `event.target`, `event.defaultPrevented`, `event.relatedTarget` and `document.activeElement`. Register on `window` in the bubble phase so app handlers have already run and `defaultPrevented` is meaningful. Wrap the setter that closes the UI to log a short stack (`new Error().stack`). Prefix every line (e.g. `[md-popup]`) so it can be filtered.
+
+3. **Run it on the device, not the Simulator**, with Safari Web Inspector attached (Develop → the iPhone → the Macro webview), filter the console by the prefix, reproduce, and read the order. A `mousedown` arriving after a `pointerdown` logged with `defaultPrevented: true`, followed by `focusout` whose `relatedTarget` is a container, is this bug.
+
+4. **Strip the instrumentation before committing.**

--- a/apps/web/src/features/block-md/component/TouchSelectionToolbar.tsx
+++ b/apps/web/src/features/block-md/component/TouchSelectionToolbar.tsx
@@ -129,8 +129,8 @@ export function TouchSelectionToolbar(props: {
       content: () => <>Copy</>,
       // execCommand is also lexical's own programmatic copy path: it routes
       // through the editor's COPY_COMMAND handler, so the clipboard gets the
-      // rich (html + lexical) payload. The button's pointerdown is prevented,
-      // which keeps the editor selection alive for it.
+      // rich (html + lexical) payload. keepEditorFocus keeps the editor
+      // selection alive for it.
       onSelect: () => {
         if (!document.execCommand('copy')) toast.failure('Could not copy');
         props.setPopupVisible(false);
@@ -369,8 +369,21 @@ export function TouchSelectionToolbar(props: {
 
   const currentPageWidth = () => pages()[clampedIndex()]?.width ?? null;
 
+  // Nothing in the toolbar may take focus from the editor: Copy/Cut act on
+  // the live selection, and the chevrons must leave the popup open (the
+  // editor's focusout closes it). Cancelling pointerdown ought to suffice —
+  // the spec then drops the compatibility mouse events, and Chrome and the
+  // iOS simulator do — but a real iPhone still synthesises mousedown for the
+  // tap, whose default moves focus to the button's nearest focusable
+  // ancestor, the block container. Cancelling mousedown too covers that.
+  const keepEditorFocus = (event: Event) => event.preventDefault();
+
   return (
-    <div class="relative flex touch-pan-y flex-row items-center">
+    <div
+      class="relative flex touch-pan-y flex-row items-center"
+      onPointerDown={keepEditorFocus}
+      onMouseDown={keepEditorFocus}
+    >
       {/* Hidden measuring row: sizes every option and a chevron. Collapsed
           to a zero-size clipped box — at natural width it would extend the
           scroll parent's overflow area and make the document pannable
@@ -412,7 +425,6 @@ export function TouchSelectionToolbar(props: {
           depth={3}
           variant="ghost"
           aria-label="Previous options"
-          onPointerDown={(e: PointerEvent) => e.preventDefault()}
           onClick={() => page(-1)}
         >
           <CaretLeftIcon class="size-4" />
@@ -473,7 +485,6 @@ export function TouchSelectionToolbar(props: {
                         depth={3}
                         variant="ghost"
                         disabled={option.disabled?.()}
-                        onPointerDown={(e: PointerEvent) => e.preventDefault()}
                         onClick={() => option.onSelect()}
                       >
                         {option.content()}
@@ -494,7 +505,6 @@ export function TouchSelectionToolbar(props: {
           depth={3}
           variant="ghost"
           aria-label="More options"
-          onPointerDown={(e: PointerEvent) => e.preventDefault()}
           onClick={() => page(1)}
         >
           <CaretRightIcon class="size-4" />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized touch-toolbar event handling and documentation; no auth, data, or API changes.
> 
> **Overview**
> Fixes the markdown **touch selection toolbar** dismissing the keyboard and closing the popup on physical iPhones when tapping Copy, paging chevrons, or gaps between controls.
> 
> **`TouchSelectionToolbar`** now uses a root-level **`keepEditorFocus`** handler that calls **`preventDefault()`** on both **`pointerdown`** and **`mousedown`**, replacing per-button **`pointerdown`** cancellation. On real WKWebView hardware, a cancelled **`pointerdown`** can still synthesize **`mousedown`**, which moves focus to a focusable ancestor and triggers the editor **`focusout`** path that hides the popup.
> 
> **`AGENTS.md`** documents this iOS event-model gotcha, the overlay UI rule, symptom signature, and device-side diagnosis steps (window event trace via Safari Web Inspector).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2028578f75082272a6c378af61446d3b95d643d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->