### PR TITLE
fix(inbox): show relative time for activity under a minute old

### DIFF
--- a/apps/web/src/features/next-soup/soup-view/views/inbox/utils.ts
+++ b/apps/web/src/features/next-soup/soup-view/views/inbox/utils.ts
@@ -10,7 +10,6 @@ import {
   differenceInMonths,
   differenceInWeeks,
   differenceInYears,
-  format,
 } from 'date-fns';
 import { match } from 'ts-pattern';
 
@@ -182,7 +181,7 @@ export function formatCompactRelativeTimestamp(value: string) {
   const now = new Date();
   const ageMs = Math.max(0, differenceInMilliseconds(now, date));
   const seconds = Math.floor(ageMs / 1000);
-  if (seconds < 60) return format(date, 'p');
+  if (seconds < 60) return 'now';
 
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) return `${minutes}m`;


### PR DESCRIPTION
The inbox activity badge rendered an absolute clock time ("10:09 AM") for rows under 60 seconds old instead of a relative indicator, so a just-created task looked out of place next to "9m"/"25m" siblings. It now shows "now" for the under-a-minute case, consistent with the compact scale.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only tweak to inbox relative timestamps with no auth, data, or API impact.
> 
> **Overview**
> Inbox activity timestamps that are **less than 60 seconds old** now display **`now`** instead of an absolute clock time (e.g. "10:09 AM") from `date-fns` **`format`**.
> 
> The change is in **`formatCompactRelativeTimestamp`** in inbox utils, which keeps the existing compact scale (`9m`, `25m`, etc.) for older items. The unused **`format`** import was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cacdd97c446774970c19634cd4f43a917dc9fca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->