### PR TITLE
Seanaye/feat/batch upsert with index

### DIFF
--- a/crates/client/cache-turso/src/storage.rs
+++ b/crates/client/cache-turso/src/storage.rs
@@ -93,9 +93,13 @@ const RECORD_UPSERT: &str = "INSERT INTO records (__typename, id, value) VALUES 
 const RECORD_DELETE: &str = "DELETE FROM records WHERE __typename = ?1 AND id = ?2";
 // Turso otherwise chooses the browse index's profile prefix for a direct composite-key delete.
 // Force a point lookup through the existing primary-key index, then delete by its rowid.
-const SEARCH_ROWID: &str = "SELECT rowid FROM search_documents INDEXED BY sqlite_autoindex_search_documents_1 WHERE profile = ?1 AND __typename = ?2 AND id = ?3";
+const SEARCH_ROWID: &str = "SELECT rowid FROM search_documents INDEXED BY sqlite_autoindex_search_documents_1 WHERE profile = ? AND __typename = ? AND id = ?";
 const SEARCH_DELETE: &str = "DELETE FROM search_documents WHERE rowid = ?1";
 const SEARCH_UPSERT: &str = "INSERT INTO search_documents (profile, __typename, id, bucket, search_text, timestamp_ms, source_hash) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) ON CONFLICT (profile, __typename, id) DO UPDATE SET bucket = excluded.bucket, search_text = excluded.search_text, timestamp_ms = excluded.timestamp_ms, source_hash = excluded.source_hash";
+const SEARCH_UPSERT_PREFIX: &str = "INSERT INTO search_documents (profile, __typename, id, bucket, search_text, timestamp_ms, source_hash) VALUES ";
+const SEARCH_UPSERT_ROW: &str = "(?, ?, ?, ?, ?, ?, ?)";
+const SEARCH_UPSERT_SUFFIX: &str = " ON CONFLICT (profile, __typename, id) DO UPDATE SET bucket = excluded.bucket, search_text = excluded.search_text, timestamp_ms = excluded.timestamp_ms, source_hash = excluded.source_hash";
+const SEARCH_WRITE_BATCH_SIZE: usize = 100;
 const SEARCH_LOAD: &str = "SELECT __typename, id, bucket, search_text, timestamp_ms, source_hash FROM search_documents WHERE profile = ?1";
 const SEARCH_BROWSE: &str = "SELECT __typename, id, bucket, search_text, timestamp_ms, source_hash FROM search_documents INDEXED BY search_documents_browse_idx WHERE profile = ?1 AND bucket = ?2 ORDER BY timestamp_ms DESC, __typename ASC, id ASC LIMIT ?3";
 const SEARCH_BROWSE_AFTER: &str = "SELECT __typename, id, bucket, search_text, timestamp_ms, source_hash FROM search_documents INDEXED BY search_documents_browse_idx WHERE profile = ?1 AND bucket = ?2 AND (timestamp_ms < ?3 OR (timestamp_ms = ?3 AND (__typename > ?4 OR (__typename = ?4 AND id > ?5)))) ORDER BY timestamp_ms DESC, __typename ASC, id ASC LIMIT ?6";
@@ -4119,39 +4123,113 @@ fn delete_search_document(
     }
 }
 
