### PR TITLE
fix(channel_bots): execute calendar event creation directly in channel mentions

### DIFF
--- a/crates/agent_inmem/src/outbound/rig_engine.rs
+++ b/crates/agent_inmem/src/outbound/rig_engine.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use agent::{AgentError, AgentLoop, StreamPart};
-use ai_tools::{ToolServiceContext, ToolSetWithPrompt, all_tools};
+use ai_tools::{AiHost, ToolServiceContext, ToolSetWithPrompt, tools_for};
 use ai_toolset::ToolSet as AiToolSet;
 use futures::StreamExt as _;
 use macro_user_id::user_id::MacroUserIdStr;
@@ -78,7 +78,7 @@ async fn drive_turn(
         cancel,
     } = request;
 
-    let tools = all_tools();
+    let tools = tools_for(AiHost::Chat);
     let user_memory = fetch_user_memory(&db, &base_context, &owner).await;
     let system_prompt = system_prompt(
         &tools.prompt,
@@ -163,7 +163,7 @@ async fn fetch_user_memory(
     tool_context: &ToolServiceContext,
     owner: &MacroUserIdStr<'static>,
 ) -> Option<String> {
-    let tools = all_tools();
+    let tools = tools_for(AiHost::Chat);
     let tools = ToolSetWithPrompt {
         toolset: tools.toolset,
         prompt: tools.prompt,

--- a/crates/ai_tools/src/bin/gen_ai_request_schemas.rs
+++ b/crates/ai_tools/src/bin/gen_ai_request_schemas.rs
@@ -20,7 +20,7 @@ fn main() {
         .to_string()
     });
 
-    let tools = ai_tools::all_tools();
+    let tools = ai_tools::tools_for(ai_tools::AiHost::Chat);
     let schemas = tools.toolset.request_schemas().unwrap_or_default();
 
     let definitions = schemas

--- a/crates/ai_tools/src/lib.rs
+++ b/crates/ai_tools/src/lib.rs
@@ -108,22 +108,61 @@ pub(crate) fn subagent_toolset() -> AiToolSet {
         .add_subtoolset::<AnthropicToolContext>(anthropic_toolset())
 }
 
-/// These are actually sent to the AI provider
-pub fn all_tools() -> ToolSetWithPrompt {
+/// The host a toolset is assembled for.
+///
+/// Hosts differ on two axes. First, whether their surface can render the
+/// composer card that finishes a chat-deferred user tool: only
+/// [`AiHost::Chat`] can, so it alone registers `SendEmail` and the deferring
+/// `CreateCalendarEvent` — on any other host those registrations would
+/// return `PendingUserExecution` forever while reading to the model as
+/// success. Second, whether the host runs the chat frontend's tool
+/// discovery and display tools.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AiHost {
+    /// The AI chat, and any host whose conversation is stored as a chat the
+    /// frontend can render (scheduled agents, agent sessions, memory
+    /// generation): composer cards finish deferred user tools there.
+    Chat,
+    /// The channel-mention bot: no composer, so `CreateCalendarEvent`
+    /// executes directly in the agent loop and `SendEmail` is omitted.
+    ChannelBot,
+    /// The MCP server: like [`AiHost::ChannelBot`] for user tools — MCP
+    /// clients apply their own confirmation policy from tool annotations —
+    /// and without the chat frontend's discovery/display tools.
+    Mcp,
+}
+
+/// Assemble the toolset and tool-use prompt for a host. These are actually
+/// sent to the AI provider.
+pub fn tools_for(host: AiHost) -> ToolSetWithPrompt {
     let toolset = subagent_toolset()
         .add_subtoolset::<ToolNotificationToolContext>(notification_toolset())
-        .add_subtoolset::<ToolRemindersToolContext>(reminders_toolset())
-        .add_subtoolset::<ToolEmailToolContext>(email_toolset())
-        .add_subtoolset::<ToolCalendarToolContext>(calendar_toolset())
+        .add_subtoolset::<ToolRemindersToolContext>(reminders_toolset());
+    let toolset = match host {
+        AiHost::Chat => toolset
+            .add_subtoolset::<ToolEmailToolContext>(email_toolset())
+            .add_subtoolset::<ToolCalendarToolContext>(calendar_toolset()),
+        AiHost::ChannelBot | AiHost::Mcp => toolset
+            .add_subtoolset::<ToolEmailToolContext>(email_mcp_toolset())
+            .add_subtoolset::<ToolCalendarToolContext>(calendar_mcp_toolset()),
+    };
+    let toolset = toolset
         .add_subtoolset::<ToolImportToolContext>(import_toolset())
-        .add_tool::<Subagent, ToolServiceContext>()
-        .add_tool::<SearchTools, ToolServiceContext>()
-        .add_tool::<LoadTools, ToolServiceContext>()
-        .add_tool::<DisplayResults, ToolServiceContext>();
-    let toolset = Arc::new(toolset);
+        .add_tool::<Subagent, ToolServiceContext>();
+    let toolset = match host {
+        AiHost::Chat | AiHost::ChannelBot => toolset
+            .add_tool::<SearchTools, ToolServiceContext>()
+            .add_tool::<LoadTools, ToolServiceContext>()
+            .add_tool::<DisplayResults, ToolServiceContext>(),
+        AiHost::Mcp => toolset,
+    };
+    let prompt: Box<dyn std::fmt::Display + Send + Sync> = match host {
+        AiHost::Chat => Box::new(&prompt::TOOL_USE_PROMPT),
+        AiHost::ChannelBot | AiHost::Mcp => Box::new(&prompt::DIRECT_TOOL_USE_PROMPT),
+    };
     ToolSetWithPrompt {
-        toolset,
-        prompt: Box::new(&prompt::TOOL_USE_PROMPT),
+        toolset: Arc::new(toolset),
+        prompt,
     }
 }
 
@@ -133,52 +172,9 @@ pub fn all_tools() -> ToolSetWithPrompt {
 /// sent to AI providers.
 pub fn all_tool_frontend_schemas() -> FrontendSchemas {
     frontend_schemas_builder()
-        .merge(&all_tools())
+        .merge(&tools_for(AiHost::Chat))
         .merge(&read::read_thread())
         .build()
-}
-
-/// Toolset for the channel-mention bot — a surface with no composer to
-/// finish a chat-deferred user tool in.
-///
-/// Matches [`all_tools`] except for the two user tools: `CreateCalendarEvent`
-/// executes directly in the agent loop (as over MCP), and `SendEmail` is
-/// omitted, since a channel reply offers no way to review a draft before it
-/// is sent. A deferred user tool here would return `PendingUserExecution`
-/// forever — nothing ever executes it — while reading to the model as
-/// success, so the bot would report an action it never performed.
-pub fn channel_bot_tools() -> ToolSetWithPrompt {
-    let toolset = subagent_toolset()
-        .add_subtoolset::<ToolNotificationToolContext>(notification_toolset())
-        .add_subtoolset::<ToolRemindersToolContext>(reminders_toolset())
-        .add_subtoolset::<ToolEmailToolContext>(email_mcp_toolset())
-        .add_subtoolset::<ToolCalendarToolContext>(calendar_mcp_toolset())
-        .add_subtoolset::<ToolImportToolContext>(import_toolset())
-        .add_tool::<Subagent, ToolServiceContext>()
-        .add_tool::<SearchTools, ToolServiceContext>()
-        .add_tool::<LoadTools, ToolServiceContext>()
-        .add_tool::<DisplayResults, ToolServiceContext>();
-    let toolset = Arc::new(toolset);
-    ToolSetWithPrompt {
-        toolset,
-        prompt: Box::new(&prompt::DIRECT_TOOL_USE_PROMPT),
-    }
-}
-
-/// Toolset for the MCP server — excludes chat-deferred user tools.
-pub fn mcp_tools() -> ToolSetWithPrompt {
-    let toolset = subagent_toolset()
-        .add_subtoolset::<ToolNotificationToolContext>(notification_toolset())
-        .add_subtoolset::<ToolRemindersToolContext>(reminders_toolset())
-        .add_subtoolset::<ToolEmailToolContext>(email_mcp_toolset())
-        .add_subtoolset::<ToolCalendarToolContext>(calendar_mcp_toolset())
-        .add_subtoolset::<ToolImportToolContext>(import_toolset())
-        .add_tool::<Subagent, ToolServiceContext>();
-    let toolset = Arc::new(toolset);
-    ToolSetWithPrompt {
-        toolset,
-        prompt: Box::new(&prompt::DIRECT_TOOL_USE_PROMPT),
-    }
 }
 
 pub fn no_tools() -> ToolSetWithPrompt {

--- a/crates/ai_tools/src/lib.rs
+++ b/crates/ai_tools/src/lib.rs
@@ -161,7 +161,7 @@ pub fn channel_bot_tools() -> ToolSetWithPrompt {
     let toolset = Arc::new(toolset);
     ToolSetWithPrompt {
         toolset,
-        prompt: Box::new(&prompt::TOOL_USE_PROMPT),
+        prompt: Box::new(&prompt::DIRECT_TOOL_USE_PROMPT),
     }
 }
 
@@ -177,7 +177,7 @@ pub fn mcp_tools() -> ToolSetWithPrompt {
     let toolset = Arc::new(toolset);
     ToolSetWithPrompt {
         toolset,
-        prompt: Box::new(&prompt::TOOL_USE_PROMPT),
+        prompt: Box::new(&prompt::DIRECT_TOOL_USE_PROMPT),
     }
 }
 

--- a/crates/ai_tools/src/lib.rs
+++ b/crates/ai_tools/src/lib.rs
@@ -138,6 +138,33 @@ pub fn all_tool_frontend_schemas() -> FrontendSchemas {
         .build()
 }
 
+/// Toolset for the channel-mention bot — a surface with no composer to
+/// finish a chat-deferred user tool in.
+///
+/// Matches [`all_tools`] except for the two user tools: `CreateCalendarEvent`
+/// executes directly in the agent loop (as over MCP), and `SendEmail` is
+/// omitted, since a channel reply offers no way to review a draft before it
+/// is sent. A deferred user tool here would return `PendingUserExecution`
+/// forever — nothing ever executes it — while reading to the model as
+/// success, so the bot would report an action it never performed.
+pub fn channel_bot_tools() -> ToolSetWithPrompt {
+    let toolset = subagent_toolset()
+        .add_subtoolset::<ToolNotificationToolContext>(notification_toolset())
+        .add_subtoolset::<ToolRemindersToolContext>(reminders_toolset())
+        .add_subtoolset::<ToolEmailToolContext>(email_mcp_toolset())
+        .add_subtoolset::<ToolCalendarToolContext>(calendar_mcp_toolset())
+        .add_subtoolset::<ToolImportToolContext>(import_toolset())
+        .add_tool::<Subagent, ToolServiceContext>()
+        .add_tool::<SearchTools, ToolServiceContext>()
+        .add_tool::<LoadTools, ToolServiceContext>()
+        .add_tool::<DisplayResults, ToolServiceContext>();
+    let toolset = Arc::new(toolset);
+    ToolSetWithPrompt {
+        toolset,
+        prompt: Box::new(&prompt::TOOL_USE_PROMPT),
+    }
+}
+
 /// Toolset for the MCP server — excludes chat-deferred user tools.
 pub fn mcp_tools() -> ToolSetWithPrompt {
     let toolset = subagent_toolset()

--- a/crates/ai_tools/src/test.rs
+++ b/crates/ai_tools/src/test.rs
@@ -20,44 +20,38 @@ fn subagent_toolset_passes_schema_validation() {
 }
 
 #[test]
-fn all_tools_passes_schema_validation() {
-    let _ = all_tools();
+fn every_host_toolset_passes_schema_validation() {
+    for host in [AiHost::Chat, AiHost::ChannelBot, AiHost::Mcp] {
+        let _ = tools_for(host);
+    }
 }
 
+/// Hosts without a composer cannot finish a deferred user tool, so their
+/// toolsets must execute calendar creation directly and omit SendEmail
+/// entirely — a `UserToolResponse` output there would mean a call that
+/// nothing can ever execute.
 #[test]
-fn mcp_tools_passes_schema_validation() {
-    let _ = mcp_tools();
-}
+fn composerless_hosts_execute_calendar_create_directly_and_omit_send_email() {
+    for host in [AiHost::ChannelBot, AiHost::Mcp] {
+        let json = frontend_schemas_builder()
+            .merge(&tools_for(host))
+            .build()
+            .to_json_pretty()
+            .expect("host schemas serialize");
+        let schemas: serde_json::Value = serde_json::from_str(&json).expect("valid schema json");
+        let tools = schemas["tools"].as_array().expect("tools array");
 
-#[test]
-fn channel_bot_tools_passes_schema_validation() {
-    let _ = channel_bot_tools();
-}
+        let create = tools
+            .iter()
+            .find(|tool| tool["name"] == "CreateCalendarEvent")
+            .expect("composer-less toolset keeps CreateCalendarEvent");
+        assert_eq!(create["output"], "ToolCalendarEvent", "{host:?}");
 
-/// The channel bot has no composer to finish a deferred user tool in, so its
-/// toolset must execute calendar creation directly and omit SendEmail
-/// entirely — a `UserToolResponse` output here would mean a call that nothing
-/// can ever execute.
-#[test]
-fn channel_bot_tools_execute_calendar_create_directly_and_omit_send_email() {
-    let json = frontend_schemas_builder()
-        .merge(&channel_bot_tools())
-        .build()
-        .to_json_pretty()
-        .expect("channel bot schemas serialize");
-    let schemas: serde_json::Value = serde_json::from_str(&json).expect("valid schema json");
-    let tools = schemas["tools"].as_array().expect("tools array");
-
-    let create = tools
-        .iter()
-        .find(|tool| tool["name"] == "CreateCalendarEvent")
-        .expect("channel bot toolset keeps CreateCalendarEvent");
-    assert_eq!(create["output"], "ToolCalendarEvent");
-
-    assert!(
-        !tools.iter().any(|tool| tool["name"] == "SendEmail"),
-        "channel bot toolset must not expose SendEmail"
-    );
+        assert!(
+            !tools.iter().any(|tool| tool["name"] == "SendEmail"),
+            "{host:?} toolset must not expose SendEmail"
+        );
+    }
 }
 
 #[test]

--- a/crates/ai_tools/src/test.rs
+++ b/crates/ai_tools/src/test.rs
@@ -30,6 +30,37 @@ fn mcp_tools_passes_schema_validation() {
 }
 
 #[test]
+fn channel_bot_tools_passes_schema_validation() {
+    let _ = channel_bot_tools();
+}
+
+/// The channel bot has no composer to finish a deferred user tool in, so its
+/// toolset must execute calendar creation directly and omit SendEmail
+/// entirely — a `UserToolResponse` output here would mean a call that nothing
+/// can ever execute.
+#[test]
+fn channel_bot_tools_execute_calendar_create_directly_and_omit_send_email() {
+    let json = frontend_schemas_builder()
+        .merge(&channel_bot_tools())
+        .build()
+        .to_json_pretty()
+        .expect("channel bot schemas serialize");
+    let schemas: serde_json::Value = serde_json::from_str(&json).expect("valid schema json");
+    let tools = schemas["tools"].as_array().expect("tools array");
+
+    let create = tools
+        .iter()
+        .find(|tool| tool["name"] == "CreateCalendarEvent")
+        .expect("channel bot toolset keeps CreateCalendarEvent");
+    assert_eq!(create["output"], "ToolCalendarEvent");
+
+    assert!(
+        !tools.iter().any(|tool| tool["name"] == "SendEmail"),
+        "channel bot toolset must not expose SendEmail"
+    );
+}
+
+#[test]
 fn no_tools_passes_schema_validation() {
     let _ = no_tools();
 }

--- a/crates/calendar_events/src/inbound/toolset.rs
+++ b/crates/calendar_events/src/inbound/toolset.rs
@@ -105,10 +105,12 @@ where
     shared_calendar_toolset().add_user_tool::<CreateCalendarEvent, CalendarToolContext<M, O>>()
 }
 
-/// Create the MCP calendar toolset.
+/// Create the calendar toolset for hosts without a composer — the MCP server
+/// and the channel-mention bot.
 ///
-/// MCP clients receive the real create tool and apply their own confirmation
-/// policy from its annotations rather than the chat-specific deferred flow.
+/// These hosts receive the real create tool and apply their own confirmation
+/// policy from its annotations rather than the chat-specific deferred flow,
+/// which only the chat frontend can finish.
 pub fn mcp_toolset<M, O>() -> AsyncToolCollection<CalendarToolContext<M, O>>
 where
     M: CalendarMutationService,

--- a/crates/email/src/inbound/toolset.rs
+++ b/crates/email/src/inbound/toolset.rs
@@ -157,7 +157,9 @@ where
     mcp_toolset().add_user_tool::<SendEmail, EmailToolContext<T, G, E>>()
 }
 
-/// Email toolset for the MCP server — excludes SendEmail.
+/// Email toolset for hosts without a composer (the MCP server and the
+/// channel-mention bot) — excludes SendEmail, whose draft only the chat
+/// frontend can review and send.
 pub fn mcp_toolset<T, G, E>() -> AsyncToolCollection<EmailToolContext<T, G, E>>
 where
     T: EmailService,

--- a/crates/memory/src/main.rs
+++ b/crates/memory/src/main.rs
@@ -1,6 +1,6 @@
 #![recursion_limit = "256"]
 
-use ai_tools::{all_tools, build_tool_service_context_from_env};
+use ai_tools::{AiHost, build_tool_service_context_from_env, tools_for};
 use anyhow::Context;
 use macro_user_id::user_id::MacroUserIdStr;
 use memory::config::Config;
@@ -29,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
     let event_broker_tracker = TaskTracker::new();
     let tool_context =
         build_tool_service_context_from_env(pool.clone(), event_broker_tracker.clone()).await?;
-    let tools = all_tools();
+    let tools = tools_for(AiHost::Chat);
     let memory_repo = PgMemoryRepo::new(pool);
     let memory_service = MemoryServiceImpl::new(memory_repo, tool_context, tools);
 

--- a/crates/prompt/src/channel_mention.rs
+++ b/crates/prompt/src/channel_mention.rs
@@ -14,10 +14,24 @@ Context is grouped into tagged blocks:
 
 Be concise and directly useful. Use your tools to look things up when helpful.
 Respond in Markdown.
+
+Tool calls in a channel execute immediately. There is no composer, review card, or pending
+confirmation here, so never tell the user an action is awaiting their approval or ask them to
+confirm it in a composer — when a tool call succeeds the action is already done, and when you
+have not made the call the action has not happened. Only take actions (creating, updating, or
+deleting things) that the mentioning user explicitly asked for, and because calendar invitations
+go out the moment an event is created, ask in the thread before creating an event with attendees.
+
+Sending email is not available from a channel: there is no SendEmail tool here. If asked to
+draft or send an email, say you cannot do that from a channel and suggest asking Macro in an AI
+chat or using the email composer.
 "##;
 
 static INTENT: &str = "The model replies to the marked mention, treats the <thread> block as \
-authoritative over <channel_background> noise, and answers concisely in Markdown.";
+authoritative over <channel_background> noise, answers concisely in Markdown, treats tool calls \
+as executing immediately (no composer or pending confirmation to point the user at), only takes \
+explicitly requested actions, checks before creating events with attendees, and declines email \
+drafting/sending with a pointer to AI chat or the email composer.";
 
 /// The channel-mention prompt for the Macro channel bot.
 pub static PROMPT: StaticPrompt<'static> = StaticPrompt::borrowed(TITLE, INSTRUCTIONS, INTENT);

--- a/crates/prompt/src/lib.rs
+++ b/crates/prompt/src/lib.rs
@@ -20,6 +20,7 @@ pub mod skills;
 pub mod tone;
 pub mod tool_usage;
 mod types;
+pub mod user_tools;
 
 pub use types::{ComposedPrompt, Section, StaticPrompt};
 
@@ -32,11 +33,25 @@ pub static BASE_PROMPT: ComposedPrompt = tone::PROMPT
     .compose(&do_not::PROMPT)
     .compose(&about_macro::PROMPT);
 
-/// The tool-enabled prompt: [`BASE_PROMPT`] with the tool use instructions,
-/// skill-following rules, document-content linking rules, and email inbox
-/// behavior appended.
+/// The tool-enabled prompt for hosts whose tools all execute directly in the
+/// agent loop (the channel-mention bot, the MCP server): [`BASE_PROMPT`] with
+/// the tool use instructions, skill-following rules, document-content linking
+/// rules, and email inbox behavior appended. Says nothing about
+/// composer-confirmed user tools — those hosts' toolsets execute
+/// `CreateCalendarEvent` directly and have no `SendEmail` at all.
+pub static DIRECT_TOOL_USE_PROMPT: ComposedPrompt = BASE_PROMPT
+    .compose(&tool_usage::PROMPT)
+    .compose(&skills::PROMPT)
+    .compose(&document_content_links::PROMPT)
+    .compose(&email::PROMPT);
+
+/// The chat tool-enabled prompt: [`DIRECT_TOOL_USE_PROMPT`] plus the rules
+/// for composer-confirmed user tools (`SendEmail`, deferred execution), which
+/// only apply on surfaces that can render the composer card. Composed as its
+/// own chain so the email section stays last.
 pub static TOOL_USE_PROMPT: ComposedPrompt = BASE_PROMPT
     .compose(&tool_usage::PROMPT)
+    .compose(&user_tools::PROMPT)
     .compose(&skills::PROMPT)
     .compose(&document_content_links::PROMPT)
     .compose(&email::PROMPT);
@@ -136,6 +151,21 @@ mod tests {
         // contradict each other: the plain-URL section explicitly scopes
         // itself to the model's own replies, not to document content.
         assert!(instructions.contains("does NOT apply to content you write into a Macro document"));
+    }
+
+    #[test]
+    fn direct_tool_use_prompt_omits_composer_confirmed_user_tool_rules() {
+        // Hosts on the direct prompt (channel bot, MCP) have no composer and
+        // no SendEmail tool; describing deferred user tools there would tell
+        // the model the opposite of what its tools actually do.
+        let direct = DIRECT_TOOL_USE_PROMPT.to_string();
+        assert!(!direct.contains("PendingUserExecution"));
+        assert!(!direct.contains("MUST use the `SendEmail` tool"));
+
+        // The chat prompt keeps both rules.
+        let chat = TOOL_USE_PROMPT.to_string();
+        assert!(chat.contains("PendingUserExecution"));
+        assert!(chat.contains("MUST use the `SendEmail` tool"));
     }
 
     #[test]

--- a/crates/prompt/src/tool_usage.rs
+++ b/crates/prompt/src/tool_usage.rs
@@ -15,10 +15,6 @@ These apply to your own conversational replies only — not to Markdown you auth
 
 ## Tool Use
 
-- User tools are tools that must be executed by a user on the frontend.
-  A user tool will return "PendingUserExecution" until a user chooses to
-  accept / reject the tool.
-
 - Use tools often and specifically.
 - Prefer precise filters (domain names, IDs) over generic queries.
 - Web tool expects natural language queries.
@@ -28,13 +24,6 @@ These apply to your own conversational replies only — not to Markdown you auth
 - IMPORTANT After finding relavent results with any tool cite the most relavent findings
   using XML mention tags (e.g. `<m-document-mention>`). Always use a mention if the tool
   returns anything relavent. IMPORTANT
-
-- IMPORTANT: When the user asks you to draft, write, compose, or send an email (or reply to one),
-  you MUST use the `SendEmail` tool to produce it. NEVER write the email body as plain text in the
-  chat. The `SendEmail` tool opens a real draft in the email composer that the user can review,
-  edit, and send — writing the email inline in chat does none of that and is wrong. Drafting and
-  sending are the same tool: it always creates a draft for the user to confirm before anything is
-  sent, so use it even when the user only wants a draft.
 
 - IMPORTANT: The code execution tools (`bash_code_execution`, and `text_editor_code_execution`) should only be used
 when the user explicitely asks you to _execute_ code.
@@ -69,10 +58,9 @@ users workspace. If the user asks you to create a document, write a code file, o
 
 static INTENT: &str = "The model proactively uses tools with precise filters instead of \
 claiming it lacks context, cites relevant tool results with mention tags, reserves code \
-execution for explicit requests, uses the SendEmail tool to draft or send emails instead of \
-writing them inline in chat, uses CreateDocument for files in the user's workspace, and keeps its \
-casual reply tone (short paragraphs, no formal formatting) scoped to its own conversational \
-replies rather than to Markdown it authors via tools.";
+execution for explicit requests, uses CreateDocument for files in the user's workspace, and \
+keeps its casual reply tone (short paragraphs, no formal formatting) scoped to its own \
+conversational replies rather than to Markdown it authors via tools.";
 
 /// The tool-use prompt.
 pub static PROMPT: StaticPrompt<'static> = StaticPrompt::borrowed(TITLE, INSTRUCTIONS, INTENT);

--- a/crates/prompt/src/user_tools.rs
+++ b/crates/prompt/src/user_tools.rs
@@ -1,0 +1,31 @@
+//! Chat-only rules for user tools — tools the user finishes in a composer.
+//!
+//! Only compose this section into prompts for hosts whose toolset registers
+//! deferred user tools (`SendEmail`, `CreateCalendarEvent`) and whose surface
+//! can render the composer card that executes them. Hosts without that
+//! surface (the channel-mention bot, MCP) get toolsets where those tools
+//! execute directly or are absent, and this section would describe the
+//! opposite of what their tools do.
+
+use crate::types::StaticPrompt;
+
+static TITLE: &str = "User Tools";
+
+static INSTRUCTIONS: &str = r##"- User tools are tools that must be executed by a user on the frontend.
+  A user tool will return "PendingUserExecution" until a user chooses to
+  accept / reject the tool.
+
+- IMPORTANT: When the user asks you to draft, write, compose, or send an email (or reply to one),
+  you MUST use the `SendEmail` tool to produce it. NEVER write the email body as plain text in the
+  chat. The `SendEmail` tool opens a real draft in the email composer that the user can review,
+  edit, and send — writing the email inline in chat does none of that and is wrong. Drafting and
+  sending are the same tool: it always creates a draft for the user to confirm before anything is
+  sent, so use it even when the user only wants a draft.
+"##;
+
+static INTENT: &str = "The model treats user tools as composer-confirmed: a PendingUserExecution \
+result means the user still has to finish the call, and email drafting or sending always goes \
+through the SendEmail tool rather than inline text in the chat.";
+
+/// The user-tools prompt section for composer-capable chat hosts.
+pub static PROMPT: StaticPrompt<'static> = StaticPrompt::borrowed(TITLE, INSTRUCTIONS, INTENT);

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -31,8 +31,12 @@ message; ordinary Markdown blockquotes remain presentation-only and do not count
 The composer always keeps an editable empty line after a block reference, including after
 the user deletes that line, so clicking below the reference can restore the text caret.
 
-`@Macro` answers in the thread (classic bot). `@macro-new` / `@coder` / `@cursor` open
-an agent session; follow-up `@` mentions of that bot in the same thread route to it.
+`@Macro` answers in the thread (classic bot). Its tool calls execute immediately — there is
+no composer or pending-confirmation card in a channel, so asking it to create a calendar
+event creates the event right away (unlike AI chat, where creation waits for the user to
+confirm a composer card), and it cannot draft or send email at all. `@macro-new` / `@coder`
+/ `@cursor` open an agent session; follow-up `@` mentions of that bot in the same thread
+route to it.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention.
 

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -33,10 +33,12 @@ the user deletes that line, so clicking below the reference can restore the text
 
 `@Macro` answers in the thread (classic bot). Its tool calls execute immediately — there is
 no composer or pending-confirmation card in a channel, so asking it to create a calendar
-event creates the event right away (unlike AI chat, where creation waits for the user to
-confirm a composer card), and it cannot draft or send email at all. `@macro-new` / `@coder`
-/ `@cursor` open an agent session; follow-up `@` mentions of that bot in the same thread
-route to it.
+event without attendees creates the event right away (unlike AI chat, where creation waits
+for the user to confirm a composer card). For an event with attendees the bot is prompted to
+ask for confirmation in the thread first, since Google sends the invitations the moment the
+event is created — no invitation goes out from the initial request. It cannot draft or send
+email at all. `@macro-new` / `@coder` / `@cursor` open an agent session; follow-up `@`
+mentions of that bot in the same thread route to it.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention.
 

--- a/services/document_cognition_service/src/api/context/test.rs
+++ b/services/document_cognition_service/src/api/context/test.rs
@@ -401,7 +401,7 @@ pub async fn test_api_context(pool: sqlx::Pool<sqlx::Postgres>) -> std::sync::Ar
         recorder: ai_usage::pg_recorder(pool.clone()),
         usage_context: ai_usage::UsageContext::system(ai_usage::AiFeature::Chat),
     };
-    let all_tools = ai_tools::all_tools();
+    let all_tools = ai_tools::tools_for(ai_tools::AiHost::Chat);
     let all_tools_toolset = all_tools.toolset.clone();
     let all_tools_prompt: Arc<dyn std::fmt::Display + Send + Sync> =
         Arc::new(all_tools.prompt.to_string());
@@ -465,7 +465,7 @@ pub async fn test_api_context(pool: sqlx::Pool<sqlx::Postgres>) -> std::sync::Ar
     let projection_generator =
         ai_projections::outbound::agent_generator::AgentProjectionGenerator::new(
             tool_service_context.clone(),
-            ai_tools::all_tools(),
+            ai_tools::tools_for(ai_tools::AiHost::Chat),
         );
 
     let projection_notifier =

--- a/services/document_cognition_service/src/main.rs
+++ b/services/document_cognition_service/src/main.rs
@@ -611,7 +611,7 @@ async fn main() -> anyhow::Result<()> {
         recorder,
         usage_context: ai_usage::UsageContext::system(ai_usage::AiFeature::Chat),
     };
-    let all_tools = ai_tools::all_tools();
+    let all_tools = ai_tools::tools_for(ai_tools::AiHost::Chat);
     let all_tools_toolset = all_tools.toolset.clone();
     let all_tools_prompt: Arc<dyn std::fmt::Display + Send + Sync> =
         Arc::new(all_tools.prompt.to_string());
@@ -639,7 +639,7 @@ async fn main() -> anyhow::Result<()> {
     let projection_generator =
         ai_projections::outbound::agent_generator::AgentProjectionGenerator::new(
             tool_service_context.clone(),
-            ai_tools::all_tools(),
+            ai_tools::tools_for(ai_tools::AiHost::Chat),
         );
     // Notifier that pushes finished materializations to the target's connected
     // clients through the connection gateway.

--- a/services/document_storage_service/src/main.rs
+++ b/services/document_storage_service/src/main.rs
@@ -1033,7 +1033,7 @@ async fn run() -> anyhow::Result<()> {
             std::sync::Arc::new(SpawnedChannelEventDispatcher::new(channel_side_effects)),
             lexical_client.clone(),
         );
-    let macro_agent_tools = ai_tools::channel_bot_tools();
+    let macro_agent_tools = ai_tools::tools_for(ai_tools::AiHost::ChannelBot);
     let bot_trigger_router = channel_bots::inbound::BotTriggerRouter::new(
         channels_service.clone(),
         Arc::new(channel_bots::outbound::AgentLoopResponder::new(

--- a/services/document_storage_service/src/main.rs
+++ b/services/document_storage_service/src/main.rs
@@ -1013,10 +1013,12 @@ async fn run() -> anyhow::Result<()> {
 
     // Wire Macro AI to react to mentions with the classic in-channel chat
     // reply. The router posts replies through the channel service we just
-    // built and runs the agent loop in-process with the same pre-configured
-    // toolset used by other AI hosts. Agent sessions belong to a different
-    // bot entirely (`bot_id::MACRO_NEW_BOT_ID`, served by the harness), so
-    // the two paths can never answer the same mention.
+    // built and runs the agent loop in-process with the channel-bot toolset:
+    // a channel has no composer to finish a chat-deferred user tool in, so
+    // calendar event creation executes directly and SendEmail is unavailable.
+    // Agent sessions belong to a different bot entirely
+    // (`bot_id::MACRO_NEW_BOT_ID`, served by the harness), so the two paths
+    // can never answer the same mention.
     let mut macro_agent_tool_context =
         ai_tools::build_tool_service_context_from_env(db.clone(), event_broker_tracker.clone())
             .await
@@ -1031,7 +1033,7 @@ async fn run() -> anyhow::Result<()> {
             std::sync::Arc::new(SpawnedChannelEventDispatcher::new(channel_side_effects)),
             lexical_client.clone(),
         );
-    let macro_agent_tools = ai_tools::all_tools();
+    let macro_agent_tools = ai_tools::channel_bot_tools();
     let bot_trigger_router = channel_bots::inbound::BotTriggerRouter::new(
         channels_service.clone(),
         Arc::new(channel_bots::outbound::AgentLoopResponder::new(

--- a/services/mcp_service/src/main.rs
+++ b/services/mcp_service/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> anyhow::Result<()> {
     // Create the MCP service with authenticated tool handler
     let mcp_service = StreamableHttpService::new(
         move || {
-            let tools = ai_tools::mcp_tools();
+            let tools = ai_tools::tools_for(ai_tools::AiHost::Mcp);
             Ok(AuthenticatedToolService::new(
                 tools.toolset,
                 context.tool_context.clone(),

--- a/services/mcp_service/src/tool_service/test.rs
+++ b/services/mcp_service/src/tool_service/test.rs
@@ -109,7 +109,7 @@ async fn empty_toolset_lists_no_tools() {
 /// newly added tool can't quietly regress the submission.
 #[test]
 fn every_exposed_tool_meets_directory_requirements() {
-    let tools = ai_tools::mcp_tools();
+    let tools = ai_tools::tools_for(ai_tools::AiHost::Mcp);
     assert!(
         !tools.toolset.tools.is_empty(),
         "the MCP toolset should not be empty"

--- a/services/scheduled_action/src/outbound/inprocess_executor/agent_task.rs
+++ b/services/scheduled_action/src/outbound/inprocess_executor/agent_task.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use agent::types::{AssistantMessagePart, ChatMessage, ChatMessageContent, Role};
 use agent::{AgentLoop, StreamAccumulator};
-use ai_tools::{ToolServiceContext, ToolSetWithPrompt, all_tools};
+use ai_tools::{AiHost, ToolServiceContext, ToolSetWithPrompt, tools_for};
 use ai_toolset::ToolSet as AiToolSet;
 use anyhow::{Context, Result};
 use chat::domain::models::CreateChatArgs;
@@ -61,7 +61,7 @@ async fn fetch_user_memory(
     tool_context: &ToolServiceContext,
     owner: &macro_user_id::user_id::MacroUserIdStr<'static>,
 ) -> Option<String> {
-    let tools = all_tools();
+    let tools = tools_for(AiHost::Chat);
     let tools = ToolSetWithPrompt {
         toolset: tools.toolset,
         prompt: tools.prompt,
@@ -127,7 +127,7 @@ async fn run_tool_loop(
     action: &ScheduledAction,
     agent_task: &AgentTask,
 ) -> Result<Vec<AssistantMessagePart>> {
-    let tools = all_tools();
+    let tools = tools_for(AiHost::Chat);
     let user_memory = fetch_user_memory(db, tool_context, &action.owner).await;
     let system_prompt = match user_memory {
         Some(memory) => format!(


### PR DESCRIPTION
The @Macro channel bot used the chat toolset, where CreateCalendarEvent is a deferred user tool: in a channel nothing can execute the pending call, but `PendingUserExecution` reads as success to the model, so the bot claimed it created events that never existed. The bot now gets a dedicated `channel_bot_tools()` toolset where CreateCalendarEvent executes directly (as over MCP) and SendEmail is omitted, and the channel-mention prompt says tool calls execute immediately, to ask before creating events with attendees, and that email sending is unavailable from a channel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tools execute vs defer per surface (calendar/email) and updates channel-bot behavior; scoped by host enum and covered by new tests, but wrong host wiring could still cause silent user-action bugs.
> 
> **Overview**
> **Fixes the @Macro channel bot falsely claiming it created calendar events** by giving each AI surface its own toolset instead of reusing the chat bundle everywhere.
> 
> Tool assembly is centralized on **`tools_for(AiHost)`** (`Chat`, `ChannelBot`, `Mcp`), replacing `all_tools()` / `mcp_tools()`. **Chat** keeps deferred `CreateCalendarEvent`, `SendEmail`, discovery tools (`SearchTools`, etc.), and **`TOOL_USE_PROMPT`** (now with a chat-only **`user_tools`** section for composer-confirmed tools). **ChannelBot** and **Mcp** use the MCP-style email/calendar toolsets—**`CreateCalendarEvent` runs in the loop**, **`SendEmail` is omitted**—plus **`DIRECT_TOOL_USE_PROMPT`** without `PendingUserExecution` / SendEmail guidance. **Mcp** additionally drops the chat discovery/display tools.
> 
> **`document_storage_service`** wires the classic @Macro mention responder to **`AiHost::ChannelBot`**. The **channel-mention** system instructions and **channels** docs now state that tools run immediately (no composer), email isn’t available in channels, and the bot should confirm in-thread before creating events with attendees.
> 
> Tests assert every host’s toolset validates and that composer-less hosts expose direct calendar create and no **SendEmail**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51abed5bb04f0587396d2c40bf8845b9ba0071b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->