### PR TITLE
fix(agent-harness): route external runtimes across replicas

### DIFF
--- a/.sqlx/query-0024e745c72d09591b5ee72598a556aad9451c58257670aec2f47f783a4d1757.json
+++ b/.sqlx/query-0024e745c72d09591b5ee72598a556aad9451c58257670aec2f47f783a4d1757.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO harness_runtime_lease (harness_id, replica_id, connection_id)\n                   VALUES ($1, $2, $3)\n                   ON CONFLICT (harness_id) DO UPDATE\n                   SET replica_id = EXCLUDED.replica_id, connection_id = EXCLUDED.connection_id,\n                       pending_until = now() + interval '5 seconds'\n                   WHERE harness_runtime_lease.pending_until <= now()\n                      OR NOT EXISTS (\n                       SELECT 1 FROM harness_replica current\n                       WHERE current.id = harness_runtime_lease.replica_id\n                         AND current.last_heartbeat_at > now() - interval '30 seconds'\n                   )",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "0024e745c72d09591b5ee72598a556aad9451c58257670aec2f47f783a4d1757"
+}

--- a/.sqlx/query-20773b4c4b24399205afa6ff3d59794c1d8cdc9f39df150e0b90fd784b9d39e5.json
+++ b/.sqlx/query-20773b4c4b24399205afa6ff3d59794c1d8cdc9f39df150e0b90fd784b9d39e5.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO macro_user (id, username, email, stripe_customer_id) VALUES ($1, $2, $2, 'stripe_test')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "20773b4c4b24399205afa6ff3d59794c1d8cdc9f39df150e0b90fd784b9d39e5"
+}

--- a/.sqlx/query-2359553bd642c12995d23dd4d86b6d73689dbe88db8d01f19f3fa20421c5f340.json
+++ b/.sqlx/query-2359553bd642c12995d23dd4d86b6d73689dbe88db8d01f19f3fa20421c5f340.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO harnesses (id, name, owner_user_id, created_by) VALUES ($1, 'test', 'owner@localhost', 'owner@localhost')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "2359553bd642c12995d23dd4d86b6d73689dbe88db8d01f19f3fa20421c5f340"
+}

--- a/.sqlx/query-332b95da89e45b1a6a3bfacb88b8ab34e47e89e27b019e3e9d6d4089f37d7051.json
+++ b/.sqlx/query-332b95da89e45b1a6a3bfacb88b8ab34e47e89e27b019e3e9d6d4089f37d7051.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE agent_session session SET manager_replica_id = NULL WHERE session.manager_replica_id = $1 AND EXISTS ( SELECT 1 FROM agent_configs config WHERE config.bot_id = session.bot_id AND config.harness_id = $2 )",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "332b95da89e45b1a6a3bfacb88b8ab34e47e89e27b019e3e9d6d4089f37d7051"
+}

--- a/.sqlx/query-44f313bb329eb630c72160d771b36855565531f9b33bcaaf65c5905d9c99d4d8.json
+++ b/.sqlx/query-44f313bb329eb630c72160d771b36855565531f9b33bcaaf65c5905d9c99d4d8.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO harness_replica (id, address) VALUES ($1, $2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "44f313bb329eb630c72160d771b36855565531f9b33bcaaf65c5905d9c99d4d8"
+}

--- a/.sqlx/query-490eef6437892763e04d501c37cc6b6fb97ca799282674661ffeb5180f3ae3db.json
+++ b/.sqlx/query-490eef6437892763e04d501c37cc6b6fb97ca799282674661ffeb5180f3ae3db.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT replica_id, connection_id FROM harness_runtime_lease WHERE harness_id = $1 FOR UPDATE",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "replica_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "connection_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "490eef6437892763e04d501c37cc6b6fb97ca799282674661ffeb5180f3ae3db"
+}

--- a/.sqlx/query-5a8663e7dc58d7700575540f5fe0762beb6d3904a20361ddfd59b00cb2bd5409.json
+++ b/.sqlx/query-5a8663e7dc58d7700575540f5fe0762beb6d3904a20361ddfd59b00cb2bd5409.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT last_connected_at IS NOT NULL AS \"connected!\", last_disconnected_at IS NOT NULL AS \"disconnected!\" FROM harnesses WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "connected!",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 1,
+        "name": "disconnected!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "5a8663e7dc58d7700575540f5fe0762beb6d3904a20361ddfd59b00cb2bd5409"
+}

--- a/.sqlx/query-60f21d055287c92d18803dfd7e253e93a7565c4348f8e9aed5a5770fdc52f467.json
+++ b/.sqlx/query-60f21d055287c92d18803dfd7e253e93a7565c4348f8e9aed5a5770fdc52f467.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH expired AS ( DELETE FROM harness_runtime_lease lease WHERE NOT EXISTS ( SELECT 1 FROM harness_replica replica WHERE replica.id = lease.replica_id AND replica.last_heartbeat_at > now() - interval '30 seconds' ) RETURNING harness_id, replica_id ), fenced AS ( UPDATE agent_session session SET manager_replica_id = NULL FROM expired WHERE session.manager_replica_id = expired.replica_id AND EXISTS ( SELECT 1 FROM agent_configs config WHERE config.bot_id = session.bot_id AND config.harness_id = expired.harness_id ) ) UPDATE harnesses SET last_disconnected_at = now() WHERE id IN (SELECT harness_id FROM expired)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "60f21d055287c92d18803dfd7e253e93a7565c4348f8e9aed5a5770fdc52f467"
+}

--- a/.sqlx/query-6a3a8cb8773eac73816f44b7e7a543d37eb1ec361eaeb54ab624cbe35a7dedb7.json
+++ b/.sqlx/query-6a3a8cb8773eac73816f44b7e7a543d37eb1ec361eaeb54ab624cbe35a7dedb7.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH released AS ( DELETE FROM harness_runtime_lease WHERE harness_id = $1 AND replica_id = $2 AND connection_id = $3 RETURNING harness_id, replica_id ), fenced AS ( UPDATE agent_session session SET manager_replica_id = NULL FROM released WHERE session.manager_replica_id = released.replica_id AND EXISTS ( SELECT 1 FROM agent_configs config WHERE config.bot_id = session.bot_id AND config.harness_id = released.harness_id ) ) UPDATE harnesses SET last_disconnected_at = now() WHERE id IN (SELECT harness_id FROM released)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6a3a8cb8773eac73816f44b7e7a543d37eb1ec361eaeb54ab624cbe35a7dedb7"
+}

--- a/.sqlx/query-77ab70235789d859b00ee86799b9e31c29b53604eb0084a5843dde7a25782b3d.json
+++ b/.sqlx/query-77ab70235789d859b00ee86799b9e31c29b53604eb0084a5843dde7a25782b3d.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO agent_session (id, owner_id, bot_id, name, model, harness, workspace, status, manager_replica_id) VALUES ($1, 'owner@localhost', $2, 'test', 'test', 'macrod', '/tmp', 'disconnected', $3)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "77ab70235789d859b00ee86799b9e31c29b53604eb0084a5843dde7a25782b3d"
+}

--- a/.sqlx/query-8472b7476260d52c3864a672f01acffd6a69b0a2ae43de7689d3d7ec594beba0.json
+++ b/.sqlx/query-8472b7476260d52c3864a672f01acffd6a69b0a2ae43de7689d3d7ec594beba0.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT last_disconnected_at >= last_connected_at AS \"disconnected_after_connected!\" FROM harnesses WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "disconnected_after_connected!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "8472b7476260d52c3864a672f01acffd6a69b0a2ae43de7689d3d7ec594beba0"
+}

--- a/.sqlx/query-865bca5ee6a3b6a9b89cfb8961338fd3fedd6f07af09f87b2d7191f7a3f8f7e8.json
+++ b/.sqlx/query-865bca5ee6a3b6a9b89cfb8961338fd3fedd6f07af09f87b2d7191f7a3f8f7e8.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT lease.replica_id, lease.connection_id, replica.address, CASE WHEN lease.pending_until = 'infinity'::timestamptz THEN NULL ELSE lease.pending_until END AS pending_until FROM harness_runtime_lease lease JOIN harness_replica replica ON replica.id = lease.replica_id WHERE lease.harness_id = $1 AND replica.last_heartbeat_at > now() - interval '30 seconds' AND lease.pending_until > now()",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "replica_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "connection_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "pending_until",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      null
+    ]
+  },
+  "hash": "865bca5ee6a3b6a9b89cfb8961338fd3fedd6f07af09f87b2d7191f7a3f8f7e8"
+}

--- a/.sqlx/query-97edf86eacb6948b3fe43e7d2fe675f337427aebcd2f671ac7793177d4310b67.json
+++ b/.sqlx/query-97edf86eacb6948b3fe43e7d2fe675f337427aebcd2f671ac7793177d4310b67.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE harness_replica SET last_heartbeat_at = now() - interval '31 seconds' WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "97edf86eacb6948b3fe43e7d2fe675f337427aebcd2f671ac7793177d4310b67"
+}

--- a/.sqlx/query-b03eb53b29f344797c96de9bac2c458aa7b3a6784e710a5548193c9bd18b6659.json
+++ b/.sqlx/query-b03eb53b29f344797c96de9bac2c458aa7b3a6784e710a5548193c9bd18b6659.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO agent_configs (bot_id, instructions, harness, default_model, channel_scope, harness_id) VALUES ($1, '', 'macrod', 'test', 'all', $2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b03eb53b29f344797c96de9bac2c458aa7b3a6784e710a5548193c9bd18b6659"
+}

--- a/.sqlx/query-b4ab788080bd0e941833b4391e26ebe2c7e47641f854d40bc71833bf22ea9d1c.json
+++ b/.sqlx/query-b4ab788080bd0e941833b4391e26ebe2c7e47641f854d40bc71833bf22ea9d1c.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT last_disconnected_at IS NOT NULL AS \"disconnected!\" FROM harnesses WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "disconnected!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "b4ab788080bd0e941833b4391e26ebe2c7e47641f854d40bc71833bf22ea9d1c"
+}

--- a/.sqlx/query-ce7690c9d34ca24b6ac4d88971882b3a0d7e02d2ff80aeb28dfafedf22de386a.json
+++ b/.sqlx/query-ce7690c9d34ca24b6ac4d88971882b3a0d7e02d2ff80aeb28dfafedf22de386a.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE agent_session SET manager_replica_id = $2 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ce7690c9d34ca24b6ac4d88971882b3a0d7e02d2ff80aeb28dfafedf22de386a"
+}

--- a/.sqlx/query-d47417ecec8bf50c4c5efba42f06138319850e5fcb8294eac6e9dda920eee517.json
+++ b/.sqlx/query-d47417ecec8bf50c4c5efba42f06138319850e5fcb8294eac6e9dda920eee517.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH activated AS ( UPDATE harness_runtime_lease SET pending_until = 'infinity'::timestamptz WHERE harness_id = $1 AND replica_id = $2 AND connection_id = $3 AND pending_until > now() RETURNING harness_id ) UPDATE harnesses SET last_connected_at = now() WHERE id IN (SELECT harness_id FROM activated)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d47417ecec8bf50c4c5efba42f06138319850e5fcb8294eac6e9dda920eee517"
+}

--- a/.sqlx/query-e6132b0890df01b46b589b473f3d5110367363b971746acd19523c4940c8bdf8.json
+++ b/.sqlx/query-e6132b0890df01b46b589b473f3d5110367363b971746acd19523c4940c8bdf8.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO \"User\" (id, email, macro_user_id) VALUES ('owner@localhost', 'owner@localhost', $1)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e6132b0890df01b46b589b473f3d5110367363b971746acd19523c4940c8bdf8"
+}

--- a/.sqlx/query-e7200d0a720a33e2ff9f3eec147f3057e45ef0eb0f25fcf5ede5139ecdffdda0.json
+++ b/.sqlx/query-e7200d0a720a33e2ff9f3eec147f3057e45ef0eb0f25fcf5ede5139ecdffdda0.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO bots (id, kind, owner_user_id, name, handle) VALUES ($1, 'owned', 'owner@localhost', 'bot', 'bot')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e7200d0a720a33e2ff9f3eec147f3057e45ef0eb0f25fcf5ede5139ecdffdda0"
+}

--- a/.sqlx/query-f751dc9e8f5c51f63133dce62d3866ff9813c8827a306570fcf26723692a9270.json
+++ b/.sqlx/query-f751dc9e8f5c51f63133dce62d3866ff9813c8827a306570fcf26723692a9270.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE harness_runtime_lease SET pending_until = now() - interval '1 second'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "f751dc9e8f5c51f63133dce62d3866ff9813c8827a306570fcf26723692a9270"
+}

--- a/.sqlx/query-fb9ca3aa9120f1b2801c10faa4d6550aec3680e7b2fcbd5d6373f903e62753a0.json
+++ b/.sqlx/query-fb9ca3aa9120f1b2801c10faa4d6550aec3680e7b2fcbd5d6373f903e62753a0.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH runtime AS MATERIALIZED (\n                SELECT harness_id\n                FROM harness_runtime_lease\n                WHERE harness_id = $3 AND replica_id = $2 AND connection_id = $4\n                  AND pending_until > now()\n                FOR UPDATE\n            )\n            UPDATE agent_session\n            SET manager_replica_id = $2,\n                manager_fence = manager_fence + 1,\n                modified_at = now()\n            WHERE id = $1\n              AND EXISTS (SELECT 1 FROM runtime)\n              AND (manager_replica_id IS NULL OR manager_replica_id = $2)\n            RETURNING manager_fence\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "manager_fence",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "fb9ca3aa9120f1b2801c10faa4d6550aec3680e7b2fcbd5d6373f903e62753a0"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "macro_aws_config",
  "macro_config",
  "macro_cors",
+ "macro_db_migrator",
  "macro_entrypoint",
  "macro_env",
  "macro_env_var",

--- a/crates/agent_harness/src/domain/model.rs
+++ b/crates/agent_harness/src/domain/model.rs
@@ -3,7 +3,9 @@
 use agent_client_protocol::schema::v1::{HttpHeader, McpServer as AcpMcpServer, McpServerHttp};
 use agent_egress::domain::model::McpServerSlug;
 use agent_runtime_protocol::domain::action::{AgentAction, AgentActionId};
-use agent_session::domain::model::{AgentSessionId, MessageId, SandboxSize};
+use agent_session::domain::model::{
+    AgentSessionId, MessageId, ReplicaAddress, ReplicaId, SandboxSize,
+};
 use agent_session::domain::ports::ControlEvent;
 use bot_id::BotId;
 use macro_user_id::user_id::MacroUserIdStr;
