### PR TITLE
fix(channels): delete channel endpoint broken

### DIFF
--- a/crates/channels/src/outbound/pg_channels_repo/tests.rs
+++ b/crates/channels/src/outbound/pg_channels_repo/tests.rs
@@ -2988,3 +2988,55 @@ async fn bot_profiles_includes_soft_deleted_bots(pool: Pool<Postgres>) -> anyhow
     assert!(!profiles.contains_key(&missing));
     Ok(())
 }
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn delete_channel_cascades_contacts_backfill_outbox_rows(pool: Pool<Postgres>) {
+    let repo = repo(pool.clone());
+    let created = repo
+        .create_channel(
+            macro_user_id(USER_A),
+            None,
+            CreateChannelRequest {
+                name: Some("delete-with-outbox".to_string()),
+                channel_type: ChannelType::Private,
+                team_id: None,
+                auto_join_team: false,
+                participants: HashSet::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+    sqlx::query!(
+        "INSERT INTO contacts_backfill_outbox (comms_channel_id, user_ids) \
+         VALUES ($1, '[\"macro|user-a@test.com\"]'::jsonb)",
+        created.id,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    repo.delete_channel(created.id, USER_A.to_string())
+        .await
+        .expect("channel delete must succeed when contacts_backfill_outbox references the channel");
+
+    let channel_count = sqlx::query_scalar!(
+        "SELECT count(*) FROM comms_channels WHERE id = $1",
+        created.id,
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(channel_count, 0);
+
+    let outbox_count = sqlx::query_scalar!(
+        "SELECT count(*) FROM contacts_backfill_outbox WHERE comms_channel_id = $1",
+        created.id,
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(outbox_count, 0);
+}

--- a/crates/macro_db_client/migrations/20260903174515_cascade_contacts_backfill_outbox_on_channel_delete.sql
+++ b/crates/macro_db_client/migrations/20260903174515_cascade_contacts_backfill_outbox_on_channel_delete.sql
@@ -1,0 +1,6 @@
+ALTER TABLE contacts_backfill_outbox
+    DROP CONSTRAINT contacts_backfill_outbox_comms_channel_id_fkey;
+
+ALTER TABLE contacts_backfill_outbox
+    ADD CONSTRAINT contacts_backfill_outbox_comms_channel_id_fkey
+    FOREIGN KEY (comms_channel_id) REFERENCES comms_channels(id) ON DELETE CASCADE;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Schema migration changes delete semantics for `contacts_backfill_outbox`; orphaned outbox rows are removed automatically on channel delete, which is intended but affects data retention for that table.
> 
> **Overview**
> **Fixes channel deletion** when `contacts_backfill_outbox` rows still reference the channel. The FK from `contacts_backfill_outbox.comms_channel_id` to `comms_channels(id)` is recreated with **`ON DELETE CASCADE`**, so deleting a channel no longer fails on that constraint and related outbox rows are removed with the channel.
> 
> Adds an integration test that seeds an outbox row, calls `delete_channel`, and asserts both the channel and outbox rows are gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1971e22fcf0f88c71ce1ae62c15580d89886dd56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->