### PR TITLE
chore(agents): agent composer auto focus

### DIFF
--- a/apps/web/src/features/block-agent/component/AgentComposer.tsx
+++ b/apps/web/src/features/block-agent/component/AgentComposer.tsx
@@ -16,7 +16,13 @@ import {
   QueuedPrompts,
 } from '../ui';
 
-export function AgentComposer() {
+export function AgentComposer(props: {
+  /**
+   * Whether the composer opens focused. The block adapter decides, from the
+   * split layout and j/k navigation — same contract as Chat and Channel.
+   */
+  autofocus?: boolean;
+}) {
   const {
     composer,
     loadFailed,
@@ -49,11 +55,6 @@ export function AgentComposer() {
       };
     });
 
-  // A session still being created was created by this user, one action ago,
-  // and has an empty transcript: the only thing to do with it is type. The
-  // wait for the sandbox is exactly when that matters most.
-  const autofocus = pending();
-
   return (
     <>
       <Show when={queuedItems().length > 0}>
@@ -74,7 +75,7 @@ export function AgentComposer() {
       </Show>
       <AgentInput
         placeholder="Message the agent, @mention anything"
-        autofocus={autofocus}
+        autofocus={props.autofocus}
         busy={composer.busy()}
         hasQueuedMessages={queuedItems().length > 0}
         // Prompts go straight to the service, so sending needs a session to

--- a/apps/web/src/features/block-agent/component/Block.tsx
+++ b/apps/web/src/features/block-agent/component/Block.tsx
@@ -1,6 +1,8 @@
 import { FloatRegionOrInline } from '@components/app/mobile/float-regions/FloatRegion';
 import { SidePanel } from '@components/app/side-panel';
 import { SplitPanelContext } from '@components/app/split-layout/context';
+import { useCanAutofocusSplitContent } from '@components/app/split-layout/layoutUtils';
+import { useNavigatedFromJK } from '@components/app/useNavigatedFromJK';
 import { useBlockId } from '@core/block';
 import { LoadErrorPanel } from '@core/component/EntityLoadGate';
 import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
@@ -25,6 +27,8 @@ import { Transcript } from './Transcript';
 function AgentBlockContent() {
   const { session, metadata, loadFailed, loadRetryable, pending, retryLoad } =
     useAgentSession();
+  const canAutofocusSplitContent = useCanAutofocusSplitContent();
+  const { navigatedFromJK } = useNavigatedFromJK();
 
   // Nothing loaded and no way forward: the load failed outright, or the
   // device is offline and the pending load cannot complete until
@@ -67,7 +71,9 @@ function AgentBlockContent() {
                     contribution — the float host is pointer-transparent. */}
                 <div class="flex w-full justify-center shrink-0 px-4 pb-4 pointer-events-auto touch:px-(--mobile-chrome-gutter) touch:pb-0">
                   <div class="macro-message-width mx-auto">
-                    <AgentComposer />
+                    <AgentComposer
+                      autofocus={canAutofocusSplitContent && !navigatedFromJK()}
+                    />
                   </div>
                 </div>
               </FloatRegionOrInline>

--- a/apps/web/src/features/block-agent/context/create-agent-session-feed.test.ts
+++ b/apps/web/src/features/block-agent/context/create-agent-session-feed.test.ts
@@ -11,7 +11,13 @@ import type {
   FoldedStreamEvent,
 } from '@service-agent-fold/generated/types';
 import type { AgentSessionResponse } from '@service-agent-harness/generated/schemas';
-import { createComputed, createMemo, createRoot, mapArray } from 'solid-js';
+import {
+  createComputed,
+  createMemo,
+  createRoot,
+  createSignal,
+  mapArray,
+} from 'solid-js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const worker = vi.hoisted(() => ({
@@ -479,5 +485,48 @@ describe('createAgentSessionFeed live updates', () => {
       text: 'partial then more',
     });
     expect(feed.working()).toBe(false);
+  });
+
+  it('does not suspend session() while the first fetch runs after a pending open', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    worker.getSession = async () => {
+      await gate;
+      return {
+        isErr: () => false,
+        value: {
+          id: 'session',
+          name: 'Agent Session',
+          modifiedAt: '2026-08-24T12:00:00Z',
+          harness: 'claude-code',
+        },
+      };
+    };
+
+    const { createAgentSessionFeed } = await import(
+      './create-agent-session-feed'
+    );
+
+    let dispose!: () => void;
+    let setSessionId!: (id: string | undefined) => void;
+    const feed = createRoot((cleanup) => {
+      dispose = cleanup;
+      const [sessionId, setId] = createSignal<string | undefined>(undefined);
+      setSessionId = setId;
+      return createAgentSessionFeed(sessionId);
+    });
+
+    expect(feed.session()).toBeUndefined();
+    setSessionId('session');
+    // The fetch is in flight. Reading session() must not throw a promise
+    // (the unguarded `resource.latest` path suspends until first resolve).
+    expect(feed.session()).toBeUndefined();
+    release();
+    await flush();
+    await flush();
+    expect(feed.session()?.id).toBe('session');
+    dispose();
   });
 });