@@ -68,6 +70,39 @@ pub enum AgentKind {
     /// The bot's operator hosts the runtime and dials the gateway; no
     /// deployment here provisions anything for it.
     External,
+}
+
+/// A fresh runtime socket claim's owning replica, used to route external sessions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeOwner {
+    /// Replica that owns the socket.
+    pub replica: ReplicaId,
+    /// Exact socket claim held by that replica.
+    pub connection_id: macro_uuid::Uuid,
+    /// Pending claim deadline. `None` means the socket was activated.
+    pub pending_until: Option<chrono::DateTime<chrono::Utc>>,
+    /// Its peer-reachable command forwarding address.
+    pub address: Option<ReplicaAddress>,
+}
+
+/// Exact runtime ownership a peer must still hold before executing a forward.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RuntimeFence {
+    /// Harness whose socket owns the command.
+    pub harness: harness_id::HarnessId,
+    /// Replica selected by the sender.
+    pub replica: macro_uuid::Uuid,
+    /// Exact socket token selected by the sender.
+    pub connection_id: macro_uuid::Uuid,
+}
+
+/// A command sent between replicas, optionally fenced to a runtime socket.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ForwardedCommand {
+    /// Command to execute.
+    pub command: HarnessCommand,
+    /// Runtime ownership that must still be current at the receiving replica.
+    pub runtime_fence: Option<RuntimeFence>,
 }
 
 impl AgentKind {

--- a/crates/agent_harness/src/domain/ports.rs
+++ b/crates/agent_harness/src/domain/ports.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use agent_session::domain::connection::RuntimeAttachment;
-use agent_session::domain::model::{AgentSessionId, ReplicaAddress, SandboxSize};
+use agent_session::domain::model::{AgentSessionId, ReplicaAddress, ReplicaId, SandboxSize};
 use agent_session::domain::ports::AgentConnector;
 use bot_id::BotId;
 use harness_id::HarnessId;
@@ -14,8 +14,8 @@ use macro_user_id::user_id::MacroUserIdStr;
 
 use super::error::{HarnessError, Result};
 use super::model::{
-    AgentRuntimeConfig, CommandOutcome, HarnessCommand, PriorChannelMessage, ProvisionedEgress,
-    SandboxEgress, SessionAnnouncement, SpawnContainer,
+    AgentRuntimeConfig, CommandOutcome, ForwardedCommand, PriorChannelMessage, ProvisionedEgress,
+    RuntimeOwner, SandboxEgress, SessionAnnouncement, SpawnContainer,
 };
 use super::sandbox::SandboxResizeEffect;
 
@@ -34,7 +34,7 @@ pub trait CommandForwarder: Send + Sync + 'static {
         &self,
         target: &ReplicaAddress,
         session: AgentSessionId,
-        command: HarnessCommand,
+        command: ForwardedCommand,
     ) -> impl Future<Output = Result<CommandOutcome>> + Send;
 }
 
