### PR TITLE
fix(web): gate the inbox notified_at sort behind a PostHog flag

### DIFF
--- a/apps/web/src/features/inbox-view/queries/inbox-query.ts
+++ b/apps/web/src/features/inbox-view/queries/inbox-query.ts
@@ -18,7 +18,6 @@ import type { InboxTab } from '../types';
 export type InboxQueryCapabilities = {
   calendar: boolean;
   foreignEntities: boolean;
-  /** The notification tabs may order by the viewer's latest notification. */
   notifiedSort: boolean;
   reminders: boolean;
   snippets: boolean;
@@ -168,8 +167,6 @@ export type InboxViewContext = {
  * notification puts it, not where its content's last edit does — a comment
  * on a week-old task is today's news. The server sort is also a filter (rows
  * without a notification are absent), which is what those tabs mean anyway.
- * Gated by the `notifiedSort` capability (a PostHog flag) while the server's
- * candidate query is reworked; off, those tabs keep update recency.
  */
 export const inboxTabOrdersByNotification = (
   context: Pick<InboxViewContext, 'tab' | 'capabilities'>

--- a/apps/web/src/features/inbox-view/queries/inbox-query.ts
+++ b/apps/web/src/features/inbox-view/queries/inbox-query.ts
@@ -18,6 +18,8 @@ import type { InboxTab } from '../types';
 export type InboxQueryCapabilities = {
   calendar: boolean;
   foreignEntities: boolean;
+  /** The notification tabs may order by the viewer's latest notification. */
+  notifiedSort: boolean;
   reminders: boolean;
   snippets: boolean;
 };
@@ -166,9 +168,14 @@ export type InboxViewContext = {
  * notification puts it, not where its content's last edit does — a comment
  * on a week-old task is today's news. The server sort is also a filter (rows
  * without a notification are absent), which is what those tabs mean anyway.
+ * Gated by the `notifiedSort` capability (a PostHog flag) while the server's
+ * candidate query is reworked; off, those tabs keep update recency.
  */
-export const inboxTabOrdersByNotification = (tab: InboxTab): boolean =>
-  tab === 'signal' || tab === 'noise';
+export const inboxTabOrdersByNotification = (
+  context: Pick<InboxViewContext, 'tab' | 'capabilities'>
+): boolean =>
+  context.capabilities.notifiedSort &&
+  (context.tab === 'signal' || context.tab === 'noise');
 
 /** Builds the heterogeneous Soup AST for the composable Inbox view. */
 export function buildInboxQuery(
@@ -200,7 +207,7 @@ export function buildInboxQuery(
     params: {
       expand: true,
       limit: 100,
-      sort_method: inboxTabOrdersByNotification(context.tab)
+      sort_method: inboxTabOrdersByNotification(context)
         ? 'notified_at'
         : 'updated_at',
       sort_direction: context.tab === 'reminders' ? 'asc' : 'desc',

--- a/apps/web/src/features/inbox-view/queries/inbox-results.test.ts
+++ b/apps/web/src/features/inbox-view/queries/inbox-results.test.ts
@@ -38,16 +38,24 @@ const freshEmail = {
   sortTs: '2026-09-02T16:00:00Z',
 } as unknown as WithNotification<EntityData>;
 
+const capabilities = {
+  calendar: false,
+  foreignEntities: false,
+  notifiedSort: true,
+  reminders: false,
+  snippets: false,
+};
+
 const context = {
   facets: {},
   facetContext: { notificationSource: undefined as never },
-  capabilities: {
-    calendar: false,
-    foreignEntities: false,
-    reminders: false,
-    snippets: false,
-  },
+  capabilities,
   userId: 'macro|alice@example.com',
+};
+
+const withoutNotifiedSort = {
+  ...context,
+  capabilities: { ...capabilities, notifiedSort: false },
 };
 
 describe('inbox sort method per tab', () => {
@@ -66,16 +74,25 @@ describe('inbox sort method per tab', () => {
       );
     }
   });
+
+  it('keeps recency ordering everywhere while the notified sort is off', () => {
+    for (const tab of ['signal', 'noise', 'all', 'reminders'] as const) {
+      expect(
+        buildInboxQuery({ ...withoutNotifiedSort, tab }).params.sort_method
+      ).toBe('updated_at');
+    }
+  });
 });
 
 describe('inbox date buckets', () => {
   it('buckets a notified row by its notification on the notification tabs', () => {
-    expect(inboxGroupTimestamp(staleTaskFreshComment, 'signal')).toBe(
+    const signal = { tab: 'signal' as const, capabilities };
+    expect(inboxGroupTimestamp(staleTaskFreshComment, signal)).toBe(
       '2026-09-02T17:00:00Z'
     );
     const groups = groupInboxEntitiesByDate(
       [freshEmail, staleTaskFreshComment],
-      'signal',
+      signal,
       now
     );
     expect(groups).toHaveLength(1);
@@ -83,15 +100,37 @@ describe('inbox date buckets', () => {
   });
 
   it('falls back to content recency without a stamp and on the other tabs', () => {
-    expect(inboxGroupTimestamp(freshEmail, 'signal')).toBe(
-      '2026-09-02T16:00:00Z'
-    );
-    expect(inboxGroupTimestamp(staleTaskFreshComment, 'all')).toBe(
+    expect(
+      inboxGroupTimestamp(freshEmail, { tab: 'signal', capabilities })
+    ).toBe('2026-09-02T16:00:00Z');
+    const all = { tab: 'all' as const, capabilities };
+    expect(inboxGroupTimestamp(staleTaskFreshComment, all)).toBe(
       '2026-08-31T19:00:00Z'
     );
     const groups = groupInboxEntitiesByDate(
       [freshEmail, staleTaskFreshComment],
-      'all',
+      all,
+      now
+    );
+    expect(groups.map((group) => group.label)).toEqual([
+      'Today',
+      'Last 7 days',
+    ]);
+  });
+
+  it('buckets by content recency while the notified sort is off', () => {
+    // A stamp left by a live notification must not move the row's header
+    // when the server page is ordered by update recency.
+    const signal = {
+      tab: 'signal' as const,
+      capabilities: withoutNotifiedSort.capabilities,
+    };
+    expect(inboxGroupTimestamp(staleTaskFreshComment, signal)).toBe(
+      '2026-08-31T19:00:00Z'
+    );
+    const groups = groupInboxEntitiesByDate(
+      [freshEmail, staleTaskFreshComment],
+      signal,
       now
     );
     expect(groups.map((group) => group.label)).toEqual([

--- a/apps/web/src/features/inbox-view/queries/inbox-results.test.ts
+++ b/apps/web/src/features/inbox-view/queries/inbox-results.test.ts
@@ -119,8 +119,6 @@ describe('inbox date buckets', () => {
   });
 
   it('buckets by content recency while the notified sort is off', () => {
-    // A stamp left by a live notification must not move the row's header
-    // when the server page is ordered by update recency.
     const signal = {
       tab: 'signal' as const,
       capabilities: withoutNotifiedSort.capabilities,

--- a/apps/web/src/features/inbox-view/queries/inbox-results.ts
+++ b/apps/web/src/features/inbox-view/queries/inbox-results.ts
@@ -4,8 +4,12 @@ import {
   type SoupGroup,
 } from '@app/features/soup/collection';
 import type { EntityData, WithNotification } from '@entity';
-import type { InboxTab } from '../types';
-import { inboxTabOrdersByNotification } from './inbox-query';
+import {
+  type InboxViewContext,
+  inboxTabOrdersByNotification,
+} from './inbox-query';
+
+type InboxOrderContext = Pick<InboxViewContext, 'tab' | 'capabilities'>;
 
 export const inboxSortTimestamp = (entity: EntityData) =>
   entity.sortTs ?? entity.updatedAt ?? entity.createdAt;
@@ -16,19 +20,22 @@ export const inboxSortTimestamp = (entity: EntityData) =>
  * arrive in; rows without a stamp (websocket inserts) and the other tabs fall
  * back to content recency.
  */
-export const inboxGroupTimestamp = (entity: EntityData, tab: InboxTab) =>
-  (inboxTabOrdersByNotification(tab) ? entity.notifiedAt : undefined) ??
+export const inboxGroupTimestamp = (
+  entity: EntityData,
+  context: InboxOrderContext
+) =>
+  (inboxTabOrdersByNotification(context) ? entity.notifiedAt : undefined) ??
   inboxSortTimestamp(entity);
 
 export function groupInboxEntitiesByDate(
   entities: WithNotification<EntityData>[],
-  tab: InboxTab,
+  context: InboxOrderContext,
   now = new Date()
 ): SoupGroup<WithNotification<EntityData>>[] {
   return groupSoupEntities(entities, {
     getGroupId: (entity) =>
-      dateBucket(inboxGroupTimestamp(entity, tab), now).key,
+      dateBucket(inboxGroupTimestamp(entity, context), now).key,
     getGroupLabel: (_groupId, firstEntity) =>
-      dateBucket(inboxGroupTimestamp(firstEntity, tab), now).label,
+      dateBucket(inboxGroupTimestamp(firstEntity, context), now).label,
   });
 }

--- a/apps/web/src/features/inbox-view/queries/use-inbox-query.ts
+++ b/apps/web/src/features/inbox-view/queries/use-inbox-query.ts
@@ -13,6 +13,8 @@ import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
 import {
   ENABLE_CALENDAR_UI,
+  ENABLE_INBOX_NOTIFIED_SORT_FLAG,
+  ENABLE_INBOX_NOTIFIED_SORT_OVERRIDE,
   ENABLE_REMINDERS,
   ENABLE_SNIPPETS,
   ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_FLAG,
@@ -108,12 +110,16 @@ export function useInboxDataSource(
     ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_FLAG,
     { enabledOverride: ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE }
   );
+  const notifiedSort = useFeatureFlag(ENABLE_INBOX_NOTIFIED_SORT_FLAG, {
+    enabledOverride: ENABLE_INBOX_NOTIFIED_SORT_OVERRIDE,
+  });
 
   const facetContext = (): InboxFacetContext => ({ notificationSource });
 
   const capabilities = (): InboxQueryCapabilities => ({
     calendar: ENABLE_CALENDAR_UI(),
     foreignEntities: foreignEntities().enabled,
+    notifiedSort: notifiedSort().enabled,
     reminders: ENABLE_REMINDERS(),
     snippets: ENABLE_SNIPPETS(),
   });
@@ -248,7 +254,7 @@ export function useInboxDataSource(
     let result: InboxDataSourceItem[];
     if (state.groupBy === 'date' && !search.isSearching()) {
       result = buildGroupedSoupRows(
-        groupInboxEntitiesByDate(entities().items, state.tab)
+        groupInboxEntitiesByDate(entities().items, viewContext())
       );
     } else {
       result = buildFlatSoupRows(entities().items);

--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -52,6 +52,8 @@ import { useEntryState } from '@components/app/split-layout/entry-state';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import {
   ENABLE_FEATURED_SEARCH_RESULTS,
+  ENABLE_INBOX_NOTIFIED_SORT_FLAG,
+  ENABLE_INBOX_NOTIFIED_SORT_OVERRIDE,
   ENABLE_REMINDERS,
   ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_FLAG,
   ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE,
@@ -668,6 +670,9 @@ export const SoupViewContextProvider: FlowComponent<
   const notificationSource = useGlobalNotificationSource();
   const userId = useUserId();
   const isTeamAdmin = useIsTeamAdmin();
+  const notifiedSortFF = useFeatureFlag(ENABLE_INBOX_NOTIFIED_SORT_FLAG, {
+    enabledOverride: ENABLE_INBOX_NOTIFIED_SORT_OVERRIDE,
+  });
 
   // Sits below `activeTab`/`userId` because the page direction comes from the
   // active tab's preset, which some views resolve against user context.
@@ -680,6 +685,15 @@ export const SoupViewContextProvider: FlowComponent<
         })
       : undefined;
   });
+
+  // The tab's forced server sort, with the notified order behind its flag:
+  // off, Signal and Noise keep update recency like before the sort existed.
+  const presetSortMethod = () => {
+    const method = activePreset()?.sortMethod;
+    return method === 'notified_at' && !notifiedSortFF().enabled
+      ? 'updated_at'
+      : method;
+  };
 
   const soupParams = createMemo(() => {
     const sortId = soup.sort.active()[0]?.id ?? 'updated_at';
@@ -695,13 +709,12 @@ export const SoupViewContextProvider: FlowComponent<
     // user's own touches — not to the sort method state, so the preset owns
     // them. Omitted when absent so the server default (desc) applies and
     // the query keys of every existing view stay byte-identical.
-    const preset = activePreset();
-    const sortDirection = preset?.sortDirection;
+    const sortDirection = activePreset()?.sortDirection;
 
     return {
       // Mail views use a smaller page size
       limit: view === 'mail' ? 30 : 100,
-      sort_method: preset?.sortMethod ?? sortMethod,
+      sort_method: presetSortMethod() ?? sortMethod,
       ...(sortDirection ? { sort_direction: sortDirection } : {}),
     };
   });
@@ -712,7 +725,7 @@ export const SoupViewContextProvider: FlowComponent<
   // inbox's All and Reminders tabs stay on update recency even when a row
   // carries a notification stamp from a Signal page or a live delivery.
   const clientSort = createMemo((): SortConfig<SoupEntity>[] =>
-    activePreset()?.sortMethod === 'notified_at'
+    presetSortMethod() === 'notified_at'
       ? [SORT_CONFIGS.notified_at]
       : soup.sort.active()
   );

--- a/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
+++ b/apps/web/src/features/next-soup/soup-view/soup-view-context.tsx
@@ -686,8 +686,6 @@ export const SoupViewContextProvider: FlowComponent<
       : undefined;
   });
 
-  // The tab's forced server sort, with the notified order behind its flag:
-  // off, Signal and Noise keep update recency like before the sort existed.
   const presetSortMethod = () => {
     const method = activePreset()?.sortMethod;
     return method === 'notified_at' && !notifiedSortFF().enabled

--- a/apps/web/src/lib/core/constant/featureFlags.ts
+++ b/apps/web/src/lib/core/constant/featureFlags.ts
@@ -522,12 +522,6 @@ export const ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE = DEV_MODE_ENV
   ? true
   : undefined;
 
-/**
- * Orders the Inbox Signal/Noise tabs by the viewer's latest notification (the
- * soup `notified_at` sort) instead of update recency. PostHog-gated and off
- * by default while the candidate query is reworked for heavy notification
- * histories; on in dev mode. Override with VITE_ENABLE_INBOX_NOTIFIED_SORT.
- */
 export const ENABLE_INBOX_NOTIFIED_SORT_FLAG = 'enable-inbox-notified-sort';
 export const ENABLE_INBOX_NOTIFIED_SORT_OVERRIDE =
   getFeatureFlagOverride('ENABLE_INBOX_NOTIFIED_SORT') ??

--- a/apps/web/src/lib/core/constant/featureFlags.ts
+++ b/apps/web/src/lib/core/constant/featureFlags.ts
@@ -522,6 +522,17 @@ export const ENABLE_SUPPORTED_SOUP_FOREIGN_ENTITIES_OVERRIDE = DEV_MODE_ENV
   ? true
   : undefined;
 
+/**
+ * Orders the Inbox Signal/Noise tabs by the viewer's latest notification (the
+ * soup `notified_at` sort) instead of update recency. PostHog-gated and off
+ * by default while the candidate query is reworked for heavy notification
+ * histories; on in dev mode. Override with VITE_ENABLE_INBOX_NOTIFIED_SORT.
+ */
+export const ENABLE_INBOX_NOTIFIED_SORT_FLAG = 'enable-inbox-notified-sort';
+export const ENABLE_INBOX_NOTIFIED_SORT_OVERRIDE =
+  getFeatureFlagOverride('ENABLE_INBOX_NOTIFIED_SORT') ??
+  (DEV_MODE_ENV ? true : undefined);
+
 export const ENABLE_GRAPHQL_SOUP_FLAG = 'enable-graphql-soup';
 export const ENABLE_GRAPHQL_SOUP_OVERRIDE = getFeatureFlagOverride(
   'ENABLE_GRAPHQL_SOUP'

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -5,9 +5,10 @@
 Unified triage list (emails, channel messages, task assignments, doc mentions, agent
 results). Filter radios: `Signal` (default, AI-filtered "needs attention") / `Noise` / `All`
 / `Reminders`; plus `Filter` menu and `Preview` toggle (split list + preview pane; the empty
-preview shows "No content selected"). `Signal` and `Noise` order rows (and their date
-headers) by when you were last notified about the item, so a fresh comment on an old task
-sits under "Today". `All` and `Reminders` order by recency. Keyboard: `j`/`k` move, `space` preview, `enter` open, `e` mark done.
+preview shows "No content selected"). With the `enable-inbox-notified-sort` flag on, `Signal`
+and `Noise` order rows (and their date headers) by when you were last notified about the
+item, so a fresh comment on an old task sits under "Today"; with it off they order by
+recency like `All` and `Reminders`. Keyboard: `j`/`k` move, `space` preview, `enter` open, `e` mark done.
 Rows are buttons named `<channel> <sender>:<snippet> <time>`.
 
 ## Email — `/app/component/mail`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only sort and grouping behavior behind a feature flag with a safe fallback to existing recency ordering; no auth or data-model changes.
> 
> **Overview**
> **Signal** and **Noise** inbox ordering by last notification (`notified_at` API sort and matching date buckets) is now behind the PostHog flag `enable-inbox-notified-sort`. When the flag is off, those tabs behave like **All** / **Reminders**: `updated_at` sort and content-recency grouping.
> 
> The composable inbox path adds `notifiedSort` to query capabilities (wired from `useInboxDataSource`) and threads tab + capabilities through `inboxTabOrdersByNotification`, `inboxGroupTimestamp`, and `groupInboxEntitiesByDate`. The legacy Soup inbox path maps preset `notified_at` to `updated_at` and aligns client sort when the flag is disabled. Tests cover the flag-off path; agent docs note the flag-controlled behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 867fa9c6c8a43842a9b0f438e51e9573ba46eeec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->