+fn delete_search_documents_batch(
+    connection: &Arc<Connection>,
+    profile: SearchProfile,
+    keys: &[&RecordKey],
+) -> Result<(), TursoStorageError> {
+    for keys in keys.chunks(SEARCH_WRITE_BATCH_SIZE) {
+        let lookup_sql = std::iter::repeat_n(SEARCH_ROWID, keys.len())
+            .collect::<Vec<_>>()
+            .join(" UNION ALL ");
+        let mut parameters = Vec::with_capacity(keys.len() * 3);
+        for key in keys {
+            parameters.push(text(profile.as_str()));
+            parameters.push(text(&key.typename));
+            parameters.push(text(&key.id));
+        }
+        let rowids = driver::query(connection, &lookup_sql, parameters)?
+            .iter()
+            .map(|row| required_i64(row, 0))
+            .collect::<Result<BTreeSet<_>, _>>()?;
+        if rowids.is_empty() {
+            continue;
+        }
+        let expected = i64::try_from(rowids.len()).map_err(|_| invariant())?;
+        require_changed(
+            driver::execute(
+                connection,
+                &format!(
+                    "DELETE FROM search_documents WHERE rowid IN ({})",
+                    sql_placeholders(rowids.len())
+                ),
+                rowids.into_iter().map(Value::from_i64).collect(),
+            )?,
+            expected,
+        )?;
+    }
+    Ok(())
+}
+
+fn upsert_search_documents_batch(
+    connection: &Arc<Connection>,
+    documents: &[(&RecordKey, &SearchDocument)],
+) -> Result<(), TursoStorageError> {
+    for documents in documents.chunks(SEARCH_WRITE_BATCH_SIZE) {
+        let values_sql = std::iter::repeat_n(SEARCH_UPSERT_ROW, documents.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let mut parameters = Vec::with_capacity(documents.len() * 7);
+        for (key, document) in documents {
+            parameters.push(text(document.profile.as_str()));
+            parameters.push(text(&key.typename));
+            parameters.push(text(&key.id));
+            parameters.push(text(&document.bucket));
+            parameters.push(text(&document.search_text));
+            parameters.push(Value::from_i64(document.timestamp_ms));
+            parameters.push(text(&document.source_hash));
+        }
+        require_changed(
+            driver::execute(
+                connection,
+                &format!("{SEARCH_UPSERT_PREFIX}{values_sql}{SEARCH_UPSERT_SUFFIX}"),
+                parameters,
+            )?,
+            i64::try_from(documents.len()).map_err(|_| invariant())?,
+        )?;
+    }
+    Ok(())
+}
+
 fn write_search_documents(
     connection: &Arc<Connection>,
     entries: &[EncodedRecord],
 ) -> Result<(), TursoStorageError> {
-    let mut rowid = driver::prepare(connection, SEARCH_ROWID)?;
-    let mut delete = driver::prepare(connection, SEARCH_DELETE)?;
-    let mut upsert = driver::prepare(connection, SEARCH_UPSERT)?;
-    for entry in entries {
-        delete_search_document(
-            &mut rowid,
-            &mut delete,
-            SearchProfile::QuickAccessV1,
-            &entry.key,
-        )?;
-        for document in &entry.search_documents {
-            require_changed(
-                driver::execute_prepared(
-                    &mut upsert,
-                    vec![
-                        text(document.profile.as_str()),
-                        text(&entry.key.typename),
-                        text(&entry.key.id),
-                        text(&document.bucket),
-                        text(&document.search_text),
-                        Value::from_i64(document.timestamp_ms),
-                        text(&document.source_hash),
-                    ],
-                )?,
-                1,
-            )?;
-        }
+    let mut last_entry_by_key = HashMap::with_capacity(entries.len());
+    for (index, entry) in entries.iter().enumerate() {
+        last_entry_by_key.insert((entry.key.typename.as_str(), entry.key.id.as_str()), index);
     }
-    Ok(())
+    let entries = entries
+        .iter()
+        .enumerate()
+        .filter_map(|(index, entry)| {
+            (last_entry_by_key.get(&(entry.key.typename.as_str(), entry.key.id.as_str()))
+                == Some(&index))
+            .then_some(entry)
+        })
+        .collect::<Vec<_>>();
+    let stale_keys = entries
+        .iter()
+        .filter(|entry| {
+            !entry
+                .search_documents
+                .iter()
+                .any(|document| document.profile == SearchProfile::QuickAccessV1)
+        })
+        .map(|entry| &entry.key)
+        .collect::<Vec<_>>();
+    delete_search_documents_batch(connection, SearchProfile::QuickAccessV1, &stale_keys)?;
+
+    let documents = entries
+        .iter()
+        .flat_map(|entry| {
+            entry
+                .search_documents
+                .iter()
+                .map(|document| (&entry.key, document))
+        })
+        .collect::<Vec<_>>();
+    upsert_search_documents_batch(connection, &documents)
 }
 
 fn parse_search_document(

--- a/crates/client/cache-turso/src/storage.rs
+++ b/crates/client/cache-turso/src/storage.rs
@@ -91,7 +91,10 @@ const CREATE_SCHEMA: [&str; 28] = [
 const RECORD_GET: &str = "SELECT value FROM records WHERE __typename = ?1 AND id = ?2";
 const RECORD_UPSERT: &str = "INSERT INTO records (__typename, id, value) VALUES (?1, ?2, ?3) ON CONFLICT (__typename, id) DO UPDATE SET value = excluded.value";
 const RECORD_DELETE: &str = "DELETE FROM records WHERE __typename = ?1 AND id = ?2";
-const SEARCH_DELETE: &str = "DELETE FROM search_documents WHERE __typename = ?1 AND id = ?2";
+// Turso otherwise chooses the browse index's profile prefix for a direct composite-key delete.
+// Force a point lookup through the existing primary-key index, then delete by its rowid.
+const SEARCH_ROWID: &str = "SELECT rowid FROM search_documents INDEXED BY sqlite_autoindex_search_documents_1 WHERE profile = ?1 AND __typename = ?2 AND id = ?3";
+const SEARCH_DELETE: &str = "DELETE FROM search_documents WHERE rowid = ?1";
 const SEARCH_UPSERT: &str = "INSERT INTO search_documents (profile, __typename, id, bucket, search_text, timestamp_ms, source_hash) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) ON CONFLICT (profile, __typename, id) DO UPDATE SET bucket = excluded.bucket, search_text = excluded.search_text, timestamp_ms = excluded.timestamp_ms, source_hash = excluded.source_hash";
 const SEARCH_LOAD: &str = "SELECT __typename, id, bucket, search_text, timestamp_ms, source_hash FROM search_documents WHERE profile = ?1";
 const SEARCH_BROWSE: &str = "SELECT __typename, id, bucket, search_text, timestamp_ms, source_hash FROM search_documents INDEXED BY search_documents_browse_idx WHERE profile = ?1 AND bucket = ?2 ORDER BY timestamp_ms DESC, __typename ASC, id ASC LIMIT ?3";
@@ -858,7 +861,8 @@ impl Storage for TursoStorage {
             let connection = self.connection();
             driver::write_transaction(&connection, || {
                 let mut record_statement = driver::prepare(&connection, RECORD_DELETE)?;
-                let mut search_statement = driver::prepare(&connection, SEARCH_DELETE)?;
+                let mut search_rowid_statement = driver::prepare(&connection, SEARCH_ROWID)?;
+                let mut search_delete_statement = driver::prepare(&connection, SEARCH_DELETE)?;
                 for (index, key) in keys.iter().enumerate() {
                     let changed = driver::execute_prepared(
                         &mut record_statement,
@@ -867,13 +871,12 @@ impl Storage for TursoStorage {
                     if !(0..=1).contains(&changed) {
                         return Err(invariant());
                     }
-                    let search_changed = driver::execute_prepared(
-                        &mut search_statement,
-                        vec![text(&key.typename), text(&key.id)],
+                    delete_search_document(
+                        &mut search_rowid_statement,
+                        &mut search_delete_statement,
+                        SearchProfile::QuickAccessV1,
+                        key,
                     )?;
-                    if search_changed < 0 {
-                        return Err(invariant());
-                    }
                     self.fault_after(TestFaultSite::Delete, index)?;
                 }
                 Ok(())
@@ -1421,7 +1424,8 @@ impl PredicateIndexStorage for TursoStorage {
             let connection = self.connection();
             driver::write_transaction(&connection, || {
                 let mut record_statement = driver::prepare(&connection, RECORD_DELETE)?;
-                let mut search_statement = driver::prepare(&connection, SEARCH_DELETE)?;
+                let mut search_rowid_statement = driver::prepare(&connection, SEARCH_ROWID)?;
+                let mut search_delete_statement = driver::prepare(&connection, SEARCH_DELETE)?;
                 for key in &keys {
                     let changed = driver::execute_prepared(
                         &mut record_statement,
@@ -1430,9 +1434,11 @@ impl PredicateIndexStorage for TursoStorage {
                     if !(0..=1).contains(&changed) {
                         return Err(invariant());
                     }
-                    driver::execute_prepared(
-                        &mut search_statement,
-                        vec![text(&key.typename), text(&key.id)],
+                    delete_search_document(
+                        &mut search_rowid_statement,
+                        &mut search_delete_statement,
+                        SearchProfile::QuickAccessV1,
+                        key,
                     )?;
                 }
                 for key in projection_keys {
@@ -2594,6 +2600,7 @@ fn initialize(
         RECORD_GET,
         RECORD_UPSERT,
         RECORD_DELETE,
+        SEARCH_ROWID,
         SEARCH_DELETE,
         SEARCH_UPSERT,
         SEARCH_LOAD,
@@ -4089,20 +4096,43 @@ fn prepare_records(
         .collect()
 }
 
+fn delete_search_document(
+    rowid_statement: &mut turso_core::Statement,
+    delete_statement: &mut turso_core::Statement,
+    profile: SearchProfile,
+    key: &RecordKey,
+) -> Result<(), TursoStorageError> {
+    let rows = driver::query_prepared(
+        rowid_statement,
+        vec![text(profile.as_str()), text(&key.typename), text(&key.id)],
+    )?;
+    match rows.as_slice() {
+        [] => Ok(()),
+        [row] => require_changed(
+            driver::execute_prepared(
+                delete_statement,
+                vec![Value::from_i64(required_i64(row, 0)?)],
+            )?,
+            1,
+        ),
+        _ => Err(invariant()),
+    }
+}
+
 fn write_search_documents(
     connection: &Arc<Connection>,
     entries: &[EncodedRecord],
 ) -> Result<(), TursoStorageError> {
+    let mut rowid = driver::prepare(connection, SEARCH_ROWID)?;
     let mut delete = driver::prepare(connection, SEARCH_DELETE)?;
     let mut upsert = driver::prepare(connection, SEARCH_UPSERT)?;
     for entry in entries {
-        let changed = driver::execute_prepared(
+        delete_search_document(
+            &mut rowid,
             &mut delete,
-            vec![text(&entry.key.typename), text(&entry.key.id)],
+            SearchProfile::QuickAccessV1,
+            &entry.key,
         )?;
-        if changed < 0 {
-            return Err(invariant());
-        }
         for document in &entry.search_documents {
             require_changed(
                 driver::execute_prepared(

--- a/crates/client/cache-turso/src/storage/test.rs
+++ b/crates/client/cache-turso/src/storage/test.rs
@@ -156,7 +156,7 @@ async fn expect_every_storage_method_latched(
 }
 
 #[test]
-fn search_projection_is_write_through_and_recent_query_uses_projection_index() {
+fn search_projection_is_write_through_and_queries_use_projection_indexes() {
     block_on(async {
         let mut storage = TursoStorage::open_in_memory("search-projection").unwrap();
         let mut document = Record::default();
@@ -248,6 +248,44 @@ fn search_projection_is_write_through_and_recent_query_uses_projection_index() {
         );
         assert!(!details.contains("records"));
 
+        let rowid_plan = driver::query(
+            &storage.connection(),
+            &format!("EXPLAIN QUERY PLAN {SEARCH_ROWID}"),
+            vec![
+                text(SearchProfile::QuickAccessV1.as_str()),
+                text("GraphqlSoupDocument"),
+                text("d1"),
+            ],
+        )
+        .unwrap();
+        let rowid_details = rowid_plan
+            .iter()
+            .filter_map(|row| required_text(row, 3).ok())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            rowid_details.contains("sqlite_autoindex_search_documents_1")
+                && rowid_details.contains("profile=? AND __typename=? AND id=?"),
+            "rowid lookup did not use the complete primary-key index: {rowid_details}"
+        );
+        assert!(
+            !rowid_details.contains("SCAN search_documents"),
+            "rowid lookup scanned the projection table: {rowid_details}"
+        );
+
+        raw_execute(
+            &storage,
+            SEARCH_UPSERT,
+            vec![
+                text("future-profile"),
+                text("GraphqlSoupDocument"),
+                text("d1"),
+                text("document"),
+                text("future profile row"),
+                Value::from_i64(123),
+                text("future-profile-hash"),
+            ],
+        );
         storage
             .delete_batch(&[key("GraphqlSoupDocument:d2")])
             .await
@@ -262,6 +300,13 @@ fn search_projection_is_write_through_and_recent_query_uses_projection_index() {
                 .await
                 .unwrap()
                 .is_empty()
+        );
+        assert_eq!(
+            raw_scalar(
+                &storage,
+                "SELECT COUNT(*) FROM search_documents WHERE profile = 'future-profile' AND __typename = 'GraphqlSoupDocument' AND id = 'd1'",
+            ),
+            1
         );
     });
 }

--- a/crates/client/cache-turso/src/storage/test.rs
+++ b/crates/client/cache-turso/src/storage/test.rs
@@ -21,6 +21,23 @@ fn record(value: &str) -> Record {
     record
 }
 
+fn quick_access_document(name: &str, timestamp: u64) -> Record {
+    let mut document = Record::default();
+    document.fields.insert(
+        "__typename".into(),
+        cache_core::value::CacheValue::String("GraphqlSoupDocument".into()),
+    );
+    document.fields.insert(
+        "name".into(),
+        cache_core::value::CacheValue::String(name.into()),
+    );
+    document.fields.insert(
+        "updatedAt".into(),
+        cache_core::value::CacheValue::Number(cache_core::value::CacheNumber::PosInt(timestamp)),
+    );
+    document
+}
+
 fn queued(label: &str) -> NewQueuedMutation {
     NewQueuedMutation {
         uuid: uuid::Uuid::new_v4(),
@@ -159,19 +176,7 @@ async fn expect_every_storage_method_latched(
 fn search_projection_is_write_through_and_queries_use_projection_indexes() {
     block_on(async {
         let mut storage = TursoStorage::open_in_memory("search-projection").unwrap();
-        let mut document = Record::default();
-        document.fields.insert(
-            "__typename".into(),
-            cache_core::value::CacheValue::String("GraphqlSoupDocument".into()),
-        );
-        document.fields.insert(
-            "name".into(),
-            cache_core::value::CacheValue::String("Quarterly Plan".into()),
-        );
-        document.fields.insert(
-            "updatedAt".into(),
-            cache_core::value::CacheValue::Number(cache_core::value::CacheNumber::PosInt(123)),
-        );
+        let document = quick_access_document("Quarterly Plan", 123);
         storage
             .put_batch(vec![
                 (key("GraphqlSoupDocument:d1"), document.clone()),
@@ -307,6 +312,56 @@ fn search_projection_is_write_through_and_queries_use_projection_indexes() {
                 "SELECT COUNT(*) FROM search_documents WHERE profile = 'future-profile' AND __typename = 'GraphqlSoupDocument' AND id = 'd1'",
             ),
             1
+        );
+    });
+}
+
+#[test]
+fn search_projection_batches_large_writes_and_keeps_the_last_duplicate() {
+    block_on(async {
+        let mut storage = TursoStorage::open_in_memory("search-projection-batches").unwrap();
+        let record_count = SEARCH_WRITE_BATCH_SIZE + 2;
+        let mut entries = (0..record_count)
+            .map(|index| {
+                (
+                    key(&format!("GraphqlSoupDocument:d{index}")),
+                    quick_access_document(&format!("Document {index}"), index as u64),
+                )
+            })
+            .collect::<Vec<_>>();
+        entries.push((key("GraphqlSoupDocument:d0"), record("internal")));
+
+        storage.put_batch(entries).await.unwrap();
+        let loaded = storage
+            .load_search_documents(SearchProfile::QuickAccessV1)
+            .await
+            .unwrap();
+        assert_eq!(loaded.len(), record_count - 1);
+        assert!(
+            loaded
+                .iter()
+                .all(|document| document.record_key.as_ref() != "GraphqlSoupDocument:d0")
+        );
+
+        storage
+            .put_batch(
+                (1..record_count)
+                    .map(|index| {
+                        (
+                            key(&format!("GraphqlSoupDocument:d{index}")),
+                            record("internal"),
+                        )
+                    })
+                    .collect(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            storage
+                .load_search_documents(SearchProfile::QuickAccessV1)
+                .await
+                .unwrap()
+                .is_empty()
         );
     });
 }


### PR DESCRIPTION
This PR fixes an issue where we were doing full table scans during backfill because we were not passing the correct profile value, so we could not leverage the index on the table. We also introduce batched inserts for searchable documents

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Turso search projection I/O paths used on every put/delete and backfill; incorrect profile or rowid handling could leave stale search rows or delete wrong profiles, though new tests cover index choice and profile isolation.
> 
> **Overview**
> Fixes **slow search projection maintenance** during backfill by changing how Turso deletes and writes `search_documents` rows.
> 
> **Deletes** no longer use a composite-key `DELETE` that could pick the browse index and scan by `profile` alone. Deletes now **look up `rowid` via the primary key** (`profile`, `__typename`, `id`) with `INDEXED BY`, then delete by `rowid`. Single-key deletes go through `delete_search_document`; batch stale cleanup uses **UNION ALL rowid lookups** and **`DELETE ... WHERE rowid IN (...)`** in chunks of 100. Record deletes and projection deletes only remove **Quick Access v1** rows for the affected keys, so other search profiles on the same entity are left intact.
> 
> **Writes** batch **multi-row upserts** (same chunk size) instead of per-row delete-then-upsert. `write_search_documents` **dedupes** multiple entries for the same record key (last wins), **batch-deletes** Quick Access rows when the final record no longer projects that profile, then **batch-upserts** all projected documents.
> 
> Tests add **EXPLAIN QUERY PLAN** checks for the rowid path, profile-scoped delete behavior, and large-batch / duplicate-key behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa34704b0c67d9bbbb30e401b536edf85eee3fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->