### PR TITLE
fix(fusionauth): carry granted scopes onto login-issued Google refresh tokens

### DIFF
--- a/infra/stacks/fusionauth-instance/index.ts
+++ b/infra/stacks/fusionauth-instance/index.ts
@@ -468,8 +468,10 @@ new FusionAuthIdpOpenIdConnect(
     oauth2ClientId: GOOGLE_CLIENT_ID,
     oauth2ClientSecret: GOOGLE_CLIENT_SECRET,
     oauth2ClientAuthenticationMethod: 'client_secret_basic',
+    // Logins mint a fresh refresh token. include_granted_scopes keeps the
+    // scopes granted earlier through /link/gmail (calendar) on that token.
     oauth2AuthorizationEndpoint:
-      'https://accounts.google.com/o/oauth2/v2/auth?prompt=consent&access_type=offline',
+      'https://accounts.google.com/o/oauth2/v2/auth?prompt=consent&access_type=offline&include_granted_scopes=true',
     oauth2TokenEndpoint: 'https://oauth2.googleapis.com/token',
     oauth2UserInfoEndpoint: 'https://openidconnect.googleapis.com/v1/userinfo',
     buttonText: 'GoogleGmail',


### PR DESCRIPTION
Google logins through the `google_gmail` IdP force `prompt=consent&access_type=offline`, so every sign-in hands FusionAuth a fresh gmail-only refresh token and calendar sync dies on the next poll with 403 `insufficientPermissions` (11 prod accounts are stuck in `reauth_required` this way). `include_granted_scopes=true` keeps the calendar scopes granted through `/link/gmail` on the login-issued token.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production OAuth authorization behavior for the Gmail IdP; misconfiguration could affect Google token scopes for all users who log in through that provider.
> 
> **Overview**
> Updates the **`google_gmail`** FusionAuth OIDC provider so Google’s authorize URL includes **`include_granted_scopes=true`** alongside the existing `prompt=consent` and `access_type=offline`.
> 
> That way, when sign-in issues a new offline refresh token, Google still attaches calendar (and other) scopes the user already granted via **`/link/gmail`**, instead of dropping them and breaking calendar sync with insufficient-permission errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a27f4bbf26fc3118f04fc0ad6a23a0060a4db6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->