### PR TITLE
feat(settings): add sidebar search across pages and inner content

### DIFF
--- a/apps/web/src/features/settings/Settings.tsx
+++ b/apps/web/src/features/settings/Settings.tsx
@@ -27,6 +27,7 @@ import SignOutIcon from '@phosphor/sign-out.svg';
 import { useLocation } from '@solidjs/router';
 import { Button, cn, Layer, SideNav } from '@ui';
 import {
+  createMemo,
   createRenderEffect,
   createSignal,
   For,
@@ -47,7 +48,9 @@ import { Crm } from './Crm';
 import { Harness } from './Harness';
 import { MobileApp } from './MobileApp';
 import { Notifications } from './Notifications';
+import { SettingsSearch } from './SettingsSearch';
 import { Shortcuts } from './Shortcuts';
+import { buildSettingsSearchIndex, searchSettings } from './settingsSearch';
 import { Tags } from './Tags';
 import { Team } from './Team';
 
@@ -218,6 +221,15 @@ export function SettingsPanel(props: SettingsPanelProps) {
   const tabItems = () =>
     flatTabs().map((tab) => ({ value: tab.tab, label: tab.label }));
 
+  // Sidebar search over pages and the content inside them. The index is built
+  // from the available tabs so gated pages never show up as results.
+  const [searchQuery, setSearchQuery] = createSignal('');
+  const searchIndex = createMemo(() => buildSettingsSearchIndex(flatTabs()));
+  const searchResults = createMemo(() =>
+    searchSettings(searchQuery(), searchIndex())
+  );
+  const searching = () => searchQuery().trim().length > 0;
+
   // "Back to app" — the close affordance for solo settings. Laid out like a nav row.
   const backToApp = () => (
     <button
@@ -322,24 +334,34 @@ export function SettingsPanel(props: SettingsPanelProps) {
                 {moveToSplitButton()}
               </div>
             </Show>
-            <For each={groups()}>
-              {(group) => (
-                <SideNav.Group label={group.label}>
-                  <For each={group.items}>
-                    {(item) => (
-                      <SideNav.Item
-                        icon={item.icon}
-                        active={activeTabId() === item.tab}
-                        onSelect={() => handleTabChange(item.tab)}
-                        class="text-xs py-1.5"
-                      >
-                        {item.label}
-                      </SideNav.Item>
-                    )}
-                  </For>
-                </SideNav.Group>
-              )}
-            </For>
+            <SettingsSearch
+              query={searchQuery()}
+              onQueryChange={setSearchQuery}
+              results={searchResults()}
+              onSelect={(entry) => handleTabChange(entry.tab)}
+              onEscape={() => closeSettings()}
+            />
+            {/* While a query is typed the search results stand in for the groups. */}
+            <Show when={!searching()}>
+              <For each={groups()}>
+                {(group) => (
+                  <SideNav.Group label={group.label}>
+                    <For each={group.items}>
+                      {(item) => (
+                        <SideNav.Item
+                          icon={item.icon}
+                          active={activeTabId() === item.tab}
+                          onSelect={() => handleTabChange(item.tab)}
+                          class="text-xs py-1.5"
+                        >
+                          {item.label}
+                        </SideNav.Item>
+                      )}
+                    </For>
+                  </SideNav.Group>
+                )}
+              </For>
+            </Show>
             <div class="mt-auto border-t border-edge-muted pt-2">
               <button
                 type="button"

--- a/apps/web/src/features/settings/SettingsSearch.test.tsx
+++ b/apps/web/src/features/settings/SettingsSearch.test.tsx
@@ -1,0 +1,147 @@
+import type { SettingsTabItem } from '@core/constant/settingsTabsConfig';
+import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library';
+import { type Accessor, createMemo, createSignal } from 'solid-js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SettingsSearch } from './SettingsSearch';
+import {
+  buildSettingsSearchIndex,
+  type SettingsSearchEntry,
+  searchSettings,
+} from './settingsSearch';
+
+const Icon = () => null;
+
+const TABS: SettingsTabItem[] = [
+  { tab: 'Account', label: 'Account', icon: Icon },
+  { tab: 'Team', label: 'Team', icon: Icon },
+  { tab: 'Connected', label: 'Connections', icon: Icon },
+];
+
+const INDEX = buildSettingsSearchIndex(TABS);
+
+/** Mounts the search with a controlled query, the way the settings panel does. */
+function setup(options: { initialQuery?: string } = {}) {
+  const onSelect = vi.fn<(entry: SettingsSearchEntry) => void>();
+  const onEscape = vi.fn();
+  // Created inside render so the computations belong to the test's root and are
+  // disposed with it.
+  let query!: Accessor<string>;
+
+  render(() => {
+    const [q, setQuery] = createSignal(options.initialQuery ?? '');
+    query = q;
+    const results = createMemo(() => searchSettings(q(), INDEX));
+    return (
+      <SettingsSearch
+        query={q()}
+        onQueryChange={setQuery}
+        results={results()}
+        onSelect={onSelect}
+        onEscape={onEscape}
+      />
+    );
+  });
+
+  const input = screen.getByLabelText('Search settings') as HTMLInputElement;
+  const type = (value: string) => {
+    input.value = value;
+    fireEvent.input(input);
+  };
+  const press = (key: string) => fireEvent.keyDown(input, { key });
+
+  return { input, type, press, query, onSelect, onEscape };
+}
+
+describe('SettingsSearch', () => {
+  afterEach(cleanup);
+
+  it('shows nothing but the field until something is typed', () => {
+    setup();
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(screen.queryByLabelText('Clear search')).toBeNull();
+  });
+
+  it('lists matches with a breadcrumb for inner items', () => {
+    const { type } = setup();
+    type('gmail');
+
+    const options = screen.getAllByRole('option');
+    expect(options[0]?.textContent).toContain('Gmail');
+    expect(options[0]?.textContent).toContain('Connections · Accounts');
+  });
+
+  it('lists a page match without a breadcrumb', () => {
+    const { type } = setup();
+    type('team');
+
+    const [first] = screen.getAllByRole('option');
+    expect(first?.textContent).toBe('Team');
+  });
+
+  it('explains when nothing matches', () => {
+    const { type } = setup();
+    type('zzzz');
+
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(screen.getByText('No settings match “zzzz”')).toBeTruthy();
+  });
+
+  it('opens the highlighted result on Enter and clears the query', () => {
+    const { type, press, query, onSelect } = setup();
+    type('team');
+    press('ArrowDown');
+    press('Enter');
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    const picked = onSelect.mock.calls[0]?.[0];
+    expect(picked?.tab).toBe('Team');
+    expect(picked?.isPage).toBe(false);
+    expect(query()).toBe('');
+  });
+
+  it('opens a result on click', () => {
+    const { type, onSelect } = setup();
+    type('gmail');
+    fireEvent.click(screen.getAllByRole('option')[0]!);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0]?.[0]?.title).toBe('Gmail');
+  });
+
+  it('keeps the highlight inside the result list', () => {
+    const { type, press } = setup();
+    type('gmail');
+    const count = screen.getAllByRole('option').length;
+
+    for (let i = 0; i < count + 3; i++) press('ArrowDown');
+    expect(
+      screen.getAllByRole('option').at(-1)?.getAttribute('aria-selected')
+    ).toBe('true');
+
+    for (let i = 0; i < count + 3; i++) press('ArrowUp');
+    expect(
+      screen.getAllByRole('option')[0]?.getAttribute('aria-selected')
+    ).toBe('true');
+  });
+
+  it('clears the query on Escape, and only closes once it is already empty', () => {
+    const { type, press, query, onEscape } = setup();
+    type('team');
+    press('Escape');
+
+    expect(query()).toBe('');
+    expect(onEscape).not.toHaveBeenCalled();
+
+    press('Escape');
+    expect(onEscape).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the query from the clear button', () => {
+    const { type, query } = setup();
+    type('team');
+    fireEvent.click(screen.getByLabelText('Clear search'));
+
+    expect(query()).toBe('');
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+});

--- a/apps/web/src/features/settings/SettingsSearch.tsx
+++ b/apps/web/src/features/settings/SettingsSearch.tsx
@@ -1,0 +1,179 @@
+import { getSettingsTabItem } from '@core/constant/settingsTabsConfig';
+import MagnifyingGlassIcon from '@phosphor/magnifying-glass.svg';
+import XIcon from '@phosphor/x.svg';
+import { Button, NavRow } from '@ui';
+import { createEffect, createSignal, For, on, Show } from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+import type {
+  SettingsSearchEntry,
+  SettingsSearchResult,
+} from './settingsSearch';
+
+/**
+ * The search field at the top of the settings sidebar plus, while a query is
+ * typed, the ranked results that stand in for the category groups. Results are
+ * pages and things inside pages (see `settingsSearch.ts`); picking one opens
+ * its page. Arrow keys move the highlight, Enter opens it, Escape clears the
+ * query (or hands off to `onEscape` when there's nothing to clear).
+ */
+export function SettingsSearch(props: {
+  query: string;
+  onQueryChange: (query: string) => void;
+  results: SettingsSearchResult[];
+  onSelect: (entry: SettingsSearchEntry) => void;
+  /** Escape pressed on an already-empty field. */
+  onEscape?: () => void;
+}) {
+  const [highlighted, setHighlighted] = createSignal(0);
+  let inputRef: HTMLInputElement | undefined;
+
+  const searching = () => props.query.trim().length > 0;
+
+  // A new result set means the old highlight index points at something else.
+  createEffect(
+    on(
+      () => props.results,
+      () => setHighlighted(0)
+    )
+  );
+
+  const clear = () => {
+    props.onQueryChange('');
+    inputRef?.focus();
+  };
+
+  const select = (entry: SettingsSearchEntry) => {
+    props.onSelect(entry);
+    props.onQueryChange('');
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    switch (event.key) {
+      case 'ArrowDown': {
+        event.preventDefault();
+        setHighlighted((i) => Math.min(i + 1, props.results.length - 1));
+        break;
+      }
+      case 'ArrowUp': {
+        event.preventDefault();
+        setHighlighted((i) => Math.max(i - 1, 0));
+        break;
+      }
+      case 'Enter': {
+        const result = props.results[highlighted()];
+        if (result) {
+          event.preventDefault();
+          select(result.entry);
+        }
+        break;
+      }
+      case 'Escape': {
+        event.preventDefault();
+        if (searching()) clear();
+        else props.onEscape?.();
+        break;
+      }
+    }
+  };
+
+  return (
+    <>
+      <div class="relative flex items-center">
+        <MagnifyingGlassIcon class="pointer-events-none absolute left-2.5 size-4 text-ink-extra-muted" />
+        <input
+          ref={inputRef}
+          type="text"
+          class="settings-input h-8 w-full pl-8 pr-8 text-xs"
+          placeholder="Search settings"
+          aria-label="Search settings"
+          autocomplete="off"
+          spellcheck={false}
+          value={props.query}
+          onInput={(event) => props.onQueryChange(event.currentTarget.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <Show when={props.query}>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            class="absolute right-1.5 rounded-md"
+            label="Clear search"
+            aria-label="Clear search"
+            onClick={clear}
+          >
+            <XIcon class="size-3.5" />
+          </Button>
+        </Show>
+      </div>
+
+      <Show when={searching()}>
+        <Show
+          when={props.results.length > 0}
+          fallback={
+            <p class="px-2 py-1.5 text-xs text-ink-extra-muted">
+              No settings match “{props.query.trim()}”
+            </p>
+          }
+        >
+          <div class="flex flex-col" role="listbox" aria-label="Search results">
+            <For each={props.results}>
+              {(result, index) => (
+                <SearchResultRow
+                  entry={result.entry}
+                  highlighted={highlighted() === index()}
+                  onHighlight={() => setHighlighted(index())}
+                  onSelect={() => select(result.entry)}
+                />
+              )}
+            </For>
+          </div>
+        </Show>
+      </Show>
+    </>
+  );
+}
+
+function SearchResultRow(props: {
+  entry: SettingsSearchEntry;
+  highlighted: boolean;
+  onHighlight: () => void;
+  onSelect: () => void;
+}) {
+  const icon = () => getSettingsTabItem(props.entry.tab)?.icon;
+  // Inner results say where they live ("Connections · MCP integrations") since
+  // the title alone ("Linear") doesn't tell you which page opens.
+  const breadcrumb = () =>
+    props.entry.section
+      ? `${props.entry.page} · ${props.entry.section}`
+      : props.entry.page;
+
+  return (
+    <NavRow
+      role="option"
+      aria-selected={props.highlighted}
+      active={props.highlighted}
+      class="px-2 py-1.5 text-xs"
+      onClick={(event: MouseEvent) => {
+        event.preventDefault();
+        props.onSelect();
+      }}
+      onMouseMove={props.onHighlight}
+    >
+      <Show when={icon()}>
+        {(icon) => (
+          <div class="size-4 shrink-0">
+            <Dynamic component={icon()} />
+          </div>
+        )}
+      </Show>
+      <span class="flex min-w-0 flex-col items-start text-left">
+        <span class="w-full truncate">{props.entry.title}</span>
+        <Show when={!props.entry.isPage}>
+          <span class="w-full truncate text-[11px] text-ink-extra-muted">
+            {breadcrumb()}
+          </span>
+        </Show>
+      </span>
+    </NavRow>
+  );
+}

--- a/apps/web/src/features/settings/settingsSearch.test.ts
+++ b/apps/web/src/features/settings/settingsSearch.test.ts
@@ -1,0 +1,146 @@
+import type { SettingsTabItem } from '@core/constant/settingsTabsConfig';
+import { describe, expect, it } from 'vitest';
+import { buildSettingsSearchIndex, searchSettings } from './settingsSearch.ts';
+
+// A stand-in icon: the index only carries icons through, it never renders them.
+const Icon = () => null;
+
+const TABS: SettingsTabItem[] = [
+  { tab: 'Account', label: 'Account', icon: Icon },
+  { tab: 'API Keys', label: 'API Keys', icon: Icon },
+  { tab: 'Notifications', label: 'Notifications', icon: Icon },
+  { tab: 'Billing', label: 'Billing', icon: Icon },
+  { tab: 'Appearance', label: 'Appearance', icon: Icon },
+  { tab: 'Shortcuts', label: 'Shortcuts', icon: Icon },
+  { tab: 'Team', label: 'Team', icon: Icon },
+  { tab: 'Tags', label: 'Tags', icon: Icon },
+  { tab: 'Connected', label: 'Connections', icon: Icon },
+  { tab: 'Agent', label: 'MCP server', icon: Icon },
+  { tab: 'Bots', label: 'Bots', icon: Icon },
+  { tab: 'Agents', label: 'Agents', icon: Icon },
+  { tab: 'Harness', label: 'Harness', icon: Icon },
+];
+
+const index = buildSettingsSearchIndex(TABS);
+
+const search = (query: string) => searchSettings(query, index);
+const titles = (query: string) => search(query).map((r) => r.entry.title);
+const tabs = (query: string) =>
+  Array.from(new Set(search(query).map((r) => r.entry.tab)));
+
+describe('buildSettingsSearchIndex', function () {
+  it('creates a page entry per tab followed by its inner items', function () {
+    const entries = buildSettingsSearchIndex([TABS[8]!]);
+    expect(entries[0]).toMatchObject({
+      tab: 'Connected',
+      title: 'Connections',
+      isPage: true,
+    });
+    expect(
+      entries.slice(1).every((e) => !e.isPage && e.tab === 'Connected')
+    ).toBe(true);
+    expect(entries.map((e) => e.title)).toContain('Gmail');
+  });
+
+  it('only indexes the tabs it is given, so gating carries over to search', function () {
+    const entries = buildSettingsSearchIndex(
+      TABS.filter((t) => t.tab !== 'Connected')
+    );
+    expect(entries.some((e) => e.tab === 'Connected')).toBe(false);
+    expect(searchSettings('gmail', entries)).toEqual([]);
+  });
+});
+
+describe('searchSettings', function () {
+  it('returns nothing for an empty or punctuation-only query', function () {
+    expect(search('')).toEqual([]);
+    expect(search('   ')).toEqual([]);
+    expect(search('-- !!')).toEqual([]);
+  });
+
+  it('finds top-level pages by their sidebar label, best match first', function () {
+    expect(titles('team')[0]).toBe('Team');
+    expect(titles('Billing')[0]).toBe('Billing');
+    expect(titles('short')[0]).toBe('Shortcuts');
+  });
+
+  it('finds inner content that is not a sidebar item', function () {
+    expect(titles('gmail')).toContain('Gmail');
+    expect(titles('linear')).toContain('Linear');
+    expect(titles('delete account')).toContain('Delete account');
+    expect(titles('slug')).toContain('Team slug');
+  });
+
+  it('matches intuitive synonyms rather than only UI labels', function () {
+    expect(tabs('google')).toContain('Connected');
+    expect(tabs('integrations')).toContain('Connected');
+    expect(tabs('dark mode')).toContain('Appearance');
+    expect(tabs('payment')).toContain('Billing');
+    expect(tabs('hotkeys')).toContain('Shortcuts');
+    expect(tabs('avatar')).toContain('Account');
+    expect(tabs('invite')).toContain('Team');
+    expect(tabs('webhook')).toContain('Bots');
+  });
+
+  it('covers the agent pages and API keys', function () {
+    expect(tabs('api key')[0]).toBe('API Keys');
+    expect(tabs('token')).toContain('API Keys');
+    expect(tabs('system prompt')).toContain('Agents');
+    expect(titles('agents')[0]).toBe('Agents');
+    expect(tabs('runtime')).toContain('Harness');
+    expect(tabs('bring your own')).toContain('Harness');
+  });
+
+  it('surfaces both MCP pages for "mcp"', function () {
+    const found = tabs('mcp');
+    expect(found).toContain('Agent');
+    expect(found).toContain('Connected');
+  });
+
+  it('is case-insensitive and ignores surrounding whitespace', function () {
+    expect(titles('  GMAIL ')).toEqual(titles('gmail'));
+  });
+
+  it('requires every word of a multi-word query to match', function () {
+    expect(titles('github app')).toContain('GitHub App');
+    expect(titles('github app')).not.toContain('Gmail');
+    expect(search('github zzzz')).toEqual([]);
+  });
+
+  it('matches prefixes and joined words', function () {
+    expect(tabs('notif')).toContain('Notifications');
+    expect(tabs('darkmode')).toContain('Appearance');
+    expect(tabs('hub')).toContain('Connected');
+  });
+
+  it('forgives a single typo in longer words', function () {
+    expect(tabs('conection')).toContain('Connected');
+    expect(tabs('apearance')).toContain('Appearance');
+    expect(tabs('biling')).toContain('Billing');
+  });
+
+  it('does not fuzz short words into unrelated matches', function () {
+    // "tea" is a prefix of Team; "tem" is neither a prefix nor long enough
+    // to be forgiven as a typo.
+    expect(tabs('tea')).toContain('Team');
+    expect(tabs('tem')).not.toContain('Team');
+  });
+
+  it('ranks page entries above inner entries on equal scores', function () {
+    const results = search('team');
+    expect(results[0]!.entry.isPage).toBe(true);
+    expect(results[0]!.entry.tab).toBe('Team');
+    // Inner "Team tags" / "Team slug" are exact title-word hits too, but the
+    // page comes first.
+    expect(titles('team')).toContain('Team tags');
+  });
+
+  it('keeps sidebar order as the final tie-break', function () {
+    // Both are exact keyword hits on the page ("integrations" appears in the
+    // Connections and Bots page keywords), so the earlier tab wins.
+    const pages = search('integrations')
+      .filter((r) => r.entry.isPage)
+      .map((r) => r.entry.tab);
+    expect(pages.indexOf('Connected')).toBeLessThan(pages.indexOf('Bots'));
+  });
+});

--- a/apps/web/src/features/settings/settingsSearch.ts
+++ b/apps/web/src/features/settings/settingsSearch.ts
@@ -1,0 +1,848 @@
+import type { SettingsTab } from '@core/constant/SettingsState';
+import type { SettingsTabItem } from '@core/constant/settingsTabsConfig';
+
+/*
+ * Search index for the settings sidebar. Two kinds of entries:
+ *
+ *   - page entries: one per available settings tab (its sidebar label plus
+ *     generous synonyms — "dark mode" finds Appearance, "payment" finds Billing)
+ *   - inner entries: sections, rows and integrations that live *inside* a page
+ *     and aren't visible from the sidebar (Gmail, Linear, "Delete account", …)
+ *
+ * The content below is hand-curated and English-only. Keywords should be what a
+ * user would plausibly type, not what the UI happens to call the thing — err on
+ * the side of adding more.
+ */
+
+/** Something inside a settings page that can be found by search. */
+type SettingsSearchItem = {
+  /** Shown as the result title, e.g. "Gmail" or "Delete account". */
+  title: string;
+  /** The section it lives in, shown in the result's breadcrumb. */
+  section?: string;
+  keywords?: readonly string[];
+};
+
+type SettingsSearchContent = {
+  /** Synonyms for the page itself. */
+  keywords: readonly string[];
+  items: readonly SettingsSearchItem[];
+};
+
+const SETTINGS_SEARCH_CONTENT: Partial<
+  Record<SettingsTab, SettingsSearchContent>
+> = {
+  Account: {
+    keywords: [
+      'profile',
+      'me',
+      'my account',
+      'user',
+      'personal',
+      'identity',
+      'login',
+      'sign in',
+    ],
+    items: [
+      {
+        title: 'Profile picture',
+        section: 'Profile',
+        keywords: ['avatar', 'photo', 'image', 'upload picture', 'headshot'],
+      },
+      {
+        title: 'Name',
+        section: 'Profile',
+        keywords: [
+          'first name',
+          'last name',
+          'full name',
+          'display name',
+          'rename',
+        ],
+      },
+      {
+        title: 'Email address',
+        section: 'Profile',
+        keywords: ['email', 'account email', 'login email', 'change email'],
+      },
+      {
+        title: 'App version',
+        keywords: [
+          'version',
+          'update',
+          'app update',
+          'build',
+          'release',
+          'upgrade app',
+        ],
+      },
+      {
+        title: 'Delete account',
+        section: 'Danger zone',
+        keywords: [
+          'remove account',
+          'close account',
+          'deactivate',
+          'erase',
+          'gdpr',
+        ],
+      },
+    ],
+  },
+  'API Keys': {
+    keywords: [
+      'api',
+      'api key',
+      'keys',
+      'token',
+      'tokens',
+      'access token',
+      'personal access token',
+      'secret',
+      'credentials',
+      'developer',
+      'scripts',
+      'ci',
+      'programmatic access',
+      'sdk',
+      'automation',
+    ],
+    items: [
+      {
+        title: 'Your keys',
+        keywords: [
+          'create key',
+          'new key',
+          'generate key',
+          'delete key',
+          'revoke key',
+          'rotate key',
+        ],
+      },
+    ],
+  },
+  Notifications: {
+    keywords: [
+      'alerts',
+      'notify',
+      'push',
+      'badges',
+      'unread',
+      'sounds',
+      'do not disturb',
+      'dnd',
+    ],
+    items: [
+      {
+        title: 'Email digest',
+        section: 'Delivery',
+        keywords: ['digest', 'summary email', 'daily email', 'unread email'],
+      },
+      {
+        title: 'Inbox notifications',
+        section: 'Delivery',
+        keywords: ['inbox', 'always on'],
+      },
+      {
+        title: 'Muted items',
+        keywords: ['mute', 'unmute', 'silence', 'quiet', 'snooze'],
+      },
+    ],
+  },
+  Billing: {
+    keywords: [
+      'payment',
+      'subscription',
+      'plan',
+      'pricing',
+      'price',
+      'invoice',
+      'receipt',
+      'credit card',
+      'upgrade',
+      'downgrade',
+      'cancel subscription',
+      'premium',
+      'free plan',
+      'pro',
+      'seats',
+      'trial',
+      'money',
+      'pay',
+    ],
+    items: [
+      {
+        title: 'Current plan',
+        keywords: [
+          'premium plan',
+          'free plan',
+          'upgrade',
+          'manage subscription',
+        ],
+      },
+    ],
+  },
+  Appearance: {
+    keywords: [
+      'theme',
+      'themes',
+      'dark mode',
+      'light mode',
+      'colors',
+      'colour',
+      'look',
+      'style',
+      'display',
+      'ui',
+      'visual',
+      'skin',
+    ],
+    items: [
+      {
+        title: 'Color theme',
+        keywords: [
+          'dark theme',
+          'light theme',
+          'dark mode',
+          'light mode',
+          'night mode',
+          'active theme',
+          'system theme',
+          'custom theme',
+          'edit theme',
+          'copy theme',
+          'accent color',
+          'background',
+        ],
+      },
+      {
+        title: 'Monochrome icons',
+        section: 'Interface',
+        keywords: [
+          'icons',
+          'icon color',
+          'grayscale',
+          'greyscale',
+          'interface',
+        ],
+      },
+    ],
+  },
+  'Mobile App': {
+    keywords: [
+      'phone',
+      'ios',
+      'iphone',
+      'ipad',
+      'android',
+      'app store',
+      'play store',
+      'download app',
+      'qr code',
+      'install',
+      'mobile',
+    ],
+    items: [],
+  },
+  Shortcuts: {
+    keywords: [
+      'keyboard',
+      'keyboard shortcuts',
+      'hotkeys',
+      'keybindings',
+      'key bindings',
+      'keys',
+      'commands',
+      'cheat sheet',
+    ],
+    items: [
+      {
+        title: 'Screencast keys',
+        keywords: ['show keys', 'key overlay', 'presentation', 'demo'],
+      },
+    ],
+  },
+  Team: {
+    keywords: [
+      'workspace',
+      'organization',
+      'org',
+      'company',
+      'members',
+      'people',
+      'users',
+      'colleagues',
+      'teammates',
+      'invite',
+      'admin',
+      'owner',
+    ],
+    items: [
+      {
+        title: 'Members',
+        keywords: [
+          'people',
+          'users',
+          'remove member',
+          'roles',
+          'permissions',
+          'admins',
+          'owner',
+          'seats',
+          'teammates',
+        ],
+      },
+      {
+        title: 'Invitations',
+        keywords: [
+          'invite',
+          'invite people',
+          'pending invites',
+          'members can invite',
+          'auto-join on domain',
+          'domain',
+          'join',
+          'add people',
+          'email invite',
+        ],
+      },
+      {
+        title: 'Team name',
+        section: 'General',
+        keywords: ['rename team', 'workspace name', 'company name'],
+      },
+      {
+        title: 'Team slug',
+        section: 'General',
+        keywords: [
+          'slug',
+          'task prefix',
+          'task references',
+          'ticket prefix',
+          'eng-42',
+        ],
+      },
+      {
+        title: 'Default link sharing',
+        section: 'General',
+        keywords: [
+          'sharing',
+          'link sharing scope',
+          'share links',
+          'public links',
+          'permissions',
+        ],
+      },
+      {
+        title: 'GitHub App',
+        section: 'Connections',
+        keywords: [
+          'github',
+          'repositories',
+          'repos',
+          'pull requests',
+          'pr sync',
+          'autolink',
+          'github autolink',
+          'source control',
+        ],
+      },
+    ],
+  },
+  Tags: {
+    keywords: ['labels', 'label', 'categories', 'tagging', 'organize'],
+    items: [
+      {
+        title: 'Personal tags',
+        keywords: ['my tags', 'private tags'],
+      },
+      {
+        title: 'Team tags',
+        keywords: ['shared tags', 'share with team', 'workspace tags'],
+      },
+    ],
+  },
+  CRM: {
+    keywords: [
+      'customers',
+      'customer relationship',
+      'sales',
+      'deals',
+      'pipeline',
+      'stages',
+      'companies',
+      'contacts',
+      'leads',
+      'accounts',
+    ],
+    items: [
+      {
+        title: 'Enable or disable CRM',
+        section: 'General',
+        keywords: ['turn off crm', 'disable crm', 'enable crm'],
+      },
+    ],
+  },
+  Connected: {
+    keywords: [
+      'connected accounts',
+      'integrations',
+      'integration',
+      'connect',
+      'accounts',
+      'apps',
+      'services',
+      'link account',
+      'third party',
+      'oauth',
+      'sync',
+      'plugins',
+      'extensions',
+      'tools',
+    ],
+    items: [
+      {
+        title: 'Gmail',
+        section: 'Accounts',
+        keywords: [
+          'google',
+          'google account',
+          'google workspace',
+          'email',
+          'email account',
+          'mail',
+          'inbox',
+          'add inbox',
+          'connect email',
+          'calendar',
+          'calendar sync',
+          'google calendar',
+          'force sync',
+          'signature',
+          'email signature',
+          'primary inbox',
+          'shared inbox',
+        ],
+      },
+      {
+        title: 'GitHub',
+        section: 'Accounts',
+        keywords: [
+          'git',
+          'github account',
+          'connect github',
+          'repositories',
+          'repos',
+          'pull requests',
+          'code',
+        ],
+      },
+      {
+        title: 'MCP integrations',
+        keywords: [
+          'mcp',
+          'mcp servers',
+          'model context protocol',
+          'add server',
+          'custom server',
+          'agent tools',
+          'ai tools',
+          'connectors',
+          'pipedream',
+        ],
+      },
+      {
+        title: 'Linear',
+        section: 'MCP integrations',
+        keywords: ['issues', 'tickets', 'project management'],
+      },
+      {
+        title: 'Slack',
+        section: 'MCP integrations',
+        keywords: ['chat', 'messaging', 'channels'],
+      },
+      {
+        title: 'Notion',
+        section: 'MCP integrations',
+        keywords: ['notes', 'wiki', 'docs', 'pages'],
+      },
+      {
+        title: 'PostHog',
+        section: 'MCP integrations',
+        keywords: ['analytics', 'product analytics', 'events'],
+      },
+      {
+        title: 'Datadog',
+        section: 'MCP integrations',
+        keywords: ['monitoring', 'observability', 'logs', 'metrics'],
+      },
+      {
+        title: 'Grafana',
+        section: 'MCP integrations',
+        keywords: ['dashboards', 'monitoring', 'observability', 'metrics'],
+      },
+      {
+        title: 'Cursor',
+        section: 'Coding sessions',
+        keywords: [
+          'coding agent',
+          'coding sessions',
+          'code agent',
+          'ide',
+          'default model',
+          'ai model',
+          'background agent',
+          'programming',
+        ],
+      },
+    ],
+  },
+  Agent: {
+    keywords: [
+      'mcp',
+      'mcp server',
+      'macro mcp',
+      'model context protocol',
+      'agent',
+      'agents',
+      'ai',
+      'assistant',
+      'claude',
+      'claude code',
+      'codex',
+      'chatgpt',
+      'ide',
+      'api',
+      'connect agent',
+      'external agents',
+      'setup',
+      'developer',
+    ],
+    items: [],
+  },
+  Bots: {
+    keywords: [
+      'bot',
+      'webhooks',
+      'webhook',
+      'automation',
+      'automations',
+      'integrations',
+      'api',
+      'teammates',
+      'channels',
+    ],
+    items: [
+      {
+        title: 'Your bots',
+        keywords: [
+          'create bot',
+          'new bot',
+          'webhook url',
+          'bot channels',
+          'credentials',
+        ],
+      },
+    ],
+  },
+  Agents: {
+    keywords: [
+      'agent',
+      'ai agents',
+      'custom agent',
+      'create agent',
+      'assistants',
+      'personas',
+      'mentions',
+      'mention',
+      'bots',
+      'system prompt',
+      'instructions',
+    ],
+    items: [
+      {
+        title: 'Team agents',
+        keywords: ['shared agents', 'workspace agents', 'macro agent'],
+      },
+      {
+        title: 'Private agents',
+        keywords: ['my agents', 'personal agents', 'own agents'],
+      },
+      {
+        title: 'Agent profile',
+        section: 'Profile',
+        keywords: ['avatar', 'agent name', 'tag', 'handle', 'identity'],
+      },
+      {
+        title: 'System prompt',
+        section: 'Behavior',
+        keywords: [
+          'instructions',
+          'prompt',
+          'persona',
+          'behavior',
+          'behaviour',
+        ],
+      },
+      {
+        title: 'Agent channels',
+        section: 'Channels',
+        keywords: [
+          'all channels',
+          'specific channels',
+          'channel access',
+          'where the agent can be mentioned',
+          'global agent',
+        ],
+      },
+      {
+        title: 'Agent runtime',
+        section: 'Runtime',
+        keywords: ['harness', 'model', 'ai model', 'which model', 'runtime'],
+      },
+    ],
+  },
+  Harness: {
+    keywords: [
+      'agent runtime',
+      'runtime',
+      'runtimes',
+      'bring your own agent',
+      'byoa',
+      'connected agents',
+      'models',
+      'sandbox',
+      'compute',
+      'execution',
+      'infrastructure',
+      'in-memory',
+    ],
+    items: [
+      {
+        title: 'Bring your own agent',
+        keywords: [
+          'connect agent',
+          'custom runtime',
+          'external harness',
+          'remove harness',
+        ],
+      },
+    ],
+  },
+  Admin: {
+    keywords: [
+      'debug',
+      'developer',
+      'internal',
+      'staff',
+      'feature flags',
+      'flags',
+      'experimental',
+      'advanced',
+    ],
+    items: [
+      {
+        title: 'Persist list filters',
+        keywords: ['filters', 'soup filters', 'remember filters', 'reload'],
+      },
+    ],
+  },
+};
+
+/** One searchable thing: a settings page, or a section/row/integration inside one. */
+export type SettingsSearchEntry = {
+  tab: SettingsTab;
+  /** The page's sidebar label. */
+  page: string;
+  /** Result title: the page label for page entries, the item title otherwise. */
+  title: string;
+  /** Breadcrumb for inner entries (e.g. "MCP integrations"); never set on pages. */
+  section?: string;
+  /** True for the entry representing the page itself. */
+  isPage: boolean;
+  keywords: readonly string[];
+};
+
+export type SettingsSearchResult = {
+  entry: SettingsSearchEntry;
+  /** Lower is a better match. */
+  score: number;
+};
+
+/**
+ * Build the search index from the *currently available* tabs, so gating
+ * (feature flags, platform, permissions) carries over to search for free — we
+ * never surface a page the panel won't render.
+ */
+export function buildSettingsSearchIndex(
+  tabs: readonly SettingsTabItem[]
+): SettingsSearchEntry[] {
+  return tabs.flatMap((item) => {
+    const content = SETTINGS_SEARCH_CONTENT[item.tab];
+    const page: SettingsSearchEntry = {
+      tab: item.tab,
+      page: item.label,
+      title: item.label,
+      isPage: true,
+      keywords: content?.keywords ?? [],
+    };
+    const inner = (content?.items ?? []).map(
+      (inner): SettingsSearchEntry => ({
+        tab: item.tab,
+        page: item.label,
+        title: inner.title,
+        section: inner.section,
+        isPage: false,
+        keywords: inner.keywords ?? [],
+      })
+    );
+    return [page, ...inner];
+  });
+}
+
+/** Lowercase, fold accents, and drop anything that isn't a letter or digit. */
+function normalize(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '');
+}
+
+function tokenize(text: string): string[] {
+  return normalize(text)
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Whether two strings are within one edit (insert, delete, substitute, or
+ * adjacent transposition) of each other — enough to forgive a typo without
+ * matching unrelated words.
+ */
+function withinOneEdit(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (Math.abs(a.length - b.length) > 1) return false;
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  if (i === a.length || i === b.length) return true;
+  // Same length: one substitution or one transposition.
+  if (a.length === b.length) {
+    if (a.slice(i + 1) === b.slice(i + 1)) return true;
+    return (
+      a[i] === b[i + 1] &&
+      a[i + 1] === b[i] &&
+      a.slice(i + 2) === b.slice(i + 2)
+    );
+  }
+  // Lengths differ by one: a single insertion/deletion.
+  return a.length > b.length
+    ? a.slice(i + 1) === b.slice(i)
+    : a.slice(i) === b.slice(i + 1);
+}
+
+// Match quality per query token, best (lowest) first. Exact word hits on the
+// title beat hits buried in keywords, which beat prefixes, which beat fuzzy.
+const EXACT_TITLE = 0;
+const EXACT_ANY = 1;
+const PREFIX_TITLE = 2;
+const PREFIX_ANY = 3;
+const SUBSTRING = 4;
+const TYPO = 5;
+
+/** Minimum token length before we forgive a typo — short words have too many neighbours. */
+const TYPO_MIN_LENGTH = 4;
+
+type IndexedEntry = {
+  entry: SettingsSearchEntry;
+  titleWords: string[];
+  allWords: string[];
+  /** Every phrase with its spaces removed, so "darkmode" still finds "dark mode". */
+  compactPhrases: string[];
+};
+
+function indexEntry(entry: SettingsSearchEntry): IndexedEntry {
+  const titleWords = tokenize(entry.title);
+  const phrases = [
+    entry.title,
+    entry.page,
+    entry.section ?? '',
+    ...entry.keywords,
+  ];
+  const allWords = Array.from(new Set(phrases.flatMap(tokenize)));
+  const compactPhrases = phrases
+    .map((p) => tokenize(p).join(''))
+    .filter(Boolean);
+  return { entry, titleWords, allWords, compactPhrases };
+}
+
+function scoreToken(token: string, indexed: IndexedEntry): number | undefined {
+  if (indexed.titleWords.includes(token)) return EXACT_TITLE;
+  if (indexed.allWords.includes(token)) return EXACT_ANY;
+  if (indexed.titleWords.some((w) => w.startsWith(token))) return PREFIX_TITLE;
+  if (indexed.allWords.some((w) => w.startsWith(token))) return PREFIX_ANY;
+  if (indexed.compactPhrases.some((p) => p.includes(token))) return SUBSTRING;
+  if (
+    token.length >= TYPO_MIN_LENGTH &&
+    indexed.allWords.some((w) => isTypoOf(token, w))
+  ) {
+    return TYPO;
+  }
+  return undefined;
+}
+
+/**
+ * Whether `token` looks like a typo of `word` or of a prefix of it, so
+ * "conection" still finds "connections". People almost never mistype the first
+ * letter, so it has to agree — that keeps "gmail" from matching "email".
+ */
+function isTypoOf(token: string, word: string): boolean {
+  if (token[0] !== word[0]) return false;
+  if (withinOneEdit(token, word)) return true;
+  // A dropped, extra or swapped letter shifts the prefix length by up to one.
+  for (const length of [token.length - 1, token.length, token.length + 1]) {
+    if (length < word.length && withinOneEdit(token, word.slice(0, length))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Rank the index against a free-text query. Every word of the query has to
+ * match somewhere in an entry (title, page, section or keywords) for it to be
+ * returned; matching is case-insensitive, prefix-tolerant, substring-tolerant
+ * and forgives a single typo in longer words. Results are ordered best match
+ * first, with page entries ahead of inner entries on ties and the index order
+ * (sidebar order) as the final tie-break.
+ */
+export function searchSettings(
+  query: string,
+  entries: readonly SettingsSearchEntry[]
+): SettingsSearchResult[] {
+  const tokens = tokenize(query);
+  if (tokens.length === 0) return [];
+
+  const results: SettingsSearchResult[] = [];
+  entries.forEach((entry) => {
+    const indexed = indexEntry(entry);
+    let score = 0;
+    for (const token of tokens) {
+      const tokenScore = scoreToken(token, indexed);
+      if (tokenScore === undefined) return;
+      score += tokenScore;
+    }
+    results.push({ entry, score });
+  });
+
+  return results
+    .map((result, order) => ({ result, order }))
+    .sort((a, b) => {
+      if (a.result.score !== b.result.score)
+        return a.result.score - b.result.score;
+      if (a.result.entry.isPage !== b.result.entry.isPage) {
+        return a.result.entry.isPage ? -1 : 1;
+      }
+      return a.order - b.order;
+    })
+    .map(({ result }) => result);
+}


### PR DESCRIPTION
## Summary

Adds a search field at the top of the settings sidebar. Results cover the settings pages themselves **and** the things inside them that aren't sidebar items — Gmail/Google, GitHub, the MCP integrations (Linear, Slack, Notion, PostHog, Datadog, Grafana), Cursor, delete account, team slug, API keys, agent system prompt, harness, and so on — each with a page/section breadcrumb (e.g. **Linear** — *Connections · MCP integrations*). Picking a result opens its page and clears the search.

Matching is deliberately generous, English-only for now:

- Case-insensitive; every word in the query must match somewhere in the entry's title, page, section, or its curated synonym list.
- A word matches as an exact word, a prefix (`notif`), a substring across joined words (`darkmode`, `hub`), or a single typo in words of 4+ letters (`conection`, `apearance`). The first letter must agree so `gmail` doesn't fuzz into `email`.
- Synonyms are hand-curated per page and per inner item, so `payment` → Billing, `hotkeys` → Shortcuts, `avatar` → Account, `google` / `calendar sync` / `signature` → Gmail, `mcp` → both the MCP server page and the MCP integrations section, `token` → API Keys, `runtime` → Harness.
- Ranking: exact title hits, then keyword hits, prefixes, substrings, typos; page entries ahead of inner entries on ties; sidebar order as the final tie-break.

The index is built from the *currently available* tabs, so feature-flag / platform / permission gating carries over — search never surfaces a page the panel won't render.

Keyboard: arrow keys move the highlight, Enter opens, Escape clears the query (a second Escape closes settings, matching the existing hotkey). The settings-scope single-key hotkeys (Tab, 1–9) are already suppressed while an input is focused, so typing in the field doesn't switch tabs.

## Files

- `settingsSearch.ts` — the index (page + inner-item keywords) and the pure `searchSettings` ranking function.
- `SettingsSearch.tsx` — the field and results list.
- `Settings.tsx` — mounts the search above the sidebar groups; results replace the groups while a query is typed.
- `settingsSearch.test.ts` (15) and `SettingsSearch.test.tsx` (9) — matching/ranking and rendering/keyboard behaviour.

## Not in this PR

- Selecting a result opens the page but doesn't scroll to the specific section (would need anchor plumbing across every settings page).
- The search only appears in the sidebar layout; the compact dropdown and mobile pill tabs don't get it yet.

## Test plan

- [x] `bunx vitest run --project app src/features/settings/` — 24 tests pass
- [x] `bunx biome check` clean on all changed files
- [x] `bunx tsc --noEmit` — no errors in changed files
- [ ] Open settings, type `google`, `mcp`, `integrations`, `dark mode`, `delete account`; confirm results and that clicking one opens the right page

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzTz2k3oeHwbZXSeUoBftn)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only settings UI and local search index; navigation reuses existing tab selection with no auth or data-path changes.
> 
> **Overview**
> Adds **settings sidebar search** so users can jump to pages and in-page items (integrations, danger-zone actions, etc.) without hunting through nav groups.
> 
> The sidebar gets a search field that **replaces the category list while a query is active**. Results come from a hand-curated index built from **currently available tabs** (same gating as the panel), with ranked matching (synonyms, multi-word AND, prefixes, joined words, light typo tolerance). Inner hits show a page/section breadcrumb; choosing a result **opens that settings tab** and clears the query—there is no scroll-to-section yet.
> 
> `SettingsSearch` handles keyboard navigation (arrows, Enter, Escape clears then can close settings) plus component and ranking tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d387f6188310e5cec82c197cd496dbca7aca0f5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->