### PR TITLE
fix(calendar): distinguish failed team OOO fetch from empty result

### DIFF
--- a/apps/web/src/features/block-calendar/components/SidePanelSections.tsx
+++ b/apps/web/src/features/block-calendar/components/SidePanelSections.tsx
@@ -16,8 +16,10 @@ import {
   createMemo,
   createSignal,
   For,
+  Match,
   on,
   Show,
+  Switch,
 } from 'solid-js';
 
 function CalendarMiniCalendarSidePanelSection() {
@@ -172,17 +174,21 @@ function TeamOooUpcomingList() {
 
   return (
     <div class="flex flex-col gap-0.5">
-      <Show when={!upcoming.isPending()} fallback={<TeamOooSkeleton />}>
-        <Show
-          when={windows().length > 0}
-          fallback={
-            <span class="px-2 py-1 text-xs text-ink-muted">
-              {upcoming.isError()
-                ? "Couldn't load time off"
-                : 'No time off in the next 90 days'}
-            </span>
-          }
-        >
+      <Switch>
+        <Match when={upcoming.isPending()}>
+          <TeamOooSkeleton />
+        </Match>
+        <Match when={upcoming.isError()}>
+          <span class="px-2 py-1 text-xs text-ink-muted">
+            Couldn't load time off
+          </span>
+        </Match>
+        <Match when={windows().length === 0}>
+          <span class="px-2 py-1 text-xs text-ink-muted">
+            No time off in the next 90 days
+          </span>
+        </Match>
+        <Match when={windows().length > 0}>
           <For each={windows().slice(0, UPCOMING_SHOWN_MAX)}>
             {(window) => (
               <button
@@ -211,8 +217,8 @@ function TeamOooUpcomingList() {
               +{windows().length - UPCOMING_SHOWN_MAX} more
             </span>
           </Show>
-        </Show>
-      </Show>
+        </Match>
+      </Switch>
     </div>
   );
 }

--- a/apps/web/src/features/block-calendar/components/SidePanelSections.tsx
+++ b/apps/web/src/features/block-calendar/components/SidePanelSections.tsx
@@ -153,47 +153,64 @@ function windowDateLabel(window: TeamOooWindow): string {
     : `${format(window.start, 'MMM d')} – ${format(lastDay, 'MMM d')}`;
 }
 
+function TeamOooSkeleton() {
+  return (
+    <div aria-hidden="true" class="flex flex-col gap-0.5">
+      <For each={[0, 1, 2]}>
+        {() => (
+          <div class="skeleton-shimmer h-8 w-full rounded-lg bg-skeleton" />
+        )}
+      </For>
+    </div>
+  );
+}
+
 function TeamOooUpcomingList() {
   const calendarPager = useCalendarPager();
-  const windows = useUpcomingTeamOoo();
+  const upcoming = useUpcomingTeamOoo();
+  const windows = upcoming.windows;
 
   return (
     <div class="flex flex-col gap-0.5">
-      <Show
-        when={windows().length > 0}
-        fallback={
-          <span class="px-2 py-1 text-xs text-ink-muted">
-            No time off in the next 90 days
-          </span>
-        }
-      >
-        <For each={windows().slice(0, UPCOMING_SHOWN_MAX)}>
-          {(window) => (
-            <button
-              type="button"
-              class="flex w-full flex-col rounded-lg px-2 py-1.5 text-left text-xs hover:bg-hover"
-              onClick={() => calendarPager.gotoDate(window.start)}
-            >
-              <span class="flex w-full items-baseline gap-2">
-                <span class="min-w-0 flex-1 truncate text-ink">
-                  {window.name}
+      <Show when={!upcoming.isPending()} fallback={<TeamOooSkeleton />}>
+        <Show
+          when={windows().length > 0}
+          fallback={
+            <span class="px-2 py-1 text-xs text-ink-muted">
+              {upcoming.isError()
+                ? "Couldn't load time off"
+                : 'No time off in the next 90 days'}
+            </span>
+          }
+        >
+          <For each={windows().slice(0, UPCOMING_SHOWN_MAX)}>
+            {(window) => (
+              <button
+                type="button"
+                class="flex w-full flex-col rounded-lg px-2 py-1.5 text-left text-xs hover:bg-hover"
+                onClick={() => calendarPager.gotoDate(window.start)}
+              >
+                <span class="flex w-full items-baseline gap-2">
+                  <span class="min-w-0 flex-1 truncate text-ink">
+                    {window.name}
+                  </span>
+                  <span class="shrink-0 text-ink-muted">
+                    {windowDateLabel(window)}
+                  </span>
                 </span>
-                <span class="shrink-0 text-ink-muted">
-                  {windowDateLabel(window)}
-                </span>
-              </span>
-              <Show when={window.title}>
-                <span class="w-full truncate text-ink-muted">
-                  {window.title}
-                </span>
-              </Show>
-            </button>
-          )}
-        </For>
-        <Show when={windows().length > UPCOMING_SHOWN_MAX}>
-          <span class="px-2 py-1 text-xs text-ink-muted">
-            +{windows().length - UPCOMING_SHOWN_MAX} more
-          </span>
+                <Show when={window.title}>
+                  <span class="w-full truncate text-ink-muted">
+                    {window.title}
+                  </span>
+                </Show>
+              </button>
+            )}
+          </For>
+          <Show when={windows().length > UPCOMING_SHOWN_MAX}>
+            <span class="px-2 py-1 text-xs text-ink-muted">
+              +{windows().length - UPCOMING_SHOWN_MAX} more
+            </span>
+          </Show>
         </Show>
       </Show>
     </div>

--- a/apps/web/src/features/calendar/hooks/use-team-ooo.ts
+++ b/apps/web/src/features/calendar/hooks/use-team-ooo.ts
@@ -99,10 +99,11 @@ export function useTeamOooEvents(
     })
   );
   const events = createMemo(() => {
-    // A failed overlay fetch degrades to no events rather than an error surface
-    // since the grid's own state is driven by the occurrences query.
-    if (!isRangeSupported() || query.isPending) return [];
-    return (query.data ?? []).map(mapTeamOooItem);
+    // Read data only on success: a failed overlay fetch degrades to no events
+    // since the grid's own state is driven by the occurrences query, and gating
+    // on success keeps this off the pending/errored resource read that suspends.
+    if (!isRangeSupported() || !query.isSuccess) return [];
+    return query.data.map(mapTeamOooItem);
   });
   const visibleEvents = createMemo(() => (isOverlayVisible() ? events() : []));
   const eventsById = createMemo(
@@ -149,10 +150,10 @@ export function useUpcomingTeamOoo(): UpcomingTeamOoo {
   const query = useTeamOutOfOfficeQuery(() => ({ userId: userId(), range }));
 
   const windows = createMemo<TeamOooWindow[]>(() => {
-    // Reading data only once settled keeps this off the pending resource read
-    // that would suspend, while still surfacing stale data through a refetch.
-    if (query.isPending) return [];
-    return (query.data ?? []).map((item) => {
+    // Read data only on success so a pending query never hits the suspending
+    // resource read and an errored refetch never surfaces stale rows.
+    if (!query.isSuccess) return [];
+    return query.data.map((item) => {
       const time = item.time;
       const [start, end, allDay] =
         time.kind === 'timed'

--- a/apps/web/src/features/calendar/hooks/use-team-ooo.ts
+++ b/apps/web/src/features/calendar/hooks/use-team-ooo.ts
@@ -99,7 +99,9 @@ export function useTeamOooEvents(
     })
   );
   const events = createMemo(() => {
-    if (!isRangeSupported()) return [];
+    // A failed overlay fetch degrades to no events rather than an error surface
+    // since the grid's own state is driven by the occurrences query.
+    if (!isRangeSupported() || query.isPending) return [];
     return (query.data ?? []).map(mapTeamOooItem);
   });
   const visibleEvents = createMemo(() => (isOverlayVisible() ? events() : []));
@@ -127,8 +129,17 @@ export interface TeamOooWindow {
 
 const UPCOMING_TEAM_OOO_DAYS = 90;
 
+/** Upcoming team out-of-office windows with the request's load/error status. */
+export interface UpcomingTeamOoo {
+  windows: Accessor<TeamOooWindow[]>;
+  /** No settled result yet, distinguishing first load from an empty result. */
+  isPending: Accessor<boolean>;
+  /** The request failed, distinguishing an error from an empty result. */
+  isError: Accessor<boolean>;
+}
+
 /** Teammates' out-of-office windows from today forward, soonest first. */
-export function useUpcomingTeamOoo(): Accessor<TeamOooWindow[]> {
+export function useUpcomingTeamOoo(): UpcomingTeamOoo {
   const userId = useUserId();
   const rangeStart = new Date();
   rangeStart.setHours(0, 0, 0, 0);
@@ -137,8 +148,11 @@ export function useUpcomingTeamOoo(): Accessor<TeamOooWindow[]> {
   const range = createCalendarOccurrenceQueryRange(rangeStart, rangeEnd);
   const query = useTeamOutOfOfficeQuery(() => ({ userId: userId(), range }));
 
-  return createMemo(() =>
-    (query.data ?? []).map((item) => {
+  const windows = createMemo<TeamOooWindow[]>(() => {
+    // Reading data only once settled keeps this off the pending resource read
+    // that would suspend, while still surfacing stale data through a refetch.
+    if (query.isPending) return [];
+    return (query.data ?? []).map((item) => {
       const time = item.time;
       const [start, end, allDay] =
         time.kind === 'timed'
@@ -154,6 +168,12 @@ export function useUpcomingTeamOoo(): Accessor<TeamOooWindow[]> {
         end,
         allDay,
       };
-    })
-  );
+    });
+  });
+
+  return {
+    windows,
+    isPending: () => query.isPending,
+    isError: () => query.isError,
+  };
 }


### PR DESCRIPTION
The calendar side panel's "Team out of office" section showed "No time off in the next 90 days" whether the request returned nothing or failed. It now renders a loading skeleton while pending and "Couldn't load time off" on error, keeping the empty copy only for a genuine empty result. The grid overlay keeps degrading to no events on failure since its own state is driven by the occurrences query.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized calendar UI and query-read gating with no auth or data-mutation changes; overlay behavior on failure is unchanged.
> 
> **Overview**
> The **Team out of office** side panel no longer treats a failed fetch like an empty schedule. **`useUpcomingTeamOoo`** now exposes **`windows`** plus **`isPending`** and **`isError`**, and both that hook and **`useTeamOooEvents`** only read query data when **`isSuccess`**, so pending loads do not hit suspending resource reads and errors do not show stale rows.
> 
> The upcoming list uses a **`Switch`** over those states: shimmer skeleton while loading, **"Couldn't load time off"** on error, and **"No time off in the next 90 days"** only after a successful empty response. The calendar overlay still shows no team OOO events when the fetch fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3953566be238a84ba0b9b6a0a82ec8f6329ddfff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->