### PR TITLE
fix(prompt): require Macro XML for math

### DIFF
--- a/crates/prompt/src/math.rs
+++ b/crates/prompt/src/math.rs
@@ -4,22 +4,18 @@ use crate::types::StaticPrompt;
 
 static TITLE: &str = "Math Rendering Rules";
 
-static INSTRUCTIONS: &str = r##"- Render **all mathematical expressions** (even simple arithmetic) in LaTeX enclosed with double dollar signs `$$ ... $$`.
-- Examples:
-  - Simple: $$ 2 + 2 = 4 $$
-  - Fractions: $$ \frac{1}{2} $$
-  - Quadratic formula: $$ x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a} $$
-  - Multi-line:
-    $$
-    \begin{aligned}
-    f(x) &= x^2 + 3x + 2 \\
-         &= (x+1)(x+2)
-    \end{aligned}
-    $$
+static INSTRUCTIONS: &str = r##"- Render **all mathematical expressions** (even simple arithmetic) with Macro equation XML tags.
+- Put the LaTeX expression in the `equation` field. Both `equation` and `inline` are required.
+- Use `"inline":true` for math within a sentence:
+  `<m-katex-equation>{"equation":"E = mc^2","inline":true}</m-katex-equation>`
+- Use `"inline":false` for standalone display math:
+  `<m-katex-equation>{"equation":"\\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}","inline":false}</m-katex-equation>`
+- Escape LaTeX backslashes for the JSON string, as shown above.
+- Do not use raw LaTeX delimiters such as `$...$`, `$$...$$`, `\(...\)`, or `\[...\]`.
 "##;
 
-static INTENT: &str = "All mathematical expressions, including simple arithmetic, are rendered \
-as LaTeX enclosed in double dollar signs.";
+static INTENT: &str = "All mathematical expressions, including simple arithmetic, use Macro's \
+equation XML tags with the required equation and inline fields, never raw LaTeX delimiters.";
 
 /// The math-rendering prompt.
 pub static PROMPT: StaticPrompt<'static> = StaticPrompt::borrowed(TITLE, INSTRUCTIONS, INTENT);

--- a/crates/prompt/tests/compose.rs
+++ b/crates/prompt/tests/compose.rs
@@ -40,6 +40,22 @@ fn base_prompt_includes_channel_message_mention_format() {
 }
 
 #[test]
+fn base_prompt_requires_macro_equation_xml_instead_of_latex_delimiters() {
+    let rendered = BASE_PROMPT.to_string();
+
+    assert!(rendered.contains(
+        r#"<m-katex-equation>{"equation":"E = mc^2","inline":true}</m-katex-equation>"#
+    ));
+    assert!(rendered.contains(
+        r#"<m-katex-equation>{"equation":"\\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}","inline":false}</m-katex-equation>"#
+    ));
+    assert!(rendered.contains(
+        r#"Do not use raw LaTeX delimiters such as `$...$`, `$$...$$`, `\(...\)`, or `\[...\]`."#
+    ));
+    assert!(!rendered.contains("LaTeX enclosed with double dollar signs"));
+}
+
+#[test]
 fn tool_use_prompt_appends_tool_section_to_base() {
     let rendered = TOOL_USE_PROMPT.to_string();
     assert!(rendered.starts_with(&BASE_PROMPT.to_string()));

--- a/crates/prompt/tests/compose.rs
+++ b/crates/prompt/tests/compose.rs
@@ -43,9 +43,11 @@ fn base_prompt_includes_channel_message_mention_format() {
 fn base_prompt_requires_macro_equation_xml_instead_of_latex_delimiters() {
     let rendered = BASE_PROMPT.to_string();
 
-    assert!(rendered.contains(
-        r#"<m-katex-equation>{"equation":"E = mc^2","inline":true}</m-katex-equation>"#
-    ));
+    assert!(
+        rendered.contains(
+            r#"<m-katex-equation>{"equation":"E = mc^2","inline":true}</m-katex-equation>"#
+        )
+    );
     assert!(rendered.contains(
         r#"<m-katex-equation>{"equation":"\\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}","inline":false}</m-katex-equation>"#
     ));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace raw LaTeX delimiter guidance in the shared Macro prompt with canonical `<m-katex-equation>` XML
- document required `equation` and `inline` fields with inline and display examples
- explicitly reject `$...$`, `$$...$$`, `\(...\)`, and `\[...\]` output
- add a prompt composition contract test

## Validation
- `cargo test -p prompt` — 16 passed
- `cargo fmt --check` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be37bc1d-cb5c-4b5c-989d-ee0ad9c78019?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be37bc1d-cb5c-4b5c-989d-ee0ad9c78019&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

