### PR TITLE
fix(local): derive DCS FusionAuth OAuth redirect from instance port

### DIFF
--- a/tooling/xtask/crates/xtask_local/src/local/fusionauth.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/fusionauth.rs
@@ -43,6 +43,7 @@ pub fn write_kickstart(
     let doc = kickstart::build(
         instance.port(Port::Frontend),
         instance.port(Port::Auth),
+        instance.port(Port::DocCognition),
         &read_lambda(POPULATE_JWT_LAMBDA)?,
         &read_lambda(RECONCILE_LAMBDA)?,
         google,

--- a/tooling/xtask/crates/xtask_local/src/local/identity.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/identity.rs
@@ -75,11 +75,14 @@ pub const MAIL_FROM: &str = "noreply@macro.local";
 /// new-user registration fail), so both sides read this one constant. Local-only.
 pub const INTERNAL_AUTH_KEY: &str = "local";
 
-/// The auth-service OAuth redirect URI for an instance on `auth_port`. The
-/// FusionAuth kickstart authorizes it and services read it as
-/// `FUSIONAUTH_OAUTH_REDIRECT_URI` — build it one way so they can't drift.
-pub fn oauth_redirect_uri(auth_port: u16) -> String {
-    format!("http://localhost:{auth_port}/oauth/redirect")
+/// Localhost OAuth redirect URI for a service published on `port`.
+///
+/// FusionAuth's kickstart authorizes both authentication_service and
+/// document_cognition_service this way so a named instance's host port cannot
+/// drift from the registered callback. Auth-service also reads the auth-port
+/// variant as `FUSIONAUTH_OAUTH_REDIRECT_URI`.
+pub fn oauth_redirect_uri(port: u16) -> String {
+    format!("http://localhost:{port}/oauth/redirect")
 }
 
 /// Deterministically derive a local-only internal secret from a label and the

--- a/tooling/xtask/crates/xtask_local/src/local/instance/test.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/instance/test.rs
@@ -76,3 +76,18 @@ fn port_base_override_wins() {
     assert_eq!(inst.port(Port::Postgres), 12000);
     assert_eq!(inst.port(Port::Auth), 12000 + Port::Auth.offset());
 }
+
+/// `DocCognition = 8085` is the default-instance discriminant, not a frozen
+/// host port. A named `--port-base` stack publishes DCS at base + offset.
+#[test]
+fn doc_cognition_host_port_is_instance_derived() {
+    let default = Instance::derive(None, None).unwrap();
+    assert_eq!(default.port(Port::DocCognition), 8085);
+
+    let named = Instance::derive(Some("macro-dev"), Some(31000)).unwrap();
+    assert_eq!(
+        named.port(Port::DocCognition),
+        31000 + Port::DocCognition.offset()
+    );
+    assert_eq!(named.port(Port::DocCognition), 31014);
+}

--- a/tooling/xtask/crates/xtask_local/src/local/kickstart.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/kickstart.rs
@@ -112,6 +112,7 @@ impl GithubIdp {
 pub fn build(
     frontend_port: u16,
     auth_port: u16,
+    doc_cognition_port: u16,
     lambda_body: &str,
     reconcile_lambda_body: &str,
     google: Option<&GoogleIdp>,
@@ -127,7 +128,11 @@ pub fn build(
         format!("http://localhost:{frontend_port}/app"),
         identity::oauth_redirect_uri(auth_port),
         "http://authentication-service:8080/oauth/redirect",
-        "http://localhost:8085/oauth/redirect",
+        // MCP client-connector callback on document_cognition_service. Must
+        // track the instance host port: a named `--port-base` stack publishes
+        // DCS somewhere other than 8085, and FusionAuth rejects (or the
+        // browser cannot reach) a callback that still points at 8085.
+        identity::oauth_redirect_uri(doc_cognition_port),
         "https://mcp-server-local.macro.com/oauth/callback",
     ]);
 

--- a/tooling/xtask/crates/xtask_local/src/local/kickstart/test.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/kickstart/test.rs
@@ -42,6 +42,7 @@ fn kickstart_without_google_has_no_idp_requests() {
     let doc = build(
         3000,
         8080,
+        8085,
         "function populate() {}",
         "function reconcile() {}",
         None,
@@ -68,6 +69,7 @@ fn kickstart_with_google_adds_lambda_and_both_idps_after_the_application() {
     let doc = build(
         3000,
         8080,
+        8085,
         "function populate() {}",
         "function reconcile() {}",
         Some(&google),
@@ -119,6 +121,7 @@ fn kickstart_adopts_the_default_tenant() {
     let doc = build(
         3000,
         8080,
+        8085,
         "function populate() {}",
         "function reconcile() {}",
         None,
@@ -198,6 +201,7 @@ fn the_github_idp_id_follows_the_env_the_service_reads() {
     let doc = build(
         3000,
         8080,
+        8085,
         "function populate() {}",
         "function reconcile() {}",
         None,
@@ -226,6 +230,7 @@ fn the_github_idp_is_created_under_both_the_name_and_the_id_the_service_uses() {
     let doc = build(
         3000,
         8080,
+        8085,
         "function populate() {}",
         "function reconcile() {}",
         None,
@@ -263,6 +268,7 @@ fn kickstart_without_github_creates_no_github_idp() {
     let doc = build(
         3000,
         8080,
+        8085,
         "function populate() {}",
         "function reconcile() {}",
         None,
@@ -277,5 +283,58 @@ fn kickstart_without_github_creates_no_github_idp() {
             .any(|request| request["url"]
                 .as_str()
                 .is_some_and(|url| url.contains(identity::GITHUB_IDP_ID)))
+    );
+}
+
+fn authorized_redirects(
+    frontend_port: u16,
+    auth_port: u16,
+    doc_cognition_port: u16,
+) -> Vec<String> {
+    let doc = build(
+        frontend_port,
+        auth_port,
+        doc_cognition_port,
+        "function populate() {}",
+        "function reconcile() {}",
+        None,
+        None,
+    );
+    doc["requests"]
+        .as_array()
+        .expect("requests")
+        .iter()
+        .find(|request| {
+            request["url"].as_str()
+                == Some(&format!("/api/application/{}", identity::APPLICATION_ID))
+        })
+        .expect("application request")["body"]["application"]["oauthConfiguration"]
+        ["authorizedRedirectURLs"]
+        .as_array()
+        .expect("authorizedRedirectURLs")
+        .iter()
+        .filter_map(|url| url.as_str().map(ToOwned::to_owned))
+        .collect()
+}
+
+/// The DCS MCP-connector callback is an instance host port. Hardcoding 8085
+/// leaves a named `--port-base` stack authorizing a port nothing binds.
+#[test]
+fn dcs_oauth_redirect_follows_the_instance_port() {
+    let default = authorized_redirects(3000, 8080, 8085);
+    assert!(
+        default.contains(&"http://localhost:8085/oauth/redirect".to_string()),
+        "default instance keeps the historical DCS callback: {default:?}"
+    );
+
+    // `--instance macro-dev --port-base 31000` publishes DCS on 31014.
+    let named = authorized_redirects(31010, 31011, 31014);
+    assert!(
+        named.contains(&"http://localhost:31014/oauth/redirect".to_string()),
+        "named instance must authorize the derived DCS port: {named:?}"
+    );
+    assert!(
+        !named.iter().any(|url| url.contains("localhost:8085")),
+        "named instance must not keep the default DCS callback: {named:?}"
     );
 }


### PR DESCRIPTION
Named instances publish document_cognition_service at port-base + offset (31014 for --port-base 31000), but the FusionAuth kickstart still authorized http://localhost:8085/oauth/redirect. MCP connector OAuth then completes at the provider and fails on callback.

Pass the instance DocCognition port into kickstart so the registered redirect tracks the host port that is actually bound.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local xtask/FusionAuth kickstart generation only; no production auth paths, and it aligns registered callbacks with bound ports.
> 
> **Overview**
> Fixes **MCP connector OAuth** on named local stacks (`--instance` / `--port-base`) where FusionAuth still authorized `http://localhost:8085/oauth/redirect` while document cognition actually listens on **base + offset** (e.g. 31014).
> 
> **`kickstart::build`** now takes **`doc_cognition_port`**; **`write_kickstart`** passes **`instance.port(Port::DocCognition)`**, and the DCS callback in **`authorizedRedirectURLs`** uses **`identity::oauth_redirect_uri(doc_cognition_port)`** instead of a fixed 8085. **`oauth_redirect_uri`** is documented as shared by auth-service and DCS.
> 
> Tests lock in instance-derived DCS host ports and assert default vs named-instance redirect lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0df746274deb52c13ed25d529da67bf3e34811f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->