@@ -49,7 +49,7 @@ impl CommandForwarder for NoPeers {
         &self,
         target: &ReplicaAddress,
         session: AgentSessionId,
-        _command: HarnessCommand,
+        _command: ForwardedCommand,
     ) -> Result<CommandOutcome> {
         Err(HarnessError::Forward(rootcause::report!(
             "this deployment has no command forwarding, yet {target} manages session {session}"
@@ -72,21 +72,109 @@ pub trait HarnessBindings: Send + Sync + 'static {
     ) -> impl Future<Output = anyhow::Result<Option<HarnessId>>> + Send;
 }
 
-/// Durable attach/detach bookkeeping for harness runtime connections.
-///
-/// The registry itself is in-process liveness; this is what lets the rest of
-/// the product (the harness settings page) see whether a daemon is up.
-/// Methods take `Arc<Self>` and return owned futures so the registry can fire
-/// them from its own background tasks.
-pub trait HarnessPresence: Send + Sync + 'static {
-    /// A runtime attached for this harness.
-    fn connected(self: Arc<Self>, harness: HarnessId) -> Pin<Box<dyn Future<Output = ()> + Send>>;
-
-    /// This harness's runtime connection closed.
-    fn disconnected(
-        self: Arc<Self>,
+/// Durable, exclusive ownership of externally hosted runtime sockets.
+pub trait RuntimeLease: Send + Sync + 'static {
+    /// Claim a harness socket token, returning false when a fresh owner exists.
+    fn claim(
+        &self,
         harness: HarnessId,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send>>;
+        replica: ReplicaId,
+        connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>>;
+    /// Promote this exact pending claim before publishing its socket locally.
+    fn activate(
+        &self,
+        harness: HarnessId,
+        replica: ReplicaId,
+        connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>>;
+    /// Release this exact token, never a newer redial.
+    fn release(
+        &self,
+        harness: HarnessId,
+        replica: ReplicaId,
+        connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>;
+    /// Find a fresh owner for a harness. The local registry waits briefly for
+    /// a pending owner to finish its WebSocket upgrade before declaring it
+    /// disconnected.
+    fn owner(
+        &self,
+        harness: HarnessId,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<RuntimeOwner>>> + Send>>;
+}
+
+impl<T: RuntimeLease + ?Sized> RuntimeLease for Arc<T> {
+    fn claim(
+        &self,
+        harness: HarnessId,
+        replica: ReplicaId,
+        connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>> {
+        (**self).claim(harness, replica, connection_id)
+    }
+
+    fn activate(
+        &self,
+        harness: HarnessId,
+        replica: ReplicaId,
+        connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>> {
+        (**self).activate(harness, replica, connection_id)
+    }
+
+    fn release(
+        &self,
+        harness: HarnessId,
+        replica: ReplicaId,
+        connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>> {
+        (**self).release(harness, replica, connection_id)
+    }
+
+    fn owner(
+        &self,
+        harness: HarnessId,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<RuntimeOwner>>> + Send>> {
+        (**self).owner(harness)
+    }
+}
+
+/// A lease directory for isolated tests and single-process tooling.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoRuntimeLease;
+
+impl RuntimeLease for NoRuntimeLease {
+    fn claim(
+        &self,
+        _harness: HarnessId,
+        _replica: ReplicaId,
+        _connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>> {
+        Box::pin(async { Ok(true) })
+    }
+    fn activate(
+        &self,
+        _harness: HarnessId,
+        _replica: ReplicaId,
+        _connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>> {
+        Box::pin(async { Ok(true) })
+    }
+    fn release(
+        &self,
+        _harness: HarnessId,
+        _replica: ReplicaId,
+        _connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>> {
+        Box::pin(async { Ok(()) })
+    }
+    fn owner(
+        &self,
+        _harness: HarnessId,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<RuntimeOwner>>> + Send>> {
+        Box::pin(async { Ok(None) })
+    }
 }
 
 /// Resolves the runtime configuration for a bot that may receive agent
@@ -160,7 +248,7 @@ pub trait RuntimeConnections: Send + Sync + 'static {
         &self,
         bot: BotId,
         session: AgentSessionId,
-    ) -> impl Future<Output = Option<RuntimeAttachment<Self::Connector>>> + Send;
+    ) -> impl Future<Output = Option<RuntimeBinding<Self::Connector>>> + Send;
 
     /// The harness a bot's sessions currently bind to, without attaching
     /// anything. `None` for an unbound bot. Same resolution as [`bind`], for
@@ -170,6 +258,31 @@ pub trait RuntimeConnections: Send + Sync + 'static {
         &self,
         bot: BotId,
     ) -> impl Future<Output = anyhow::Result<Option<HarnessId>>> + Send;
+
+    /// The fresh owner for a harness's runtime socket.
+    fn runtime_owner(
+        &self,
+        harness: HarnessId,
+    ) -> impl Future<Output = anyhow::Result<Option<RuntimeOwner>>> + Send;
+
+    /// Whether this process holds the locally attached socket for `harness`.
+    fn owns_runtime(&self, harness: HarnessId, owner: &RuntimeOwner) -> bool;
+
+    /// Whether `owner` names this replica, including a socket still upgrading.
+    fn is_local_runtime_owner(&self, owner: &RuntimeOwner) -> bool;
+
+    /// Whether missing durable ownership must block external command execution.
+    fn requires_runtime_owner(&self) -> bool;
+}
+
+/// A session attachment and the exact durable socket authorizing its claim.
+pub struct RuntimeBinding<Connector> {
+    /// Session-scoped transport attachment.
+    pub attachment: RuntimeAttachment<Connector>,
+    /// Harness owning the shared socket.
+    pub harness: HarnessId,
+    /// Exact shared socket token, nil when durable routing is disabled.
+    pub connection_id: macro_uuid::Uuid,
 }
 
 /// Mints the one secret a sandbox is given, and the config that points it at

--- a/crates/agent_harness/src/domain/service.rs
+++ b/crates/agent_harness/src/domain/service.rs
@@ -49,6 +49,7 @@ struct QueuedCommand {
     /// forwarding single-hop - two replicas with momentarily different lease
     /// views cannot bounce a command between each other.
     route: bool,
+    runtime_fence: Option<super::model::RuntimeFence>,
 }
 
 /// [`CommandForwarder`], object-safe.
@@ -61,7 +62,7 @@ trait ErasedForwarder: Send + Sync + 'static {
         &'a self,
         target: &'a agent_session::domain::model::ReplicaAddress,
         session: AgentSessionId,
-        command: HarnessCommand,
+        command: super::model::ForwardedCommand,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<CommandOutcome>> + Send + 'a>>;
 }
 
@@ -70,7 +71,7 @@ impl<F: CommandForwarder> ErasedForwarder for F {
         &'a self,
         target: &'a agent_session::domain::model::ReplicaAddress,
         session: AgentSessionId,
-        command: HarnessCommand,
+        command: super::model::ForwardedCommand,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<CommandOutcome>> + Send + 'a>> {
         Box::pin(CommandForwarder::forward(self, target, session, command))
     }
@@ -215,7 +216,7 @@ where
         session_id: AgentSessionId,
         command: HarnessCommand,
     ) -> impl Future<Output = Result<CommandOutcome>> + Send + 'static {
-        self.enqueue(session_id, command, true)
+        self.enqueue(session_id, command, true, None)
     }
 
     /// [`execute`](Self::execute), without resolving which replica manages
@@ -231,7 +232,7 @@ where
         session_id: AgentSessionId,
         command: HarnessCommand,
     ) -> impl Future<Output = Result<CommandOutcome>> + Send + 'static {
-        self.enqueue(session_id, command, false)
+        self.enqueue(session_id, command, false, None)
     }
 
     fn enqueue(
@@ -239,6 +240,7 @@ where
         session_id: AgentSessionId,
         mut command: HarnessCommand,
         route: bool,
+        runtime_fence: Option<super::model::RuntimeFence>,
     ) -> impl Future<Output = Result<CommandOutcome>> + Send + 'static {
         let caller = tracing::Span::current();
         let result = loop {
@@ -249,6 +251,7 @@ where
                 completed,
                 span: caller.clone(),
                 route,
+                runtime_fence: runtime_fence.clone(),
             };
 
             match commands.send(queued) {
@@ -344,7 +347,7 @@ pub trait ForwardedCommands: Send + Sync + 'static {
     fn execute_forwarded(
         &self,
         session_id: AgentSessionId,
-        command: HarnessCommand,
+        command: super::model::ForwardedCommand,
     ) -> impl Future<Output = Result<CommandOutcome>> + Send;
 }
 
@@ -371,9 +374,15 @@ where
     async fn execute_forwarded(
         &self,
         session_id: AgentSessionId,
-        command: HarnessCommand,
+        forwarded: super::model::ForwardedCommand,
     ) -> Result<CommandOutcome> {
-        self.execute_here(session_id, command).await
+        self.enqueue(
+            session_id,
+            forwarded.command,
+            false,
+            forwarded.runtime_fence,
+        )
+        .await
     }
 }
 
@@ -820,6 +829,107 @@ where
             span.record("agent.command.forwarded", false);
             return self.execute(session_id, command).await;
         }
+        let session = self.sessions.get_session(session_id).await?;
+        if AgentKind::for_session(session.bot_id, &session.harness) == AgentKind::External {
+            let harness = self
+                .runtimes
+                .bound_harness(session.bot_id)
+                .await
+                .map_err(AgentSessionError::Unknown)?;
+            if harness.is_none() && self.runtimes.requires_runtime_owner() {
+                return Err(HarnessError::Disconnected(session_id));
+            }
+            let Some(harness) = harness else {
+                return self
+                    .route_by_session_manager(session_id, command, span)
+                    .await;
+            };
+            let owner = self
+                .runtimes
+                .runtime_owner(harness)
+                .await
+                .map_err(AgentSessionError::Unknown)?;
+            if owner.is_none() && self.runtimes.requires_runtime_owner() {
+                return Err(HarnessError::Disconnected(session_id));
+            }
+            let Some(owner) = owner else {
+                return self
+                    .route_by_session_manager(session_id, command, span)
+                    .await;
+            };
+            if self.runtimes.is_local_runtime_owner(&owner) {
+                span.record("agent.session.management", "runtime_local");
+                span.record("agent.command.forwarded", false);
+                return self.execute(session_id, command).await;
+            }
+            let attempted_owner = (owner.replica, owner.connection_id);
+            let Some(address) = owner.address else {
+                return Err(HarnessError::ManagerUnreachable(session_id));
+            };
+            span.record("agent.session.management", "runtime_peer");
+            span.record("agent.command.forwarded", true);
+            return match self
+                .forwarder
+                .forward(
+                    &address,
+                    session_id,
+                    super::model::ForwardedCommand {
+                        command: command.clone(),
+                        runtime_fence: Some(super::model::RuntimeFence {
+                            harness,
+                            replica: owner.replica.as_uuid(),
+                            connection_id: owner.connection_id,
+                        }),
+                    },
+                )
+                .await
+            {
+                Ok(outcome) => Ok(outcome),
+                Err(forward_error) => {
+                    let owner = self
+                        .runtimes
+                        .runtime_owner(harness)
+                        .await
+                        .map_err(AgentSessionError::Unknown)?;
+                    match owner {
+                        Some(owner) if self.runtimes.owns_runtime(harness, &owner) => {
+                            span.record("agent.command.stale_fallback", true);
+                            self.execute(session_id, command).await
+                        }
+                        Some(owner) if (owner.replica, owner.connection_id) != attempted_owner => {
+                            let Some(address) = owner.address else {
+                                return Err(HarnessError::ManagerUnreachable(session_id));
+                            };
+                            self.forwarder
+                                .forward(
+                                    &address,
+                                    session_id,
+                                    super::model::ForwardedCommand {
+                                        command,
+                                        runtime_fence: Some(super::model::RuntimeFence {
+                                            harness,
+                                            replica: owner.replica.as_uuid(),
+                                            connection_id: owner.connection_id,
+                                        }),
+                                    },
+                                )
+                                .await
+                        }
+                        _ => Err(forward_error),
+                    }
+                }
+            };
+        }
+        self.route_by_session_manager(session_id, command, span)
+            .await
+    }
+
+    async fn route_by_session_manager(
+        &self,
+        session_id: AgentSessionId,
+        command: HarnessCommand,
+        span: tracing::Span,
+    ) -> Result<CommandOutcome> {
         let manager = match self.sessions.management(session_id).await? {
             SessionManagement::Unmanaged => {
                 span.record("agent.session.management", "unmanaged");
@@ -848,7 +958,14 @@ where
         tracing::info!(%session_id, peer = %manager.replica, "forwarding an agent session command");
         match self
             .forwarder
-            .forward(&address, session_id, command.clone())
+            .forward(
+                &address,
+                session_id,
+                super::model::ForwardedCommand {
+                    command: command.clone(),
+                    runtime_fence: None,
+                },
+            )
             .await
         {
             Ok(outcome) => Ok(outcome),
@@ -1342,15 +1459,27 @@ where
                     // yet. That is the ordinary case: sessions bind when they
                     // are prompted, not when the runtime dials, so the first
                     // prompt after a reconnect is what restores the session.
-                    let Some(attachment) = self.runtimes.bind(session.bot_id, session_id).await
-                    else {
+                    let Some(binding) = self.runtimes.bind(session.bot_id, session_id).await else {
                         // Kept in the session vocabulary so transports report
                         // it as a disconnect, not an internal error.
                         return Err(HarnessError::Session(AgentSessionError::Disconnected(
                             session_id,
                         )));
                     };
-                    self.sessions.attach_session(session_id, attachment).await?;
+                    if self.runtimes.requires_runtime_owner() {
+                        self.sessions
+                            .attach_runtime_session(
+                                session_id,
+                                binding.attachment,
+                                binding.harness,
+                                binding.connection_id,
+                            )
+                            .await?;
+                    } else {
+                        self.sessions
+                            .attach_session(session_id, binding.attachment)
+                            .await?;
+                    }
                 }
                 self.sessions
                     .send_action(session_id, actor, action, id)
@@ -1494,8 +1623,26 @@ async fn run_session_worker<
             completed,
             span,
             route,
+            runtime_fence,
         } = queued;
-        let result = if route {
+        let result = if let Some(fence) = runtime_fence {
+            let owner = inner
+                .runtimes
+                .runtime_owner(fence.harness)
+                .await
+                .map_err(AgentSessionError::Unknown);
+            match owner {
+                Ok(Some(owner))
+                    if owner.replica.as_uuid() == fence.replica
+                        && owner.connection_id == fence.connection_id
+                        && inner.runtimes.is_local_runtime_owner(&owner) =>
+                {
+                    inner.execute(session_id, command).instrument(span).await
+                }
+                Ok(_) => Err(HarnessError::Disconnected(session_id)),
+                Err(error) => Err(error.into()),
+            }
+        } else if route {
             inner
                 .route_then_execute(session_id, command)
                 .instrument(span)

--- a/crates/agent_harness/src/domain/service/test.rs
+++ b/crates/agent_harness/src/domain/service/test.rs
@@ -2153,12 +2153,57 @@ struct RecordingForwarder {
     calls: Arc<Mutex<Vec<(String, AgentSessionId)>>>,
 }
 
+struct PeerOwnedExternalRuntime {
+    inner: TestConnections,
+    owner: Arc<Mutex<crate::domain::model::RuntimeOwner>>,
+    local: bool,
+}
+
+impl crate::domain::ports::RuntimeConnections for PeerOwnedExternalRuntime {
+    type Connector = <TestConnections as crate::domain::ports::RuntimeConnections>::Connector;
+
+    async fn bind(
+        &self,
+        bot: BotId,
+        session: AgentSessionId,
+    ) -> Option<crate::domain::ports::RuntimeBinding<Self::Connector>> {
+        crate::domain::ports::RuntimeConnections::bind(&self.inner, bot, session).await
+    }
+
+    async fn bound_harness(&self, bot: BotId) -> anyhow::Result<Option<harness_id::HarnessId>> {
+        crate::domain::ports::RuntimeConnections::bound_harness(&self.inner, bot).await
+    }
+
+    async fn runtime_owner(
+        &self,
+        _harness: harness_id::HarnessId,
+    ) -> anyhow::Result<Option<crate::domain::model::RuntimeOwner>> {
+        Ok(Some(self.owner.lock().unwrap().clone()))
+    }
+
+    fn owns_runtime(
+        &self,
+        _harness: harness_id::HarnessId,
+        _owner: &crate::domain::model::RuntimeOwner,
+    ) -> bool {
+        self.local && self.owner.lock().unwrap().connection_id == _owner.connection_id
+    }
+
+    fn is_local_runtime_owner(&self, _owner: &crate::domain::model::RuntimeOwner) -> bool {
+        self.local
+    }
+
+    fn requires_runtime_owner(&self) -> bool {
+        true
+    }
+}
+
 impl crate::domain::ports::CommandForwarder for RecordingForwarder {
     async fn forward(
         &self,
         target: &agent_session::domain::model::ReplicaAddress,
         session: AgentSessionId,
-        _command: HarnessCommand,
+        _command: crate::domain::model::ForwardedCommand,
     ) -> crate::domain::error::Result<CommandOutcome> {
         self.calls
             .lock()
@@ -2181,13 +2226,39 @@ impl crate::domain::ports::CommandForwarder for DyingPeerForwarder {
         &self,
         _target: &agent_session::domain::model::ReplicaAddress,
         _session: AgentSessionId,
-        _command: HarnessCommand,
+        _command: crate::domain::model::ForwardedCommand,
     ) -> crate::domain::error::Result<CommandOutcome> {
         use agent_session::domain::ports::SessionOwnership as _;
         self.repo.release(&self.claim).await.expect("peer releases");
         Err(HarnessError::Forward(rootcause::report!(
             "the peer went away"
         )))
+    }
+}
+
+#[derive(Clone)]
+struct MovingRuntimeForwarder {
+    owner: Arc<Mutex<crate::domain::model::RuntimeOwner>>,
+    next_owner: crate::domain::model::RuntimeOwner,
+    calls: Arc<Mutex<Vec<String>>>,
+}
+
+impl crate::domain::ports::CommandForwarder for MovingRuntimeForwarder {
+    async fn forward(
+        &self,
+        target: &agent_session::domain::model::ReplicaAddress,
+        _session: AgentSessionId,
+        _command: crate::domain::model::ForwardedCommand,
+    ) -> crate::domain::error::Result<CommandOutcome> {
+        let mut calls = self.calls.lock().unwrap();
+        calls.push(target.as_str().to_owned());
+        if calls.len() == 1 {
+            *self.owner.lock().unwrap() = self.next_owner.clone();
+            return Err(HarnessError::Forward(rootcause::report!(
+                "the runtime moved"
+            )));
+        }
+        Ok(CommandOutcome::Completed)
     }
 }
 
@@ -2253,6 +2324,122 @@ async fn commands_for_a_peer_managed_session_forward_to_its_address() {
     assert!(
         repo.get(id).await.is_ok(),
         "the delete ran on the peer, not here"
+    );
+}
+
+#[tokio::test]
+async fn first_command_for_an_unmanaged_external_session_routes_to_runtime_owner() {
+    let repo = InMemoryAgentSessionRepo::new();
+    let session = agent_session::testing::test_agent_session(AgentSessionId::new());
+    let id = session.id;
+    repo.insert_session(session);
+    let forwarder = RecordingForwarder::default();
+    let service = AgentHarnessService::new(
+        AgentSessionServiceImpl::new(
+            repo.clone(),
+            FoldedMessageService::new(repo.clone()),
+            NoOpRealtime,
+        ),
+        MockContainerManager::new(),
+        AnnouncerMock::new(),
+        PeerOwnedExternalRuntime {
+            inner: TestConnections::new(MirrorBindings, RuntimeRegistry::new()),
+            owner: Arc::new(Mutex::new(crate::domain::model::RuntimeOwner {
+                replica: agent_session::domain::model::ReplicaId::mint(),
+                connection_id: macro_uuid::Uuid::new_v4(),
+                pending_until: None,
+                address: Some(agent_session::domain::model::ReplicaAddress::new(
+                    "http://10.0.0.8:8100",
+                )),
+            })),
+            local: false,
+        },
+        PromptContextMock::default(),
+        PromptComposerMock::default(),
+        EgressProvisionerMock::new(),
+        forwarder.clone(),
+        SessionDefaults {
+            bot_id: BotId::TEST_A,
+            model: "claude".to_owned(),
+            harness: "opencode".to_owned(),
+            repo_url: "https://github.com/macro-inc/macro".to_owned(),
+        },
+    );
+
+    service
+        .execute(id, HarnessCommand::Deliver(forward_message("first prompt")))
+        .await
+        .expect("the runtime owner handles the first command");
+
+    assert_eq!(
+        forwarder.calls.lock().unwrap().clone(),
+        vec![("http://10.0.0.8:8100".to_owned(), id)]
+    );
+    assert!(
+        repo.get(id).await.is_ok(),
+        "the command did not run locally"
+    );
+}
+
+#[tokio::test]
+async fn first_command_retries_when_the_runtime_owner_moves_mid_forward() {
+    let repo = InMemoryAgentSessionRepo::new();
+    let session = agent_session::testing::test_agent_session(AgentSessionId::new());
+    let id = session.id;
+    repo.insert_session(session);
+    let owner = Arc::new(Mutex::new(crate::domain::model::RuntimeOwner {
+        replica: agent_session::domain::model::ReplicaId::mint(),
+        connection_id: macro_uuid::Uuid::new_v4(),
+        pending_until: None,
+        address: Some(agent_session::domain::model::ReplicaAddress::new(
+            "http://10.0.0.8:8100",
+        )),
+    }));
+    let next_owner = crate::domain::model::RuntimeOwner {
+        replica: owner.lock().unwrap().replica,
+        connection_id: macro_uuid::Uuid::new_v4(),
+        pending_until: None,
+        address: Some(agent_session::domain::model::ReplicaAddress::new(
+            "http://10.0.0.9:8100",
+        )),
+    };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let service = AgentHarnessService::new(
+        AgentSessionServiceImpl::new(repo.clone(), FoldedMessageService::new(repo), NoOpRealtime),
+        MockContainerManager::new(),
+        AnnouncerMock::new(),
+        PeerOwnedExternalRuntime {
+            inner: TestConnections::new(MirrorBindings, RuntimeRegistry::new()),
+            owner: Arc::clone(&owner),
+            local: false,
+        },
+        PromptContextMock::default(),
+        PromptComposerMock::default(),
+        EgressProvisionerMock::new(),
+        MovingRuntimeForwarder {
+            owner,
+            next_owner,
+            calls: Arc::clone(&calls),
+        },
+        SessionDefaults {
+            bot_id: BotId::TEST_A,
+            model: "claude".to_owned(),
+            harness: "opencode".to_owned(),
+            repo_url: "https://github.com/macro-inc/macro".to_owned(),
+        },
+    );
+
+    service
+        .execute(id, HarnessCommand::Deliver(forward_message("first prompt")))
+        .await
+        .expect("the new runtime owner handles the retry");
+
+    assert_eq!(
+        *calls.lock().unwrap(),
+        [
+            "http://10.0.0.8:8100".to_owned(),
+            "http://10.0.0.9:8100".to_owned(),
+        ]
     );
 }
 

--- a/crates/agent_harness/src/inbound/forward.rs
+++ b/crates/agent_harness/src/inbound/forward.rs
@@ -20,7 +20,7 @@ use macro_authorization::{
 use macro_uuid::Uuid;
 
 use crate::domain::error::HarnessError;
-use crate::domain::model::HarnessCommand;
+use crate::domain::model::ForwardedCommand;
 use crate::domain::service::ForwardedCommands;
 
 /// State for the command-forwarding route.
@@ -91,7 +91,7 @@ async fn forward_handler<Harness, Auth>(
     State(state): State<ForwardGatewayState<Harness, Auth>>,
     _caller: MacroAuthorizationExtractor<Auth, InternalOnly>,
     Path(session_id): Path<Uuid>,
-    Json(command): Json<HarnessCommand>,
+    Json(command): Json<ForwardedCommand>,
 ) -> Response
 where
     Harness: ForwardedCommands,

--- a/crates/agent_harness/src/inbound/runtime_gateway.rs
+++ b/crates/agent_harness/src/inbound/runtime_gateway.rs
@@ -20,15 +20,37 @@ use std::sync::Arc;
 
 use agent_runtime_protocol::domain::schema::v0::{ToRuntimeMessage, ToServerMessage};
 use agent_runtime_protocol::outbound::websocket::connect_socket;
+use agent_session::domain::model::ReplicaId;
 use axum::Router;
 use axum::extract::ws::WebSocketUpgrade;
 use axum::extract::{FromRef, State};
-use axum::response::Response;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 use axum::routing::get;
+use harness_id::HarnessId;
 use macro_authorization::{
     HarnessOnly, MacroAuthorizationExtractor, MacroAuthorizationService, MacroAuthorizationState,
 };
+use macro_uuid::Uuid;
 
+use crate::domain::ports::RuntimeLease;
+
+async fn release_claim<Lease: RuntimeLease>(
+    lease: Lease,
+    harness: HarnessId,
+    replica: ReplicaId,
+    connection_id: Uuid,
+) {
+    loop {
+        match lease.release(harness, replica, connection_id).await {
+            Ok(()) => return,
+            Err(error) => {
+                tracing::error!(error = ?error, %harness, "failed to release runtime socket claim; retrying");
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+        }
+    }
+}
 use crate::outbound::runtime_registry::RuntimeRegistry;
 
 #[cfg(test)]
@@ -38,69 +60,112 @@ mod test;
 pub type GatewaySender = tokio::sync::mpsc::UnboundedSender<ToRuntimeMessage>;
 
 /// State for the runtime gateway route.
-pub struct RuntimeGatewayState<Auth> {
+pub struct RuntimeGatewayState<Auth, Lease> {
     runtimes: Arc<RuntimeRegistry<GatewaySender>>,
     authorization_state: MacroAuthorizationState<Auth>,
+    replica: agent_session::domain::model::ReplicaId,
+    lease: Lease,
 }
 
-impl<Auth> RuntimeGatewayState<Auth> {
+impl<Auth, Lease> RuntimeGatewayState<Auth, Lease> {
     /// Create gateway state.
     pub fn new(
         runtimes: Arc<RuntimeRegistry<GatewaySender>>,
         authorization_state: MacroAuthorizationState<Auth>,
+        replica: agent_session::domain::model::ReplicaId,
+        lease: Lease,
     ) -> Self {
         Self {
             runtimes,
             authorization_state,
+            replica,
+            lease,
         }
     }
 }
 
 // Manual Clone impl: everything is behind an Arc.
-impl<Auth> Clone for RuntimeGatewayState<Auth> {
+impl<Auth, Lease: Clone> Clone for RuntimeGatewayState<Auth, Lease> {
     fn clone(&self) -> Self {
         Self {
             runtimes: Arc::clone(&self.runtimes),
             authorization_state: self.authorization_state.clone(),
+            replica: self.replica,
+            lease: self.lease.clone(),
         }
     }
 }
 
-impl<Auth> FromRef<RuntimeGatewayState<Auth>> for MacroAuthorizationState<Auth> {
-    fn from_ref(state: &RuntimeGatewayState<Auth>) -> Self {
+impl<Auth, Lease> FromRef<RuntimeGatewayState<Auth, Lease>> for MacroAuthorizationState<Auth> {
+    fn from_ref(state: &RuntimeGatewayState<Auth, Lease>) -> Self {
         state.authorization_state.clone()
     }
 }
 
 /// Build the router serving `GET /ws`. Mount it under `/runtime`.
-pub fn runtime_gateway_router<Auth, S>(state: RuntimeGatewayState<Auth>) -> Router<S>
+pub fn runtime_gateway_router<Auth, Lease, S>(state: RuntimeGatewayState<Auth, Lease>) -> Router<S>
 where
     Auth: MacroAuthorizationService,
+    Lease: RuntimeLease + Clone,
     S: Clone + Send + Sync + 'static,
 {
     Router::new()
-        .route("/ws", get(dial_handler::<Auth>))
+        .route("/ws", get(dial_handler::<Auth, Lease>))
         .with_state(state)
 }
 
 /// Authenticate a dial and take the socket as this harness's connection.
-async fn dial_handler<Auth>(
-    State(state): State<RuntimeGatewayState<Auth>>,
+async fn dial_handler<Auth, Lease>(
+    State(state): State<RuntimeGatewayState<Auth, Lease>>,
     caller: MacroAuthorizationExtractor<Auth, HarnessOnly>,
     ws: WebSocketUpgrade,
 ) -> Response
 where
     Auth: MacroAuthorizationService,
+    Lease: RuntimeLease + Clone,
 {
     let harness = caller.authorization.harness_id;
+    let connection_id = Uuid::new_v4();
+    match state
+        .lease
+        .claim(harness, state.replica, connection_id)
+        .await
+    {
+        Ok(true) => {}
+        Ok(false) => return StatusCode::CONFLICT.into_response(),
+        Err(error) => {
+            tracing::error!(error = ?error, %harness, "failed to claim harness runtime socket");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    }
 
     let runtimes = Arc::clone(&state.runtimes);
-    ws.on_upgrade(move |socket| async move {
+    let failed_lease = state.lease.clone();
+    let lease = state.lease;
+    let replica = state.replica;
+    ws.on_failed_upgrade(move |error| {
+        let lease = failed_lease.clone();
+        tokio::spawn(async move {
+            tracing::warn!(error = ?error, %harness, "runtime websocket upgrade failed");
+            release_claim(lease, harness, replica, connection_id).await;
+        });
+    })
+    .on_upgrade(move |socket| async move {
+        match lease.activate(harness, replica, connection_id).await {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::warn!(%harness, "runtime socket lease was superseded before it became ready");
+                release_claim(lease, harness, replica, connection_id).await;
+                return;
+            }
+            Err(error) => {
+                tracing::error!(error = ?error, %harness, "failed to mark harness runtime socket ready");
+                release_claim(lease, harness, replica, connection_id).await;
+                return;
+            }
+        }
         let transport = connect_socket::<ToRuntimeMessage, ToServerMessage>(socket);
-        // Last dial wins. A runtime that redials has lost its old socket
-        // whether or not this side has noticed, so displacing is the only
-        // answer that lets it recover.
-        runtimes.attach(harness, transport);
+        runtimes.attach_with_id(harness, connection_id, transport);
         tracing::info!(%harness, "a runtime dialed in");
     })
 }

--- a/crates/agent_harness/src/inbound/runtime_gateway/test.rs
+++ b/crates/agent_harness/src/inbound/runtime_gateway/test.rs
@@ -15,6 +15,10 @@ use macro_authorization::{
 };
 use macro_user_id::user_id::MacroUserIdStr;
 use rootcause::Report;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio_tungstenite::tungstenite;
 
 const HARNESS_TOKEN: &str = "mhns_self_test";
@@ -70,7 +74,60 @@ impl HarnessAuthorizer for SelfHarnessAuthorizer {
 
 /// Serve the gateway on a loopback port, returning the registry it feeds and
 /// the `ws://` base to dial.
-async fn serve() -> (Arc<RuntimeRegistry<GatewaySender>>, String) {
+#[derive(Clone)]
+struct FakeLease {
+    claim: Result<bool, &'static str>,
+    activate: Result<bool, &'static str>,
+    claimed: Arc<AtomicBool>,
+}
+
+impl RuntimeLease for FakeLease {
+    fn claim(
+        &self,
+        _harness: HarnessId,
+        _replica: agent_session::domain::model::ReplicaId,
+        _connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>> {
+        let result = self.claim;
+        let claimed = Arc::clone(&self.claimed);
+        Box::pin(async move {
+            claimed.store(true, Ordering::SeqCst);
+            result.map_err(anyhow::Error::msg)
+        })
+    }
+
+    fn activate(
+        &self,
+        _harness: HarnessId,
+        _replica: agent_session::domain::model::ReplicaId,
+        _connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>> {
+        let result = self.activate;
+        Box::pin(async move { result.map_err(anyhow::Error::msg) })
+    }
+
+    fn release(
+        &self,
+        _harness: HarnessId,
+        _replica: agent_session::domain::model::ReplicaId,
+        _connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn owner(
+        &self,
+        _harness: HarnessId,
+    ) -> Pin<
+        Box<dyn Future<Output = anyhow::Result<Option<crate::domain::model::RuntimeOwner>>> + Send>,
+    > {
+        Box::pin(async { Ok(None) })
+    }
+}
+
+async fn serve_with_lease<Lease: RuntimeLease + Clone>(
+    lease: Lease,
+) -> (Arc<RuntimeRegistry<GatewaySender>>, String) {
     let runtimes = RuntimeRegistry::new();
     let authorization = MacroAuthorizationServiceImpl::new(
         FakeJwtValidator,
@@ -87,12 +144,18 @@ async fn serve() -> (Arc<RuntimeRegistry<GatewaySender>>, String) {
         runtime_gateway_router(RuntimeGatewayState::new(
             Arc::clone(&runtimes),
             MacroAuthorizationState::new(Arc::new(authorization)),
+            agent_session::domain::model::ReplicaId::mint(),
+            lease,
         )),
     );
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
     tokio::spawn(async move { axum::serve(listener, app).await });
     (runtimes, format!("ws://{address}"))
+}
+
+async fn serve() -> (Arc<RuntimeRegistry<GatewaySender>>, String) {
+    serve_with_lease(crate::domain::ports::NoRuntimeLease).await
 }
 
 fn dial_request(base: &str, token: Option<&str>) -> tungstenite::handshake::client::Request {
@@ -147,4 +210,64 @@ async fn a_missing_token_is_rejected() {
     // No credentials at all: the extractor rejects before anything runs.
     assert_eq!(status, StatusCode::UNAUTHORIZED);
     assert!(!runtimes.is_connected(HarnessId::TEST_A));
+}
+
+#[tokio::test]
+async fn a_duplicate_fresh_claim_is_rejected_before_upgrade() {
+    let claimed = Arc::new(AtomicBool::new(false));
+    let (runtimes, base) = serve_with_lease(FakeLease {
+        claim: Ok(false),
+        activate: Ok(true),
+        claimed: Arc::clone(&claimed),
+    })
+    .await;
+
+    let status = rejected(dial_request(&base, Some(HARNESS_TOKEN))).await;
+
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(claimed.load(Ordering::SeqCst));
+    assert!(!runtimes.is_connected(HarnessId::TEST_A));
+}
+
+#[tokio::test]
+async fn a_claim_failure_is_rejected_before_upgrade() {
+    let (runtimes, base) = serve_with_lease(FakeLease {
+        claim: Err("database unavailable"),
+        activate: Ok(true),
+        claimed: Arc::new(AtomicBool::new(false)),
+    })
+    .await;
+
+    let status = rejected(dial_request(&base, Some(HARNESS_TOKEN))).await;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(!runtimes.is_connected(HarnessId::TEST_A));
+}
+
+#[tokio::test]
+async fn a_superseded_upgrade_cannot_evict_the_current_socket() {
+    let (runtimes, base) = serve_with_lease(FakeLease {
+        claim: Ok(true),
+        activate: Ok(false),
+        claimed: Arc::new(AtomicBool::new(false)),
+    })
+    .await;
+    let current_id = macro_uuid::Uuid::new_v4();
+    let (current, _runtime) = agent_runtime_protocol::domain::channel::Channel::<
+        ToRuntimeMessage,
+        ToServerMessage,
+    >::duplex();
+    runtimes.attach_with_id(HarnessId::TEST_A, current_id, current);
+
+    let (socket, _) = tokio_tungstenite::connect_async(dial_request(&base, Some(HARNESS_TOKEN)))
+        .await
+        .expect("the pending claim upgrades before activation is refused");
+    drop(socket);
+    tokio::task::yield_now().await;
+
+    assert_eq!(
+        runtimes.connection_id(HarnessId::TEST_A),
+        Some(current_id),
+        "a stale upgrade must not touch the socket for the authoritative token"
+    );
 }

--- a/crates/agent_harness/src/outbound/forward.rs
+++ b/crates/agent_harness/src/outbound/forward.rs
@@ -9,7 +9,7 @@ use agent_session::domain::model::{AgentSessionId, ReplicaAddress};
 use reqwest::StatusCode;
 
 use crate::domain::error::{HarnessError, Result};
-use crate::domain::model::{CommandOutcome, HarnessCommand};
+use crate::domain::model::{CommandOutcome, ForwardedCommand};
 use crate::domain::ports::CommandForwarder;
 
 /// Header carrying the deployment's shared internal key, as
@@ -56,7 +56,7 @@ impl CommandForwarder for HttpCommandForwarder {
         &self,
         target: &ReplicaAddress,
         session: AgentSessionId,
-        command: HarnessCommand,
+        command: ForwardedCommand,
     ) -> Result<CommandOutcome> {
         let url = format!(
             "{}/internal/agent-sessions/{}/command",

--- a/crates/agent_harness/src/outbound/runtime_registry.rs
+++ b/crates/agent_harness/src/outbound/runtime_registry.rs
@@ -10,6 +10,7 @@
 //! - across many bots - share one harness process.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use agent_runtime_protocol::domain::ports::{Transport, TransportSender};
 use agent_runtime_protocol::domain::schema::v0::{ToRuntimeMessage, ToServerMessage};
@@ -19,22 +20,32 @@ use bot_id::BotId;
 use dashmap::DashMap;
 use harness_id::HarnessId;
 
-use crate::domain::ports::{HarnessBindings, HarnessPresence, RuntimeConnections};
+use crate::domain::ports::{HarnessBindings, RuntimeBinding, RuntimeConnections, RuntimeLease};
+
+#[cfg(not(test))]
+const PENDING_ATTACH_WAIT: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const PENDING_ATTACH_WAIT: Duration = Duration::from_millis(25);
 
 #[cfg(test)]
 mod test;
 
 /// Every harness's live runtime connection.
 pub struct RuntimeRegistry<Sender> {
-    connections: DashMap<HarnessId, Arc<RuntimeConnection<Sender>>>,
-    presence: Option<Arc<dyn HarnessPresence>>,
+    connections: DashMap<HarnessId, (macro_uuid::Uuid, Arc<RuntimeConnection<Sender>>)>,
+    attached: tokio::sync::Notify,
+    lease: Option<(
+        agent_session::domain::model::ReplicaId,
+        Arc<dyn RuntimeLease>,
+    )>,
 }
 
 impl<Sender> Default for RuntimeRegistry<Sender> {
     fn default() -> Self {
         Self {
             connections: DashMap::new(),
-            presence: None,
+            attached: tokio::sync::Notify::new(),
+            lease: None,
         }
     }
 }
@@ -49,12 +60,16 @@ where
         Arc::new(Self::default())
     }
 
-    /// An empty registry that reports attach/detach to `presence`.
+    /// An empty registry that releases exact leases on close.
     #[must_use]
-    pub fn with_presence(presence: Arc<dyn HarnessPresence>) -> Arc<Self> {
+    pub fn with_lease(
+        replica: agent_session::domain::model::ReplicaId,
+        lease: Arc<dyn RuntimeLease>,
+    ) -> Arc<Self> {
         Arc::new(Self {
             connections: DashMap::new(),
-            presence: Some(presence),
+            attached: tokio::sync::Notify::new(),
+            lease: Some((replica, lease)),
         })
     }
 
@@ -63,18 +78,52 @@ where
     pub fn is_connected(&self, harness: HarnessId) -> bool {
         self.connections.contains_key(&harness)
     }
+
+    #[cfg(test)]
+    pub(crate) fn connection_id(&self, harness: HarnessId) -> Option<macro_uuid::Uuid> {
+        self.connections.get(&harness).map(|entry| entry.0)
+    }
+
+    fn owns(&self, harness: HarnessId, owner: &crate::domain::model::RuntimeOwner) -> bool {
+        self.lease.as_ref().is_some_and(|(replica, _)| {
+            *replica == owner.replica
+                && self
+                    .connections
+                    .get(&harness)
+                    .is_some_and(|connection| connection.0 == owner.connection_id)
+        })
+    }
 }
 
 impl<Sender> RuntimeRegistry<Sender>
 where
     Sender: TransportSender<ToRuntimeMessage>,
 {
-    /// Take over as `harness`'s connection, displacing whatever it had.
-    ///
-    /// Last dial wins: a runtime that redials has necessarily lost its old
-    /// socket, and the sessions it was carrying rebind as they are next used.
-    pub fn attach<Carrier>(self: &Arc<Self>, harness: HarnessId, carrier: Carrier)
+    /// Attach a test or single-process runtime with a freshly minted token.
+    pub fn attach<Carrier>(self: &Arc<Self>, harness: HarnessId, carrier: Carrier) -> bool
     where
+        Carrier: Transport<ToRuntimeMessage, ToServerMessage, Sender = Sender>,
+    {
+        let connection = RuntimeConnection::connect(carrier);
+        let connection_id = macro_uuid::Uuid::new_v4();
+        if let Some((_, displaced)) = self
+            .connections
+            .insert(harness, (connection_id, Arc::clone(&connection)))
+        {
+            displaced.evict();
+        }
+        self.attached.notify_waiters();
+        self.watch_for_close(harness, connection_id, connection);
+        true
+    }
+
+    /// Attach the socket whose durable claim is `connection_id`.
+    pub fn attach_with_id<Carrier>(
+        self: &Arc<Self>,
+        harness: HarnessId,
+        connection_id: macro_uuid::Uuid,
+        carrier: Carrier,
+    ) where
         Carrier: Transport<ToRuntimeMessage, ToServerMessage, Sender = Sender>,
     {
         let connection = RuntimeConnection::connect(carrier);
@@ -82,14 +131,14 @@ where
         // Listed before it is watched: a socket that dies immediately would
         // otherwise have its eviction run before the entry it is meant to
         // remove exists, leaving the dead connection listed for good.
-        if let Some(displaced) = self.connections.insert(harness, Arc::clone(&connection)) {
+        if let Some((_, displaced)) = self
+            .connections
+            .insert(harness, (connection_id, Arc::clone(&connection)))
+        {
             displaced.evict();
-            tracing::info!(%harness, "a redialed runtime replaced this harness's connection");
         }
-        if let Some(presence) = &self.presence {
-            tokio::spawn(Arc::clone(presence).connected(harness));
-        }
-        self.watch_for_close(harness, connection);
+        self.attached.notify_waiters();
+        self.watch_for_close(harness, connection_id, connection);
     }
 
     /// Drop `connection` from the registry once its transport ends.
@@ -102,9 +151,10 @@ where
     fn watch_for_close(
         self: &Arc<Self>,
         harness: HarnessId,
+        connection_id: macro_uuid::Uuid,
         connection: Arc<RuntimeConnection<Sender>>,
     ) {
-        tokio::spawn(Arc::clone(self).drop_when_closed(harness, connection));
+        tokio::spawn(Arc::clone(self).drop_when_closed(harness, connection_id, connection));
     }
 
     /// The body of that watch: wait for the end, then unlist it.
@@ -114,24 +164,112 @@ where
     async fn drop_when_closed(
         self: Arc<Self>,
         harness: HarnessId,
+        connection_id: macro_uuid::Uuid,
         connection: Arc<RuntimeConnection<Sender>>,
     ) {
         connection.closed().await;
-        // Only if it is still this connection: a redial that already replaced
-        // it owns the entry now, and evicting that would take the live socket
-        // down along with the dead one. The presence write follows the same
-        // rule, so a displaced socket's death never marks the live redial
-        // disconnected.
+        // Only if it is still this exact token: a newer dial must remain
+        // listed, and a stale close must not release its durable lease.
         let removed = self
             .connections
-            .remove_if(&harness, |_, current| Arc::ptr_eq(current, &connection))
+            .remove_if(&harness, |_, current| {
+                current.0 == connection_id && Arc::ptr_eq(&current.1, &connection)
+            })
             .is_some();
         if removed {
-            if let Some(presence) = &self.presence {
-                tokio::spawn(Arc::clone(presence).disconnected(harness));
+            if let Some((replica, lease)) = &self.lease {
+                let lease = Arc::clone(lease);
+                let replica = *replica;
+                tokio::spawn(async move {
+                    loop {
+                        match lease.release(harness, replica, connection_id).await {
+                            Ok(()) => break,
+                            Err(error) => {
+                                tracing::error!(error = ?error, %harness, "failed to release closed runtime socket lease; retrying");
+                                tokio::time::sleep(Duration::from_secs(1)).await;
+                            }
+                        }
+                    }
+                });
             }
             tracing::info!(%harness, "dropped this harness's closed runtime connection");
         }
+    }
+
+    /// Remove a socket only when it still holds `connection_id`.
+    pub fn remove_and_evict(&self, harness: HarnessId, connection_id: macro_uuid::Uuid) {
+        if let Some((_, (_, connection))) = self
+            .connections
+            .remove_if(&harness, |_, current| current.0 == connection_id)
+        {
+            connection.evict();
+        }
+    }
+
+    /// Evict local sockets whose exact durable ownership has been superseded.
+    pub async fn reconcile(&self) {
+        let Some((replica, lease)) = &self.lease else {
+            return;
+        };
+        let local = self
+            .connections
+            .iter()
+            .map(|entry| (*entry.key(), entry.value().0))
+            .collect::<Vec<_>>();
+        for (harness, connection_id) in local {
+            match lease.owner(harness).await {
+                Ok(Some(owner))
+                    if owner.replica == *replica && owner.connection_id == connection_id => {}
+                Ok(_) => self.remove_and_evict(harness, connection_id),
+                Err(error) => {
+                    tracing::warn!(error = ?error, %harness, "failed to reconcile runtime socket ownership");
+                }
+            }
+        }
+    }
+
+    async fn bind(
+        &self,
+        harness: HarnessId,
+        session: AgentSessionId,
+        connection_id: macro_uuid::Uuid,
+        pending_until: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Option<RuntimeAttachment<SessionChannel<Sender>>> {
+        let remaining = pending_until
+            .map(|deadline| {
+                (deadline - chrono::Utc::now())
+                    .to_std()
+                    .unwrap_or(Duration::ZERO)
+            })
+            .unwrap_or(PENDING_ATTACH_WAIT)
+            .min(PENDING_ATTACH_WAIT);
+        let deadline = tokio::time::Instant::now() + remaining;
+        loop {
+            let notified = self.attached.notified();
+            if let Some(connection) = self
+                .connections
+                .get(&harness)
+                .filter(|entry| entry.0 == connection_id)
+                .map(|entry| Arc::clone(&entry.1))
+            {
+                return Some(connection.bind(session).await);
+            }
+            if tokio::time::timeout_at(deadline, notified).await.is_err() {
+                return None;
+            }
+        }
+    }
+
+    async fn bind_any(
+        &self,
+        harness: HarnessId,
+        session: AgentSessionId,
+    ) -> Option<RuntimeAttachment<SessionChannel<Sender>>> {
+        let connection = self
+            .connections
+            .get(&harness)
+            .map(|entry| Arc::clone(&entry.1))?;
+        Some(connection.bind(session).await)
     }
 }
 
@@ -140,21 +278,41 @@ where
 /// The domain binds sessions by bot; this resolves the bot's *current*
 /// harness binding on every bind, so rebinding an agent to another harness
 /// re-routes its existing sessions without restamping anything.
-pub struct HarnessKeyedConnections<Bindings, Sender> {
+pub struct HarnessKeyedConnections<Bindings, Sender, Lease = crate::domain::ports::NoRuntimeLease> {
     bindings: Bindings,
+    lease: Lease,
     registry: Arc<RuntimeRegistry<Sender>>,
 }
 
-impl<Bindings, Sender> HarnessKeyedConnections<Bindings, Sender> {
+impl<Bindings, Sender, Lease> HarnessKeyedConnections<Bindings, Sender, Lease> {
     /// Wrap the registry with a bot-to-harness resolver.
-    pub fn new(bindings: Bindings, registry: Arc<RuntimeRegistry<Sender>>) -> Self {
-        Self { bindings, registry }
+    pub fn with_lease(
+        bindings: Bindings,
+        lease: Lease,
+        registry: Arc<RuntimeRegistry<Sender>>,
+    ) -> Self {
+        Self {
+            bindings,
+            lease,
+            registry,
+        }
     }
 }
 
-impl<Bindings, Sender> RuntimeConnections for HarnessKeyedConnections<Bindings, Sender>
+impl<Bindings, Sender>
+    HarnessKeyedConnections<Bindings, Sender, crate::domain::ports::NoRuntimeLease>
+{
+    /// Wrap a registry without durable routing, for tests and local tooling.
+    pub fn new(bindings: Bindings, registry: Arc<RuntimeRegistry<Sender>>) -> Self {
+        Self::with_lease(bindings, crate::domain::ports::NoRuntimeLease, registry)
+    }
+}
+
+impl<Bindings, Sender, Lease> RuntimeConnections
+    for HarnessKeyedConnections<Bindings, Sender, Lease>
 where
     Bindings: HarnessBindings,
+    Lease: RuntimeLease,
     Sender: TransportSender<ToRuntimeMessage>,
 {
     type Connector = SessionChannel<Sender>;
@@ -163,7 +321,7 @@ where
         &self,
         bot: BotId,
         session: AgentSessionId,
-    ) -> Option<RuntimeAttachment<SessionChannel<Sender>>> {
+    ) -> Option<RuntimeBinding<SessionChannel<Sender>>> {
         let harness = match self.bindings.harness_for(bot).await {
             Ok(Some(harness)) => harness,
             Ok(None) => return None,
@@ -172,15 +330,80 @@ where
                 return None;
             }
         };
-        let connection = self
+        if self.registry.lease.is_none() {
+            return self
+                .registry
+                .bind_any(harness, session)
+                .await
+                .map(|attachment| RuntimeBinding {
+                    attachment,
+                    harness,
+                    connection_id: macro_uuid::Uuid::nil(),
+                });
+        }
+        let owner = match self.lease.owner(harness).await {
+            Ok(Some(owner)) => owner,
+            Ok(None) => return None,
+            Err(error) => {
+                tracing::error!(error = ?error, %harness, "runtime owner resolution failed");
+                return None;
+            }
+        };
+        if !self
             .registry
-            .connections
-            .get(&harness)
-            .map(|entry| Arc::clone(&entry))?;
-        Some(connection.bind(session).await)
+            .lease
+            .as_ref()
+            .is_some_and(|(replica, _)| *replica == owner.replica)
+        {
+            return None;
+        }
+        let attachment = self
+            .registry
+            .bind(harness, session, owner.connection_id, owner.pending_until)
+            .await?;
+        let current = match self.lease.owner(harness).await {
+            Ok(owner) => owner,
+            Err(error) => {
+                tracing::error!(error = ?error, %harness, "runtime owner revalidation failed");
+                return None;
+            }
+        };
+        if current.as_ref().is_some_and(|current| {
+            current.replica == owner.replica && current.connection_id == owner.connection_id
+        }) {
+            Some(RuntimeBinding {
+                attachment,
+                harness,
+                connection_id: owner.connection_id,
+            })
+        } else {
+            None
+        }
     }
 
     async fn bound_harness(&self, bot: BotId) -> anyhow::Result<Option<HarnessId>> {
         self.bindings.harness_for(bot).await
+    }
+
+    async fn runtime_owner(
+        &self,
+        harness: HarnessId,
+    ) -> anyhow::Result<Option<crate::domain::model::RuntimeOwner>> {
+        self.lease.owner(harness).await
+    }
+
+    fn owns_runtime(&self, harness: HarnessId, owner: &crate::domain::model::RuntimeOwner) -> bool {
+        self.registry.owns(harness, owner)
+    }
+
+    fn is_local_runtime_owner(&self, owner: &crate::domain::model::RuntimeOwner) -> bool {
+        self.registry
+            .lease
+            .as_ref()
+            .is_some_and(|(replica, _)| *replica == owner.replica)
+    }
+
+    fn requires_runtime_owner(&self) -> bool {
+        self.registry.lease.is_some()
     }
 }

--- a/crates/agent_harness/src/outbound/runtime_registry/test.rs
+++ b/crates/agent_harness/src/outbound/runtime_registry/test.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashMap;
 use std::future::Future;
+use std::pin::Pin;
 use std::sync::Mutex;
 
 use super::*;
@@ -26,6 +27,55 @@ impl FakeBindings {
 impl HarnessBindings for Arc<FakeBindings> {
     async fn harness_for(&self, bot: BotId) -> anyhow::Result<Option<HarnessId>> {
         Ok(self.bindings.lock().unwrap().get(&bot).copied())
+    }
+}
+
+#[derive(Clone)]
+struct FakeLease {
+    owner: crate::domain::model::RuntimeOwner,
+    releases: Arc<Mutex<Vec<macro_uuid::Uuid>>>,
+}
+
+impl RuntimeLease for FakeLease {
+    fn claim(
+        &self,
+        _harness: HarnessId,
+        _replica: agent_session::domain::model::ReplicaId,
+        _connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>> {
+        Box::pin(async { Ok(true) })
+    }
+
+    fn activate(
+        &self,
+        _harness: HarnessId,
+        _replica: agent_session::domain::model::ReplicaId,
+        _connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>> {
+        Box::pin(async { Ok(true) })
+    }
+
+    fn release(
+        &self,
+        _harness: HarnessId,
+        _replica: agent_session::domain::model::ReplicaId,
+        connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>> {
+        let releases = Arc::clone(&self.releases);
+        Box::pin(async move {
+            releases.lock().unwrap().push(connection_id);
+            Ok(())
+        })
+    }
+
+    fn owner(
+        &self,
+        _harness: HarnessId,
+    ) -> Pin<
+        Box<dyn Future<Output = anyhow::Result<Option<crate::domain::model::RuntimeOwner>>> + Send>,
+    > {
+        let owner = self.owner.clone();
+        Box::pin(async move { Ok(Some(owner)) })
     }
 }
 
@@ -156,7 +206,7 @@ async fn a_closed_connection_is_unlisted_so_nothing_binds_onto_it() {
     let connection = registry
         .connections
         .get(&HarnessId::TEST_A)
-        .map(|entry| Arc::clone(&entry))
+        .map(|entry| (entry.0, Arc::clone(&entry.1)))
         .expect("the dial is listed");
     let bound = connections(
         Arc::new(FakeBindings::bound(BotId::TEST_A, HarnessId::TEST_A)),
@@ -166,7 +216,7 @@ async fn a_closed_connection_is_unlisted_so_nothing_binds_onto_it() {
     runtime.disconnects();
     // The same work `attach` spawns, awaited here rather than raced.
     Arc::clone(&registry)
-        .drop_when_closed(HarnessId::TEST_A, connection)
+        .drop_when_closed(HarnessId::TEST_A, connection.0, connection.1)
         .await;
 
     assert!(!registry.is_connected(HarnessId::TEST_A));
@@ -186,7 +236,7 @@ async fn a_redials_connection_outlives_the_one_it_displaced() {
     let displaced = registry
         .connections
         .get(&HarnessId::TEST_A)
-        .map(|entry| Arc::clone(&entry))
+        .map(|entry| (entry.0, Arc::clone(&entry.1)))
         .expect("the first dial is listed");
     let bound = connections(
         Arc::new(FakeBindings::bound(BotId::TEST_A, HarnessId::TEST_A)),
@@ -196,7 +246,7 @@ async fn a_redials_connection_outlives_the_one_it_displaced() {
     registry.attach(HarnessId::TEST_A, ContainerMock::default());
     first.disconnects();
     Arc::clone(&registry)
-        .drop_when_closed(HarnessId::TEST_A, displaced)
+        .drop_when_closed(HarnessId::TEST_A, displaced.0, displaced.1)
         .await;
 
     // The dead connection's eviction must not unlist the live one that took
@@ -211,56 +261,202 @@ async fn a_redials_connection_outlives_the_one_it_displaced() {
 }
 
 #[tokio::test]
-async fn attach_and_close_report_presence() {
-    #[derive(Default)]
-    struct RecordingPresence {
-        events: Mutex<Vec<(HarnessId, &'static str)>>,
-    }
+async fn a_stale_close_cannot_remove_a_newer_token() {
+    let replica = agent_session::domain::model::ReplicaId::mint();
+    let releases = Arc::new(Mutex::new(Vec::new()));
+    let lease = FakeLease {
+        owner: crate::domain::model::RuntimeOwner {
+            replica,
+            connection_id: macro_uuid::Uuid::new_v4(),
+            pending_until: None,
+            address: None,
+        },
+        releases: Arc::clone(&releases),
+    };
+    let registry = RuntimeRegistry::with_lease(replica, Arc::new(lease));
+    let first = ContainerMock::default();
+    let first_id = macro_uuid::Uuid::new_v4();
+    registry.attach_with_id(HarnessId::TEST_A, first_id, first.clone());
+    let first_connection = registry
+        .connections
+        .get(&HarnessId::TEST_A)
+        .map(|entry| Arc::clone(&entry.1))
+        .expect("the first dial is listed");
 
-    impl HarnessPresence for RecordingPresence {
-        fn connected(
-            self: Arc<Self>,
-            harness: HarnessId,
-        ) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send>> {
-            Box::pin(async move {
-                self.events.lock().unwrap().push((harness, "connected"));
-            })
+    registry.remove_and_evict(HarnessId::TEST_A, first_id);
+    let second_id = macro_uuid::Uuid::new_v4();
+    registry.attach_with_id(HarnessId::TEST_A, second_id, ContainerMock::default());
+    first.disconnects();
+    Arc::clone(&registry)
+        .drop_when_closed(HarnessId::TEST_A, first_id, first_connection)
+        .await;
+
+    assert!(registry.is_connected(HarnessId::TEST_A));
+    assert!(
+        releases.lock().unwrap().is_empty(),
+        "a stale close must not release either token"
+    );
+}
+
+#[tokio::test]
+async fn an_expired_pending_owner_does_not_start_a_fresh_wait() {
+    let replica = agent_session::domain::model::ReplicaId::mint();
+    let lease = FakeLease {
+        owner: crate::domain::model::RuntimeOwner {
+            replica,
+            connection_id: macro_uuid::Uuid::new_v4(),
+            pending_until: Some(chrono::Utc::now() - chrono::Duration::milliseconds(1)),
+            address: None,
+        },
+        releases: Arc::default(),
+    };
+    let registry = RuntimeRegistry::<ContainerSender>::with_lease(replica, Arc::new(lease.clone()));
+    let connections = HarnessKeyedConnections::with_lease(
+        Arc::new(FakeBindings::bound(BotId::TEST_A, HarnessId::TEST_A)),
+        lease,
+        registry,
+    );
+
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(5),
+            connections.bind(BotId::TEST_A, AgentSessionId::TEST_A),
+        )
+        .await
+        .expect("an expired deadline returns immediately")
+        .is_none()
+    );
+}
+
+#[tokio::test]
+async fn a_pending_local_owner_waits_only_a_bounded_time_for_its_exact_socket() {
+    let replica = agent_session::domain::model::ReplicaId::mint();
+    let connection_id = macro_uuid::Uuid::new_v4();
+    let lease = FakeLease {
+        owner: crate::domain::model::RuntimeOwner {
+            replica,
+            connection_id,
+            pending_until: Some(chrono::Utc::now() + chrono::Duration::milliseconds(25)),
+            address: None,
+        },
+        releases: Arc::default(),
+    };
+    let registry = RuntimeRegistry::<ContainerSender>::with_lease(replica, Arc::new(lease.clone()));
+    let connections = HarnessKeyedConnections::with_lease(
+        Arc::new(FakeBindings::bound(BotId::TEST_A, HarnessId::TEST_A)),
+        lease,
+        registry,
+    );
+
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            connections.bind(BotId::TEST_A, AgentSessionId::TEST_A),
+        )
+        .await
+        .expect("pending attach wait is bounded")
+        .is_none()
+    );
+}
+
+#[tokio::test]
+async fn a_pending_local_owner_wakes_when_its_exact_socket_attaches() {
+    let replica = agent_session::domain::model::ReplicaId::mint();
+    let connection_id = macro_uuid::Uuid::new_v4();
+    let lease = FakeLease {
+        owner: crate::domain::model::RuntimeOwner {
+            replica,
+            connection_id,
+            pending_until: Some(chrono::Utc::now() + chrono::Duration::milliseconds(25)),
+            address: None,
+        },
+        releases: Arc::default(),
+    };
+    let registry = RuntimeRegistry::<ContainerSender>::with_lease(replica, Arc::new(lease.clone()));
+    let connections = HarnessKeyedConnections::with_lease(
+        Arc::new(FakeBindings::bound(BotId::TEST_A, HarnessId::TEST_A)),
+        lease,
+        Arc::clone(&registry),
+    );
+
+    let binding = connections.bind(BotId::TEST_A, AgentSessionId::TEST_A);
+    let attach = async {
+        tokio::task::yield_now().await;
+        registry.attach_with_id(HarnessId::TEST_A, connection_id, ContainerMock::default());
+    };
+    let (bound, ()) = tokio::join!(binding, attach);
+    assert!(bound.is_some());
+}
+
+#[tokio::test]
+async fn ownership_requires_the_exact_local_connection_token() {
+    let replica = agent_session::domain::model::ReplicaId::mint();
+    let local_token = macro_uuid::Uuid::new_v4();
+    let lease = FakeLease {
+        owner: crate::domain::model::RuntimeOwner {
+            replica,
+            connection_id: local_token,
+            pending_until: None,
+            address: None,
+        },
+        releases: Arc::default(),
+    };
+    let registry = RuntimeRegistry::with_lease(replica, Arc::new(lease));
+    registry.attach_with_id(HarnessId::TEST_A, local_token, ContainerMock::default());
+
+    assert!(registry.owns(
+        HarnessId::TEST_A,
+        &crate::domain::model::RuntimeOwner {
+            replica,
+            connection_id: local_token,
+            pending_until: None,
+            address: None,
         }
-
-        fn disconnected(
-            self: Arc<Self>,
-            harness: HarnessId,
-        ) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send>> {
-            Box::pin(async move {
-                self.events.lock().unwrap().push((harness, "disconnected"));
-            })
+    ));
+    assert!(!registry.owns(
+        HarnessId::TEST_A,
+        &crate::domain::model::RuntimeOwner {
+            replica,
+            connection_id: macro_uuid::Uuid::new_v4(),
+            pending_until: None,
+            address: None,
         }
-    }
+    ));
+}
 
-    let presence = Arc::new(RecordingPresence::default());
-    let registry: Arc<RuntimeRegistry<ContainerSender>> =
-        RuntimeRegistry::with_presence(Arc::clone(&presence) as Arc<dyn HarnessPresence>);
+#[tokio::test]
+async fn close_releases_only_the_closed_connections_exact_token() {
+    let replica = agent_session::domain::model::ReplicaId::mint();
+    let connection_id = macro_uuid::Uuid::new_v4();
+    let releases = Arc::new(Mutex::new(Vec::new()));
+    let lease = FakeLease {
+        owner: crate::domain::model::RuntimeOwner {
+            replica,
+            connection_id,
+            pending_until: None,
+            address: None,
+        },
+        releases: Arc::clone(&releases),
+    };
+    let registry = RuntimeRegistry::with_lease(replica, Arc::new(lease));
     let runtime = ContainerMock::default();
-    registry.attach(HarnessId::TEST_A, runtime.clone());
+    registry.attach_with_id(HarnessId::TEST_A, connection_id, runtime.clone());
     let connection = registry
         .connections
         .get(&HarnessId::TEST_A)
-        .map(|entry| Arc::clone(&entry))
-        .expect("the dial is listed");
+        .map(|entry| Arc::clone(&entry.1))
+        .unwrap();
 
     runtime.disconnects();
     Arc::clone(&registry)
-        .drop_when_closed(HarnessId::TEST_A, connection)
+        .drop_when_closed(HarnessId::TEST_A, connection_id, connection)
         .await;
-
-    // The connected write is spawned; give it a beat to land.
-    for _ in 0..100 {
-        if presence.events.lock().unwrap().len() >= 2 {
+    for _ in 0..10 {
+        if !releases.lock().unwrap().is_empty() {
             break;
         }
         tokio::task::yield_now().await;
     }
-    let events = presence.events.lock().unwrap().clone();
-    assert!(events.contains(&(HarnessId::TEST_A, "connected")));
-    assert!(events.contains(&(HarnessId::TEST_A, "disconnected")));
+
+    assert_eq!(*releases.lock().unwrap(), vec![connection_id]);
 }

--- a/crates/agent_session/src/domain/ports.rs
+++ b/crates/agent_session/src/domain/ports.rs
@@ -306,6 +306,15 @@ pub trait SessionOwnership: Send + Sync + 'static {
         replica: ReplicaId,
     ) -> impl Future<Output = Result<ClaimOutcome>> + Send;
 
+    /// Claim only while `replica` owns the exact external runtime socket.
+    fn claim_for_runtime(
+        &self,
+        session: AgentSessionId,
+        replica: ReplicaId,
+        harness: harness_id::HarnessId,
+        connection_id: macro_uuid::Uuid,
+    ) -> impl Future<Output = Result<ClaimOutcome>> + Send;
+
     /// Release a claim this replica holds. Conditional on the claim's fence
     /// still being current: releasing after having been superseded is a
     /// no-op, never a theft of the successor's claim. A session already

--- a/crates/agent_session/src/domain/service.rs
+++ b/crates/agent_session/src/domain/service.rs
@@ -171,6 +171,17 @@ pub trait AgentSessionService: Send + Sync + 'static {
     where
         Connector: AgentConnector;
 
+    /// Attach while atomically conditioning the session claim on a runtime lease.
+    fn attach_runtime_session<Connector>(
+        &self,
+        id: AgentSessionId,
+        attachment: RuntimeAttachment<Connector>,
+        harness: harness_id::HarnessId,
+        connection_id: macro_uuid::Uuid,
+    ) -> impl Future<Output = Result<()>> + Send
+    where
+        Connector: AgentConnector;
+
     /// Deliver an action through the session's active transport, under the
     /// action id it will carry onto the wire.
     fn send_action(
@@ -679,6 +690,40 @@ where
                     );
                 })
                 .ok();
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    async fn attach_runtime_session<Connector>(
+        &self,
+        id: AgentSessionId,
+        attachment: RuntimeAttachment<Connector>,
+        harness: harness_id::HarnessId,
+        connection_id: macro_uuid::Uuid,
+    ) -> Result<()>
+    where
+        Connector: AgentConnector,
+    {
+        let reservation = self.reserve_attach(id).await?;
+        let claim = match self
+            .repo
+            .claim_for_runtime(id, self.replica, harness, connection_id)
+            .await?
+        {
+            ClaimOutcome::Claimed(claim) => claim,
+            ClaimOutcome::ManagedElsewhere(_) => {
+                return Err(AgentSessionError::ManagedElsewhere(id));
+            }
+        };
+        let activated = async {
+            let session = self.repo.get(id).await?;
+            self.activate_reserved(session, attachment, reservation, claim)
+                .await
+        }
+        .await;
+        if let Err(error) = activated {
+            self.repo.release(&claim).await.ok();
             return Err(error);
         }
         Ok(())

--- a/crates/agent_session/src/domain/service/test.rs
+++ b/crates/agent_session/src/domain/service/test.rs
@@ -424,6 +424,18 @@ impl SessionOwnership for BlockingPromptLogs {
         self.repo.claim(session, replica).await
     }
 
+    async fn claim_for_runtime(
+        &self,
+        session: AgentSessionId,
+        replica: ReplicaId,
+        harness: harness_id::HarnessId,
+        connection_id: macro_uuid::Uuid,
+    ) -> Result<ClaimOutcome> {
+        self.repo
+            .claim_for_runtime(session, replica, harness, connection_id)
+            .await
+    }
+
     async fn release(&self, claim: &SessionClaim) -> Result<()> {
         self.repo.release(claim).await
     }

--- a/crates/agent_session/src/outbound/postgres.rs
+++ b/crates/agent_session/src/outbound/postgres.rs
@@ -940,6 +940,49 @@ impl SessionOwnership for PgAgentSessionRepo {
         }
     }
 
+    async fn claim_for_runtime(
+        &self,
+        session: AgentSessionId,
+        replica: ReplicaId,
+        harness: harness_id::HarnessId,
+        connection_id: macro_uuid::Uuid,
+    ) -> Result<ClaimOutcome> {
+        let fence = sqlx::query_scalar!(
+            r#"
+            WITH runtime AS MATERIALIZED (
+                SELECT harness_id
+                FROM harness_runtime_lease
+                WHERE harness_id = $3 AND replica_id = $2 AND connection_id = $4
+                  AND pending_until > now()
+                FOR UPDATE
+            )
+            UPDATE agent_session
+            SET manager_replica_id = $2,
+                manager_fence = manager_fence + 1,
+                modified_at = now()
+            WHERE id = $1
+              AND EXISTS (SELECT 1 FROM runtime)
+              AND (manager_replica_id IS NULL OR manager_replica_id = $2)
+            RETURNING manager_fence
+            "#,
+            session.as_uuid(),
+            replica.as_uuid(),
+            harness.as_uuid(),
+            connection_id,
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .context("failed to claim agent session for runtime")?;
+        match fence {
+            Some(fence) => Ok(ClaimOutcome::Claimed(SessionClaim {
+                session,
+                replica,
+                fence: ManagerFence(fence),
+            })),
+            None => Err(AgentSessionError::ManagedElsewhere(session)),
+        }
+    }
+
     async fn release(&self, claim: &SessionClaim) -> Result<()> {
         // Conditional on both holder and fence: a release arriving after a
         // successor claimed must not free the successor's lease, and a

--- a/crates/agent_session/src/testing.rs
+++ b/crates/agent_session/src/testing.rs
@@ -374,6 +374,16 @@ impl SessionOwnership for InMemoryAgentSessionRepo {
         }))
     }
 
+    async fn claim_for_runtime(
+        &self,
+        session: AgentSessionId,
+        replica: ReplicaId,
+        _harness: harness_id::HarnessId,
+        _connection_id: macro_uuid::Uuid,
+    ) -> Result<ClaimOutcome> {
+        self.claim(session, replica).await
+    }
+
     async fn release(&self, claim: &SessionClaim) -> Result<()> {
         let mut leases = self
             .leases

--- a/crates/macro_db_client/migrations/20260903165729_harness_runtime_location.sql
+++ b/crates/macro_db_client/migrations/20260903165729_harness_runtime_location.sql
@@ -1,0 +1,12 @@
+-- One globally exclusive socket owner for each externally hosted harness.
+-- A pending owner is immediately routable but expires quickly unless the
+-- gateway promotes its exact token after attaching the socket locally.
+CREATE TABLE harness_runtime_lease (
+    harness_id UUID PRIMARY KEY REFERENCES harnesses(id) ON DELETE CASCADE,
+    replica_id UUID NOT NULL REFERENCES harness_replica(id) ON DELETE CASCADE,
+    connection_id UUID NOT NULL,
+    pending_until TIMESTAMPTZ NOT NULL DEFAULT now() + interval '5 seconds'
+);
+
+CREATE INDEX harness_runtime_lease_replica_id_idx
+    ON harness_runtime_lease (replica_id);

--- a/services/agent_harness_service/Cargo.toml
+++ b/services/agent_harness_service/Cargo.toml
@@ -82,3 +82,4 @@ workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 
 [dev-dependencies]
 agent_session = { path = "../../crates/agent_session", features = ["test-utils"] }
+macro_db_migrator = { path = "../../crates/macro_db_migrator" }

--- a/services/agent_harness_service/src/api.rs
+++ b/services/agent_harness_service/src/api.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use agent_egress::domain::service::EgressService;
 use agent_egress::inbound::axum_router::{EgressRouterState, egress_router};
+use agent_harness::domain::ports::RuntimeLease;
 use agent_harness::domain::service::ForwardedCommands;
 use agent_harness::inbound::forward::{ForwardGatewayState, forward_router};
 use agent_harness::inbound::runtime_gateway::{RuntimeGatewayState, runtime_gateway_router};
@@ -74,11 +75,11 @@ where
 }
 
 /// Build the router and serve it until the process is asked to stop.
-pub async fn setup_and_serve<T, R, Opener, Bots, Access, Auth, Harness>(
+pub async fn setup_and_serve<T, R, Opener, Bots, Access, Auth, Harness, Lease>(
     read_state: AgentSessionRouterState<T, Access, Auth>,
     control_state: AgentSessionControlState<R, Access, Auth>,
     create_state: CreateSessionState<Opener, Bots, Auth>,
-    gateway_state: RuntimeGatewayState<Auth>,
+    gateway_state: RuntimeGatewayState<Auth, Lease>,
     forward_state: ForwardGatewayState<Harness, Auth>,
     port: u16,
     shutdown: impl Future<Output = ()> + Send + 'static,
@@ -91,6 +92,7 @@ where
     Access: EntityAccessService,
     Auth: MacroAuthorizationService,
     Harness: ForwardedCommands,
+    Lease: RuntimeLease + Clone,
 {
     let inner = api_router(
         read_state,
@@ -121,11 +123,11 @@ where
         .context("agent harness service http failed")
 }
 
-fn api_router<T, R, Opener, Bots, Access, Auth, Harness>(
+fn api_router<T, R, Opener, Bots, Access, Auth, Harness, Lease>(
     read_state: AgentSessionRouterState<T, Access, Auth>,
     control_state: AgentSessionControlState<R, Access, Auth>,
     create_state: CreateSessionState<Opener, Bots, Auth>,
-    gateway_state: RuntimeGatewayState<Auth>,
+    gateway_state: RuntimeGatewayState<Auth, Lease>,
     forward_state: ForwardGatewayState<Harness, Auth>,
 ) -> Router
 where
@@ -136,6 +138,7 @@ where
     Access: EntityAccessService,
     Auth: MacroAuthorizationService,
     Harness: ForwardedCommands,
+    Lease: RuntimeLease + Clone,
 {
     let agent_sessions = agent_session_read_router(read_state.clone())
         .merge(agent_session_control_router(control_state))

--- a/services/agent_harness_service/src/harness_bindings.rs
+++ b/services/agent_harness_service/src/harness_bindings.rs
@@ -2,17 +2,21 @@
 //!
 //! Composition-root adapters: [`PgHarnessBindings`] answers "which registered
 //! harness serves this bot right now" for session binding, and
-//! [`PgHarnessPresence`] writes the attach/detach bookkeeping the harness
-//! settings page reads connection state from.
+//! [`PgRuntimeLease`] owns the cluster-wide runtime socket lease and updates
+//! UI presence from its exact-token transitions.
 
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
 
-use agent_harness::domain::ports::{HarnessBindings, HarnessPresence};
+use agent_harness::domain::model::RuntimeOwner;
+use agent_harness::domain::ports::{HarnessBindings, RuntimeLease};
+use agent_session::domain::model::{ReplicaAddress, ReplicaId};
 use bot_id::BotId;
 use harness_id::HarnessId;
 use sqlx::PgPool;
+
+#[cfg(test)]
+mod test;
 
 /// [`HarnessBindings`] over the `agent_configs` table.
 #[derive(Clone)]
@@ -45,47 +49,190 @@ impl HarnessBindings for PgHarnessBindings {
     }
 }
 
-/// [`HarnessPresence`] over the `harnesses` table.
-pub struct PgHarnessPresence {
+/// [`RuntimeLease`] over the durable harness runtime owner row.
+#[derive(Clone)]
+pub struct PgRuntimeLease {
     pool: PgPool,
 }
 
-impl PgHarnessPresence {
+impl PgRuntimeLease {
     /// Wrap a pool.
     pub fn new(pool: PgPool) -> Self {
         Self { pool }
     }
+
+    /// Remove owners whose replica heartbeat expired and record disconnects.
+    pub async fn expire_stale(&self) -> anyhow::Result<()> {
+        sqlx::query!(
+            "WITH expired AS ( \
+               DELETE FROM harness_runtime_lease lease \
+               WHERE NOT EXISTS ( \
+                 SELECT 1 FROM harness_replica replica \
+                 WHERE replica.id = lease.replica_id \
+                   AND replica.last_heartbeat_at > now() - interval '30 seconds' \
+               ) RETURNING harness_id, replica_id \
+             ), fenced AS ( \
+               UPDATE agent_session session SET manager_replica_id = NULL \
+               FROM expired \
+               WHERE session.manager_replica_id = expired.replica_id \
+                 AND EXISTS ( \
+                   SELECT 1 FROM agent_configs config \
+                   WHERE config.bot_id = session.bot_id \
+                     AND config.harness_id = expired.harness_id \
+                 ) \
+             ) UPDATE harnesses SET last_disconnected_at = now() \
+               WHERE id IN (SELECT harness_id FROM expired)"
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
 }
 
-impl HarnessPresence for PgHarnessPresence {
-    fn connected(self: Arc<Self>, harness: HarnessId) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+impl RuntimeLease for PgRuntimeLease {
+    fn claim(
+        &self,
+        harness: HarnessId,
+        replica: ReplicaId,
+        connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>> {
+        let pool = self.pool.clone();
         Box::pin(async move {
-            let result = sqlx::query!(
-                r#"UPDATE harnesses SET last_connected_at = now() WHERE id = $1"#,
+            let mut transaction = pool.begin().await?;
+            let previous = sqlx::query!(
+                "SELECT replica_id, connection_id FROM harness_runtime_lease WHERE harness_id = $1 FOR UPDATE",
                 harness.as_uuid(),
             )
-            .execute(&self.pool)
-            .await;
-            if let Err(error) = result {
-                tracing::error!(error = ?error, %harness, "failed to record harness attach");
+            .fetch_optional(&mut *transaction)
+            .await?;
+            let claimed = sqlx::query!(
+                r#"INSERT INTO harness_runtime_lease (harness_id, replica_id, connection_id)
+                   VALUES ($1, $2, $3)
+                   ON CONFLICT (harness_id) DO UPDATE
+                   SET replica_id = EXCLUDED.replica_id, connection_id = EXCLUDED.connection_id,
+                       pending_until = now() + interval '5 seconds'
+                   WHERE harness_runtime_lease.pending_until <= now()
+                      OR NOT EXISTS (
+                       SELECT 1 FROM harness_replica current
+                       WHERE current.id = harness_runtime_lease.replica_id
+                         AND current.last_heartbeat_at > now() - interval '30 seconds'
+                   )"#,
+                harness.as_uuid(),
+                replica.as_uuid(),
+                connection_id,
+            )
+            .execute(&mut *transaction)
+            .await?
+            .rows_affected()
+                == 1;
+            if claimed
+                && previous.as_ref().is_some_and(|previous| {
+                    previous.replica_id != replica.as_uuid()
+                        || previous.connection_id != connection_id
+                })
+            {
+                sqlx::query!(
+                    "UPDATE agent_session session SET manager_replica_id = NULL \
+                     WHERE session.manager_replica_id = $1 \
+                       AND EXISTS ( \
+                         SELECT 1 FROM agent_configs config \
+                         WHERE config.bot_id = session.bot_id AND config.harness_id = $2 \
+                       )",
+                    previous.expect("checked above").replica_id,
+                    harness.as_uuid(),
+                )
+                .execute(&mut *transaction)
+                .await?;
             }
+            transaction.commit().await?;
+            Ok(claimed)
         })
     }
 
-    fn disconnected(
-        self: Arc<Self>,
+    fn activate(
+        &self,
         harness: HarnessId,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        replica: ReplicaId,
+        connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>> {
+        let pool = self.pool.clone();
         Box::pin(async move {
             let result = sqlx::query!(
-                r#"UPDATE harnesses SET last_disconnected_at = now() WHERE id = $1"#,
+                "WITH activated AS ( \
+                   UPDATE harness_runtime_lease SET pending_until = 'infinity'::timestamptz \
+                   WHERE harness_id = $1 AND replica_id = $2 AND connection_id = $3 \
+                     AND pending_until > now() RETURNING harness_id \
+                 ) UPDATE harnesses SET last_connected_at = now() \
+                   WHERE id IN (SELECT harness_id FROM activated)",
+                harness.as_uuid(),
+                replica.as_uuid(),
+                connection_id,
+            )
+            .execute(&pool)
+            .await;
+            Ok(result?.rows_affected() == 1)
+        })
+    }
+
+    fn release(
+        &self,
+        harness: HarnessId,
+        replica: ReplicaId,
+        connection_id: macro_uuid::Uuid,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>> {
+        let pool = self.pool.clone();
+        Box::pin(async move {
+            sqlx::query!(
+                "WITH released AS ( \
+                   DELETE FROM harness_runtime_lease \
+                   WHERE harness_id = $1 AND replica_id = $2 AND connection_id = $3 \
+                   RETURNING harness_id, replica_id \
+                 ), fenced AS ( \
+                   UPDATE agent_session session SET manager_replica_id = NULL \
+                   FROM released \
+                   WHERE session.manager_replica_id = released.replica_id \
+                     AND EXISTS ( \
+                       SELECT 1 FROM agent_configs config \
+                       WHERE config.bot_id = session.bot_id \
+                         AND config.harness_id = released.harness_id \
+                     ) \
+                 ) UPDATE harnesses SET last_disconnected_at = now() \
+                   WHERE id IN (SELECT harness_id FROM released)",
+                harness.as_uuid(),
+                replica.as_uuid(),
+                connection_id,
+            )
+            .execute(&pool)
+            .await?;
+            Ok(())
+        })
+    }
+
+    fn owner(
+        &self,
+        harness: HarnessId,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<RuntimeOwner>>> + Send>> {
+        let pool = self.pool.clone();
+        Box::pin(async move {
+            let owner = sqlx::query!(
+                "SELECT lease.replica_id, lease.connection_id, replica.address, \
+                        CASE WHEN lease.pending_until = 'infinity'::timestamptz \
+                             THEN NULL ELSE lease.pending_until END AS pending_until \
+                 FROM harness_runtime_lease lease \
+                 JOIN harness_replica replica ON replica.id = lease.replica_id \
+                 WHERE lease.harness_id = $1 \
+                   AND replica.last_heartbeat_at > now() - interval '30 seconds' \
+                   AND lease.pending_until > now()",
                 harness.as_uuid(),
             )
-            .execute(&self.pool)
-            .await;
-            if let Err(error) = result {
-                tracing::error!(error = ?error, %harness, "failed to record harness detach");
-            }
+            .fetch_optional(&pool)
+            .await?;
+            Ok(owner.map(|owner| RuntimeOwner {
+                replica: ReplicaId::from_uuid(owner.replica_id),
+                connection_id: owner.connection_id,
+                pending_until: owner.pending_until,
+                address: owner.address.map(ReplicaAddress::new),
+            }))
         })
     }
 }

--- a/services/agent_harness_service/src/harness_bindings/test.rs
+++ b/services/agent_harness_service/src/harness_bindings/test.rs
@@ -1,0 +1,258 @@
+use super::*;
+use macro_db_migrator::MACRO_DB_MIGRATIONS;
+
+async fn insert_harness(pool: &PgPool, harness: HarnessId) {
+    sqlx::query!(
+        "INSERT INTO harnesses (id, name, owner_user_id, created_by) VALUES ($1, 'test', 'owner@localhost', 'owner@localhost')",
+        harness.as_uuid(),
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn insert_replica(pool: &PgPool, replica: ReplicaId, address: &str) {
+    sqlx::query!(
+        "INSERT INTO harness_replica (id, address) VALUES ($1, $2)",
+        replica.as_uuid(),
+        address,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn insert_user(pool: &PgPool) {
+    let macro_user = macro_uuid::Uuid::new_v4();
+    sqlx::query!(
+        "INSERT INTO macro_user (id, username, email, stripe_customer_id) VALUES ($1, $2, $2, 'stripe_test')",
+        macro_user,
+        "owner@localhost",
+    )
+    .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query!(
+        r#"INSERT INTO "User" (id, email, macro_user_id) VALUES ('owner@localhost', 'owner@localhost', $1)"#,
+        macro_user,
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn lease_is_exclusive_and_exact_tokens_control_presence(pool: PgPool) {
+    let harness = HarnessId::new_from_uuid(macro_uuid::Uuid::new_v4());
+    let first = ReplicaId::mint();
+    let second = ReplicaId::mint();
+    insert_harness(&pool, harness).await;
+    insert_replica(&pool, first, "http://first").await;
+    insert_replica(&pool, second, "http://second").await;
+    let lease = PgRuntimeLease::new(pool.clone());
+    let first_token = macro_uuid::Uuid::new_v4();
+    let second_token = macro_uuid::Uuid::new_v4();
+
+    assert!(lease.claim(harness, first, first_token).await.unwrap());
+    assert!(!lease.claim(harness, second, second_token).await.unwrap());
+    assert!(lease.activate(harness, first, first_token).await.unwrap());
+    assert!(!lease.activate(harness, first, second_token).await.unwrap());
+
+    lease.release(harness, first, second_token).await.unwrap();
+    assert_eq!(
+        lease.owner(harness).await.unwrap().unwrap().connection_id,
+        first_token
+    );
+    let presence = sqlx::query!(
+        "SELECT last_connected_at IS NOT NULL AS \"connected!\", last_disconnected_at IS NOT NULL AS \"disconnected!\" FROM harnesses WHERE id = $1",
+        harness.as_uuid(),
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(presence.connected);
+    assert!(!presence.disconnected);
+
+    lease.release(harness, first, first_token).await.unwrap();
+    assert!(lease.owner(harness).await.unwrap().is_none());
+    let disconnected = sqlx::query_scalar!(
+        "SELECT last_disconnected_at IS NOT NULL AS \"disconnected!\" FROM harnesses WHERE id = $1",
+        harness.as_uuid(),
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(disconnected);
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn expired_pending_and_stale_replica_claims_can_be_taken_over(pool: PgPool) {
+    let harness = HarnessId::new_from_uuid(macro_uuid::Uuid::new_v4());
+    let first = ReplicaId::mint();
+    let second = ReplicaId::mint();
+    insert_harness(&pool, harness).await;
+    insert_replica(&pool, first, "http://first").await;
+    insert_replica(&pool, second, "http://second").await;
+    let lease = PgRuntimeLease::new(pool.clone());
+
+    assert!(
+        lease
+            .claim(harness, first, macro_uuid::Uuid::new_v4())
+            .await
+            .unwrap()
+    );
+    sqlx::query!("UPDATE harness_runtime_lease SET pending_until = now() - interval '1 second'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let second_token = macro_uuid::Uuid::new_v4();
+    assert!(lease.claim(harness, second, second_token).await.unwrap());
+    assert!(lease.activate(harness, second, second_token).await.unwrap());
+
+    sqlx::query!(
+        "UPDATE harness_replica SET last_heartbeat_at = now() - interval '31 seconds' WHERE id = $1",
+        second.as_uuid(),
+    )
+        .execute(&pool)
+        .await
+        .unwrap();
+    let first_token = macro_uuid::Uuid::new_v4();
+    assert!(lease.claim(harness, first, first_token).await.unwrap());
+    let owner = lease.owner(harness).await.unwrap().unwrap();
+    assert_eq!(owner.replica, first);
+    assert_eq!(owner.connection_id, first_token);
+    assert!(owner.pending_until.is_some());
+}
+
+#[sqlx::test(migrator = "MACRO_DB_MIGRATIONS")]
+async fn stale_takeover_fences_sessions_and_expiry_updates_presence(pool: PgPool) {
+    let harness = HarnessId::new_from_uuid(macro_uuid::Uuid::new_v4());
+    let first = ReplicaId::mint();
+    let second = ReplicaId::mint();
+    let bot = BotId::new_from_uuid(macro_uuid::Uuid::new_v4());
+    insert_harness(&pool, harness).await;
+    insert_replica(&pool, first, "http://first").await;
+    insert_replica(&pool, second, "http://second").await;
+    insert_user(&pool).await;
+    sqlx::query!(
+        "INSERT INTO bots (id, kind, owner_user_id, name, handle) VALUES ($1, 'owned', 'owner@localhost', 'bot', 'bot')",
+        bot.as_uuid(),
+    )
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query!(
+        "INSERT INTO agent_configs (bot_id, instructions, harness, default_model, channel_scope, harness_id) VALUES ($1, '', 'macrod', 'test', 'all', $2)",
+        bot.as_uuid(),
+        harness.as_uuid(),
+    )
+        .execute(&pool)
+        .await
+        .unwrap();
+    let session_id = macro_uuid::Uuid::new_v4();
+    sqlx::query!(
+        "INSERT INTO agent_session (id, owner_id, bot_id, name, model, harness, workspace, status, manager_replica_id) VALUES ($1, 'owner@localhost', $2, 'test', 'test', 'macrod', '/tmp', 'disconnected', $3)",
+        session_id,
+        bot.as_uuid(),
+        first.as_uuid(),
+    )
+        .execute(&pool)
+        .await
+        .unwrap();
+    let lease = PgRuntimeLease::new(pool.clone());
+    let first_token = macro_uuid::Uuid::new_v4();
+    assert!(lease.claim(harness, first, first_token).await.unwrap());
+    assert!(lease.activate(harness, first, first_token).await.unwrap());
+    sqlx::query!(
+        "UPDATE harness_replica SET last_heartbeat_at = now() - interval '31 seconds' WHERE id = $1",
+        first.as_uuid(),
+    )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let second_token = macro_uuid::Uuid::new_v4();
+    assert!(lease.claim(harness, second, second_token).await.unwrap());
+    let manager = sqlx::query_scalar!(
+        "SELECT manager_replica_id FROM agent_session WHERE id = $1",
+        session_id,
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(
+        manager.is_none(),
+        "takeover fences the stale replica's actor"
+    );
+
+    assert!(lease.activate(harness, second, second_token).await.unwrap());
+    sqlx::query!(
+        "UPDATE agent_session SET manager_replica_id = $2 WHERE id = $1",
+        session_id,
+        second.as_uuid(),
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query!(
+        "UPDATE harness_replica SET last_heartbeat_at = now() - interval '31 seconds' WHERE id = $1",
+        second.as_uuid(),
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    let replacement_token = macro_uuid::Uuid::new_v4();
+    assert!(
+        lease
+            .claim(harness, second, replacement_token)
+            .await
+            .unwrap()
+    );
+    let manager = sqlx::query_scalar!(
+        "SELECT manager_replica_id FROM agent_session WHERE id = $1",
+        session_id,
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(manager.is_none(), "same-replica replacement fences actors");
+    assert!(
+        lease
+            .activate(harness, second, replacement_token)
+            .await
+            .unwrap()
+    );
+    sqlx::query!(
+        "UPDATE agent_session SET manager_replica_id = $2 WHERE id = $1",
+        session_id,
+        second.as_uuid(),
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query!(
+        "UPDATE harness_replica SET last_heartbeat_at = now() - interval '31 seconds' WHERE id = $1",
+        second.as_uuid(),
+    )
+        .execute(&pool)
+        .await
+        .unwrap();
+    lease.expire_stale().await.unwrap();
+    assert!(lease.owner(harness).await.unwrap().is_none());
+    let manager = sqlx::query_scalar!(
+        "SELECT manager_replica_id FROM agent_session WHERE id = $1",
+        session_id,
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(manager.is_none(), "expiry fences the disconnected actor");
+    let disconnected_after_connected = sqlx::query_scalar!(
+        "SELECT last_disconnected_at >= last_connected_at AS \"disconnected_after_connected!\" FROM harnesses WHERE id = $1",
+        harness.as_uuid(),
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(disconnected_after_connected);
+}

--- a/services/agent_harness_service/src/main.rs
+++ b/services/agent_harness_service/src/main.rs
@@ -82,7 +82,7 @@ use cursor_cloud_agents::domain::model::RepoUrl as CursorRepoUrl;
 use github::domain::service::{InstallationTokenConfig, InstallationTokenService};
 use github::outbound::github_sync_client::GithubSyncClientImpl;
 use github::outbound::pg_github_sync_repo::PgGithubSyncRepo;
-use harness_bindings::{PgHarnessBindings, PgHarnessPresence};
+use harness_bindings::{PgHarnessBindings, PgRuntimeLease};
 use kafka_util::{GroupName, KafkaEventConsumer, consumer_span, record_span_error};
 use lexical_client::LexicalClient;
 use macro_auth::middleware::decode_jwt::JwtValidationArgs;
@@ -463,9 +463,10 @@ async fn run() -> anyhow::Result<()> {
 
     // One connection per harness, shared by every session of every agent
     // bound to it. Held here because the gateway puts dialed-in sockets into
-    // it and the harness takes sessions out of it. Attach/detach is mirrored
-    // to the harnesses table so the settings page can show connection state.
-    let runtimes = RuntimeRegistry::with_presence(Arc::new(PgHarnessPresence::new(pool.clone())));
+    // it and the harness takes sessions out of it. The lease makes the socket
+    // owner exclusive across replicas before the gateway accepts an upgrade.
+    let runtime_lease = Arc::new(PgRuntimeLease::new(pool.clone()));
+    let runtimes = RuntimeRegistry::with_lease(replica, runtime_lease.clone());
     let mut defaults = HarnessDefaults::new(SessionDefaults {
         bot_id,
         model: config.harness_model.clone(),
@@ -514,7 +515,11 @@ async fn run() -> anyhow::Result<()> {
         sessions,
         containers,
         announcer,
-        HarnessKeyedConnections::new(PgHarnessBindings::new(pool.clone()), Arc::clone(&runtimes)),
+        HarnessKeyedConnections::with_lease(
+            PgHarnessBindings::new(pool.clone()),
+            runtime_lease.clone(),
+            Arc::clone(&runtimes),
+        ),
         prompt_context,
         prompt_composer,
         EgressProvisioner::new(Arc::clone(&mcp_connections), config.egress_base_url.clone()),
@@ -564,13 +569,19 @@ async fn run() -> anyhow::Result<()> {
         MacroAuthorizationState::new(Arc::new(authorization_service.clone())),
     );
     let gateway_state = RuntimeGatewayState::new(
-        runtimes,
+        Arc::clone(&runtimes),
         MacroAuthorizationState::new(Arc::new(authorization_service.clone())),
+        replica,
+        runtime_lease.clone(),
     );
     let forward_state = ForwardGatewayState::new(
         harness.clone(),
         MacroAuthorizationState::new(Arc::new(authorization_service)),
     );
+    session_repo
+        .heartbeat(replica, replica_address.as_ref())
+        .await
+        .context("failed to record initial harness replica heartbeat")?;
     let http_port = config.port;
     let http = tokio::spawn(async move {
         if let Err(error) = api::setup_and_serve(
@@ -595,6 +606,8 @@ async fn run() -> anyhow::Result<()> {
     // what covers the ungraceful ones.
     let heartbeat_repo = session_repo.clone();
     let heartbeat_address = replica_address.clone();
+    let heartbeat_runtime_lease = runtime_lease.clone();
+    let heartbeat_runtimes = runtimes;
     let heartbeat = tokio::spawn(async move {
         let mut ticker =
             tokio::time::interval(agent_session::domain::ports::REPLICA_HEARTBEAT_INTERVAL);
@@ -606,6 +619,10 @@ async fn run() -> anyhow::Result<()> {
             {
                 tracing::warn!(error = ?error, %replica, "failed to heartbeat harness replica");
             }
+            if let Err(error) = heartbeat_runtime_lease.expire_stale().await {
+                tracing::warn!(error = ?error, "failed to expire stale runtime socket leases");
+            }
+            heartbeat_runtimes.reconcile().await;
         }
     });
 


### PR DESCRIPTION
## Summary
- add an exclusive, fenced Postgres lease for each externally hosted harness runtime socket
- route first and existing external-session commands to the replica holding the exact runtime token
- fence stale actors during takeover, release, and expiry, including atomic runtime-conditioned session claims
- reconcile superseded local sockets and bound pending upgrades to their exact claim deadline

## Verification
- `cargo test -p agent_harness` (152 passed)
- `cargo test -p agent_harness_service harness_bindings::test` (3 passed against isolated Postgres)
- `SQLX_OFFLINE=true cargo clippy -p agent_harness_service --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- manual two-replica proof: runtime WebSocket on replica A; session create and first command on replica B; command arrived at A; duplicate socket rejected; reconnect to B succeeded after disconnect

## Architecture
- runtime-routing policy remains in the domain service and ports
- WebSocket/HTTP handling remains in inbound/outbound adapters
- PostgreSQL lease and fencing mechanics remain in persistence adapters

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes multi-replica command routing, WebSocket admission, and durable session fencing; mis-ordered lease/attach logic could drop commands or run work on the wrong replica.
> 
> **Overview**
> **Replaces** simple harness connect/disconnect bookkeeping with a **cluster-wide exclusive lease** (`harness_runtime_lease`) keyed by harness, owning replica, and an exact **connection token**. The runtime WebSocket gateway must **claim** before upgrade, **activate** after a successful dial, and **release** on failure or close; conflicting fresh claims return **409**.
> 
> **External-session commands** now resolve the **runtime socket owner** first (not only the session manager): peers receive **`ForwardedCommand`** payloads carrying an optional **`RuntimeFence`**, and the receiving replica refuses work if that token is no longer local. Session attach can use **`attach_runtime_session` / `claim_for_runtime`**, tying manager claims to the live lease row in Postgres.
> 
> **Takeover, release, and heartbeat expiry** clear `manager_replica_id` for affected harness sessions, update harness presence from lease transitions, **reconcile** superseded local sockets, and bound waits for pending upgrades to the claim deadline. SQLx query metadata, migration, and integration tests cover the new lease SQL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e83024b774f5bb787694723403540799d5238ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->