### PR TITLE
fix(email): include viewed history in backfill catch-up

### DIFF
--- a/apps/web/src/lib/queries/soup/backfill.test.tsx
+++ b/apps/web/src/lib/queries/soup/backfill.test.tsx
@@ -173,8 +173,17 @@ describe('runSoupBackfills', () => {
         filters: {
           emailFilter: {
             tree: {
-              literal: {
-                updatedAt: { gte: '2026-09-02T12:00:00.000Z' },
+              or: {
+                left: {
+                  literal: {
+                    updatedAt: { gte: '2026-09-02T12:00:00.000Z' },
+                  },
+                },
+                right: {
+                  literal: {
+                    viewedAt: { gte: '2026-09-02T12:00:00.000Z' },
+                  },
+                },
               },
             },
           },
@@ -255,8 +264,17 @@ describe('runSoupBackfills', () => {
         filters: {
           emailFilter: {
             tree: {
-              literal: {
-                updatedAt: { gte: '2026-09-02T12:00:00.000Z' },
+              or: {
+                left: {
+                  literal: {
+                    updatedAt: { gte: '2026-09-02T12:00:00.000Z' },
+                  },
+                },
+                right: {
+                  literal: {
+                    viewedAt: { gte: '2026-09-02T12:00:00.000Z' },
+                  },
+                },
               },
             },
           },
@@ -375,7 +393,7 @@ describe('runSoupBackfills', () => {
 
   it('restarts from the beginning when the cache generation is replaced', async () => {
     localStorage.setItem(
-      'graphql-soup-backfill:v7:user-1:core-entities',
+      'graphql-soup-backfill:v8:user-1:core-entities',
       JSON.stringify({
         userId: 'user-1',
         nextCursor: 'stale-cursor',

--- a/apps/web/src/lib/queries/soup/backfill.ts
+++ b/apps/web/src/lib/queries/soup/backfill.ts
@@ -22,7 +22,7 @@ import { createEffect, createSignal, onCleanup } from 'solid-js';
 
 // Bump when a default backfill input or completion guarantee changes so
 // persisted cursors cannot retain an older hydration contract.
-const BACKFILL_VERSION = 7;
+const BACKFILL_VERSION = 8;
 const PAGE_LIMIT = 100;
 // Five threads × twenty messages reaches the backend's 100-message cap.
 const EMAIL_CONTENT_PAGE_LIMIT = 5;
@@ -310,8 +310,13 @@ export function withUpdatedSince(
     literal: { updatedAt: { gte: updatedSince } },
   };
 
-  const emailUpdatedAt = {
-    literal: { updatedAt: { gte: updatedSince } },
+  // VIEWED_UPDATED can move a row ahead of the scan cursor through either
+  // the thread timestamp or this viewer's history timestamp. Cover both.
+  const emailSortWatermark = {
+    or: {
+      left: { literal: { updatedAt: { gte: updatedSince } } },
+      right: { literal: { viewedAt: { gte: updatedSince } } },
+    },
   };
 
   return {
@@ -323,7 +328,7 @@ export function withUpdatedSince(
       chatFilter: and(filters.chatFilter, chatUpdatedAt),
       emailFilter: {
         ...(filters.emailFilter ?? {}),
-        tree: and(filters.emailFilter?.tree, emailUpdatedAt),
+        tree: and(filters.emailFilter?.tree, emailSortWatermark),
       },
     },
   };

--- a/apps/web/src/lib/service-clients/service-storage/graphql/generated/graphql.ts
+++ b/apps/web/src/lib/service-clients/service-storage/graphql/generated/graphql.ts
@@ -428,33 +428,35 @@ export type GraphqlEmailFilterAst = {
 /** GraphQL input representing the email literal. */
 export type GraphqlEmailLiteral =
   {   /** The bcc option. */
-  bcc: GraphqlEmailValue; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  bcc: GraphqlEmailValue; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; viewedAt?: never; }
   |  { bcc?: never;   /** The calendar only option. */
-  calendarOnly: boolean; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  calendarOnly: boolean; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; viewedAt?: never; }
   |  { bcc?: never; calendarOnly?: never;   /** The cc option. */
-  cc: GraphqlEmailValue; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  cc: GraphqlEmailValue; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; viewedAt?: never; }
   |  { bcc?: never; calendarOnly?: never; cc?: never;   /** The created at option. */
-  createdAt: GraphqlDateLiteral; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  createdAt: GraphqlDateLiteral; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; viewedAt?: never; }
   |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never;   /** The importance option. */
-  importance: boolean; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  importance: boolean; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; viewedAt?: never; }
   |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never;   /** The notification done option. */
-  notificationDone: boolean; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  notificationDone: boolean; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; viewedAt?: never; }
   |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never;   /** The notification seen option. */
-  notificationSeen: boolean; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  notificationSeen: boolean; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; viewedAt?: never; }
   |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never;   /** The owner option. */
-  owner: string | number; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  owner: string | number; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; viewedAt?: never; }
   |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never;   /** The project id option. */
-  projectId: string; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  projectId: string; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never; viewedAt?: never; }
   |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never;   /** The recipient option. */
-  recipient: GraphqlEmailValue; sender?: never; shared?: never; threadId?: never; updatedAt?: never; }
+  recipient: GraphqlEmailValue; sender?: never; shared?: never; threadId?: never; updatedAt?: never; viewedAt?: never; }
   |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never;   /** The sender option. */
-  sender: GraphqlEmailValue; shared?: never; threadId?: never; updatedAt?: never; }
+  sender: GraphqlEmailValue; shared?: never; threadId?: never; updatedAt?: never; viewedAt?: never; }
   |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never;   /** The shared option. */
-  shared: GraphqlSharedEmailFilter; threadId?: never; updatedAt?: never; }
+  shared: GraphqlSharedEmailFilter; threadId?: never; updatedAt?: never; viewedAt?: never; }
   |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never;   /** The thread id option. */
-  threadId: string | number; updatedAt?: never; }
+  threadId: string | number; updatedAt?: never; viewedAt?: never; }
   |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never;   /** The updated at option. */
-  updatedAt: GraphqlDateLiteral; };
+  updatedAt: GraphqlDateLiteral; viewedAt?: never; }
+  |  { bcc?: never; calendarOnly?: never; cc?: never; createdAt?: never; importance?: never; notificationDone?: never; notificationSeen?: never; owner?: never; projectId?: never; recipient?: never; sender?: never; shared?: never; threadId?: never; updatedAt?: never;   /** The per-viewer viewed at option. */
+  viewedAt: GraphqlDateLiteral; };
 
 /** GraphQL input representing the email value. */
 export type GraphqlEmailValue =

--- a/crates/email/src/outbound/email_pg_repo/dynamic/filters.rs
+++ b/crates/email/src/outbound/email_pg_repo/dynamic/filters.rs
@@ -183,48 +183,149 @@ fn build_address_text_match(
     }
 }
 
+fn build_message_literal_predicate(
+    literal: &EmailLiteral,
+    resolved: &ResolvedFilters,
+) -> SqlFragment {
+    match literal {
+        EmailLiteral::Sender(email) => {
+            build_address_predicate_on_m(AddressKind::Sender, email, resolved)
+        }
+        EmailLiteral::Recipient(email) => {
+            build_address_predicate_on_m(AddressKind::Recipient, email, resolved)
+        }
+        EmailLiteral::Cc(email) => build_address_predicate_on_m(AddressKind::Cc, email, resolved),
+        EmailLiteral::Bcc(email) => build_address_predicate_on_m(AddressKind::Bcc, email, resolved),
+        _ => unreachable!("expected a message-level email literal"),
+    }
+}
+
+fn build_thread_literal_predicate(
+    literal: &EmailLiteral,
+    sort_ts_field: &str,
+    thread_alias: &str,
+    history_alias: &str,
+) -> SqlFragment {
+    match literal {
+        EmailLiteral::ThreadId(id) => {
+            let mut f = SqlFragment::raw(format!("{thread_alias}.id = "));
+            f.extend(SqlFragment::bind_uuid(*id));
+            f
+        }
+        EmailLiteral::Owner(id) => {
+            let mut f = SqlFragment::raw(format!("{thread_alias}.link_id = "));
+            f.extend(SqlFragment::bind_uuid(*id));
+            f
+        }
+        EmailLiteral::ProjectId(id) => {
+            let mut f = SqlFragment::raw(format!("{thread_alias}.project_id = "));
+            f.extend(SqlFragment::bind_string(id.clone()));
+            f
+        }
+        // Denormalized flag maintained at attachment ingest — deriving this
+        // from email_attachments at query time is prohibitively slow.
+        EmailLiteral::CalendarOnly(true) => {
+            SqlFragment::raw(format!("{thread_alias}.has_calendar_attachment"))
+        }
+        EmailLiteral::CalendarOnly(false) => SqlFragment::raw("TRUE"),
+        // Denormalized importance flag maintained by update_thread_metadata
+        // (sync_thread_signal_flag) and the email_filters resync fan-out.
+        EmailLiteral::Importance(true) => SqlFragment::raw(format!("{thread_alias}.is_signal")),
+        EmailLiteral::Importance(false) => {
+            SqlFragment::raw(format!("(NOT {thread_alias}.is_signal)"))
+        }
+        EmailLiteral::CreatedAt(lit) => date_predicate(&format!("{thread_alias}.created_at"), lit),
+        EmailLiteral::UpdatedAt(lit) => date_predicate(sort_ts_field, lit),
+        EmailLiteral::ViewedAt(lit) => date_predicate(&format!("{history_alias}.updated_at"), lit),
+        EmailLiteral::Property(lit) => build_thread_property_predicate(lit, thread_alias),
+        EmailLiteral::NotificationSeen(true) => {
+            SqlFragment::raw(format!("{thread_alias}.is_read = TRUE"))
+        }
+        EmailLiteral::NotificationSeen(false) => {
+            SqlFragment::raw(format!("{thread_alias}.is_read = FALSE"))
+        }
+        // These literals are handled outside the thread/message predicate.
+        EmailLiteral::NotificationDone(_) | EmailLiteral::Shared(_) => SqlFragment::raw("TRUE"),
+        EmailLiteral::Sender(_)
+        | EmailLiteral::Cc(_)
+        | EmailLiteral::Bcc(_)
+        | EmailLiteral::Recipient(_) => unreachable!("expected a thread-level email literal"),
+    }
+}
+
+/// Builds the full filter for one candidate `(thread, message)` pair. Keeping
+/// the original boolean tree inside one correlated message probe preserves
+/// single-message semantics through mixed-level OR and NOT expressions.
+fn build_candidate_pair_predicate(
+    ast: &Expr<EmailLiteral>,
+    sort_ts_field: &str,
+    resolved: &ResolvedFilters,
+) -> SqlFragment {
+    ast.collapse_frames(|frame| match frame {
+        filter_ast::ExprFrame::And(a, b) => SqlFragment::and(a, b),
+        filter_ast::ExprFrame::Or(a, b) => SqlFragment::or(a, b),
+        filter_ast::ExprFrame::Not(a) => SqlFragment::not(a),
+        filter_ast::ExprFrame::Literal(literal) => match literal {
+            EmailLiteral::Sender(_)
+            | EmailLiteral::Cc(_)
+            | EmailLiteral::Bcc(_)
+            | EmailLiteral::Recipient(_) => build_message_literal_predicate(&literal, resolved),
+            _ => build_thread_literal_predicate(&literal, sort_ts_field, "t", "uh"),
+        },
+    })
+}
+
+/// Lowers a thread-level literal inside the per-message LATERAL as a scalar
+/// correlated predicate. A scalar subquery intentionally preserves SQL NULL
+/// semantics under NOT (notably for threads without a ViewedAt history row).
+fn build_correlated_thread_predicate(literal: &EmailLiteral, sort_ts_field: &str) -> SqlFragment {
+    if matches!(
+        literal,
+        EmailLiteral::NotificationDone(_) | EmailLiteral::Shared(_)
+    ) {
+        return SqlFragment::raw("TRUE");
+    }
+
+    let thread_alias = "email_filter_thread";
+    let history_alias = "email_filter_history";
+    let correlated_sort_ts_field = sort_ts_field.replace("t.", &format!("{thread_alias}."));
+    let predicate = build_thread_literal_predicate(
+        literal,
+        &correlated_sort_ts_field,
+        thread_alias,
+        history_alias,
+    );
+
+    let mut f = SqlFragment::raw("(SELECT ");
+    f.extend(predicate);
+    f.push_raw(format!(" FROM email_threads {thread_alias}"));
+    if matches!(literal, EmailLiteral::ViewedAt(_)) {
+        f.push_raw(format!(
+            " LEFT JOIN email_user_history {history_alias} \
+             ON {history_alias}.thread_id = {thread_alias}.id \
+             AND {history_alias}.link_id = {thread_alias}.link_id"
+        ));
+    }
+    f.push_raw(format!(" WHERE {thread_alias}.id = m.thread_id)"));
+    f
+}
+
 pub(super) fn build_message_email_filter(
     ast: &Expr<EmailLiteral>,
     resolved: &ResolvedFilters,
+    sort_ts_field: &str,
 ) -> SqlFragment {
     let fragment = ast.collapse_frames(|frame| match frame {
         filter_ast::ExprFrame::And(a, b) => SqlFragment::and(a, b),
         filter_ast::ExprFrame::Or(a, b) => SqlFragment::or(a, b),
         filter_ast::ExprFrame::Not(a) => SqlFragment::not(a),
-
-        filter_ast::ExprFrame::Literal(
-            EmailLiteral::ThreadId(_) | EmailLiteral::Owner(_) | EmailLiteral::ProjectId(_),
-        ) => SqlFragment::raw("TRUE"),
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::Sender(email)) => {
-            build_address_predicate_on_m(AddressKind::Sender, &email, resolved)
-        }
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::Recipient(email)) => {
-            build_address_predicate_on_m(AddressKind::Recipient, &email, resolved)
-        }
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::Cc(email)) => {
-            build_address_predicate_on_m(AddressKind::Cc, &email, resolved)
-        }
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::Bcc(email)) => {
-            build_address_predicate_on_m(AddressKind::Bcc, &email, resolved)
-        }
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::Importance(_)) => SqlFragment::raw("TRUE"),
-        filter_ast::ExprFrame::Literal(EmailLiteral::NotificationDone(_)) => {
-            SqlFragment::raw("TRUE")
-        }
-        filter_ast::ExprFrame::Literal(EmailLiteral::NotificationSeen(_)) => {
-            SqlFragment::raw("TRUE")
-        }
-        filter_ast::ExprFrame::Literal(EmailLiteral::Shared(_)) => SqlFragment::raw("TRUE"),
-        filter_ast::ExprFrame::Literal(EmailLiteral::CalendarOnly(_)) => SqlFragment::raw("TRUE"),
-        filter_ast::ExprFrame::Literal(EmailLiteral::CreatedAt(_)) => SqlFragment::raw("TRUE"),
-        filter_ast::ExprFrame::Literal(EmailLiteral::UpdatedAt(_)) => SqlFragment::raw("TRUE"),
-        filter_ast::ExprFrame::Literal(EmailLiteral::ViewedAt(_)) => SqlFragment::raw("TRUE"),
-        filter_ast::ExprFrame::Literal(EmailLiteral::Property(_)) => SqlFragment::raw("TRUE"),
+        filter_ast::ExprFrame::Literal(literal) => match literal {
+            EmailLiteral::Sender(_)
+            | EmailLiteral::Cc(_)
+            | EmailLiteral::Bcc(_)
+            | EmailLiteral::Recipient(_) => build_message_literal_predicate(&literal, resolved),
+            _ => build_correlated_thread_predicate(&literal, sort_ts_field),
+        },
     });
 
     fragment.with_and_prefix()
