### PR TITLE
fix(inbox): restore soup rows to done-filtered feeds on incoming notifications

### DIFF
--- a/apps/web/src/lib/queries/notification/tests/user-notifications.test.tsx
+++ b/apps/web/src/lib/queries/notification/tests/user-notifications.test.tsx
@@ -79,6 +79,7 @@ vi.mock('@queries/soup/normalized-cache', () => ({
   optimisticUpdateSoupItemUpdatedAt: vi.fn(),
   hasSoupEntity: vi.fn(() => false),
   refetchSoupEntity: vi.fn(),
+  restoreSoupEntityToDoneFilteredQueries: vi.fn(),
 }));
 
 vi.mock('@service-storage/graphql-soup', () => ({
@@ -90,6 +91,7 @@ import {
   hasSoupEntity,
   optimisticUpdateSoupItemUpdatedAt,
   refetchSoupEntity,
+  restoreSoupEntityToDoneFilteredQueries,
 } from '@queries/soup/normalized-cache';
 
 const mockOptimisticUpdateSoupItemUpdatedAt = vi.mocked(
@@ -715,6 +717,11 @@ describe('optimisticInsertNotification', () => {
       newNotification.entity_id,
       newNotification.created_at
     );
+    // A row marked done was removed from the done-filtered feeds; the merge
+    // above can't restore page membership, so the insert path re-adds it.
+    expect(
+      vi.mocked(restoreSoupEntityToDoneFilteredQueries)
+    ).toHaveBeenCalledWith(newNotification.entity_id);
     expect(mockRefetchSoupEntity).not.toHaveBeenCalled();
   });
 
@@ -777,6 +784,14 @@ describe('optimisticInsertNotification', () => {
       'channel-1',
       expect.anything()
     );
+    // The feed row for a thread-scoped notification is the thread, so that is
+    // the row restored into the done-filtered feeds.
+    expect(
+      vi.mocked(restoreSoupEntityToDoneFilteredQueries)
+    ).toHaveBeenCalledWith('thread-1');
+    expect(
+      vi.mocked(restoreSoupEntityToDoneFilteredQueries)
+    ).not.toHaveBeenCalledWith('channel-1');
   });
 
   it('should bump the updatedAt of an already-cached email thread', () => {

--- a/apps/web/src/lib/queries/notification/user-notifications.ts
+++ b/apps/web/src/lib/queries/notification/user-notifications.ts
@@ -12,6 +12,7 @@ import {
   hasSoupEntity,
   optimisticUpdateSoupItemUpdatedAt,
   refetchSoupEntity,
+  restoreSoupEntityToDoneFilteredQueries,
   type SoupEntityTag,
 } from '@queries/soup/normalized-cache';
 import { type MutationCallbacks, withCallbacks } from '@queries/utils';
@@ -1092,6 +1093,16 @@ export function optimisticInsertNotification(
     if (threadRootId && !hasSoupEntity(threadRootId)) {
       refetchSoupEntity(threadRootId, 'channelThread');
     }
+
+    // A cached row may be absent from the done-filtered feeds — dropped when
+    // it was marked done, or the feed was fetched while it had nothing
+    // outstanding. The field merges above only patch rows already present,
+    // so put the row back where it is missing; otherwise this notification
+    // stays invisible in the inbox until the next refetch. No-op for rows
+    // the refetch paths above insert.
+    restoreSoupEntityToDoneFilteredQueries(
+      threadRootId ?? notification.entity_id
+    );
   }
 
   // Cache is already updated via setQueriesData above. Mark as stale without

--- a/apps/web/src/lib/queries/soup/normalized-cache/grouped-operations.ts
+++ b/apps/web/src/lib/queries/soup/normalized-cache/grouped-operations.ts
@@ -277,12 +277,17 @@ export function insertGroupedPage(
 }
 
 /** Inserts an item into the first page of any expanded group query it matches. */
-export function insertGroupQueries(item: SoupApiItem, itemId: string) {
+export function insertGroupQueries(
+  item: SoupApiItem,
+  itemId: string,
+  keyFilter?: (key: QueryKey) => boolean
+) {
   const queries = queryClient.getQueryCache().findAll({
     queryKey: soupKeys.groupedGroup._def,
   });
 
   for (const query of queries) {
+    if (keyFilter && !keyFilter(query.queryKey)) continue;
     const prev = query.state.data as GroupedGroupInfiniteData | undefined;
     if (!prev?.pages?.length) continue;
 
@@ -299,8 +304,12 @@ export function insertGroupQueries(item: SoupApiItem, itemId: string) {
     }
     if (!targetKeys.includes(meta.groupKey)) continue;
 
+    // Continuation pages hold their own itemIds, so check them all — a
+    // restore of an entity sitting on a later page must not duplicate it.
+    if (prev.pages.some((page) => page.group.itemIds.includes(itemId)))
+      continue;
+
     const firstPage = prev.pages[0];
-    if (firstPage.group.itemIds.includes(itemId)) continue;
 
     query.setData(
       {

--- a/apps/web/src/lib/queries/soup/normalized-cache/index.ts
+++ b/apps/web/src/lib/queries/soup/normalized-cache/index.ts
@@ -16,6 +16,7 @@ export {
   removeSoupEntities,
   removeSoupEntitiesFromDoneFilteredQueries,
   removeSoupEntitiesFromQueriesReferencing,
+  restoreSoupEntityToDoneFilteredQueries,
 } from './operations';
 export type {
   SoupEntityTag,

--- a/apps/web/src/lib/queries/soup/normalized-cache/operations.test.ts
+++ b/apps/web/src/lib/queries/soup/normalized-cache/operations.test.ts
@@ -65,6 +65,7 @@ import {
   removeSearchEntities,
   removeSoupEntities,
   removeSoupEntitiesFromDoneFilteredQueries,
+  restoreSoupEntityToDoneFilteredQueries,
 } from './operations';
 
 // -- Fixtures --
@@ -1088,5 +1089,170 @@ describe('insertSoupEntity — folder membership gate', () => {
         key
       )!.pages[0];
     expect(page.items.map(getSoupItemId)).toEqual(['d-new', 'd-in']);
+  });
+});
+
+/**
+ * Regression coverage for macro-3258: a channel row marked done is removed
+ * from the done-filtered inbox pages, but the entity stays in the normalized
+ * cache (the sidebar still references it), so an incoming notification took
+ * the field-merge path and the inbox showed nothing until a refetch.
+ */
+describe('restoreSoupEntityToDoneFilteredQueries', () => {
+  const doneFilteredAstKey = (suffix: string) => [
+    ...soupKeys.astItems._def,
+    { chanf: [{ l: { NotificationDone: false } }] },
+    suffix,
+  ];
+  const doneFilteredItemsKey = [
+    ...soupKeys.items._def,
+    { ef: [{ l: { NotificationDone: false } }] },
+    'legacy-inbox',
+  ];
+  const allViewAstKey = [
+    ...soupKeys.astItems._def,
+    { emailView: 'all' },
+    'all-view',
+  ];
+
+  function seedFlatAstQuery(key: unknown[], pages: SoupApiItem[][]) {
+    const data: InfiniteData<SoupAstItemsFlatPage, unknown> = {
+      pages: pages.map((items) => ({ kind: 'flat', items, nextCursor: null })),
+      pageParams: pages.map((_, i) => (i === 0 ? null : `cursor-${i}`)),
+    };
+    testQueryClient.setQueryData(key, data);
+  }
+
+  function flatAstItemsAt(key: unknown[], page = 0) {
+    return testQueryClient
+      .getQueryData<InfiniteData<SoupAstItemsFlatPage, unknown>>(key)!
+      .pages[page].items.map(getSoupItemId);
+  }
+
+  function cacheChannel(id: string) {
+    const item = mockChannelItem(id);
+    mockNormalizer.getObjectById.mockImplementation((normKey) =>
+      normKey === `soup:${id}` ? item : null
+    );
+    return item;
+  }
+
+  it('prepends the cached entity to done-filtered queries missing it', () => {
+    cacheChannel('ch-1');
+    seedFlatAstQuery(doneFilteredAstKey('inbox'), [[mockChatItem('c-1')]]);
+    testQueryClient.setQueryData(
+      doneFilteredItemsKey,
+      mockSoupCache([[mockChatItem('c-1')]])
+    );
+    seedFlatAstQuery(allViewAstKey, [[mockChatItem('c-1')]]);
+
+    restoreSoupEntityToDoneFilteredQueries('ch-1');
+
+    expect(flatAstItemsAt(doneFilteredAstKey('inbox'))).toEqual([
+      'ch-1',
+      'c-1',
+    ]);
+    expect(
+      testQueryClient
+        .getQueryData<InfiniteData<SoupPage, unknown>>(doneFilteredItemsKey)!
+        .pages[0].items.map(getSoupItemId)
+    ).toEqual(['ch-1', 'c-1']);
+    // Done-inclusive views are left alone.
+    expect(flatAstItemsAt(allViewAstKey)).toEqual(['c-1']);
+  });
+
+  it('skips queries that already contain the entity on any page', () => {
+    cacheChannel('ch-1');
+    seedFlatAstQuery(doneFilteredAstKey('inbox'), [
+      [mockChatItem('c-1')],
+      [mockChannelItem('ch-1')],
+    ]);
+
+    restoreSoupEntityToDoneFilteredQueries('ch-1');
+
+    expect(flatAstItemsAt(doneFilteredAstKey('inbox'), 0)).toEqual(['c-1']);
+    expect(flatAstItemsAt(doneFilteredAstKey('inbox'), 1)).toEqual(['ch-1']);
+  });
+
+  it('no-ops when the entity is not in the normalized cache', () => {
+    mockNormalizer.getObjectById.mockReturnValue(null);
+    seedFlatAstQuery(doneFilteredAstKey('inbox'), [[mockChatItem('c-1')]]);
+
+    restoreSoupEntityToDoneFilteredQueries('ch-1');
+
+    expect(flatAstItemsAt(doneFilteredAstKey('inbox'))).toEqual(['c-1']);
+  });
+
+  it("respects the query's item filter", () => {
+    const item = cacheChannel('ch-1');
+    const key = doneFilteredAstKey('filtered');
+    testQueryClient.setQueryDefaults(key, {
+      meta: { itemFilter: (candidate: SoupApiItem) => candidate !== item },
+    });
+    seedFlatAstQuery(key, [[mockChatItem('c-1')]]);
+
+    restoreSoupEntityToDoneFilteredQueries('ch-1');
+
+    expect(flatAstItemsAt(key)).toEqual(['c-1']);
+  });
+
+  it('inserts into a resolvable group of a done-filtered grouped parent', () => {
+    const task = mockTaskItem('t-new', 'in_progress');
+    mockNormalizer.getObjectById.mockImplementation((normKey) =>
+      normKey === 'soup:t-new' ? task : null
+    );
+    const key = [
+      ...soupKeys.astItems._def,
+      { df: [{ l: { nd: false } }] },
+      STATUS_GROUP_BY,
+      'grouped-inbox',
+    ];
+    testQueryClient.setQueryDefaults(key, {
+      meta: { groupBy: STATUS_GROUP_BY },
+    });
+    testQueryClient.setQueryData(
+      key,
+      mockGroupedParentCache(
+        [mockTaskItem('t-1', 'in_progress')],
+        [buildGroup('in_progress', ['t-1'], 1, 0)]
+      )
+    );
+
+    restoreSoupEntityToDoneFilteredQueries('t-new');
+
+    const page =
+      testQueryClient.getQueryData<
+        InfiniteData<SoupAstItemsGroupedPage, unknown>
+      >(key)!.pages[0];
+    expect(page.items['t-new']).toBeDefined();
+    expect(page.groups[0].itemIds).toEqual(['t-new', 't-1']);
+  });
+
+  it('invalidates a grouped parent whose group cannot be resolved locally', () => {
+    cacheChannel('ch-1');
+    // No groupBy meta mirrors groupings the client cannot bucket (e.g. date):
+    // insertGroupedPage cannot resolve a target group, so the query refetches.
+    const key = [
+      ...soupKeys.astItems._def,
+      { chanf: [{ l: { NotificationDone: false } }] },
+      'grouped-date-inbox',
+    ];
+    testQueryClient.setQueryData(
+      key,
+      mockGroupedParentCache(
+        [mockChatItem('c-1')],
+        [buildGroup('today', ['c-1'], 1, 0)]
+      )
+    );
+
+    restoreSoupEntityToDoneFilteredQueries('ch-1');
+
+    expect(testQueryClient.getQueryState(key)?.isInvalidated).toBe(true);
+    // The page itself is untouched until the refetch lands.
+    const page =
+      testQueryClient.getQueryData<
+        InfiniteData<SoupAstItemsGroupedPage, unknown>
+      >(key)!.pages[0];
+    expect(page.items['ch-1']).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/queries/soup/normalized-cache/operations.test.ts
+++ b/apps/web/src/lib/queries/soup/normalized-cache/operations.test.ts
@@ -1228,6 +1228,57 @@ describe('restoreSoupEntityToDoneFilteredQueries', () => {
     expect(page.groups[0].itemIds).toEqual(['t-new', 't-1']);
   });
 
+  it('restores the entity into done-filtered expanded group queries', () => {
+    const task = mockTaskItem('t-new', 'in_progress');
+    mockNormalizer.getObjectById.mockImplementation((normKey) =>
+      normKey === 'soup:t-new' ? task : null
+    );
+
+    const makeGroupQueryKey = (bodyMarker: object, suffix: string) => [
+      ...soupKeys.groupedGroup._def,
+      'in_progress',
+      STATUS_GROUP_BY,
+      bodyMarker,
+      suffix,
+    ];
+    const doneFilteredKey = makeGroupQueryKey(
+      { df: [{ l: { nd: false } }] },
+      'done-filtered'
+    );
+    const allViewKey = makeGroupQueryKey({ emailView: 'all' }, 'all-view');
+    const groupData = () => ({
+      pages: [
+        {
+          items: { 't-1': mockTaskItem('t-1', 'in_progress') },
+          group: buildGroup('in_progress', ['t-1'], 1, 0),
+        },
+      ],
+      pageParams: [null],
+    });
+    for (const key of [doneFilteredKey, allViewKey]) {
+      testQueryClient.setQueryDefaults(key, {
+        meta: { groupBy: STATUS_GROUP_BY, groupKey: 'in_progress' },
+      });
+      testQueryClient.setQueryData(key, groupData());
+    }
+
+    restoreSoupEntityToDoneFilteredQueries('t-new');
+
+    type GroupPage = { items: Record<string, SoupApiItem>; group: GroupMeta };
+    const restored =
+      testQueryClient.getQueryData<InfiniteData<GroupPage, unknown>>(
+        doneFilteredKey
+      )!.pages[0];
+    expect(restored.items['t-new']).toBeDefined();
+    expect(restored.group.itemIds).toEqual(['t-new', 't-1']);
+    // Done-inclusive expanded groups are left alone.
+    const untouched =
+      testQueryClient.getQueryData<InfiniteData<GroupPage, unknown>>(
+        allViewKey
+      )!.pages[0];
+    expect(untouched.group.itemIds).toEqual(['t-1']);
+  });
+
   it('invalidates a grouped parent whose group cannot be resolved locally', () => {
     cacheChannel('ch-1');
     // No groupBy meta mirrors groupings the client cannot bucket (e.g. date):

--- a/apps/web/src/lib/queries/soup/normalized-cache/operations.ts
+++ b/apps/web/src/lib/queries/soup/normalized-cache/operations.ts
@@ -472,6 +472,110 @@ export function removeSoupEntitiesFromDoneFilteredQueries(
   return removeSoupEntitiesWhere(entityIds, soupQueryExcludesDone);
 }
 
+/**
+ * Prepend a cached entity to the done-excluding soup queries (see
+ * `soupQueryExcludesDone`) whose pages don't contain it. A fresh notification
+ * puts its entity back into those feeds server-side, but the client row may
+ * have been optimistically removed when it was marked done — or the feed was
+ * fetched while the entity had nothing outstanding — and the normalized
+ * field merge only patches rows already present, so without this the feeds
+ * would not show the entity again until their next refetch. Grouped pages
+ * whose target group can't be resolved locally (e.g. date buckets)
+ * invalidate instead.
+ */
+export function restoreSoupEntityToDoneFilteredQueries(entityId: string): void {
+  const item = getSoupEntityById(entityId);
+  if (!item) return;
+
+  const cancelQuery = (key: QueryKey) =>
+    queryClient.cancelQueries({
+      queryKey: key,
+      exact: true,
+      predicate: (query) => query.state.data !== undefined,
+    });
+
+  const metaFor = (key: QueryKey) =>
+    getSoupQueryMeta(queryClient.getQueryCache().find({ queryKey: key })?.meta);
+
+  const containsEntity = (items: SoupApiItem[]) =>
+    items.some((existing) => getSoupItemId(existing) === entityId);
+
+  for (const [key, prev] of queryClient.getQueriesData<SoupItemsInfiniteData>({
+    queryKey: soupKeys.items._def,
+  })) {
+    if (!soupQueryExcludesDone(key)) continue;
+    if (!prev?.pages?.length) continue;
+    if (prev.pages.some((page) => containsEntity(page.items))) continue;
+
+    const filter = metaFor(key).itemFilter;
+    if (filter && !filter(item)) continue;
+
+    cancelQuery(key);
+    queryClient.setQueryData<SoupItemsInfiniteData>(key, {
+      ...prev,
+      pages: prev.pages.map((page, index) =>
+        index === 0 ? { ...page, items: [item, ...page.items] } : page
+      ),
+    });
+  }
+
+  for (const [
+    key,
+    prev,
+  ] of queryClient.getQueriesData<SoupAstItemsInfiniteData>({
+    queryKey: soupKeys.astItems._def,
+  })) {
+    if (!soupQueryExcludesDone(key)) continue;
+    if (!prev?.pages?.length) continue;
+
+    const meta = metaFor(key);
+    if (meta.itemFilter && !meta.itemFilter(item)) continue;
+
+    const firstPage = prev.pages[0];
+
+    if (firstPage.kind === 'flat') {
+      if (
+        prev.pages.some(
+          (page) => page.kind === 'flat' && containsEntity(page.items)
+        )
+      ) {
+        continue;
+      }
+
+      cancelQuery(key);
+      queryClient.setQueryData<SoupAstItemsInfiniteData>(key, {
+        ...prev,
+        pages: prev.pages.map((page, index) =>
+          index === 0 && page.kind === 'flat'
+            ? { ...page, items: [item, ...page.items] }
+            : page
+        ),
+      });
+      continue;
+    }
+
+    // Grouped parents keep membership entirely on the first page.
+    if (
+      entityId in firstPage.items ||
+      firstPage.groups.some((group) => group.itemIds.includes(entityId))
+    ) {
+      continue;
+    }
+
+    const nextPage = insertGroupedPage(firstPage, item, entityId, meta.groupBy);
+    if (!nextPage) {
+      queryClient.invalidateQueries({ queryKey: key });
+      continue;
+    }
+
+    cancelQuery(key);
+    queryClient.setQueryData<SoupAstItemsInfiniteData>(key, {
+      ...prev,
+      pages: [nextPage, ...prev.pages.slice(1)],
+    });
+  }
+}
+
 /** Remove entities from the soup queries whose key matches the predicate. */
 function removeSoupEntitiesWhere(
   entityIds: Set<string>,

--- a/apps/web/src/lib/queries/soup/normalized-cache/operations.ts
+++ b/apps/web/src/lib/queries/soup/normalized-cache/operations.ts
@@ -480,8 +480,9 @@ export function removeSoupEntitiesFromDoneFilteredQueries(
  * fetched while the entity had nothing outstanding — and the normalized
  * field merge only patches rows already present, so without this the feeds
  * would not show the entity again until their next refetch. Grouped pages
- * whose target group can't be resolved locally (e.g. date buckets)
- * invalidate instead.
+ * and expanded single-group caches (which back grouped views' rows and are
+ * cached with staleTime Infinity) are restored the same way; groups that
+ * can't be resolved locally (e.g. date buckets) invalidate instead.
  */
 export function restoreSoupEntityToDoneFilteredQueries(entityId: string): void {
   const item = getSoupEntityById(entityId);
@@ -574,6 +575,8 @@ export function restoreSoupEntityToDoneFilteredQueries(entityId: string): void {
       pages: [nextPage, ...prev.pages.slice(1)],
     });
   }
+
+  insertGroupQueries(item, entityId, soupQueryExcludesDone);
 }
 
 /** Remove entities from the soup queries whose key matches the predicate. */


### PR DESCRIPTION
Marking a channel notification done removes the row from the inbox's done-filtered soup pages, but the entity stays in the normalized cache, so the next websocket notification took the field-merge path and could never re-add the row — new channel notifications stayed invisible until refresh (the sidebar still updated because its queries kept the row). Incoming notifications now re-insert the cached entity into the done-excluding queries it is missing from, which also covers rows whose feed was fetched while they had nothing outstanding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client-side React Query soup cache consistency across inbox, grouped, and paginated feeds; incorrect restore logic could duplicate rows or show items in wrong filters, but scope is limited to done-filtered queries and is heavily tested.
> 
> **Overview**
> Fixes inbox rows staying hidden after a new notification when the entity was already in the normalized cache but had been dropped from **done-filtered** soup list pages (e.g. after marking done).
> 
> Adds **`restoreSoupEntityToDoneFilteredQueries`**, which prepends the cached entity into legacy `items`, flat/grouped `astItems`, and done-filtered expanded group queries when they no longer list it—honoring per-query **item filters**, skipping done-inclusive views, avoiding duplicates across paginated pages, and **invalidating** grouped parents when the target bucket cannot be resolved client-side. **`insertGroupQueries`** gains an optional query-key filter (used for done-only restores) and scans all continuation pages before inserting.
> 
> The websocket **optimistic notification insert** path now calls this restore (using the channel **thread root id** when applicable) after the existing field merges, with regression tests on the cache helper and notification handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a61c43fcdcc9015c5c8c777f9b4d3cabfc2cbbc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->