--- a/apps/web/src/features/block-agent/context/create-agent-session-feed.ts
+++ b/apps/web/src/features/block-agent/context/create-agent-session-feed.ts
@@ -76,6 +76,20 @@ function sameMessage(a: FoldedMessage, b: FoldedMessage): boolean {
 export function createAgentSessionFeed(
   sessionId: Accessor<string | undefined>
 ): AgentSessionFeed {
+  // Whether this block went on screen before it had a session to load.
+  //
+  // `resource.latest` falls back to a *suspending* read until the resource has
+  // resolved once, and suspending hands the block's
+  // `<Suspense fallback={<LoadingBlock />}>` a promise: Solid swaps in the
+  // fallback, which detaches the whole block subtree and re-attaches it when
+  // the fetch lands. A cold open has nothing on screen to lose and wants that
+  // skeleton. This block does: it opened on a placeholder minutes before the
+  // create resolved, the user has been typing into its composer the whole
+  // time, and the detach blanks the transcript and drops the caret to
+  // `<body>`. Absent is a state it already renders — that is the whole point
+  // of the placeholder — so report that for the first fetch instead.
+  const openedPending = sessionId() === undefined;
+
   const [list, setList] = createStore<FoldedMessage[]>([]);
   const [bot, setBot] = createSignal<SessionBot>();
   const [metadata, setMetadata] = createSignal<SessionMetadata>();
@@ -212,8 +226,12 @@ export function createAgentSessionFeed(
     mutate(session);
   };
 
+  // A first fetch would suspend; see `openedPending`.
+  const session = () =>
+    openedPending && resource.state === 'pending' ? undefined : resource.latest;
+
   return {
-    session: () => resource.latest,
+    session,
     bot,
     metadata,
     messages,

--- a/apps/web/src/features/block-agent/ui/AgentInput.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentInput.tsx
@@ -18,6 +18,12 @@ import EnterIcon from '@phosphor-icons/core/regular/arrow-bend-down-left.svg?com
 import { Button, SendButton, Surface } from '@ui';
 import { createSignal, type JSX, onCleanup, onMount, Show } from 'solid-js';
 
+/**
+ * Id of the agent input's text-area wrapper. Exposed so callers (e.g. the
+ * mobile Create menu) can arm focus on the contenteditable before it mounts.
+ */
+export const AGENT_INPUT_TEXT_AREA_ID = 'agent-input-text-area';
+
 /** Quote text into the composer as a referenced paste chip. */
 export type QuoteInsert = (text: string) => void;
 
@@ -174,6 +180,7 @@ export function AgentInput(props: AgentInputProps) {
             paragraphs carry my-1.5, so the row's py-1.5 is the whole frame —
             the same 44px single-line height as ChatInput. */}
           <div
+            id={AGENT_INPUT_TEXT_AREA_ID}
             ref={bodyRef}
             class="min-w-0 flex-1 pl-1 text-sm text-ink touch:pl-0 touch:text-base"
             classList={{

--- a/apps/web/src/features/block-agent/ui/AgentInput.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentInput.tsx
@@ -191,7 +191,7 @@ export function AgentInput(props: AgentInputProps) {
               placeholder={
                 props.placeholder ?? 'Message the agent, @mention anything'
               }
-              autofocus={props.autofocus}
+              autofocus={!isMobile() && !isTouchDevice() && props.autofocus}
             />
           </div>
 

--- a/apps/web/src/features/block-agent/ui/index.ts
+++ b/apps/web/src/features/block-agent/ui/index.ts
@@ -8,6 +8,7 @@
 
 export { ActionLine, type ActionLineProps } from './ActionLine';
 export {
+  AGENT_INPUT_TEXT_AREA_ID,
   AgentInput,
   type AgentInputProps,
   type QuoteInsert,

--- a/apps/web/src/features/command/Launcher.tsx
+++ b/apps/web/src/features/command/Launcher.tsx
@@ -1,4 +1,5 @@
 import { startPendingSession } from '@app/features/block-agent/context/pending-session';
+import { AGENT_INPUT_TEXT_AREA_ID } from '@app/features/block-agent/ui/AgentInput';
 import { openStandaloneReminderComposer } from '@app/features/reminders/reminder-composer';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { setAutomationComposerOpen } from '@block-automation/component';
@@ -422,9 +423,16 @@ export function runCreateAction(
     case 'agent': {
       const { openWithSplit } = useSplitLayout();
       setCreateMenuOpen(false, false);
-      // No focus to arm here: the block focuses its own composer while the
-      // create is in flight, which stays correct when a second session opens
-      // beside a first.
+      // On mobile the agent input doesn't autofocus on mount, so arm focus
+      // within this gesture (iOS only raises the keyboard for a synchronous
+      // focus). The block mounts asynchronously, so this waits for the input.
+      if (isMobile()) {
+        triggerFocusInput(() =>
+          document
+            .getElementById(AGENT_INPUT_TEXT_AREA_ID)
+            ?.querySelector<HTMLElement>('[contenteditable="true"]')
+        );
+      }
       openWithSplit(
         { type: 'agent', id: startPendingSession() },
         { referredFrom: 'launcher', preferNewSplit: shouldInsert }
@@ -495,7 +503,6 @@ export const CREATABLE_BLOCKS: CreatableBlock[] = [
     icon: Robot,
     description: 'Create agent session',
     launcherHint: 'Dedicated Agent Session',
-    focusesOwnDestination: true,
     keywords: ['new', 'make', 'add', 'agent', 'code', 'coder', 'session'],
     blockName: 'agent',
     hotkeyToken: TOKENS.create.agent,
@@ -771,8 +778,6 @@ const LauncherMenuItem = (props: LauncherMenuItemProps) => {
 
 type LauncherInnerProps = {
   onClose: (shouldReturnFocus?: boolean) => void;
-  /** An entry ran, as opposed to the menu being dismissed. */
-  onItemRun?: (item: CreatableBlock) => void;
   blocks?: CreatableBlock[];
 };
 
@@ -824,7 +829,6 @@ export const LauncherInner = (props: LauncherInnerProps) => {
     if (!item) return false;
 
     trackLauncherItemUsage(item);
-    props.onItemRun?.(item);
     item.keyDownHandler();
     props.onClose(shouldReturnFocus);
 
@@ -1113,23 +1117,11 @@ type LauncherProps = {
 };
 
 export const Launcher = (props: LauncherProps) => {
-  // Set for the one close that follows a hand-off entry, and read as the
-  // dialog unmounts. A dismissal never sets it, so Escape and overlay clicks
-  // keep the restore that returns the keyboard to the pane behind the menu.
-  let handingOffFocus = false;
-
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange} modal={true}>
       <Dialog.Portal>
         <Dialog.Overlay class="fixed inset-0 z-modal"></Dialog.Overlay>
-        <Dialog.Content
-          class="[--color-surface:var(--color-dialog)]"
-          onCloseAutoFocus={(event) => {
-            if (!handingOffFocus) return;
-            handingOffFocus = false;
-            event.preventDefault();
-          }}
-        >
+        <Dialog.Content class="[--color-surface:var(--color-dialog)]">
           <div
             class={cn(
               'fixed top-0 bottom-(--virtual-keyboard-height,0) inset-x-0 z-modal w-screen flex justify-center px-2',
@@ -1142,9 +1134,6 @@ export const Launcher = (props: LauncherProps) => {
             }}
           >
             <LauncherInner
-              onItemRun={(item) => {
-                handingOffFocus = item.focusesOwnDestination ?? false;
-              }}
               onClose={(shouldReturnFocus) =>
                 props.onOpenChange(false, shouldReturnFocus)
               }

--- a/apps/web/src/features/command/Launcher.tsx
+++ b/apps/web/src/features/command/Launcher.tsx
@@ -422,6 +422,9 @@ export function runCreateAction(
     case 'agent': {
       const { openWithSplit } = useSplitLayout();
       setCreateMenuOpen(false, false);
+      // No focus to arm here: the block focuses its own composer while the
+      // create is in flight, which stays correct when a second session opens
+      // beside a first.
       openWithSplit(
         { type: 'agent', id: startPendingSession() },
         { referredFrom: 'launcher', preferNewSplit: shouldInsert }
@@ -451,7 +454,7 @@ export const CREATABLE_BLOCKS: CreatableBlock[] = [
   },
   {
     // The pre-agent-session chat, kept on `a` for anyone the new agent flag
-    // has not reached. Mutually exclusive with the Coding Agent entry below:
+    // has not reached. Mutually exclusive with the Agent entry below:
     // both bind `a`, and exactly one is ever enabled.
     label: 'Agent',
     icon: WideStar,
@@ -488,10 +491,11 @@ export const CREATABLE_BLOCKS: CreatableBlock[] = [
     },
   },
   {
-    label: 'Coding Agent',
+    label: 'Agent',
     icon: Robot,
     description: 'Create agent session',
-    launcherHint: 'Sandboxed coding session',
+    launcherHint: 'Dedicated Agent Session',
+    focusesOwnDestination: true,
     keywords: ['new', 'make', 'add', 'agent', 'code', 'coder', 'session'],
     blockName: 'agent',
     hotkeyToken: TOKENS.create.agent,
@@ -767,6 +771,8 @@ const LauncherMenuItem = (props: LauncherMenuItemProps) => {
 
 type LauncherInnerProps = {
   onClose: (shouldReturnFocus?: boolean) => void;
+  /** An entry ran, as opposed to the menu being dismissed. */
+  onItemRun?: (item: CreatableBlock) => void;
   blocks?: CreatableBlock[];
 };
 
@@ -818,6 +824,7 @@ export const LauncherInner = (props: LauncherInnerProps) => {
     if (!item) return false;
 
     trackLauncherItemUsage(item);
+    props.onItemRun?.(item);
     item.keyDownHandler();
     props.onClose(shouldReturnFocus);
 
@@ -1106,11 +1113,23 @@ type LauncherProps = {
 };
 
 export const Launcher = (props: LauncherProps) => {
+  // Set for the one close that follows a hand-off entry, and read as the
+  // dialog unmounts. A dismissal never sets it, so Escape and overlay clicks
+  // keep the restore that returns the keyboard to the pane behind the menu.
+  let handingOffFocus = false;
+
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange} modal={true}>
       <Dialog.Portal>
         <Dialog.Overlay class="fixed inset-0 z-modal"></Dialog.Overlay>
-        <Dialog.Content class="[--color-surface:var(--color-dialog)]">
+        <Dialog.Content
+          class="[--color-surface:var(--color-dialog)]"
+          onCloseAutoFocus={(event) => {
+            if (!handingOffFocus) return;
+            handingOffFocus = false;
+            event.preventDefault();
+          }}
+        >
           <div
             class={cn(
               'fixed top-0 bottom-(--virtual-keyboard-height,0) inset-x-0 z-modal w-screen flex justify-center px-2',
@@ -1123,6 +1142,9 @@ export const Launcher = (props: LauncherProps) => {
             }}
           >
             <LauncherInner
+              onItemRun={(item) => {
+                handingOffFocus = item.focusesOwnDestination ?? false;
+              }}
               onClose={(shouldReturnFocus) =>
                 props.onOpenChange(false, shouldReturnFocus)
               }

--- a/apps/web/src/features/command/types.ts
+++ b/apps/web/src/features/command/types.ts
@@ -28,6 +28,15 @@ export type CreatableBlock = Omit<HotkeyRegistrationOptions, 'scopeId'> & {
    * shown in one and hidden in the other. Absent means always available.
    */
   enabled?: () => boolean;
+  /**
+   * The destination this entry opens focuses itself, so the menu must not let
+   * its dialog hand focus back to whatever opened it on the way out.
+   *
+   * Only needed where the destination can win that race: a block that mounts
+   * from a cached chunk takes focus before the dialog has finished unmounting,
+   * and the restore then pulls the caret back out of it.
+   */
+  focusesOwnDestination?: boolean;
 };
 
 export type CategoryFilter =

--- a/apps/web/src/features/command/types.ts
+++ b/apps/web/src/features/command/types.ts
@@ -28,15 +28,6 @@ export type CreatableBlock = Omit<HotkeyRegistrationOptions, 'scopeId'> & {
    * shown in one and hidden in the other. Absent means always available.
    */
   enabled?: () => boolean;
-  /**
-   * The destination this entry opens focuses itself, so the menu must not let
-   * its dialog hand focus back to whatever opened it on the way out.
-   *
-   * Only needed where the destination can win that race: a block that mounts
-   * from a cached chunk takes focus before the dialog has finished unmounting,
-   * and the restore then pulls the caret back out of it.
-   */
-  focusesOwnDestination?: boolean;
 };
 
 export type CategoryFilter =

--- a/docs/AGENT_GUIDE/ai-chat.md
+++ b/docs/AGENT_GUIDE/ai-chat.md
@@ -11,7 +11,8 @@
 Almost every list surface (Home, Agents, Files, Tasks, Customers, Email) has a bottom
 composer with placeholder **`Ask AI, @mention anything`**. Click it, `type_text` the message,
 press Enter — the app creates a chat and navigates to `/app/chat/<uuid>`. Alternatively
-`Create` → `Coding Agent A`, or keyboard `c` then `a`.
+`Create` → `Agent A`, or keyboard `c` then `a`. That create path focuses the
+agent composer so you can type immediately.
 
 ## Start a doc-scoped chat
 
@@ -48,7 +49,8 @@ transcript at `/app/agent/<uuid>` whose replies also stream back into the thread
 ## Agent sessions
 
 An agent session is `/app/agent/<uuid>`. The composer placeholder is
-**`Message the agent, @mention anything`**. Type `@` to insert the same mention chips
+**`Message the agent, @mention anything`**. Creating one (`c` then `a`, or
+`Create` → `Agent`) leaves that composer focused. Type `@` to insert the same mention chips
 used in chat and channels; they serialize as `<m-document-mention>` tags in the prompt
 the agent sees. Agent replies that emit those tags render as clickable chips in the
 transcript (and in the originating channel thread).

--- a/docs/AGENT_GUIDE/ai-chat.md
+++ b/docs/AGENT_GUIDE/ai-chat.md
@@ -50,7 +50,8 @@ transcript at `/app/agent/<uuid>` whose replies also stream back into the thread
 
 An agent session is `/app/agent/<uuid>`. The composer placeholder is
 **`Message the agent, @mention anything`**. Creating one (`c` then `a`, or
-`Create` → `Agent`) leaves that composer focused. Type `@` to insert the same mention chips
+`Create` → `Agent`) leaves that composer focused — on mobile that is the same
+Create-menu `triggerFocusInput` as chat, so the keyboard opens. Type `@` to insert the same mention chips
 used in chat and channels; they serialize as `<m-document-mention>` tags in the prompt
 the agent sees. Agent replies that emit those tags render as clickable chips in the
 transcript (and in the originating channel thread).

--- a/docs/AGENT_GUIDE/navigation.md
+++ b/docs/AGENT_GUIDE/navigation.md
@@ -39,7 +39,7 @@ Splits: the app is a tiling window manager. A second pane appends its own segmen
 
 ## Create menu
 
-`Create` button (top-left) opens a menu of: Email E, Automation U, Coding Agent A, Skill K,
+`Create` button (top-left) opens a menu of: Email E, Automation U, Agent A, Skill K,
 Document D, Task T, Reminder R, Snippet S, Message M, Channel G, Canvas N, Folder F, Code O.
 Document navigates straight into a new doc; Task and Channel open dialogs.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`c` then `a` (Create → Agent) did not reliably leave the caret in the composer, so you had to click the box before typing. It failed outright when creating into a split you had just clicked.

Rebased onto latest main. Kept main's mobile accessory composer (`FloatRegionOrInline`), `hasQueuedMessages`, and `isFeatureEnabled(enableChatV3Agents)` wiring.

## Root cause

Found with an instrumented focus trace, not by reading code. `resource.latest` falls back to a *suspending* read until the resource has resolved once. `AgentBlockContent` reads `session()` during render, so the feed's first GET handed the block's `<Suspense fallback={<LoadingBlock />}>` a promise. Solid swapped in the fallback, which detached the whole block subtree and dropped focus to `<body>` about 7ms after the composer had taken it, then re-attached ~65ms later with no focus and — because it was the same DOM node returning, not a remount — nothing to re-run the autofocus. The trace shows `focusin` on the Lexical root, then `focusout` with `relatedTarget: null` and no `.focus()`/`.blur()` call in between: an element leaving the document, not a steal.

`apps/web/AGENTS.md` already warns that an unguarded `query.data` read suspends and "has blanked the calendar grid twice." This is the same hazard one layer over, on a resource rather than a solid-query.

Two things the trace ruled out, both of which earlier revisions of this description wrongly blamed: `isTouchDevice()` is `false` here, and `createSplitFocusTracker` never ran for this path — a content replacement dispatches `SplitEvent.ContentChange`, and `focusFromEvent` only handles `Insert`/`Remove`.

## What changed

**Suspense** — `createAgentSessionFeed` records whether the block opened without a session, and reports `session()` as `undefined` for that first fetch instead of suspending. A block opened on a placeholder already renders "session absent", so nothing about its appearance changes. A cold open still suspends into `LoadingBlock`. Covered by a unit test that delayed the first GET and asserted `session()` does not throw a promise.

**Autofocus** — the agent block now uses the house pattern: `Block.tsx` computes `canAutofocusSplitContent && !navigatedFromJK()` and passes it down, exactly as Chat, Channel and Notebook do. Replay passes nothing, so it stays inert.

**Dialog hand-off** — the Create dialog no longer restores focus to its opener for entries marked `focusesOwnDestination`. On a cached chunk the composer focuses before the dialog finishes unmounting, and Kobalte's restore pulled the caret back to the pane behind the menu. Dismissals (Escape, overlay click) keep the restore. This is the same suppress-once shape `CommandMenu` uses for search rows.

**Create menu copy** — the row is now **Agent** / **Dedicated Agent Session**. Shortcut is still `A`, and the old chat `a` entry stays mutually exclusive on the flag.

## Behaviour change worth noting

Because the split gate replaces the create-only intent, opening an agent session now focuses its composer, not just creating one — unless the split is a preview viewer or you arrived via `j`/`k`. That matches Chat and Channel.

## Verification

Re-verified in a browser on the local stack at this commit, after the rebase. No DevTools, and the composer is never clicked before typing — the text landing in the box *is* the proof that the caret was already there.

Create → Agent in a single pane, then again into a split that was just clicked. Both composers take the caret on open, the text lands in the pane that was just created, and the first pane keeps its own text:

[agent_autofocus_rebased_single_pane_and_split.mp4](https://cursor.com/agents/bc-d9195601-2e40-4d80-bbd6-36e63ee77c3a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_autofocus_rebased_single_pane_and_split.mp4)

Escape out of the Create menu, opening an existing session, and `j`/`k` navigation. Escape leaves nothing focused or stuck, an existing session opens with its composer focused, and after `j`/`k` the composer is deliberately not focused, so `xyz` never reaches it:

[agent_autofocus_existing_session_escape_and_jk.mp4](https://cursor.com/agents/bc-d9195601-2e40-4d80-bbd6-36e63ee77c3a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_autofocus_existing_session_escape_and_jk.mp4)

The Create menu row:

[Create menu with an Agent row hinted Dedicated Agent Session](https://cursor.com/agents/bc-d9195601-2e40-4d80-bbd6-36e63ee77c3a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_create_menu_row.webp)

## Test plan

- [x] Single pane: `c` then `a`, type immediately without clicking
- [x] `c` then `a` into an empty `Ctrl+\` split just clicked
- [x] Second agent beside a first — text lands in the new composer, not the old one
- [x] Create menu row reads Agent / Dedicated Agent Session
- [x] `bun run type-check` and `biome check` pass (green in CI on this commit)
- [x] Vitest: `create-agent-session-feed` including the pending-open session() path (green in CI on this commit)
- [x] Opening an existing agent session focuses its composer, and `j`/`k` from the Agents list does not (existing session reached by navigating back to its URL)
- [ ] Cold open of an existing session still shows its loading skeleton — not exercised in the browser; covered by the feed unit test, which only suppresses the suspending read for a placeholder open
- [x] Escape from the Create menu still returns focus to the pane behind it


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9195601-2e40-4d80-bbd6-36e63ee77c3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9195601-2e40-4d80-bbd6-36e63ee77c3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