@@ -389,7 +490,11 @@ pub(super) fn build_thread_message_exists_filter(
         f.extend(view_message_filter);
     }
     if has_message_literals(ast) {
-        f.extend(build_message_email_filter(ast, resolved));
+        f.extend(build_message_email_filter(
+            ast,
+            resolved,
+            get_sort_timestamp_field(view),
+        ));
     }
     f.push_raw(")");
     f
@@ -822,87 +927,33 @@ impl MatchingThreadsCtes {
     }
 }
 
-/// Builds thread-level SQL WHERE conditions. Message-level literals map to TRUE.
+/// Builds thread-level SQL WHERE conditions. When the tree contains message
+/// literals, the complete expression is evaluated inside one correlated
+/// message predicate instead of replacing those literals with `TRUE`.
 pub(super) fn build_thread_email_filter(
     ast: &Expr<EmailLiteral>,
     sort_ts_field: &str,
+    resolved: &ResolvedFilters,
 ) -> SqlFragment {
-    let fragment = ast.collapse_frames(|frame| match frame {
-        filter_ast::ExprFrame::And(a, b) => SqlFragment::and(a, b),
-        filter_ast::ExprFrame::Or(a, b) => SqlFragment::or(a, b),
-        filter_ast::ExprFrame::Not(a) => SqlFragment::not(a),
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::ThreadId(id)) => {
-            let mut f = SqlFragment::raw("t.id = ");
-            f.extend(SqlFragment::bind_uuid(id));
-            f
-        }
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::Owner(id)) => {
-            let mut f = SqlFragment::raw("t.link_id = ");
-            f.extend(SqlFragment::bind_uuid(id));
-            f
-        }
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::ProjectId(id)) => {
-            let mut f = SqlFragment::raw("t.project_id = ");
-            f.extend(SqlFragment::bind_string(id));
-            f
-        }
-
-        // Denormalized flag maintained at attachment ingest — deriving this
-        // from email_attachments at query time is prohibitively slow.
-        filter_ast::ExprFrame::Literal(EmailLiteral::CalendarOnly(true)) => {
-            SqlFragment::raw("t.has_calendar_attachment")
-        }
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::CalendarOnly(false)) => {
-            SqlFragment::raw("TRUE")
-        }
-
-        // Denormalized importance flag maintained by update_thread_metadata
-        // (sync_thread_signal_flag) and the email_filters resync fan-out.
-        filter_ast::ExprFrame::Literal(EmailLiteral::Importance(true)) => {
-            SqlFragment::raw("t.is_signal")
-        }
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::Importance(false)) => {
-            SqlFragment::raw("(NOT t.is_signal)")
-        }
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::CreatedAt(ref lit)) => {
-            date_predicate("t.created_at", lit)
-        }
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::UpdatedAt(ref lit)) => {
-            date_predicate(sort_ts_field, lit)
-        }
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::ViewedAt(ref lit)) => {
-            date_predicate("uh.updated_at", lit)
-        }
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::Property(ref lit)) => {
-            build_thread_property_predicate(lit)
-        }
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::NotificationSeen(true)) => {
-            SqlFragment::raw("t.is_read = TRUE")
-        }
-
-        filter_ast::ExprFrame::Literal(EmailLiteral::NotificationSeen(false)) => {
-            SqlFragment::raw("t.is_read = FALSE")
-        }
-
-        filter_ast::ExprFrame::Literal(
-            EmailLiteral::Sender(_)
-            | EmailLiteral::Cc(_)
-            | EmailLiteral::Bcc(_)
-            | EmailLiteral::Recipient(_)
-            | EmailLiteral::NotificationDone(_)
-            | EmailLiteral::Shared(_),
-        ) => SqlFragment::raw("TRUE"),
-    });
+    let fragment = if has_message_literals(ast) {
+        let mut f = SqlFragment::raw(
+            "EXISTS (SELECT 1 FROM email_messages m WHERE m.thread_id = t.id AND ",
+        );
+        f.extend(build_trash_check(resolved));
+        f.push_raw(" AND ");
+        f.extend(build_candidate_pair_predicate(ast, sort_ts_field, resolved));
+        f.push_raw(")");
+        f
+    } else {
+        ast.collapse_frames(|frame| match frame {
+            filter_ast::ExprFrame::And(a, b) => SqlFragment::and(a, b),
+            filter_ast::ExprFrame::Or(a, b) => SqlFragment::or(a, b),
+            filter_ast::ExprFrame::Not(a) => SqlFragment::not(a),
+            filter_ast::ExprFrame::Literal(literal) => {
+                build_thread_literal_predicate(&literal, sort_ts_field, "t", "uh")
+            }
+        })
+    };
 
     fragment.with_and_prefix()
 }
