### PR TITLE
fix(auth): update auth to use gateway urls

### DIFF
--- a/apps/web/scripts/services.ts
+++ b/apps/web/scripts/services.ts
@@ -34,8 +34,8 @@ export const services: Service[] = [
 	},
 	{
 		name: "auth-service",
-		dev: "https://auth-service-dev.macro.com/api-doc/openapi.json",
-		prod: "https://auth-service.macro.com/api-doc/openapi.json",
+		dev: "https://dev-gateway.macro.com/auth/api-doc/openapi.json",
+		prod: "https://gateway.macro.com/auth/api-doc/openapi.json",
 		local: "http://localhost:8080/api-doc/openapi.json",
 		output: "../src/lib/service-clients/service-auth/",
 		orvalKey: "authService",

--- a/apps/web/tauri/src-tauri/src/lib.rs
+++ b/apps/web/tauri/src-tauri/src/lib.rs
@@ -51,8 +51,8 @@ impl AppEnvironment {
 
     fn auth_service_url(self) -> &'static str {
         match self {
-            Self::Development => "https://auth-service-dev.macro.com/",
-            Self::Production => "https://auth-service.macro.com/",
+            Self::Development => "https://dev-gateway.macro.com/auth/",
+            Self::Production => "https://gateway.macro.com/auth/",
         }
     }
 

--- a/services/ai-editing-worker/wrangler.toml
+++ b/services/ai-editing-worker/wrangler.toml
@@ -36,8 +36,8 @@ OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4318/v1/traces"
 SYNC_WS_BASE = "wss://sync-service-prod2.macroverse.workers.dev"
 DSS_BASE = "https://gateway.macro.com/dss"
 SEARCH_SERVICE_BASE = "https://gateway.macro.com/dss"
-CONTACTS_SERVICE_BASE = "https://contacts.macro.com"
-AUTH_SERVICE_BASE = "https://auth-service.macro.com"
+CONTACTS_SERVICE_BASE = "https://gateway.macro.com/contacts"
+AUTH_SERVICE_BASE = "https://gateway.macro.com/auth"
 
 [dev]
 port = 8933
@@ -63,8 +63,8 @@ OTEL_EXPORTER_OTLP_ENDPOINT = "https://macro-prox-dev.macroverse.workers.dev/i/o
 SYNC_WS_BASE = "wss://sync-service-dev3.macroverse.workers.dev"
 DSS_BASE = "https://dev-gateway.macro.com/dss"
 SEARCH_SERVICE_BASE = "https://dev-gateway.macro.com/dss"
-CONTACTS_SERVICE_BASE = "https://contacts-dev.macro.com"
-AUTH_SERVICE_BASE = "https://auth-service-dev.macro.com"
+CONTACTS_SERVICE_BASE = "https://dev-gateway.macro.com/contacts"
+AUTH_SERVICE_BASE = "https://dev-gateway.macro.com/auth"
 
 [[env.dev.d1_databases]]
 binding = "TRACES_DB"
@@ -79,8 +79,8 @@ ENVIRONMENT = "development"
 SYNC_WS_BASE = "wss://sync-service-dev3.macroverse.workers.dev"
 DSS_BASE = "https://dev-gateway.macro.com/dss"
 SEARCH_SERVICE_BASE = "https://dev-gateway.macro.com/dss"
-CONTACTS_SERVICE_BASE = "https://contacts-dev.macro.com"
-AUTH_SERVICE_BASE = "https://auth-service-dev.macro.com"
+CONTACTS_SERVICE_BASE = "https://dev-gateway.macro.com/contacts"
+AUTH_SERVICE_BASE = "https://dev-gateway.macro.com/auth"
 
 [[env.playground.d1_databases]]
 binding = "TRACES_DB"
@@ -96,8 +96,8 @@ OTEL_EXPORTER_OTLP_ENDPOINT = "https://macro-prox-prod.macroverse.workers.dev/i/
 SYNC_WS_BASE = "wss://sync-service-prod2.macroverse.workers.dev"
 DSS_BASE = "https://gateway.macro.com/dss"
 SEARCH_SERVICE_BASE = "https://gateway.macro.com/dss"
-CONTACTS_SERVICE_BASE = "https://contacts.macro.com"
-AUTH_SERVICE_BASE = "https://auth-service.macro.com"
+CONTACTS_SERVICE_BASE = "https://gateway.macro.com/contacts"
+AUTH_SERVICE_BASE = "https://gateway.macro.com/auth"
 
 [[env.prod.d1_databases]]
 binding = "TRACES_DB"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Auth and contacts base URLs change for web codegen, Tauri auth/bundle updates, and deployed worker envs—misconfigured gateway paths would break login and downstream calls until fixed.
> 
> **Overview**
> This PR **repoints auth (and contacts in the worker)** from standalone `auth-service*.macro.com` / `contacts*.macro.com` hosts to the shared **`dev-gateway` / `gateway`** paths (`/auth`, `/contacts`), matching how other web service clients are already configured.
> 
> **Web:** `auth-service` OpenAPI schema URLs in `services.ts` now use `…/auth/api-doc/openapi.json` for dev and prod (local unchanged), which affects Orval client generation for the auth service.
> 
> **Tauri:** `auth_service_url()` in the desktop/mobile shell now hits `https://dev-gateway.macro.com/auth/` and `https://gateway.macro.com/auth/`; that base is also the default for bundle update checks when `MACRO_BUNDLE_UPDATE_BASE_URL` is unset.
> 
> **ai-editing-worker:** `AUTH_SERVICE_BASE` and `CONTACTS_SERVICE_BASE` in `wrangler.toml` are updated for default, dev, playground, and prod; **local/docker vars are unchanged** (still direct service hostnames).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72726404fd83361c3c6b173192b18204196d514e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->