### PR TITLE
fix(channels): attribute AI-created channels to Automation

### DIFF
--- a/crates/channels/src/domain/ports.rs
+++ b/crates/channels/src/domain/ports.rs
@@ -672,7 +672,18 @@ pub trait ChannelService: Send + Sync + 'static {
     /// `owner`; ownership and permissions are unchanged.
     fn create_system_channel(
         &self,
+        owner: MacroUserIdStr<'static>,
+        req: CreateChannelRequest,
+    ) -> impl Future<Output = Result<CreateChannelResponse, ChannelMutationErr>> + Send {
+        self.create_channel_on_behalf(owner, bot_id::MACRO_SYSTEM_BOT_ID, req)
+    }
+
+    /// Create a channel owned by `owner` with Created attributed to `actor`
+    /// acting for that owner. Ownership and permissions stay with `owner`.
+    fn create_channel_on_behalf(
+        &self,
         _owner: MacroUserIdStr<'static>,
+        _actor: BotId,
         _req: CreateChannelRequest,
     ) -> impl Future<Output = Result<CreateChannelResponse, ChannelMutationErr>> + Send {
         async move {

--- a/crates/channels/src/domain/service.rs
+++ b/crates/channels/src/domain/service.rs
@@ -344,9 +344,20 @@ where
         owner: MacroUserIdStr<'static>,
         req: crate::domain::models::CreateChannelRequest,
     ) -> Result<crate::domain::models::CreateChannelResponse, ChannelMutationErr> {
+        self.create_channel_on_behalf(owner, bot_id::MACRO_SYSTEM_BOT_ID, req)
+            .await
+    }
+
+    #[tracing::instrument(err, skip(self, req))]
+    async fn create_channel_on_behalf(
+        &self,
+        owner: MacroUserIdStr<'static>,
+        actor: BotId,
+        req: crate::domain::models::CreateChannelRequest,
+    ) -> Result<crate::domain::models::CreateChannelResponse, ChannelMutationErr> {
         self.create_owned_channel(
             owner.clone(),
-            Sender::new_from_bot(bot_id::MACRO_SYSTEM_BOT_ID),
+            Sender::new_from_bot(actor),
             Some(owner),
             req,
         )
@@ -1881,6 +1892,15 @@ where
         req: crate::domain::models::CreateChannelRequest,
     ) -> Result<crate::domain::models::CreateChannelResponse, ChannelMutationErr> {
         ChannelServiceImpl::create_system_channel(self, owner, req).await
+    }
+
+    async fn create_channel_on_behalf(
+        &self,
+        owner: MacroUserIdStr<'static>,
+        actor: BotId,
+        req: crate::domain::models::CreateChannelRequest,
+    ) -> Result<crate::domain::models::CreateChannelResponse, ChannelMutationErr> {
+        ChannelServiceImpl::create_channel_on_behalf(self, owner, actor, req).await
     }
 
     #[tracing::instrument(err, skip(self, user_id))]

--- a/crates/channels/src/domain/service.rs
+++ b/crates/channels/src/domain/service.rs
@@ -355,13 +355,8 @@ where
         actor: BotId,
         req: crate::domain::models::CreateChannelRequest,
     ) -> Result<crate::domain::models::CreateChannelResponse, ChannelMutationErr> {
-        self.create_owned_channel(
-            owner.clone(),
-            Sender::new_from_bot(actor),
-            Some(owner),
-            req,
-        )
-        .await
+        self.create_owned_channel(owner.clone(), Sender::new_from_bot(actor), Some(owner), req)
+            .await
     }
 
     async fn create_owned_channel(

--- a/crates/channels/src/domain/service/test.rs
+++ b/crates/channels/src/domain/service/test.rs
@@ -2303,6 +2303,41 @@ async fn create_system_channel_event_uses_system_actor() {
     ));
 }
 
+#[tokio::test]
+async fn create_channel_on_behalf_attributes_created_to_the_bot() {
+    let channel_id = Uuid::new_v4();
+    let repo = FakeMutationRepo::new(channel_id, "macro|owner@test.com");
+    let events = FakeEvents::default();
+    let svc = mutation_service(repo, events.clone(), FakeReferenceSharing::default());
+
+    svc.create_channel_on_behalf(
+        macro_id("macro|owner@test.com"),
+        bot_id::MACRO_AI_BOT_ID,
+        crate::domain::models::CreateChannelRequest {
+            name: Some("Planning".to_string()),
+            channel_type: ChannelType::Private,
+            team_id: None,
+            auto_join_team: false,
+            participants: HashSet::from([macro_id("macro|teo@macro.com")]),
+        },
+    )
+    .await
+    .unwrap();
+
+    let events = events.events.lock().unwrap();
+    assert!(matches!(
+        events.as_slice(),
+        [ChannelEvent::ChannelCreated {
+            actor,
+            on_behalf_of: Some(owner),
+            channel_name: Some(name),
+            ..
+        }] if actor == &Sender::new_from_bot(bot_id::MACRO_AI_BOT_ID)
+            && owner.as_ref() == "macro|owner@test.com"
+            && name == "Planning"
+    ));
+}
+
 /// Signup on main called `create_channel(Sender::new_from_user(owner))`.
 /// That is the path that made "Created # Macro Support x …" render as You.
 #[tokio::test]