@@ -910,20 +961,20 @@ pub(super) fn build_thread_email_filter(
 /// Entity-property predicate for a candidate thread: EXISTS against
 /// `entity_properties` keyed on the thread id. A literal typed to a
 /// non-thread entity can never match a thread, so it renders FALSE.
-fn build_thread_property_predicate(lit: &PropertiesLiteral) -> SqlFragment {
+fn build_thread_property_predicate(lit: &PropertiesLiteral, thread_alias: &str) -> SqlFragment {
     if lit
         .entity_type
         .is_some_and(|et| et != PropertyEntityType::Thread)
     {
         return SqlFragment::raw("FALSE");
     }
-    let mut f = SqlFragment::raw(
+    let mut f = SqlFragment::raw(format!(
         r#"EXISTS (
                 SELECT 1 FROM entity_properties ep_prop
-                WHERE ep_prop.entity_id = t.id::text
+                WHERE ep_prop.entity_id = {thread_alias}.id::text
                 AND ep_prop.entity_type = 'THREAD'
                 AND ep_prop.property_definition_id = "#,
-    );
+    ));
     f.extend(SqlFragment::bind_uuid(lit.property_definition_id));
     match &lit.value {
         PropertyMatchValue::SelectOption(option_id) => {

--- a/crates/email/src/outbound/email_pg_repo/dynamic/filters.rs
+++ b/crates/email/src/outbound/email_pg_repo/dynamic/filters.rs
@@ -40,6 +40,7 @@ pub(super) fn has_thread_literals(ast: &Expr<EmailLiteral>) -> bool {
             | EmailLiteral::NotificationDone(_)
             | EmailLiteral::CreatedAt(_)
             | EmailLiteral::UpdatedAt(_)
+            | EmailLiteral::ViewedAt(_)
             | EmailLiteral::Property(_),
         ) => true,
         filter_ast::ExprFrame::Literal(EmailLiteral::Shared(_)) => false,
@@ -62,6 +63,7 @@ pub(super) fn has_message_literals(ast: &Expr<EmailLiteral>) -> bool {
             | EmailLiteral::NotificationDone(_)
             | EmailLiteral::CreatedAt(_)
             | EmailLiteral::UpdatedAt(_)
+            | EmailLiteral::ViewedAt(_)
             | EmailLiteral::Property(_),
         ) => false,
         filter_ast::ExprFrame::Literal(_) => true,
@@ -221,6 +223,7 @@ pub(super) fn build_message_email_filter(
         filter_ast::ExprFrame::Literal(EmailLiteral::CalendarOnly(_)) => SqlFragment::raw("TRUE"),
         filter_ast::ExprFrame::Literal(EmailLiteral::CreatedAt(_)) => SqlFragment::raw("TRUE"),
         filter_ast::ExprFrame::Literal(EmailLiteral::UpdatedAt(_)) => SqlFragment::raw("TRUE"),
+        filter_ast::ExprFrame::Literal(EmailLiteral::ViewedAt(_)) => SqlFragment::raw("TRUE"),
         filter_ast::ExprFrame::Literal(EmailLiteral::Property(_)) => SqlFragment::raw("TRUE"),
     });
 
@@ -873,6 +876,10 @@ pub(super) fn build_thread_email_filter(
 
         filter_ast::ExprFrame::Literal(EmailLiteral::UpdatedAt(ref lit)) => {
             date_predicate(sort_ts_field, lit)
+        }
+
+        filter_ast::ExprFrame::Literal(EmailLiteral::ViewedAt(ref lit)) => {
+            date_predicate("uh.updated_at", lit)
         }
 
         filter_ast::ExprFrame::Literal(EmailLiteral::Property(ref lit)) => {

--- a/crates/email/src/outbound/email_pg_repo/dynamic/query.rs
+++ b/crates/email/src/outbound/email_pg_repo/dynamic/query.rs
@@ -63,6 +63,21 @@ fn sort_uses_view_history(sort_method_str: &str) -> bool {
     matches!(sort_method_str, "viewed_at" | "viewed_updated")
 }
 
+/// A viewed_at predicate also requires the caller-specific history row in
+/// the candidate stage, even when ordering uses a non-viewed timestamp.
+fn filter_uses_view_history(ast: &Expr<EmailLiteral>) -> bool {
+    ast.collapse_frames(|frame| match frame {
+        filter_ast::ExprFrame::And(a, b) | filter_ast::ExprFrame::Or(a, b) => a || b,
+        filter_ast::ExprFrame::Not(a) => a,
+        filter_ast::ExprFrame::Literal(EmailLiteral::ViewedAt(_)) => true,
+        filter_ast::ExprFrame::Literal(_) => false,
+    })
+}
+
+fn uses_view_history(ast: &Expr<EmailLiteral>, sort_method_str: &str) -> bool {
+    sort_uses_view_history(sort_method_str) || filter_uses_view_history(ast)
+}
+
 /// Pushes the `user_source_ids AS (…), SharedEmailThreads AS (…)` CTE pair
 /// (without the leading `WITH` keyword and without trailing comma) into the
 /// builder. Caller is responsible for emitting the `WITH` keyword and any
@@ -107,7 +122,7 @@ fn push_thread_candidate_select(
     sort_ts_field: &str,
     source: ThreadCandidateSource,
 ) {
-    let defer_uh = !sort_uses_view_history(&params.sort_method_str);
+    let defer_uh = !uses_view_history(email_filter, &params.sort_method_str);
 
     // Multi-inbox owned scans fan out one ordered, LIMITed subscan per link:
     // `link_id = ANY(...)` index scans can't return ordered output (pre-PG17),
@@ -413,10 +428,10 @@ fn build_query(
 ) -> QueryBuilder<'static, Postgres> {
     let sort_ts_field = get_sort_timestamp_field(view);
     let view_message_filter = build_view_message_filter(view);
-    // When viewed-history isn't the sort key, the `email_user_history` join is
-    // pushed past the candidate `LIMIT` so it runs once per returned row
-    // instead of once per candidate thread (see `sort_uses_view_history`).
-    let defer_uh = !sort_uses_view_history(&params.sort_method_str);
+    // When neither ordering nor filtering needs view history, the
+    // `email_user_history` join is pushed past the candidate `LIMIT` so it
+    // runs once per returned row instead of once per candidate thread.
+    let defer_uh = !uses_view_history(email_filter, &params.sort_method_str);
 
     let needs_shared_cte = !matches!(params.shared, SharedEmailFilter::Exclude);
     // When the candidate stage pushes a full per-message EXISTS (view-level

--- a/crates/email/src/outbound/email_pg_repo/dynamic/query.rs
+++ b/crates/email/src/outbound/email_pg_repo/dynamic/query.rs
@@ -328,7 +328,7 @@ fn push_thread_candidate_select(
     }
 
     if has_thread_literals(email_filter) {
-        build_thread_email_filter(email_filter, sort_ts_field).push_into(builder);
+        build_thread_email_filter(email_filter, sort_ts_field, &params.resolved).push_into(builder);
     }
 
     // Ensure the candidate LIMIT only counts threads that will survive the
@@ -673,7 +673,8 @@ fn build_query(
     }
 
     if has_message_literals(email_filter) {
-        build_message_email_filter(email_filter, &params.resolved).push_into(&mut builder);
+        build_message_email_filter(email_filter, &params.resolved, sort_ts_field)
+            .push_into(&mut builder);
     }
 
     builder.push(

--- a/crates/email/src/outbound/email_pg_repo/dynamic/tests.rs
+++ b/crates/email/src/outbound/email_pg_repo/dynamic/tests.rs
@@ -35,6 +35,14 @@ fn resolved_with_random_ids(emails: &[&str]) -> ResolvedFilters {
     r
 }
 
+fn build_message_email_filter(ast: &Expr<EmailLiteral>, resolved: &ResolvedFilters) -> SqlFragment {
+    super::filters::build_message_email_filter(ast, resolved, "t.updated_at")
+}
+
+fn build_thread_email_filter(ast: &Expr<EmailLiteral>, sort_ts_field: &str) -> SqlFragment {
+    super::filters::build_thread_email_filter(ast, sort_ts_field, &ResolvedFilters::empty())
+}
+
 #[test]
 fn unresolved_sender_short_circuits() {
     let expr = Expr::Literal(EmailLiteral::Sender(complete("missing@x.com")));
@@ -278,15 +286,15 @@ fn test_notification_seen_compiles_to_thread_is_read() {
 }
 
 #[test]
-fn test_notification_seen_is_noop_in_message_filter() {
+fn test_notification_seen_is_correlated_in_message_filter() {
     for seen in [true, false] {
         let result = build_message_email_filter(
             &Expr::Literal(EmailLiteral::NotificationSeen(seen)),
             &ResolvedFilters::empty(),
         );
         let debug = result.to_debug_sql();
-        assert!(debug.contains("TRUE"));
-        assert!(!debug.contains("is_read"));
+        assert!(debug.contains("email_filter_thread.is_read"));
+        assert!(debug.contains("email_filter_thread.id = m.thread_id"));
     }
 }
 
@@ -331,15 +339,14 @@ fn test_importance_compiles_to_thread_signal_flag() {
 }
 
 #[test]
-fn test_importance_is_noop_in_message_filter() {
-    // The heuristic lives in the denormalized flag now; the lateral must not
-    // re-evaluate it per message.
+fn test_importance_is_correlated_to_thread_signal_flag_in_message_filter() {
     for imp in [true, false] {
         let result = build_message_email_filter(
             &Expr::Literal(EmailLiteral::Importance(imp)),
             &ResolvedFilters::empty(),
         );
         let debug = result.to_debug_sql();
+        assert!(debug.contains("email_filter_thread.is_signal"));
         assert!(!debug.contains("email_filters"));
         assert!(!debug.contains("CATEGORY"));
         assert!(!debug.contains("is_important"));
@@ -872,45 +879,114 @@ fn test_build_thread_email_filter_multiple_thread_ids() {
 }
 
 #[test]
-fn test_build_thread_email_filter_maps_sender_to_true() {
+fn test_build_thread_email_filter_correlates_sender() {
+    let contact_id = Uuid::new_v4();
     let expr = Expr::Literal(EmailLiteral::Sender(complete("test@example.com")));
-    let result = build_thread_email_filter(&expr, DEFAULT_SORT_TS);
+    let resolved = resolved_with(&[("test@example.com", contact_id)]);
+    let result = super::filters::build_thread_email_filter(&expr, DEFAULT_SORT_TS, &resolved);
     let debug = result.to_debug_sql();
 
-    assert!(debug.contains("TRUE"));
-    assert!(!debug.contains("t.id"));
+    assert!(debug.contains("EXISTS (SELECT 1 FROM email_messages m"));
+    assert!(debug.contains("m.thread_id = t.id"));
+    assert!(debug.contains("m.from_contact_id"));
+    assert!(result.has_bind_uuid(&contact_id));
 }
 
 #[test]
-fn test_build_message_email_filter_maps_thread_id_to_true() {
+fn test_build_message_email_filter_correlates_thread_id() {
     let id = Uuid::new_v4();
     let expr = Expr::Literal(EmailLiteral::ThreadId(id));
     let result = build_message_email_filter(&expr, &ResolvedFilters::empty());
     let debug = result.to_debug_sql();
 
-    assert!(debug.contains("TRUE"));
-    assert!(!debug.contains("t.id"));
+    assert!(debug.contains("SELECT email_filter_thread.id ="));
+    assert!(debug.contains("email_filter_thread.id = m.thread_id"));
+    assert!(result.has_bind_uuid(&id));
 }
 
 #[test]
-fn test_combined_thread_id_and_sender_splits_correctly() {
+fn test_combined_thread_id_and_sender_uses_both_predicates_at_each_level() {
     let id = Uuid::new_v4();
     let contact_id = Uuid::new_v4();
     let expr = Expr::and(
         Expr::Literal(EmailLiteral::ThreadId(id)),
         Expr::Literal(EmailLiteral::Sender(complete("sender@example.com"))),
     );
-
-    let thread_result = build_thread_email_filter(&expr, DEFAULT_SORT_TS);
-    let thread_debug = thread_result.to_debug_sql();
-    assert!(thread_result.has_bind_uuid(&id));
-    assert!(!thread_debug.contains("from_contact_id"));
-
     let resolved = resolved_with(&[("sender@example.com", contact_id)]);
+
+    let thread_result =
+        super::filters::build_thread_email_filter(&expr, DEFAULT_SORT_TS, &resolved);
+    let thread_debug = thread_result.to_debug_sql();
+    assert!(thread_debug.contains("t.id ="));
+    assert!(thread_debug.contains("m.from_contact_id"));
+    assert!(thread_result.has_bind_uuid(&id));
+    assert!(thread_result.has_bind_uuid(&contact_id));
+
     let message_result = build_message_email_filter(&expr, &resolved);
     let message_debug = message_result.to_debug_sql();
-    assert!(message_debug.contains("from_contact_id"));
+    assert!(message_debug.contains("email_filter_thread.id ="));
+    assert!(message_debug.contains("m.from_contact_id"));
+    assert!(message_result.has_bind_uuid(&id));
     assert!(message_result.has_bind_uuid(&contact_id));
+}
+
+#[test]
+fn test_mixed_sender_or_viewed_at_keeps_both_correlated_predicates() {
+    use chrono::TimeZone;
+    use item_filters::ast::date::DateLiteral;
+
+    let contact_id = Uuid::new_v4();
+    let cutoff = chrono::Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap();
+    let expr = Expr::or(
+        Expr::Literal(EmailLiteral::Sender(complete("sender@example.com"))),
+        Expr::Literal(EmailLiteral::ViewedAt(DateLiteral::GreaterThanOrEqual(
+            cutoff,
+        ))),
+    );
+    let resolved = resolved_with(&[("sender@example.com", contact_id)]);
+
+    let thread = super::filters::build_thread_email_filter(&expr, DEFAULT_SORT_TS, &resolved);
+    let thread_sql = thread.to_debug_sql();
+    assert!(thread_sql.contains("EXISTS (SELECT 1 FROM email_messages m"));
+    assert!(thread_sql.contains("m.from_contact_id"));
+    assert!(thread_sql.contains("OR uh.updated_at >="));
+    assert!(thread.has_bind_uuid(&contact_id));
+
+    let message = build_message_email_filter(&expr, &resolved);
+    let message_sql = message.to_debug_sql();
+    assert!(message_sql.contains("m.from_contact_id"));
+    assert!(message_sql.contains("OR (SELECT email_filter_history.updated_at >="));
+    assert!(message_sql.contains("email_filter_thread.id = m.thread_id"));
+    assert!(message.has_bind_uuid(&contact_id));
+}
+
+#[test]
+fn test_mixed_not_sender_or_viewed_at_keeps_both_correlated_predicates() {
+    use chrono::TimeZone;
+    use item_filters::ast::date::DateLiteral;
+
+    let contact_id = Uuid::new_v4();
+    let cutoff = chrono::Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap();
+    let expr = Expr::is_not(Expr::or(
+        Expr::Literal(EmailLiteral::Sender(complete("sender@example.com"))),
+        Expr::Literal(EmailLiteral::ViewedAt(DateLiteral::GreaterThanOrEqual(
+            cutoff,
+        ))),
+    ));
+    let resolved = resolved_with(&[("sender@example.com", contact_id)]);
+
+    let thread = super::filters::build_thread_email_filter(&expr, DEFAULT_SORT_TS, &resolved);
+    let thread_sql = thread.to_debug_sql();
+    assert!(thread_sql.contains("(NOT ("));
+    assert!(thread_sql.contains("m.from_contact_id"));
+    assert!(thread_sql.contains("uh.updated_at >="));
+
+    let message = build_message_email_filter(&expr, &resolved);
+    let message_sql = message.to_debug_sql();
+    assert!(message_sql.contains("(NOT ("));
+    assert!(message_sql.contains("m.from_contact_id"));
+    assert!(message_sql.contains("email_filter_history.updated_at >="));
+    assert!(message_sql.contains("email_filter_thread.id = m.thread_id"));
 }
 
 #[test]
@@ -978,13 +1054,14 @@ fn test_build_thread_email_filter_multiple_project_ids() {
 }
 
 #[test]
-fn test_build_message_email_filter_maps_project_id_to_true() {
+fn test_build_message_email_filter_correlates_project_id() {
     let expr = Expr::Literal(EmailLiteral::ProjectId("project-123".to_string()));
     let result = build_message_email_filter(&expr, &ResolvedFilters::empty());
     let debug = result.to_debug_sql();
 
-    assert!(debug.contains("TRUE"));
-    assert!(!debug.contains("project_id"));
+    assert!(debug.contains("email_filter_thread.project_id ="));
+    assert!(debug.contains("email_filter_thread.id = m.thread_id"));
+    assert!(result.has_bind_string("project-123"));
 }
 
 #[test]
@@ -1000,25 +1077,28 @@ fn test_has_message_literals_false_when_only_project_id() {
 }
 
 #[test]
-fn test_combined_project_id_and_sender_splits_correctly() {
+fn test_combined_project_id_and_sender_uses_both_predicates_at_each_level() {
     let contact_id = Uuid::new_v4();
     let expr = Expr::and(
         Expr::Literal(EmailLiteral::ProjectId("project-123".to_string())),
         Expr::Literal(EmailLiteral::Sender(complete("sender@example.com"))),
     );
+    let resolved = resolved_with(&[("sender@example.com", contact_id)]);
 
-    let thread_result = build_thread_email_filter(&expr, DEFAULT_SORT_TS);
+    let thread_result =
+        super::filters::build_thread_email_filter(&expr, DEFAULT_SORT_TS, &resolved);
     let thread_debug = thread_result.to_debug_sql();
     assert!(thread_debug.contains("t.project_id = "));
+    assert!(thread_debug.contains("m.from_contact_id"));
     assert!(thread_result.has_bind_string("project-123"));
-    assert!(!thread_debug.contains("from_contact_id"));
+    assert!(thread_result.has_bind_uuid(&contact_id));
 
-    let resolved = resolved_with(&[("sender@example.com", contact_id)]);
     let message_result = build_message_email_filter(&expr, &resolved);
     let message_debug = message_result.to_debug_sql();
-    assert!(message_debug.contains("from_contact_id"));
+    assert!(message_debug.contains("email_filter_thread.project_id ="));
+    assert!(message_debug.contains("m.from_contact_id"));
     assert!(message_result.has_bind_uuid(&contact_id));
-    assert!(!message_result.has_bind_string("project-123"));
+    assert!(message_result.has_bind_string("project-123"));
 }
 
 #[test]
@@ -1551,12 +1631,13 @@ fn test_build_thread_email_filter_calendar_only_false_maps_to_true() {
 }
 
 #[test]
-fn test_build_message_email_filter_maps_calendar_only_to_true() {
+fn test_build_message_email_filter_correlates_calendar_only() {
     let expr = Expr::Literal(EmailLiteral::CalendarOnly(true));
     let result = build_message_email_filter(&expr, &ResolvedFilters::empty());
     let debug = result.to_debug_sql();
 
-    assert!(debug.contains("TRUE"));
+    assert!(debug.contains("email_filter_thread.has_calendar_attachment"));
+    assert!(debug.contains("email_filter_thread.id = m.thread_id"));
     assert!(!debug.contains("email_attachments"));
 }
 

--- a/crates/email/src/outbound/email_pg_repo/dynamic/tests.rs
+++ b/crates/email/src/outbound/email_pg_repo/dynamic/tests.rs
@@ -784,6 +784,34 @@ fn test_build_query_defers_user_history_join_for_updated_at_sort() {
 }
 
 #[test]
+fn test_viewed_at_filter_keeps_user_history_join_inline_for_updated_sort() {
+    use chrono::TimeZone;
+    use item_filters::ast::date::DateLiteral;
+
+    let view = PreviewView::StandardLabel(PreviewViewStandardLabel::Sent);
+    let dt = chrono::Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap();
+    let expr = Expr::Literal(EmailLiteral::ViewedAt(DateLiteral::GreaterThanOrEqual(dt)));
+    let sql = super::query::debug_build_query_sql_with_sort(
+        &view,
+        &expr,
+        models_pagination::SimpleSortMethod::UpdatedAt,
+    );
+
+    assert_eq!(
+        sql.matches("LEFT JOIN email_user_history").count(),
+        1,
+        "viewed_at filtering needs one inline history join: {sql}"
+    );
+    let uh_pos = sql.find("LEFT JOIN email_user_history").unwrap();
+    let el_pos = sql.find("JOIN email_links el").unwrap();
+    assert!(
+        uh_pos < el_pos,
+        "viewed_at filter must join history before the candidate filter: {sql}"
+    );
+    assert!(sql.contains("uh.updated_at >="));
+}
+
+#[test]
 fn test_build_query_keeps_user_history_join_inline_for_viewed_at_sort() {
     let view = PreviewView::StandardLabel(PreviewViewStandardLabel::Sent);
     let expr = Expr::Literal(EmailLiteral::Sender(Email::Domain("acme.com".to_string())));
@@ -1616,6 +1644,22 @@ fn test_has_thread_literals_true_when_created_at_present() {
     let dt = chrono::Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
     let expr = Expr::Literal(EmailLiteral::CreatedAt(DateLiteral::GreaterThan(dt)));
     assert!(has_thread_literals(&expr));
+}
+
+#[test]
+fn test_build_thread_email_filter_viewed_at_uses_user_history_timestamp() {
+    use chrono::TimeZone;
+    use item_filters::ast::date::DateLiteral;
+
+    let dt = chrono::Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap();
+    let expr = Expr::Literal(EmailLiteral::ViewedAt(DateLiteral::GreaterThanOrEqual(dt)));
+    let result = build_thread_email_filter(&expr, DEFAULT_SORT_TS);
+    let debug = result.to_debug_sql();
+
+    assert!(debug.contains("uh.updated_at >="));
+    assert!(debug.contains("2024-03-01"));
+    assert!(has_thread_literals(&expr));
+    assert!(!has_message_literals(&expr));
 }
 
 #[test]

--- a/crates/email/src/outbound/email_pg_repo/test/dynamic_query.rs
+++ b/crates/email/src/outbound/email_pg_repo/test/dynamic_query.rs
@@ -838,22 +838,11 @@ async fn test_dynamic_query_with_importance_filter(pool: Pool<Postgres>) -> anyh
     Ok(())
 }
 
-// KNOWN LIMITATION (pinned, not desired): an OR mixing a message-level
-// literal (Sender) with a thread-level literal (Importance) broadens to
-// match-everything. The thread stage maps Sender to TRUE and the lateral
-// maps Importance to TRUE, so `(TRUE OR t.is_signal)` / `(sender OR TRUE)`
-// both collapse. The correct result here would be the 6 signal threads
-// (john's threads 1/2/5 are all signal), but noise threads 6 and 7 leak in.
-// This predates the is_signal flip for every other thread-level literal
-// (CalendarOnly, ProjectId, dates); Importance joined the risk surface when
-// it moved thread-level. The FE and AI toolset only emit AND-shaped
-// importance filters, so no caller hits this today. If this test starts
-// failing with 6, cross-level OR was fixed — delete this test with joy.
 #[sqlx::test(
     migrator = "MACRO_DB_MIGRATIONS",
     fixtures(path = "../../../../fixtures", scripts("email_dynamic_query"))
 )]
-async fn test_mixed_or_sender_importance_broadens_known_limitation(
+async fn test_mixed_or_sender_importance_preserves_both_branches(
     pool: Pool<Postgres>,
 ) -> anyhow::Result<()> {
     sync_all_signal_flags(&pool).await?;
@@ -876,11 +865,11 @@ async fn test_mixed_or_sender_importance_broadens_known_limitation(
     let result_ids: std::collections::HashSet<String> =
         results.iter().map(|r| r.id.to_string()).collect();
 
-    // Broadened: every thread with a surfaceable message (1-8), including
-    // noise threads 6 and 7 that match neither OR branch.
-    assert_eq!(results.len(), 8, "mixed OR currently broadens to all");
-    assert!(result_ids.contains("20000006-0000-0000-0000-000000000006"));
-    assert!(result_ids.contains("20000007-0000-0000-0000-000000000007"));
+    // Threads 6 and 7 match neither branch. The other six surfaceable
+    // threads are signal threads, including all three John threads.
+    assert_eq!(results.len(), 6, "mixed OR must preserve both predicates");
+    assert!(!result_ids.contains("20000006-0000-0000-0000-000000000006"));
+    assert!(!result_ids.contains("20000007-0000-0000-0000-000000000007"));
 
     Ok(())
 }
@@ -2854,6 +2843,82 @@ async fn test_viewed_at_filter_uses_view_history_with_updated_sort(
     let ids: Vec<String> = results.iter().map(|row| row.id.to_string()).collect();
     assert_eq!(ids, vec![THREAD_7.to_string()]);
     assert_eq!(results[0].viewed_at, Some(viewed_7));
+
+    Ok(())
+}
+
+#[sqlx::test(
+    migrator = "MACRO_DB_MIGRATIONS",
+    fixtures(path = "../../../../fixtures", scripts("email_dynamic_query"))
+)]
+async fn test_mixed_sender_or_viewed_at_and_not_preserve_semantics(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    use item_filters::ast::date::DateLiteral;
+
+    let link_id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")?;
+    let cutoff = Utc.with_ymd_and_hms(2024, 5, 15, 0, 0, 0).unwrap();
+    let older_view = Utc.with_ymd_and_hms(2024, 5, 1, 0, 0, 0).unwrap();
+    let recent_view = Utc.with_ymd_and_hms(2024, 6, 1, 0, 0, 0).unwrap();
+    for thread_id in [THREAD_1, THREAD_4, THREAD_5] {
+        record_view(&pool, link_id, thread_id, older_view).await?;
+    }
+    record_view(&pool, link_id, THREAD_7, recent_view).await?;
+
+    let sender_or_viewed = Expr::or(
+        Expr::Literal(EmailLiteral::Sender(Email::Complete(
+            EmailStr::parse_from_str("john@example.com")?.into_owned(),
+        ))),
+        Expr::Literal(EmailLiteral::ViewedAt(DateLiteral::GreaterThanOrEqual(
+            cutoff,
+        ))),
+    );
+    let view = PreviewView::StandardLabel(PreviewViewStandardLabel::Inbox);
+    let results = dynamic::dynamic_email_thread_cursor(
+        &pool,
+        &[link_id],
+        50,
+        &view,
+        Query::new(
+            None,
+            SimpleSortMethod::UpdatedAt,
+            Arc::new(sender_or_viewed.clone()),
+        ),
+        "",
+        None,
+    )
+    .await?;
+    let ids: std::collections::HashSet<String> =
+        results.iter().map(|row| row.id.to_string()).collect();
+    assert_eq!(
+        ids,
+        [THREAD_1, THREAD_5, THREAD_7]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        "OR must include John threads and the recently viewed Jane thread"
+    );
+
+    let results = dynamic::dynamic_email_thread_cursor(
+        &pool,
+        &[link_id],
+        50,
+        &view,
+        Query::new(
+            None,
+            SimpleSortMethod::UpdatedAt,
+            Arc::new(Expr::is_not(sender_or_viewed)),
+        ),
+        "",
+        None,
+    )
+    .await?;
+    let ids: Vec<String> = results.iter().map(|row| row.id.to_string()).collect();
+    assert_eq!(
+        ids,
+        vec![THREAD_4.to_string()],
+        "NOT must exclude every message matching either inner branch"
+    );
 
     Ok(())
 }

--- a/crates/email/src/outbound/email_pg_repo/test/dynamic_query.rs
+++ b/crates/email/src/outbound/email_pg_repo/test/dynamic_query.rs
@@ -2824,6 +2824,44 @@ async fn test_viewed_at_sort_orders_by_view_history(pool: Pool<Postgres>) -> any
     migrator = "MACRO_DB_MIGRATIONS",
     fixtures(path = "../../../../fixtures", scripts("email_dynamic_query"))
 )]
+async fn test_viewed_at_filter_uses_view_history_with_updated_sort(
+    pool: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    use item_filters::ast::date::DateLiteral;
+
+    let link_id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")?;
+    let cutoff = Utc.with_ymd_and_hms(2024, 5, 15, 0, 0, 0).unwrap();
+    let viewed_7 = Utc.with_ymd_and_hms(2024, 6, 1, 0, 0, 0).unwrap();
+    let viewed_4 = Utc.with_ymd_and_hms(2024, 5, 1, 0, 0, 0).unwrap();
+    record_view(&pool, link_id, THREAD_7, viewed_7).await?;
+    record_view(&pool, link_id, THREAD_4, viewed_4).await?;
+
+    let view = PreviewView::StandardLabel(PreviewViewStandardLabel::Inbox);
+    let filter = Arc::new(Expr::Literal(EmailLiteral::ViewedAt(
+        DateLiteral::GreaterThanOrEqual(cutoff),
+    )));
+    let results = dynamic::dynamic_email_thread_cursor(
+        &pool,
+        &[link_id],
+        50,
+        &view,
+        Query::new(None, SimpleSortMethod::UpdatedAt, filter),
+        "",
+        None,
+    )
+    .await?;
+
+    let ids: Vec<String> = results.iter().map(|row| row.id.to_string()).collect();
+    assert_eq!(ids, vec![THREAD_7.to_string()]);
+    assert_eq!(results[0].viewed_at, Some(viewed_7));
+
+    Ok(())
+}
+
+#[sqlx::test(
+    migrator = "MACRO_DB_MIGRATIONS",
+    fixtures(path = "../../../../fixtures", scripts("email_dynamic_query"))
+)]
 async fn test_viewed_updated_sort_falls_back_to_view_timestamp(
     pool: Pool<Postgres>,
 ) -> anyhow::Result<()> {

--- a/crates/graphql_soup_filter_input/src/lib.rs
+++ b/crates/graphql_soup_filter_input/src/lib.rs
@@ -817,6 +817,8 @@ enum GraphqlEmailLiteral {
     CreatedAt(GraphqlDateLiteral),
     /// The updated at option.
     UpdatedAt(GraphqlDateLiteral),
+    /// The per-viewer viewed at option.
+    ViewedAt(GraphqlDateLiteral),
 }
 
 impl IntoFilterExpr<EmailLiteral> for GraphqlEmailLiteral {
@@ -837,6 +839,7 @@ impl IntoFilterExpr<EmailLiteral> for GraphqlEmailLiteral {
             Self::CalendarOnly(calendar_only) => EmailLiteral::CalendarOnly(calendar_only),
             Self::CreatedAt(date) => EmailLiteral::CreatedAt(date.into_ast()?),
             Self::UpdatedAt(date) => EmailLiteral::UpdatedAt(date.into_ast()?),
+            Self::ViewedAt(date) => EmailLiteral::ViewedAt(date.into_ast()?),
         };
         Ok(Expr::val(literal))
     }

--- a/crates/item_filters/src/ast/email.rs
+++ b/crates/item_filters/src/ast/email.rs
@@ -73,6 +73,9 @@ pub enum EmailLiteral {
     /// Filter by thread updated_at timestamp (view-dependent field)
     #[serde(rename = "ua")]
     UpdatedAt(DateLiteral),
+    /// Filter by the viewer's per-thread viewed_at timestamp.
+    #[serde(rename = "va")]
+    ViewedAt(DateLiteral),
     /// Thread-level entity-property condition, checked against
     /// `entity_properties` keyed on the thread id. Injected by the soup
     /// service when a request carries a properties filter; never produced

--- a/static_assets/schema.graphql
+++ b/static_assets/schema.graphql
@@ -1689,6 +1689,10 @@ input GraphqlEmailLiteral @oneOf {
 	The updated at option.
 	"""
 	updatedAt: GraphqlDateLiteral
+	"""
+	The per-viewer viewed at option.
+	"""
+	viewedAt: GraphqlDateLiteral
 }
 
 """


### PR DESCRIPTION
Fixes a bug which can skip over backfill items due to their viewed at timestamp changing on the server

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core email list filtering SQL and pagination semantics; incorrect lowering could drop or over-include threads, while the backfill version bump forces clients to re-run hydration lanes.
> 
> **Overview**
> Fixes **graphql soup backfill** missing threads when only **per-viewer viewed history** moves them past a `VIEWED_UPDATED` scan cursor. Catch-up now applies an **`updatedAt` OR `viewedAt`** watermark on email filters, and **`BACKFILL_VERSION` is bumped to 8** so stored checkpoints don’t keep the old contract.
> 
> Adds a **`viewedAt`** email filter literal end-to-end (GraphQL schema, AST, generated types). The Postgres dynamic query layer **implements `ViewedAt` against `email_user_history`**, keeps that join in the **candidate** stage when the filter needs it (not only for viewed-based sorts), and **refactors thread/message filter lowering** so mixed **OR/NOT** trees (e.g. sender OR importance) evaluate the full boolean expression via correlated predicates instead of collapsing cross-level branches to `TRUE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9684ab7d1fad360a69a5342495fd666ef3c91015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->