### PR TITLE
feat(ui): add bubble tabs

### DIFF
--- a/apps/web/src/components/ui/components/Tabs.tsx
+++ b/apps/web/src/components/ui/components/Tabs.tsx
@@ -49,7 +49,7 @@ export const Tabs = (props: TabsProps) => {
         local.class
       )}
     >
-      <KSegmentedControl.Indicator class="pointer-events-none absolute top-0 left-0 z-0 rounded-xl bg-ink/6 outline outline-ink/10 transition-[transform,width,height] duration-50" />
+      <KSegmentedControl.Indicator class="pointer-events-none absolute top-0 left-0 z-0 rounded-xl border border-edge-muted bg-active transition-[transform,width,height] duration-50" />
       <For each={local.list}>
         {(item) => (
           <KSegmentedControl.Item

--- a/apps/web/src/components/ui/components/Tabs.tsx
+++ b/apps/web/src/components/ui/components/Tabs.tsx
@@ -1,0 +1,85 @@
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
+import {
+  SegmentedControl as KSegmentedControl,
+  type SegmentedControlRootProps,
+} from '@kobalte/core/segmented-control';
+import { For, type JSX, splitProps } from 'solid-js';
+import { cn } from '../utils/classname';
+
+export type TabItem = {
+  value: string;
+  label: string | JSX.Element;
+};
+
+export type TabsProps = {
+  list: TabItem[];
+  value?: string;
+  defaultValue?: string;
+  class?: string;
+  itemClass?: string;
+  labelClass?: string;
+  fullWidth?: boolean;
+} & Omit<SegmentedControlRootProps, 'defaultValue'>;
+
+/**
+ * Borderless tab switcher. No track chrome — a rounded pill slides behind
+ * the active item.
+ */
+export const Tabs = (props: TabsProps) => {
+  const [local, rootProps] = splitProps(props, [
+    'list',
+    'value',
+    'defaultValue',
+    'disabled',
+    'class',
+    'itemClass',
+    'labelClass',
+    'fullWidth',
+  ]);
+
+  return (
+    <KSegmentedControl
+      value={local.value}
+      defaultValue={local.defaultValue ?? local.list[0]?.value}
+      disabled={local.disabled}
+      {...rootProps}
+      class={cn(
+        'relative inline-flex h-8 items-center',
+        local.fullWidth && 'flex w-full',
+        local.class
+      )}
+    >
+      <KSegmentedControl.Indicator class="pointer-events-none absolute top-0 left-0 z-0 rounded-xl bg-ink/6 outline outline-ink/10 transition-[transform,width,height] duration-50" />
+      <For each={local.list}>
+        {(item) => (
+          <KSegmentedControl.Item
+            value={item.value}
+            disabled={local.disabled}
+            class={cn(
+              'relative z-1',
+              local.fullWidth && 'flex-1',
+              local.itemClass
+            )}
+          >
+            <KSegmentedControl.ItemInput class="pointer-events-none absolute inset-0" />
+            <KSegmentedControl.ItemLabel
+              class={cn(
+                'flex h-8 items-center px-4 text-xs font-medium rounded-full select-none',
+                'text-ink-extra-muted hover:text-ink data-checked:text-ink',
+                'has-focus-visible:ring-2 has-focus-visible:ring-accent/20',
+                local.fullWidth && 'w-full justify-center',
+                local.labelClass
+              )}
+              onPointerDown={(e) => {
+                if (isTouchDevice()) e.preventDefault();
+              }}
+              onClick={() => rootProps.onChange?.(item.value)}
+            >
+              {item.label}
+            </KSegmentedControl.ItemLabel>
+          </KSegmentedControl.Item>
+        )}
+      </For>
+    </KSegmentedControl>
+  );
+};

--- a/apps/web/src/components/ui/components/Tabs.tsx
+++ b/apps/web/src/components/ui/components/Tabs.tsx
@@ -1,4 +1,3 @@
-import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import {
   SegmentedControl as KSegmentedControl,
   type SegmentedControlRootProps,
@@ -56,7 +55,7 @@ export const Tabs = (props: TabsProps) => {
             value={item.value}
             disabled={local.disabled}
             class={cn(
-              'relative z-1',
+              'relative z-1 rounded-full has-focus-visible:ring-2 has-focus-visible:ring-accent/20',
               local.fullWidth && 'flex-1',
               local.itemClass
             )}
@@ -66,14 +65,9 @@ export const Tabs = (props: TabsProps) => {
               class={cn(
                 'flex h-8 items-center px-4 text-xs font-medium rounded-full select-none',
                 'text-ink-extra-muted hover:text-ink data-checked:text-ink',
-                'has-focus-visible:ring-2 has-focus-visible:ring-accent/20',
                 local.fullWidth && 'w-full justify-center',
                 local.labelClass
               )}
-              onPointerDown={(e) => {
-                if (isTouchDevice()) e.preventDefault();
-              }}
-              onClick={() => rootProps.onChange?.(item.value)}
             >
               {item.label}
             </KSegmentedControl.ItemLabel>

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -116,6 +116,8 @@ export { SendButton } from './components/SendButton';
 export { SideNav } from './components/SideNav';
 export { Surface } from './components/Surface';
 export { TabbedControl } from './components/TabbedControl';
+export type { TabItem, TabsProps } from './components/Tabs';
+export { Tabs } from './components/Tabs';
 export type { ToggleSwitchProps } from './components/ToggleSwitch';
 export { ToggleSwitch } from './components/ToggleSwitch';
 export { Tooltip } from './components/Tooltip';

--- a/apps/web/src/features/inbox-view/components/InboxTabs.tsx
+++ b/apps/web/src/features/inbox-view/components/InboxTabs.tsx
@@ -1,8 +1,8 @@
 import { useViewTabHotkeys } from '@app/components/view-shell';
 import { PillTabs } from '@components/app/mobile/PillTabs';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
-import { TabsInset } from '@core/component/TabsInset';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
+import { Tabs } from '@ui';
 import { Show } from 'solid-js';
 import { useInboxView } from '../inbox-view-context';
 import type { InboxTab } from '../types';
@@ -40,17 +40,12 @@ export function InboxTabs() {
       when={isTouchDevice()}
       fallback={
         <div class="flex h-8 min-w-0 flex-1 items-center gap-3">
-          <div class="h-8 min-w-0 basis-3/4 shrink max-w-72">
-            <TabsInset
-              aria-label="Inbox views"
-              list={INBOX_TABS}
-              value={state.tab}
-              onChange={handleTabChange}
-              class="h-8"
-              trackClass="h-full"
-              fullWidth
-            />
-          </div>
+          <Tabs
+            aria-label="Inbox views"
+            list={INBOX_TABS}
+            value={state.tab}
+            onChange={handleTabChange}
+          />
           <InboxFilterDropdown />
         </div>
       }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized UI addition and a single inbox header swap with no auth, data, or API changes.
> 
> **Overview**
> Introduces a shared **`Tabs`** control in `@ui`: a borderless segmented switcher built on Kobalte, with a sliding pill indicator, optional full-width layout, and the usual controlled `value` / `onChange` API (`list` of `{ value, label }`).
> 
> **`Tabs`**, **`TabItem`**, and **`TabsProps`** are re-exported from the UI package. Desktop **Inbox** category switching now uses **`Tabs`** instead of **`TabsInset`**, dropping the extra width-constraint wrapper and `fullWidth` / `trackClass` props while keeping the same tab list and handlers; mobile still uses **`PillTabs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02bec38e056aeb58cf56a0d04b4035546f5443ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->