--- a/crates/channels/src/inbound/toolset/create_channel.rs
+++ b/crates/channels/src/inbound/toolset/create_channel.rs
@@ -2,7 +2,7 @@ use super::{
     ChannelToolContext, channel_mutation_error, channel_name, parse_participants,
     participant_id_strings,
 };
-use crate::domain::models::{ChannelType, CreateChannelRequest, Sender};
+use crate::domain::models::{ChannelType, CreateChannelRequest};
 use crate::domain::ports::ChannelService;
 use ai_toolset::{
     AsyncTool, RequestContext, ServiceContext, ToolAnnotated, ToolAnnotations, ToolCallError,
@@ -118,9 +118,9 @@ where
         let participant_ids = participant_id_strings(&participants);
         let response = service_context
             .service
-            .create_channel(
-                Sender::new_from_user(request_context.user_id.clone()),
-                None,
+            .create_channel_on_behalf(
+                request_context.user_id.clone(),
+                service_context.actor,
                 CreateChannelRequest {
                     name: Some(name.clone()),
                     channel_type: self.channel_type.to_domain(),

--- a/crates/channels/src/inbound/toolset/test.rs
+++ b/crates/channels/src/inbound/toolset/test.rs
@@ -171,7 +171,8 @@ impl ChannelService for ToolTestChannelService {
         _actor_org_id: Option<i64>,
         req: CreateChannelRequest,
     ) -> Result<CreateChannelResponse, ChannelMutationErr> {
-        self.record_created(actor, actor.as_user().cloned(), req)
+        let on_behalf_of = actor.as_user().cloned();
+        self.record_created(actor, on_behalf_of, req)
     }
 
     async fn create_channel_on_behalf(

--- a/crates/channels/src/inbound/toolset/test.rs
+++ b/crates/channels/src/inbound/toolset/test.rs
@@ -499,7 +499,10 @@ async fn create_private_channel_does_not_resolve_a_team() {
         .expect("create lock")
         .clone()
         .expect("called");
-    assert_eq!(actor.as_user(), Some(&user_id()));
+    assert_eq!(
+        actor.as_bot().map(|id| id.bot_id()),
+        Some(bot_id::MACRO_AI_BOT_ID)
+    );
     assert_eq!(org_id, None);
     assert_eq!(req.channel_type, ChannelType::Private);
     assert_eq!(req.team_id, None);
@@ -541,6 +544,58 @@ async fn create_team_channel_injects_the_caller_when_participants_are_empty() {
     assert_eq!(req.channel_type, ChannelType::Team);
     assert_eq!(req.team_id, Some(team_id));
     assert!(req.participants.contains(&user_id()));
+}
+
+#[tokio::test]
+async fn create_private_channel_uses_the_context_actor_for_the_user() {
+    let default_service = ToolTestChannelService::default();
+    let default_created = default_service.created.clone();
+    let custom_service = ToolTestChannelService::default();
+    let custom_created = custom_service.created.clone();
+
+    let tool = CreateChannel {
+        name: "Planning".to_string(),
+        channel_type: NewChannelType::Private,
+        participants: Vec::new(),
+    };
+
+    tool.call(
+        ServiceContext(ChannelToolContext::new(
+            default_service,
+            NoOpEntityAccessService,
+        )),
+        RequestContext::new(user_id()),
+    )
+    .await
+    .expect("default actor can create");
+    tool.call(
+        ServiceContext(
+            ChannelToolContext::new(custom_service, NoOpEntityAccessService)
+                .with_actor(BotId::TEST_A),
+        ),
+        RequestContext::new(user_id()),
+    )
+    .await
+    .expect("custom actor can create");
+
+    let (default_actor, _, _) = default_created
+        .lock()
+        .expect("create lock")
+        .clone()
+        .expect("called");
+    let (custom_actor, _, _) = custom_created
+        .lock()
+        .expect("create lock")
+        .clone()
+        .expect("called");
+    assert_eq!(
+        default_actor.as_bot().map(|id| id.bot_id()),
+        Some(bot_id::MACRO_AI_BOT_ID)
+    );
+    assert_eq!(
+        custom_actor.as_bot().map(|id| id.bot_id()),
+        Some(BotId::TEST_A)
+    );
 }
 
 #[tokio::test]

--- a/crates/channels/src/inbound/toolset/test.rs
+++ b/crates/channels/src/inbound/toolset/test.rs
@@ -39,7 +39,11 @@ fn user_id() -> MacroUserIdStr<'static> {
     MacroUserIdStr::try_from(TEST_USER_ID.to_string()).expect("valid macro user id")
 }
 
-type CreatedChannelCall = (Sender, Option<i64>, CreateChannelRequest);
+type CreatedChannelCall = (
+    Sender,
+    Option<MacroUserIdStr<'static>>,
+    CreateChannelRequest,
+);
 type PatchChannelCall = (Sender, Uuid, PatchChannelRequest);
 type AddParticipantsCall = (Sender, Uuid, AddParticipantsRequest);
 type RemoveParticipantsCall = (Sender, Uuid, RemoveParticipantsRequest);
@@ -56,6 +60,23 @@ struct ToolTestChannelService {
     removes: Arc<Mutex<Vec<RemoveParticipantsCall>>>,
     posts: Arc<Mutex<Vec<PostMessageCall>>>,
     metadata_name: Option<String>,
+}
+
+impl ToolTestChannelService {
+    fn record_created(
+        &self,
+        actor: Sender,
+        on_behalf_of: Option<MacroUserIdStr<'static>>,
+        req: CreateChannelRequest,
+    ) -> Result<CreateChannelResponse, ChannelMutationErr> {
+        if let Some(message) = &self.create_error {
+            return Err(ChannelMutationErr::BadRequest(message.clone()));
+        }
+        *self.created.lock().expect("create lock") = Some((actor, on_behalf_of, req));
+        Ok(CreateChannelResponse {
+            id: self.created_id.unwrap_or_else(Uuid::new_v4).to_string(),
+        })
+    }
 }
 
 impl ChannelService for ToolTestChannelService {
@@ -147,16 +168,19 @@ impl ChannelService for ToolTestChannelService {
     async fn create_channel(
         &self,
         actor: Sender,
-        actor_org_id: Option<i64>,
+        _actor_org_id: Option<i64>,
         req: CreateChannelRequest,
     ) -> Result<CreateChannelResponse, ChannelMutationErr> {
-        if let Some(message) = &self.create_error {
-            return Err(ChannelMutationErr::BadRequest(message.clone()));
-        }
-        *self.created.lock().expect("create lock") = Some((actor, actor_org_id, req));
-        Ok(CreateChannelResponse {
-            id: self.created_id.unwrap_or_else(Uuid::new_v4).to_string(),
-        })
+        self.record_created(actor, actor.as_user().cloned(), req)
+    }
+
+    async fn create_channel_on_behalf(
+        &self,
+        owner: MacroUserIdStr<'static>,
+        actor: BotId,
+        req: CreateChannelRequest,
+    ) -> Result<CreateChannelResponse, ChannelMutationErr> {
+        self.record_created(Sender::new_from_bot(actor), Some(owner), req)
     }
 
     async fn patch_channel(
@@ -494,7 +518,7 @@ async fn create_private_channel_does_not_resolve_a_team() {
     assert_eq!(response.name, "Planning");
     assert_eq!(response.channel_type, NewChannelType::Private);
     assert_eq!(response.participants, vec!["macro|bo@acme.com"]);
-    let (actor, org_id, req) = created
+    let (actor, on_behalf_of, req) = created
         .lock()
         .expect("create lock")
         .clone()
@@ -503,7 +527,7 @@ async fn create_private_channel_does_not_resolve_a_team() {
         actor.as_bot().map(|id| id.bot_id()),
         Some(bot_id::MACRO_AI_BOT_ID)
     );
-    assert_eq!(org_id, None);
+    assert_eq!(on_behalf_of.as_ref(), Some(&user_id()));
     assert_eq!(req.channel_type, ChannelType::Private);
     assert_eq!(req.team_id, None);
     assert!(!req.auto_join_team);
@@ -536,11 +560,16 @@ async fn create_team_channel_injects_the_caller_when_participants_are_empty() {
     .expect("team create injects the caller");
 
     assert_eq!(response.participants, vec![TEST_USER_ID]);
-    let (_, _, req) = created
+    let (actor, on_behalf_of, req) = created
         .lock()
         .expect("create lock")
         .clone()
         .expect("called");
+    assert_eq!(
+        actor.as_bot().map(|id| id.bot_id()),
+        Some(bot_id::MACRO_AI_BOT_ID)
+    );
+    assert_eq!(on_behalf_of.as_ref(), Some(&user_id()));
     assert_eq!(req.channel_type, ChannelType::Team);
     assert_eq!(req.team_id, Some(team_id));
     assert!(req.participants.contains(&user_id()));
@@ -578,12 +607,12 @@ async fn create_private_channel_uses_the_context_actor_for_the_user() {
     .await
     .expect("custom actor can create");
 
-    let (default_actor, _, _) = default_created
+    let (default_actor, default_on_behalf_of, _) = default_created
         .lock()
         .expect("create lock")
         .clone()
         .expect("called");
-    let (custom_actor, _, _) = custom_created
+    let (custom_actor, custom_on_behalf_of, _) = custom_created
         .lock()
         .expect("create lock")
         .clone()
@@ -592,10 +621,12 @@ async fn create_private_channel_uses_the_context_actor_for_the_user() {
         default_actor.as_bot().map(|id| id.bot_id()),
         Some(bot_id::MACRO_AI_BOT_ID)
     );
+    assert_eq!(default_on_behalf_of.as_ref(), Some(&user_id()));
     assert_eq!(
         custom_actor.as_bot().map(|id| id.bot_id()),
         Some(BotId::TEST_A)
     );
+    assert_eq!(custom_on_behalf_of.as_ref(), Some(&user_id()));
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Activity showed "You created" for a channel the AI created with CreateChannel, then "Automation sent a message" in the same turn. CreateChannel always called `create_channel` with a user `Sender`. The domain rebuilds that sender as the owner, so Created is the user. SendChannelMessage already posts as the tool bot with `triggered_by` set to the user.

This is the #6050 follow-up for CreateChannel. The domain did not accept a bot principal on create. PR #5919 added the tool without widening that port. The desired end state is the AI acting for the requesting user, not a product exception.

## Scope

- Add `ChannelService::create_channel_on_behalf(owner, BotId, req)`.
- Attribute Created to that bot acting for `owner`. Ownership stays with `owner`.
- `create_system_channel` is the SYSTEM wrapper over the same port.
- CreateChannel extracts `request_context.user_id` and `ChannelToolContext.actor` and calls the new port.
- HTTP, team create, import, DMs, RenameChannel, and ManageChannelParticipants are unchanged.

## Tradeoffs

A new port instead of widening `create_channel` to `activity::Attribution` or a `ChannelCreator` value type. That keeps teams, import, and HTTP fakes off this change. The two create paths stay explicit. Owner and activity actor stay different facts.

## Blast Radius

Callers of `create_channel` are untouched. Fakes that do not implement the new method keep the trait default. Contact sync already accepts `on_behalf_of` on ChannelCreated. `with_actor` on the tool context now flows through create the same way it does for send.

## Verification

- `cargo test -p channels --features ai_tools --lib inbound::toolset`: 28 passed, including `create_private_channel_does_not_resolve_a_team` and `create_private_channel_uses_the_context_actor_for_the_user`.
- `create_channel_on_behalf_attributes_created_to_the_bot`: passed.
- `create_system_channel_event_uses_system_actor`: passed.
- `signup_support_channel_via_user_create_channel_attributes_created_to_owner`: passed.
- Local Activity before remount. AI CreateChannel rendered "You created # Attribution Repro Channel" while the message rendered "Automation sent a message".
- Local Activity after remount. AI CreateChannel renders "Automation created # Postfix Attr Channel". The follow-up message renders "Automation sent a message in # Postfix Attr Channel". HTTP Create still renders "You created # HTTP Attr Channel".
- CI `cloud storage code check` is green after rustfmt.

[Before. Activity shows You created for the AI channel](https://cursor.com/agents/bc-fc8043d0-d298-4762-a654-2d180cdafa3b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity-prefix-you-created.webp)
[After. Automation created the AI channel. You created the HTTP channel](https://cursor.com/agents/bc-fc8043d0-d298-4762-a654-2d180cdafa3b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity-postfix-attribution.webp)
[postfix-activity-attribution.mp4](https://cursor.com/agents/bc-fc8043d0-d298-4762-a654-2d180cdafa3b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpostfix-activity-attribution.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc8043d0-d298-4762-a654-2d180cdafa3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc8043d0-d298-4762-a654-2d180cdafa3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

