### PR TITLE
perf(soup): linearize the notified-at candidate query

### DIFF
--- a/crates/soup/src/outbound/pg_soup_repo/candidate_gates.rs
+++ b/crates/soup/src/outbound/pg_soup_repo/candidate_gates.rs
@@ -10,7 +10,7 @@
 
 use filter_ast::Expr;
 use item_filters::ast::EntityFilterAst;
-use item_filters::ast::channel::ChannelLiteral;
+use item_filters::ast::channel::{ChannelLiteral, ChannelThreadLiteral};
 use item_filters::ast::email::EmailLiteral;
 use item_filters::ast::properties::{PropertyEntityType, properties_filter_matches_propertyless};
 use system_properties::SystemPropertyKey;
@@ -41,7 +41,10 @@ fn and_conjuncts<'a, T>(expr: &'a Expr<T>, out: &mut Vec<&'a T>) {
 
 /// Renders the implied conjuncts of `tree` that `fold` knows how to express
 /// as ` AND ...` clauses, in tree order.
-fn implied_conjuncts_sql<T>(tree: Option<&Expr<T>>, fold: impl Fn(&T) -> Option<String>) -> String {
+pub(super) fn implied_conjuncts_sql<T>(
+    tree: Option<&Expr<T>>,
+    fold: impl Fn(&T) -> Option<String>,
+) -> String {
     let Some(tree) = tree else {
         return String::new();
     };
@@ -190,8 +193,29 @@ pub(super) fn channel_gate(id_sql: &str, filter: Option<&EntityFilterAst>) -> St
 
 /// Channel-thread rows are root messages; one is visible iff it is undeleted
 /// and the caller is an active participant of its channel. The thread tree
-/// folds in the channels crate, which hydration applies in full.
-pub(super) fn channel_thread_gate(id_sql: &str) -> String {
+/// folds in the channels crate, which hydration applies in full; the
+/// notification-state conjuncts it implies are pre-applied here over the
+/// thread's own notifications (the channel notifications naming this root
+/// as their secondary item, the same rows the channels fold predicates on).
+pub(super) fn channel_thread_gate(id_sql: &str, filter: Option<&EntityFilterAst>) -> String {
+    let implied = implied_conjuncts_sql(
+        filter.and_then(|f| f.channel_thread_filter.as_deref()),
+        |literal| {
+            let predicate = match literal {
+                ChannelThreadLiteral::NotificationDone(done) => NotificationPredicate::Done(*done),
+                ChannelThreadLiteral::NotificationSeen(seen) => NotificationPredicate::Seen(*seen),
+                _ => return None,
+            };
+            Some(build_notification_exists_clause(
+                "m.channel_id",
+                "channel",
+                &format!(
+                    "n.secondary_event_item_type = 'channel_message' AND n.secondary_event_item_id = m.id::text AND {}",
+                    predicate.sql()
+                ),
+            ))
+        },
+    );
     uuid_guarded(
         id_sql,
         format!(
@@ -204,6 +228,7 @@ pub(super) fn channel_thread_gate(id_sql: &str) -> String {
                 WHERE m.id = {id_sql}::uuid
                 AND m.thread_id IS NULL
                 AND m.deleted_at IS NULL
+                {implied}
             )"#
         ),
     )

--- a/crates/soup/src/outbound/pg_soup_repo/notified.rs
+++ b/crates/soup/src/outbound/pg_soup_repo/notified.rs
@@ -4,9 +4,9 @@
 //! Every candidate is gated on existence, deletion and access, and on the
 //! request's filters where soup owns the fold (documents, chats, projects,
 //! calendar events, properties). Channel, channel-thread, email,
-//! foreign-entity and reminder candidates are gated on access (plus, for
-//! channels and emails, the notification-state and importance conjuncts
-//! their trees imply): their filter trees fold in their own domains' query
+//! foreign-entity and reminder candidates are gated on access (plus the
+//! notification-state and, for emails, importance conjuncts their trees
+//! imply): their filter trees fold in their own domains' query
 //! builders, so the service applies them in full when it hydrates the page
 //! through those legs and drops the candidates that fail, refilling from the
 //! next candidate page. A short page from this query therefore still means
@@ -30,9 +30,9 @@ use std::str::FromStr;
 
 use crate::domain::models::{NotifiedEntity, NotifiedSoupRequest};
 use crate::outbound::pg_soup_repo::candidate_gates::{
-    channel_gate, channel_thread_gate, chat_gate, document_gate, email_gate, includes_channels,
-    includes_chats, includes_documents, includes_email_threads, includes_projects, project_gate,
-    uuid_guarded,
+    channel_gate, channel_thread_gate, chat_gate, document_gate, email_gate, implied_conjuncts_sql,
+    includes_channels, includes_chats, includes_documents, includes_email_threads,
+    includes_projects, project_gate, uuid_guarded,
 };
 use crate::outbound::pg_soup_repo::expanded::dynamic::{
     build_notification_done_clause, build_notification_seen_clause, build_properties_filter,
@@ -102,8 +102,23 @@ fn calendar_event_gate(filter: Option<&EntityFilterAst>) -> String {
 
 /// Foreign entities are visible through the source they were stored for:
 /// the caller themselves or a team they belong to (`$7`/`$8` are the
-/// parallel id / auth-entity arrays of those sources).
-fn foreign_entity_gate() -> String {
+/// parallel id / auth-entity arrays of those sources). The foreign-entity
+/// tree folds in its own crate, which hydration applies in full; the
+/// notification-state conjuncts it implies are pre-applied here.
+fn foreign_entity_gate(filter: Option<&EntityFilterAst>) -> String {
+    let implied =
+        implied_conjuncts_sql(
+            filter.and_then(|f| f.foreign_entity_filter.as_deref()),
+            |literal| match literal {
+                ForeignEntityLiteral::NotificationDone(done) => Some(
+                    build_notification_done_clause("fe.id", "foreign_entity", *done),
+                ),
+                ForeignEntityLiteral::NotificationSeen(seen) => Some(
+                    build_notification_seen_clause("fe.id", "foreign_entity", *seen),
+                ),
+                _ => None,
+            },
+        );
     uuid_guarded(
         ID_SQL,
         format!(
@@ -115,6 +130,7 @@ fn foreign_entity_gate() -> String {
                     WHERE source.id = fe.stored_for_id
                     AND source.auth_entity = fe.stored_for_auth_entity
                 )
+                {implied}
             )"#
         ),
     )
@@ -199,11 +215,14 @@ fn included_types(req: &NotifiedSoupRequest<'_>) -> Vec<&'static str> {
 
 /// Fetches one page of notified-at candidates.
 ///
-/// Shape: keyset scan of the user's live notifications in `created_at DESC`
-/// order over the `notified` CTE's derived entity key, keeping only each
-/// entity's newest notification (the `NOT EXISTS` group-max), gated per
-/// entity type on existence/deletion/access and the soup-owned filters so
-/// `LIMIT` lands after gating.
+/// Shape: the user's live notifications collapse to one row per derived
+/// entity key, its newest notification (the `latest` window's first row per
+/// partition), which the fenced subquery orders and keysets; the outer query
+/// gates those per entity type on existence/deletion/access and the
+/// soup-owned filters in that order until `LIMIT` is met. The `OFFSET 0`
+/// fence keeps the gates outside the dedupe and the inner order intact, so
+/// the planner neither pushes the gates down onto every notification nor
+/// re-sorts after them.
 ///
 /// `user_notification.created_at` is a naive `TIMESTAMP` written in UTC, so
 /// the keyset binds and the returned value stay naive and are re-tagged as
@@ -245,18 +264,29 @@ pub(super) async fn notified_soup_page(
             JOIN notification n ON n.id = un.notification_id
             WHERE un.user_id = $1
             AND un.deleted_at IS NULL
+        ),
+        latest AS NOT MATERIALIZED (
+            SELECT
+                entity_type,
+                entity_id,
+                created_at,
+                row_number() OVER (
+                    PARTITION BY entity_type, entity_id
+                    ORDER BY created_at DESC, notification_id DESC
+                ) AS rn
+            FROM notified
+            WHERE entity_type = ANY($2)
         )
-        SELECT nc.entity_type, nc.entity_id, nc.created_at AS notified_at
-        FROM notified nc
-        WHERE nc.entity_type = ANY($2)
-        AND ($3::timestamp IS NULL OR (nc.created_at, nc.entity_id) < ($3, $4))
-        AND NOT EXISTS (
-            SELECT 1 FROM notified newer
-            WHERE newer.entity_type = nc.entity_type
-            AND newer.entity_id = nc.entity_id
-            AND (newer.created_at, newer.notification_id) > (nc.created_at, nc.notification_id)
-        )
-        AND CASE nc.entity_type
+        SELECT nc.entity_type, nc.entity_id, nc.notified_at
+        FROM (
+            SELECT entity_type, entity_id, created_at AS notified_at
+            FROM latest
+            WHERE rn = 1
+            AND ($3::timestamp IS NULL OR (created_at, entity_id) < ($3, $4))
+            ORDER BY created_at DESC, entity_id DESC
+            OFFSET 0
+        ) nc
+        WHERE CASE nc.entity_type
             WHEN 'document' THEN {document_gate}
             WHEN 'chat' THEN {chat_gate}
             WHEN 'project' THEN {project_gate}
@@ -268,17 +298,17 @@ pub(super) async fn notified_soup_page(
             WHEN 'reminder' THEN {reminder_gate}
             ELSE FALSE
         END
-        ORDER BY nc.created_at DESC, nc.entity_id DESC
+        ORDER BY nc.notified_at DESC, nc.entity_id DESC
         LIMIT $6
         "#,
         document_gate = document_gate(ID_SQL, req.filter),
         chat_gate = chat_gate(ID_SQL, req.filter),
         project_gate = project_gate(ID_SQL, req.filter),
         channel_gate = channel_gate(ID_SQL, req.filter),
-        channel_thread_gate = channel_thread_gate(ID_SQL),
+        channel_thread_gate = channel_thread_gate(ID_SQL, req.filter),
         email_gate = email_gate(ID_SQL, req.filter),
         calendar_event_gate = calendar_event_gate(req.filter),
-        foreign_entity_gate = foreign_entity_gate(),
+        foreign_entity_gate = foreign_entity_gate(req.filter),
         reminder_gate = reminder_gate(),
     );
 

--- a/crates/soup/src/outbound/pg_soup_repo/notified/test.rs
+++ b/crates/soup/src/outbound/pg_soup_repo/notified/test.rs
@@ -25,6 +25,8 @@ const REMINDER_R1: &str = "88888888-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 const LINK_1: &str = "55555555-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 const TEAM_T: &str = "eeeeeeee-1111-1111-1111-111111111111";
 const CHANNEL_X_INVITE: &str = "0190a000-0000-7000-8000-000000000000";
+const THREAD_M_MENTION: &str = "0190a000-0000-7000-8000-000000000006";
+const PR_F1_EVENT: &str = "0190a000-0000-7000-8000-000000000003";
 
 const EVERYTHING: NotifiedHydratableTypes = NotifiedHydratableTypes {
     channels: true,
@@ -358,6 +360,72 @@ async fn channel_conjuncts_ignore_thread_scoped_notifications(
         notified_soup_page(&pool, req(Some(&filter), &link_ids, &sources, EVERYTHING)).await?;
     assert!(!keys(&page).contains(&(EntityType::Channel, CHANNEL_X.to_string())));
     assert!(keys(&page).contains(&(EntityType::ChannelMessage, THREAD_M.to_string())));
+    assert_eq!(page.len(), 10);
+
+    Ok(())
+}
+
+/// Channel-thread and foreign-entity trees fold at hydration, but the
+/// notification-state conjuncts they imply pre-filter the candidates over
+/// the rows their folds predicate on: the thread's own notifications (not
+/// its channel's) and the foreign entity's notifications.
+#[sqlx::test(
+    fixtures(path = "../../../../fixtures", scripts("notified_at")),
+    migrator = "MACRO_DB_MIGRATIONS"
+)]
+async fn thread_and_foreign_entity_conjuncts_prefilter_candidates(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    use item_filters::ast::channel::ChannelThreadLiteral;
+
+    sqlx::query("UPDATE user_notification SET done = TRUE WHERE notification_id = ANY($1::uuid[])")
+        .bind(vec![
+            Uuid::parse_str(THREAD_M_MENTION)?,
+            Uuid::parse_str(PR_F1_EVENT)?,
+        ])
+        .execute(&pool)
+        .await?;
+
+    let link_ids = [Uuid::parse_str(LINK_1)?];
+    let sources = sources();
+    let thread = (EntityType::ChannelMessage, THREAD_M.to_string());
+    let pr_f1 = (EntityType::ForeignEntity, PR_F1.to_string());
+    let pr_f3 = (EntityType::ForeignEntity, PR_F3.to_string());
+
+    // Not-done trees drop the done mention and the done pull request; the
+    // channel's live invite does not keep the thread row.
+    let filter = EntityFilterAst {
+        channel_thread_filter: Some(Arc::new(filter_ast::Expr::val(
+            ChannelThreadLiteral::NotificationDone(false),
+        ))),
+        foreign_entity_filter: Some(Arc::new(filter_ast::Expr::val(
+            ForeignEntityLiteral::NotificationDone(false),
+        ))),
+        ..EntityFilterAst::default()
+    };
+    let page =
+        notified_soup_page(&pool, req(Some(&filter), &link_ids, &sources, EVERYTHING)).await?;
+    assert!(!keys(&page).contains(&thread));
+    assert!(!keys(&page).contains(&pr_f1));
+    assert!(keys(&page).contains(&pr_f3));
+    assert!(keys(&page).contains(&(EntityType::Channel, CHANNEL_X.to_string())));
+    assert_eq!(page.len(), 9);
+
+    // Done trees keep them and drop the live pull request instead.
+    let filter = EntityFilterAst {
+        channel_thread_filter: Some(Arc::new(filter_ast::Expr::val(
+            ChannelThreadLiteral::NotificationDone(true),
+        ))),
+        foreign_entity_filter: Some(Arc::new(filter_ast::Expr::val(
+            ForeignEntityLiteral::NotificationDone(true),
+        ))),
+        ..EntityFilterAst::default()
+    };
+    let page =
+        notified_soup_page(&pool, req(Some(&filter), &link_ids, &sources, EVERYTHING)).await?;
+    assert!(keys(&page).contains(&thread));
+    assert!(keys(&page).contains(&pr_f1));
+    assert!(!keys(&page).contains(&pr_f3));
     assert_eq!(page.len(), 10);
 
     Ok(())


### PR DESCRIPTION
The notified-at candidate query's `NOT EXISTS` group-max was planned as a nested-loop anti-join over every live notification per candidate, so Inbox loads scaled with the square of a user's notification count (2.0 s on prod for a 26k-notification Signal request, with up to four refill rounds on top). This replaces it with a `row_number()` window inside an `OFFSET 0` fenced subquery so the dedupe is one sorted pass and the per-type gates only run until `LIMIT` is met, and pre-folds the channel-thread and foreign-entity done/seen conjuncts into their gates so done rows no longer spend refill rounds; the same prod requests now plan at 50–80 ms warm with no change to the feed's order or contents.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core inbox notified-at pagination SQL and filter semantics at the candidate layer; behavior is covered by tests but mistakes could affect feed contents or ordering for large notification volumes.
> 
> **Overview**
> **Notified-at candidate SQL** no longer uses a per-row `NOT EXISTS` to keep only each entity’s newest notification. It adds a `latest` CTE with `row_number()` partitioned by derived `(entity_type, entity_id)`, then orders and keyset-paginates inside an `OFFSET 0` subquery before applying per-type gates and `LIMIT`, so dedupe is a single pass and gates are not pushed onto every raw notification row.
> 
> **Gates** now accept filters where they were missing: `channel_thread_gate` and `foreign_entity_gate` use shared `implied_conjuncts_sql` (now `pub(super)`) to fold **notification done/seen** literals from `channel_thread_filter` and `foreign_entity_filter` into SQL at candidate time—thread rows match thread-scoped channel notifications; foreign entities match their own notification rows—reducing hydration refill rounds for done/seen filters.
> 
> A new integration test asserts thread and foreign-entity done filters pre-filter candidates without conflating channel-level notifications with thread mentions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ce6fb47e1efbf28ecfc4bf453909e5701c48ded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->