### PR TITLE
fix(app): bundle updater with new auth gateway

### DIFF
--- a/apps/web/tauri/macro_bundle_updater_plugin/src/outbound/api_client.rs
+++ b/apps/web/tauri/macro_bundle_updater_plugin/src/outbound/api_client.rs
@@ -9,6 +9,9 @@ use thiserror::Error;
 use tokio::io::AsyncWriteExt;
 use url::Url;
 
+#[cfg(test)]
+mod test;
+
 /// HTTP client for checking and downloading bundle updates.
 pub struct BundleClient {
     /// Reusable HTTP client.
@@ -31,9 +34,30 @@ pub enum BundleClientErr {
 impl BundleClient {
     /// Create a new client pointing at the given base URL.
     pub fn new(mut base: Url) -> Self {
-        base.set_path("");
+        base.set_query(None);
+        base.set_fragment(None);
         let client = reqwest::Client::new();
         Self { client, base }
+    }
+
+    fn update_check_url(
+        &self,
+        request: crate::domain::models::AppInfo,
+    ) -> Result<Url, BundleClientErr> {
+        let mut url = self.base.clone();
+        url.path_segments_mut()
+            .map_err(|_| BundleClientErr::CannotBeABase(self.base.clone()))?
+            .push("update")
+            .push("bundle")
+            .push(request.target.into())
+            .push(request.arch.into());
+        url.query_pairs_mut()
+            .append_pair(
+                "current_bundle_build",
+                &request.current_bundle_build.to_string(),
+            )
+            .append_pair("native_build", &request.native_build.to_string());
+        Ok(url)
     }
 
     // pub async fn request(&self) -> Result<Option<BundleUpdate>, BundleClientErr> {
@@ -45,20 +69,7 @@ impl UpdateRepo for BundleClient {
         &self,
         request: crate::domain::models::AppInfo,
     ) -> Result<Option<BundleAction>, rootcause::Report> {
-        let mut url = self.base.clone();
-        url.path_segments_mut()
-            .map_err(|_| BundleClientErr::CannotBeABase(self.base.clone()))?
-            .clear()
-            .push("update")
-            .push("bundle")
-            .push(request.target.into())
-            .push(request.arch.into());
-        url.query_pairs_mut()
-            .append_pair(
-                "current_bundle_build",
-                &request.current_bundle_build.to_string(),
-            )
-            .append_pair("native_build", &request.native_build.to_string());
+        let url = self.update_check_url(request)?;
 
         let res = self.client.get(url).send().await?.error_for_status()?;
 

--- a/apps/web/tauri/macro_bundle_updater_plugin/src/outbound/api_client/test.rs
+++ b/apps/web/tauri/macro_bundle_updater_plugin/src/outbound/api_client/test.rs
@@ -1,0 +1,51 @@
+use super::*;
+use crate::domain::models::{AppInfo, Arch, Target};
+
+fn app_info() -> AppInfo {
+    AppInfo {
+        current_bundle_build: 42,
+        native_build: 7,
+        arch: Arch::Aarch64,
+        target: Target::Ios,
+    }
+}
+
+#[test]
+fn update_check_url_preserves_base_path_prefix() {
+    let client = BundleClient::new("https://gateway.macro.com/auth/".parse().unwrap());
+
+    let url = client.update_check_url(app_info()).unwrap();
+
+    assert_eq!(
+        url.as_str(),
+        "https://gateway.macro.com/auth/update/bundle/ios/aarch64?current_bundle_build=42&native_build=7"
+    );
+}
+
+#[test]
+fn update_check_url_still_supports_gateway_root_base() {
+    let client = BundleClient::new("https://gateway.macro.com/".parse().unwrap());
+
+    let url = client.update_check_url(app_info()).unwrap();
+
+    assert_eq!(
+        url.as_str(),
+        "https://gateway.macro.com/update/bundle/ios/aarch64?current_bundle_build=42&native_build=7"
+    );
+}
+
+#[test]
+fn update_check_url_strips_base_query_and_fragment() {
+    let client = BundleClient::new(
+        "https://gateway.macro.com/auth/?stale=true#section"
+            .parse()
+            .unwrap(),
+    );
+
+    let url = client.update_check_url(app_info()).unwrap();
+
+    assert_eq!(
+        url.as_str(),
+        "https://gateway.macro.com/auth/update/bundle/ios/aarch64?current_bundle_build=42&native_build=7"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how update-check URLs are resolved for all clients using this plugin; incorrect URLs would break bundle updates, but behavior is covered by new tests and is a targeted URL-construction fix.
> 
> **Overview**
> Fixes bundle update checks when the configured gateway base URL includes a path prefix (e.g. `https://gateway.macro.com/auth/`).
> 
> **`BundleClient`** no longer clears the base URL path on construction; it only strips query and fragment. Update-check URLs are built by appending `update/bundle/{target}/{arch}` onto that base path instead of replacing the path entirely.
> 
> Adds unit tests for prefixed gateway bases, root-only bases, and stripping stale query/fragment from the configured base URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fe4bfe8cc677d7df48430275b5b68bc1b688e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->