### PR TITLE
fix(md): fix skeleton + error bug, improve error styling

### DIFF
--- a/apps/web/src/features/block-md/component/ComposeSkill.tsx
+++ b/apps/web/src/features/block-md/component/ComposeSkill.tsx
@@ -44,6 +44,7 @@ import {
   Show,
   untrack,
 } from 'solid-js';
+import { EditorSystemMessage } from './EditorSystemMessage';
 
 function composerTitleNavigationPlugin(
   bodyEditor: Accessor<LexicalEditor | undefined>
@@ -422,7 +423,9 @@ export function ComposeSkill(props: ComposeSkillProps) {
       <Show when={errorMessage()}>
         <div class="w-full border-b border-edge-muted" />
         <div class="p-2">
-          <div class="text-sm text-failure-ink px-3 py-2">{errorMessage()}</div>
+          <EditorSystemMessage variant="error">
+            {errorMessage()}
+          </EditorSystemMessage>
         </div>
       </Show>
 

--- a/apps/web/src/features/block-md/component/ComposeTask.tsx
+++ b/apps/web/src/features/block-md/component/ComposeTask.tsx
@@ -77,6 +77,7 @@ import {
   saveTaskComposerDraft,
   updateDraftTimestamp,
 } from '../util/taskComposerStorage';
+import { EditorSystemMessage } from './EditorSystemMessage';
 import { InlinePropertyValue } from './InlinePropertyValue';
 import { SimilarTasksSection } from './TaskDuplicateList';
 
@@ -960,7 +961,9 @@ export function ComposeTask(props: ComposeTaskProps) {
       <Show when={errorMessage()}>
         <div class="w-full border-b border-edge-muted" />
         <div class="p-2">
-          <div class="text-sm text-failure-ink px-3 py-2">{errorMessage()}</div>
+          <EditorSystemMessage variant="error">
+            {errorMessage()}
+          </EditorSystemMessage>
         </div>
       </Show>
 

--- a/apps/web/src/features/block-md/component/EditorSystemMessage.test.tsx
+++ b/apps/web/src/features/block-md/component/EditorSystemMessage.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { render } from '@solidjs/testing-library';
+import { describe, expect, it } from 'vitest';
+import { EditorSystemMessage } from './EditorSystemMessage';
+
+describe('EditorSystemMessage', () => {
+  it('renders the base variant by default', () => {
+    const { getByRole } = render(() => (
+      <EditorSystemMessage>Document status</EditorSystemMessage>
+    ));
+
+    const message = getByRole('status');
+    expect(message.dataset.variant).toBe('base');
+    expect(message.classList.contains('rounded-lg')).toBe(true);
+    expect(message.classList.contains('p-3')).toBe(true);
+  });
+
+  it('renders errors as alerts with a line-height-aligned icon', () => {
+    const { getByRole } = render(() => (
+      <EditorSystemMessage variant="error">Document error</EditorSystemMessage>
+    ));
+
+    const message = getByRole('alert');
+    expect(message.dataset.variant).toBe('error');
+    expect(message.classList.contains('items-start')).toBe(true);
+    expect(message.querySelector('[aria-hidden="true"]')?.classList).toContain(
+      'h-lh'
+    );
+  });
+
+  it('renders warnings as statuses', () => {
+    const { getByRole } = render(() => (
+      <EditorSystemMessage variant="warning">
+        Document warning
+      </EditorSystemMessage>
+    ));
+
+    expect(getByRole('status').dataset.variant).toBe('warning');
+  });
+});

--- a/apps/web/src/features/block-md/component/EditorSystemMessage.tsx
+++ b/apps/web/src/features/block-md/component/EditorSystemMessage.tsx
@@ -1,0 +1,56 @@
+import InfoIcon from '@phosphor/info.svg';
+import WarningIcon from '@phosphor/warning.svg';
+import WarningCircleIcon from '@phosphor/warning-circle.svg';
+import { cn, createVariants, type VariantProps } from '@ui';
+import { type ComponentProps, splitProps } from 'solid-js';
+import { Dynamic } from 'solid-js/web';
+
+export const editorSystemMessageVariants = createVariants(
+  'pointer-events-none flex w-full items-start gap-2 rounded-lg border p-3 text-sm',
+  {
+    variant: {
+      base: 'border-edge-muted bg-surface-2 text-ink-muted',
+      error: 'border-failure/30 bg-failure-bg text-failure-ink',
+      warning: 'border-alert/30 bg-alert-bg text-alert-ink',
+    },
+  },
+  {
+    variant: 'base',
+  }
+);
+
+export type EditorSystemMessageVariantProps = VariantProps<
+  typeof editorSystemMessageVariants
+>;
+
+export type EditorSystemMessageProps = ComponentProps<'div'> &
+  EditorSystemMessageVariantProps;
+
+const icons = {
+  base: InfoIcon,
+  error: WarningCircleIcon,
+  warning: WarningIcon,
+} as const;
+
+export function EditorSystemMessage(props: EditorSystemMessageProps) {
+  const [local, others] = splitProps(props, ['variant', 'class', 'children']);
+  const variant = () => local.variant ?? 'base';
+
+  return (
+    <div
+      data-slot="editor-system-message"
+      data-variant={variant()}
+      role={variant() === 'error' ? 'alert' : 'status'}
+      class={cn(
+        editorSystemMessageVariants({ variant: variant() }),
+        local.class
+      )}
+      {...others}
+    >
+      <span class="flex h-lh shrink-0 items-center" aria-hidden="true">
+        <Dynamic component={icons[variant()]} class="size-4" />
+      </span>
+      <div class="min-w-0 flex-1">{local.children}</div>
+    </div>
+  );
+}

--- a/apps/web/src/features/block-md/component/InstructionsEditor.tsx
+++ b/apps/web/src/features/block-md/component/InstructionsEditor.tsx
@@ -58,7 +58,6 @@ import {
   type PeerIdValidator,
   peerIdPlugin,
 } from '@macro-inc/lexical-core';
-import WarningIcon from '@phosphor/warning.svg';
 import { onElementConnect } from '@solid-primitives/lifecycle';
 import { debounce } from '@solid-primitives/scheduled';
 import type { EditorState } from 'lexical';
@@ -73,6 +72,7 @@ import {
 import { blockDataSignal, mdStore } from '../signal/markdownBlockData';
 import type { MarkdownRewriteOutput } from '../signal/rewriteSignal';
 import { useBlockSave, useSaveMarkdownDocument } from '../signal/save';
+import { EditorSystemMessage } from './EditorSystemMessage';
 import { MarkdownCollabProvider } from './MarkdownCollabProvider';
 
 const EDITOR_PADDING_BOTTOM = 120;
@@ -371,13 +371,11 @@ export function InstructionsEditor(props: {
 
   return (
     <LexicalWrapperContext.Provider value={lexicalWrapper}>
-      {/* SCUFFED: are these the right transparency values? */}
       <Show when={editorError()}>
         {(error) => (
-          <div class="pointer-events-none text-alert-ink p-2 bg-alert-bg w-full border-alert/30 border mb-2 flex items-center gap-2">
-            <WarningIcon class="size-6 shrink-0" />
+          <EditorSystemMessage variant="warning" class="mb-2">
             {getErrorDescription(error())}
-          </div>
+          </EditorSystemMessage>
         )}
       </Show>
       <div class="relative" ref={editorContainerRef}>

--- a/apps/web/src/features/block-md/component/MarkdownEditor.tsx
+++ b/apps/web/src/features/block-md/component/MarkdownEditor.tsx
@@ -171,7 +171,6 @@ import {
   type PeerIdValidator,
   peerIdPlugin,
 } from '@macro-inc/lexical-core';
-import WarningIcon from '@phosphor/warning.svg';
 import { useDocTags } from '@property/tags';
 import { EntityType } from '@service-properties/generated/schemas/entityType';
 import { onElementConnect } from '@solid-primitives/lifecycle';
@@ -202,8 +201,10 @@ import {
 import { blockDataSignal, mdStore } from '../signal/markdownBlockData';
 import type { MarkdownRewriteOutput } from '../signal/rewriteSignal';
 import { useBlockSave, useSaveMarkdownDocument } from '../signal/save';
+import { EditorSystemMessage } from './EditorSystemMessage';
 import { MarkdownCollabProvider } from './MarkdownCollabProvider';
 import { MarkdownPopup } from './MarkdownPopup';
+import { isMarkdownEditorLoading } from './markdownEditorLoadingState';
 
 false && fileFolderDrop;
 
@@ -973,13 +974,11 @@ export function MarkdownEditor(props: {
 
   return (
     <LexicalWrapperContext.Provider value={lexicalWrapper}>
-      {/* SCUFFED: are these the right transparency values? */}
       <Show when={editorError()}>
         {(error) => (
-          <div class="pointer-events-none text-alert-ink p-2 bg-alert-bg w-full border-alert/30 border mb-2 flex items-center gap-2">
-            <WarningIcon class="size-6 shrink-0" />
+          <EditorSystemMessage variant="warning" class="mb-2">
             {getErrorDescription(error())}
-          </div>
+          </EditorSystemMessage>
         )}
       </Show>
       {/* Note: the mt-1.5 here is to preserve markdown node margin tops. which means this div should avoid padding and border. */}
@@ -1033,7 +1032,7 @@ export function MarkdownEditor(props: {
           editorFocus={editorFocus}
           style={{ height: `${clickTargetHeight()}px` }}
         />
-        <Show when={!editorReady()}>
+        <Show when={isMarkdownEditorLoading(editorReady(), editorError())}>
           <div
             aria-hidden="true"
             class="pointer-events-none absolute inset-x-0 top-0 flex flex-col gap-2.5 pt-1"

--- a/apps/web/src/features/block-md/component/markdownEditorLoadingState.test.ts
+++ b/apps/web/src/features/block-md/component/markdownEditorLoadingState.test.ts
@@ -1,0 +1,19 @@
+import { MarkdownEditorErrors } from '@core/component/LexicalMarkdown/constants';
+import { describe, expect, it } from 'vitest';
+import { isMarkdownEditorLoading } from './markdownEditorLoadingState';
+
+describe('isMarkdownEditorLoading', () => {
+  it('stops loading when the editor resolves to an error', () => {
+    expect(isMarkdownEditorLoading(false, null)).toBe(true);
+    expect(
+      isMarkdownEditorLoading(
+        false,
+        MarkdownEditorErrors.VERSION_MISMATCH_ERROR
+      )
+    ).toBe(false);
+  });
+
+  it('stays hidden after the editor is ready', () => {
+    expect(isMarkdownEditorLoading(true, null)).toBe(false);
+  });
+});

--- a/apps/web/src/features/block-md/component/markdownEditorLoadingState.ts
+++ b/apps/web/src/features/block-md/component/markdownEditorLoadingState.ts
@@ -1,0 +1,8 @@
+import type { MarkdownEditorErrors } from '@core/component/LexicalMarkdown/constants';
+
+export function isMarkdownEditorLoading(
+  editorReady: boolean,
+  editorError: MarkdownEditorErrors | null
+): boolean {
+  return !editorReady && editorError === null;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only refactor and a small loading-state guard in the markdown editor; no auth, data, or API changes.
> 
> **Overview**
> Introduces a shared **`EditorSystemMessage`** component (base / warning / error variants with icons and `role="alert"` vs `role="status"`) and wires it into task/skill composers and the main markdown / instructions editors, replacing one-off error and warning markup.
> 
> **`MarkdownEditor`** now drives the loading skeleton through **`isMarkdownEditorLoading`**, so the shimmer hides when load fails with an error instead of staying visible over the warning banner. Unit tests cover the component variants and loading helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11d983462410c03aab0e915ef6cc49db2758d0a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->