### PR TITLE
fix(channel): start typing from composer text changes

### DIFF
--- a/apps/web/src/features/channel/Input/ChannelInput.tsx
+++ b/apps/web/src/features/channel/Input/ChannelInput.tsx
@@ -210,6 +210,7 @@ export function ChannelInput(props: ChannelInputProps) {
   const isCollapsed = () => !!props.collapsible && collapsedInput.isCollapsed();
 
   let isEditorConnected = false;
+  let acceptTyping = false;
   let pendingRestore:
     | {
         snapshot: InputSnapshot;
@@ -225,11 +226,15 @@ export function ChannelInput(props: ChannelInputProps) {
     snapshot: InputSnapshot,
     options?: RestoreSnapshotOptions
   ) => {
+    acceptTyping = false;
     markdownEditor.controls.setMarkdown(snapshot.value);
     pendingCursor = options?.cursor;
     attachmentTracker.setAttachments(snapshot.attachments);
     mentionsTracker.setMentions(snapshot.mentions);
     if (options?.focus !== false) focusEditorNow();
+    queueMicrotask(() => {
+      acceptTyping = true;
+    });
   };
 
   const flushPendingRestore = () => {
@@ -315,6 +320,7 @@ export function ChannelInput(props: ChannelInputProps) {
     onChange: (markdown) => {
       const previous = inputState.view().value;
       inputState.setValue(markdown);
+      if (!acceptTyping) return;
       if (markdown.trim() === previous.trim()) return;
       typingTracker.keystroke();
     },
@@ -486,6 +492,9 @@ export function ChannelInput(props: ChannelInputProps) {
                   isEditorConnected = true;
                   flushPendingRestore();
                   flushPendingFocus();
+                  queueMicrotask(() => {
+                    acceptTyping = true;
+                  });
                 }}
               />
               <DragInsertIndicator

--- a/apps/web/src/features/channel/Input/ChannelInput.tsx
+++ b/apps/web/src/features/channel/Input/ChannelInput.tsx
@@ -314,7 +314,6 @@ export function ChannelInput(props: ChannelInputProps) {
     },
     onChange: (markdown) => {
       inputState.setValue(markdown);
-      typingTracker.keystroke();
     },
     onEnter: () => {
       if (isTouchDevice()) return false;
@@ -472,7 +471,7 @@ export function ChannelInput(props: ChannelInputProps) {
               }
             }}
           >
-            <Input.Editor>
+            <Input.Editor onInput={() => typingTracker.keystroke()}>
               <MarkdownShell
                 config={markdownEditor}
                 placeholder={props.input.placeholder}

--- a/apps/web/src/features/channel/Input/ChannelInput.tsx
+++ b/apps/web/src/features/channel/Input/ChannelInput.tsx
@@ -318,7 +318,7 @@ export function ChannelInput(props: ChannelInputProps) {
       mentionsTracker.onMentionRemove(mention);
     },
     onChange: (markdown) => {
-      const previous = inputState.view().value;
+      const previous = inputState.view().value ?? '';
       inputState.setValue(markdown);
       if (!acceptTyping) return;
       if (markdown.trim() === previous.trim()) return;

--- a/apps/web/src/features/channel/Input/ChannelInput.tsx
+++ b/apps/web/src/features/channel/Input/ChannelInput.tsx
@@ -313,7 +313,10 @@ export function ChannelInput(props: ChannelInputProps) {
       mentionsTracker.onMentionRemove(mention);
     },
     onChange: (markdown) => {
+      const previous = inputState.view().value;
       inputState.setValue(markdown);
+      if (markdown.trim() === previous.trim()) return;
+      typingTracker.keystroke();
     },
     onEnter: () => {
       if (isTouchDevice()) return false;
@@ -471,7 +474,7 @@ export function ChannelInput(props: ChannelInputProps) {
               }
             }}
           >
-            <Input.Editor onInput={() => typingTracker.keystroke()}>
+            <Input.Editor>
               <MarkdownShell
                 config={markdownEditor}
                 placeholder={props.input.placeholder}

--- a/apps/web/src/features/channel/Input/tests/input-slots.test.tsx
+++ b/apps/web/src/features/channel/Input/tests/input-slots.test.tsx
@@ -5,13 +5,14 @@
 import { render as renderBare, screen } from '@solidjs/testing-library';
 import { QueryClient, QueryClientProvider } from '@tanstack/solid-query';
 import userEvent from '@testing-library/user-event';
-import type { JSX } from 'solid-js';
+import { type JSX, onMount } from 'solid-js';
 import { Portal } from 'solid-js/web';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const editorMocks = vi.hoisted(() => ({
   clear: vi.fn(),
   focus: vi.fn(),
+  emitChange: undefined as ((markdown: string) => void) | undefined,
 }));
 
 vi.hoisted(() => {
@@ -119,19 +120,29 @@ vi.mock('@core/component/VideoPreview', () => ({
 }));
 
 vi.mock('@core/component/LexicalMarkdown/builder/MarkdownShell', () => ({
-  MarkdownShell: (props: { placeholder?: string; initialValue?: string }) => (
-    <>
-      <div
-        data-testid="markdown-shell"
-        data-initial-value={props.initialValue ?? ''}
-      >
-        {props.placeholder}
-      </div>
-      <Portal>
-        <input data-testid="markdown-portal-input" />
-      </Portal>
-    </>
-  ),
+  MarkdownShell: (props: {
+    placeholder?: string;
+    initialValue?: string;
+    onConnect?: () => void;
+  }) => {
+    onMount(() => {
+      editorMocks.emitChange?.(props.initialValue ?? '');
+      props.onConnect?.();
+    });
+    return (
+      <>
+        <div
+          data-testid="markdown-shell"
+          data-initial-value={props.initialValue ?? ''}
+        >
+          {props.placeholder}
+        </div>
+        <Portal>
+          <input data-testid="markdown-portal-input" />
+        </Portal>
+      </>
+    );
+  },
 }));
 
 vi.mock(
@@ -169,7 +180,10 @@ vi.mock(
         withSelectionData: () => builder,
         withFloatingFormatMenu: () => builder,
         use: () => builder,
-        onChange: () => builder,
+        onChange: (handler: (markdown: string) => void) => {
+          editorMocks.emitChange = handler;
+          return builder;
+        },
         onEnter: () => builder,
         buildHandle: () => handle,
         controls,
@@ -243,6 +257,22 @@ describe('Input slots', () => {
   beforeEach(() => {
     editorMocks.clear.mockClear();
     editorMocks.focus.mockClear();
+    editorMocks.emitChange = undefined;
+  });
+
+  it('does not start typing when the editor hydrates an empty composer', async () => {
+    const onStartTyping = vi.fn();
+    render(() => (
+      <ChannelInput input={baseInput} onStartTyping={onStartTyping} />
+    ));
+
+    await Promise.resolve();
+    expect(onStartTyping).not.toHaveBeenCalled();
+
+    screen
+      .getByTestId('markdown-shell')
+      .dispatchEvent(new InputEvent('input', { bubbles: true }));
+    expect(onStartTyping).toHaveBeenCalledTimes(1);
   });
 
   it('does not refocus the editor when a portaled editor control is clicked', async () => {

--- a/apps/web/src/features/channel/Input/tests/input-slots.test.tsx
+++ b/apps/web/src/features/channel/Input/tests/input-slots.test.tsx
@@ -152,6 +152,9 @@ vi.mock(
       const controls = {
         clear: editorMocks.clear,
         focus: editorMocks.focus,
+        setMarkdown: (markdown: string) => {
+          editorMocks.emitChange?.(markdown);
+        },
       };
       const lexical = {
         focus: vi.fn(),
@@ -289,6 +292,32 @@ describe('Input slots', () => {
     expect(onStartTyping).not.toHaveBeenCalled();
 
     editorMocks.emitChange?.('draft plus');
+    expect(onStartTyping).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start typing when a snapshot is restored', async () => {
+    const onStartTyping = vi.fn();
+    let handle: InputHandle | undefined;
+    render(() => (
+      <ChannelInput
+        input={baseInput}
+        onReady={(nextHandle) => {
+          handle = nextHandle;
+        }}
+        onStartTyping={onStartTyping}
+      />
+    ));
+
+    await Promise.resolve();
+    handle?.restoreSnapshot({
+      value: 'restored draft',
+      mentions: [],
+      attachments: [],
+    });
+    expect(onStartTyping).not.toHaveBeenCalled();
+
+    await Promise.resolve();
+    editorMocks.emitChange?.('user typed');
     expect(onStartTyping).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/src/features/channel/Input/tests/input-slots.test.tsx
+++ b/apps/web/src/features/channel/Input/tests/input-slots.test.tsx
@@ -269,9 +269,26 @@ describe('Input slots', () => {
     await Promise.resolve();
     expect(onStartTyping).not.toHaveBeenCalled();
 
-    screen
-      .getByTestId('markdown-shell')
-      .dispatchEvent(new InputEvent('input', { bubbles: true }));
+    editorMocks.emitChange?.('hello');
+    expect(onStartTyping).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start typing when hydrate echoes an existing draft', async () => {
+    const onStartTyping = vi.fn();
+    render(() => (
+      <ChannelInput
+        input={{ ...baseInput, value: 'draft' }}
+        onStartTyping={onStartTyping}
+      />
+    ));
+
+    await Promise.resolve();
+    expect(onStartTyping).not.toHaveBeenCalled();
+
+    editorMocks.emitChange?.('draft');
+    expect(onStartTyping).not.toHaveBeenCalled();
+
+    editorMocks.emitChange?.('draft plus');
     expect(onStartTyping).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Opening a channel mounted `ChannelInput` and `MarkdownShell` pushed the empty initial value through `onChange`. That path called `typingTracker.keystroke()`, so other people saw "X is typing" even when nobody typed.

Typing should mean the user edited the live composer. Hydrate, draft restore, and `restoreSnapshot` are not edits.

## Scope

- `ChannelInput` calls `typingTracker.keystroke()` from markdown `onChange` only after connect, and only when trimmed composer text changes.
- `applySnapshot` turns that gate off while `setMarkdown` runs, then turns it back on.
- `InputData.value` is optional, so the hydrate guard defaults a missing value to `''` before `trim`.
- A wrapper `input` listener does not start typing. Lexical cancels `beforeinput`, so that event never reaches `Input.Editor`.
- `input-slots.test.tsx` hydrates an empty composer and a draft, restores a snapshot, then asserts `onStartTyping` stays quiet until the user-facing markdown value changes.

Out of scope: backend `comms_typing` fan-out, the 8s stale-indicator timeout, thread-only UI copy.

## Tradeoffs

Format-toolbar edits that change markdown start typing. Quote inserts that change markdown after connect also start typing. That matches a user-facing compose action.

## Blast Radius

Channel and thread composers share `ChannelInput`. Recipients stop seeing a ghost typing line when someone opens the pane or the client restores a snapshot. Maintainers inherit one rule. The composer must be live, and the text must have changed.

## Verification

- Red then green: `input-slots.test.tsx` "does not start typing when the editor hydrates an empty composer". Before the fix, `onStartTyping` fired once on mount. After, it stays at 0 until the markdown value changes after connect. Extra cases cover draft hydrate and `restoreSnapshot`. Isolated run after the type default: 12 passed.
- Two-user Playwright against the local stack. Before the fix, Alice and Bob each `POST /channels/:id/typing` with `{"action":"start"}` on open, then `stop` 2s later. After the fix, open sends no typing posts. Bob's keystrokes send `start`, and Alice sees `bob-typing-script is typing`.
- CI on `c3dc32497`: Web App Typecheck, Test, Build, and Web App Status Check are green. The earlier Typecheck failure was `TS18048` on `previous.trim()`.

[Alice after Bob opens the channel, no typing indicator](https://cursor.com/agents/bc-c0078e87-0eec-4ed7-a971-68f85f631e69/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falice_after_bob_open_with_seed.png)
[Alice sees bob-typing-script is typing after Bob types](https://cursor.com/agents/bc-c0078e87-0eec-4ed7-a971-68f85f631e69/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falice_sees_bob_is_typing.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0078e87-0eec-4ed7-a971-68f85f631e69?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0078e87-0eec-4ed7-a971-68f85f631e69&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

