### PR TITLE
fix(channel/agent): extract magic chip message + id on all reply paths

### DIFF
--- a/apps/web/src/features/channel/Channel/create-channel-hotkeys.ts
+++ b/apps/web/src/features/channel/Channel/create-channel-hotkeys.ts
@@ -3,6 +3,7 @@ import { TOKENS } from '@core/hotkey/tokens';
 import type { ApiChannelMessage } from '@service-storage/generated/schemas/apiChannelMessage';
 import type { Accessor } from 'solid-js';
 import type { MessageActions, MessageData } from '../Message';
+import { getMessageReplyPreviewTexts } from '../Message/browser-selection';
 import { isBotMessage } from '../Thread/utils/message-actions';
 import type { MessageSelection } from './create-message-selection';
 import type { ThreadListNavigation } from './ThreadList';
@@ -123,7 +124,10 @@ export function createChannelHotkeys(options: CreateChannelHotkeysOptions) {
       const msg = getSelectedMessage();
       if (!msg) return false;
       const actions = options.getMessageActions(msg);
-      actions?.onReply?.({ message: msg });
+      actions?.onReply?.({
+        message: msg,
+        ...getMessageReplyPreviewTexts(msg.id),
+      });
       return true;
     },
   });

--- a/apps/web/src/features/channel/Channel/tests/create-channel-hotkeys.test.tsx
+++ b/apps/web/src/features/channel/Channel/tests/create-channel-hotkeys.test.tsx
@@ -77,6 +77,13 @@ function ChannelEditHarness(props: {
   return (
     <div ref={attachGlobalDOMScope}>
       <div ref={attachMessageListRef} tabIndex={-1} data-testid="message-list">
+        <div data-message data-message-id={originalMessage.id}>
+          <div data-message-content>
+            <div data-message-reply-preview="Resolved bot response">
+              Resolved bot response
+            </div>
+          </div>
+        </div>
         <Show when={isEditing()}>
           <TestMessageEditor
             onSave={() => {
@@ -135,5 +142,22 @@ describe('createChannelHotkeys', () => {
     fireEvent.keyUp(messageList, { key: 'd' });
     fireEvent.keyUp(messageList, { key: 'Enter' });
     expect(onReply).not.toHaveBeenCalled();
+  });
+
+  it('passes resolved decorator text when Enter opens a reply', () => {
+    const onSave = vi.fn();
+    const onReply = vi.fn();
+    render(() => <ChannelEditHarness onSave={onSave} onReply={onReply} />);
+
+    const messageList = screen.getByTestId('message-list');
+    messageList.focus();
+    fireEvent.keyDown(messageList, { key: 'Enter' });
+
+    expect(onReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: originalMessage,
+        renderedText: 'Resolved bot response',
+      })
+    );
   });
 });

--- a/apps/web/src/features/channel/Message/SwipeToReplyRow.tsx
+++ b/apps/web/src/features/channel/Message/SwipeToReplyRow.tsx
@@ -6,6 +6,7 @@ import { triggerFocusInput } from '@core/directive/focusInput';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import ReplyIcon from '@phosphor/arrow-bend-up-left.svg';
 import { type ParentProps, Show, useContext } from 'solid-js';
+import { getMessageReplyPreviewTexts } from './browser-selection';
 import type { MessageActions, MessageData } from './types';
 
 /**
@@ -54,7 +55,10 @@ export function MaybeSwipeToReplyRow(
         `[data-input-id="thread-reply-input-${threadId}"] [contenteditable]`
       )
     );
-    void onReply({ message: props.message });
+    void onReply({
+      message: props.message,
+      ...getMessageReplyPreviewTexts(props.message.id),
+    });
   };
 
   return (

--- a/apps/web/src/features/channel/Message/browser-selection.ts
+++ b/apps/web/src/features/channel/Message/browser-selection.ts
@@ -49,3 +49,22 @@ export function getRenderedMessageReplyText(
   const text = (explicitText || renderedText || preview?.textContent)?.trim();
   return text || undefined;
 }
+
+/**
+ * Look up a mounted message by id and return the same reply-preview fields
+ * the hover Reply action captures. Keyboard and swipe replies have no click
+ * target, so they need this DOM lookup instead.
+ */
+export function getMessageReplyPreviewTexts(messageId: string): {
+  selectedText?: string;
+  renderedText?: string;
+} {
+  const messageRoot = document.querySelector<HTMLElement>(
+    `[data-message-id="${messageId}"]`
+  );
+  if (!messageRoot) return {};
+  return {
+    selectedText: getSelectedMessageText(messageRoot, messageId),
+    renderedText: getRenderedMessageReplyText(messageRoot, messageId),
+  };
+}

--- a/apps/web/src/features/channel/Thread/create-thread-hotkeys.ts
+++ b/apps/web/src/features/channel/Thread/create-thread-hotkeys.ts
@@ -10,6 +10,7 @@ import type { ApiThreadReply } from '@service-storage/generated/schemas/apiThrea
 import { type Accessor, onCleanup } from 'solid-js';
 import type { MessageSelection } from '../Channel/create-message-selection';
 import type { MessageActions, MessageData } from '../Message';
+import { getMessageReplyPreviewTexts } from '../Message/browser-selection';
 import { scrollMessageIntoView } from '../scroll-utils';
 import { isBotMessage } from './utils/message-actions';
 
@@ -179,7 +180,10 @@ export function createThreadHotkeys(options: CreateThreadHotkeysOptions) {
       if (event?.repeat) return true;
       const parentMsg = options.parentMessage();
       const actions = options.getMessageActions(parentMsg);
-      actions?.onReply?.({ message: parentMsg });
+      actions?.onReply?.({
+        message: parentMsg,
+        ...getMessageReplyPreviewTexts(parentMsg.id),
+      });
       return true;
     },
   }).withGroup(group);

--- a/apps/web/src/features/channel/Thread/tests/message-actions.test.ts
+++ b/apps/web/src/features/channel/Thread/tests/message-actions.test.ts
@@ -116,6 +116,28 @@ describe('message-actions helpers', () => {
     ).toContain('"displayText":"> original prompt"');
   });
 
+  it('needs rendered text when a reply-target plus magic chip leaves no preview', () => {
+    const agentSessionReply = {
+      ...threadReply,
+      content:
+        '<m-reply-target>{"channelId":"channel-1","targetMessageId":"earlier-reply","targetThreadId":"thread-1","displayText":"earlier preview","senderId":"macro|earlier@example.com"}</m-reply-target>\n\n<m-magic-chip>{"agentSessionId":"session-1","promptedMessage":{"turn":0,"author":"user"},"status":"booting"}</m-magic-chip>',
+    };
+
+    expect(
+      buildReplyTargetValue({
+        channelId: 'channel-1',
+        message: agentSessionReply,
+      })
+    ).toContain('"displayText":""');
+    expect(
+      buildReplyTargetValue({
+        channelId: 'channel-1',
+        message: agentSessionReply,
+        renderedText: 'Resolved bot response',
+      })
+    ).toContain('"displayText":"Resolved bot response"');
+  });
+
   it('ignores a leading reply-target block in the automatic preview', () => {
     expect(
       buildReplyTargetValue({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized to reply UX and reply-target preview construction; no auth or API changes, with tests for the new paths.
> 
> **Overview**
> Keyboard **Enter** replies (channel and thread) and mobile **swipe-to-reply** now pass the same `selectedText` / `renderedText` preview fields as the hover Reply action, via a new `getMessageReplyPreviewTexts` DOM lookup in `browser-selection.ts`.
> 
> That matters when message bodies are mostly **reply-target** and **magic-chip** markup: automatic preview text can be empty, but decorators expose resolved text through `[data-message-reply-preview]`. Without these fields, agent-session replies could open with a blank `displayText` in the reply-target node.
> 
> Tests cover Enter opening reply with `renderedText` and `buildReplyTargetValue` when reply-target + magic chip leaves no fallback preview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4af026aa124c04c93be73a413d24dc9ff187b552. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->