### PR TITLE
fix(ui): add hovercard one-at-a-time restriction

### DIFF
--- a/apps/web/src/components/ui/components/HoverCard.tsx
+++ b/apps/web/src/components/ui/components/HoverCard.tsx
@@ -1,7 +1,7 @@
+import { HoverCard as CoreHoverCard } from '@core/component/HoverCard';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import type { Placement } from '@floating-ui/dom';
-import { Tooltip as KobalteTooltip } from '@kobalte/core/tooltip';
-import { createSignal, type JSX, type ParentProps, Show } from 'solid-js';
+import { type JSX, type ParentProps, Show } from 'solid-js';
 import { cn } from '../utils/classname';
 import { Surface } from './Surface';
 
@@ -18,26 +18,36 @@ type HoverCardProps = ParentProps<{
    * instead of stacking it on top of the popover.
    */
   disabled?: boolean;
+  /** Rich hover cards in the same group share one open nested branch. */
+  chokeGroup?: string | false;
 }>;
 
 /**
+ * Styled rich hover content that can contain controls and nested hover cards.
+ * Use `Tooltip` instead when the content is only a short text hint; its
+ * string-only `label` API and coordination group are intentionally separate.
+ *
  * @example
- * <HoverCard content={<span>Tooltip text</span>}>
+ * <HoverCard content={<PreviewActions />}>
  *   <button>Hover me</button>
  * </HoverCard>
  */
 export function HoverCard(props: HoverCardProps) {
-  // Controlled open: mirror Kobalte's hover-driven state via onOpenChange, then
-  // gate it on `disabled` so the card hides immediately when suppressed — even
-  // if it was already open when `disabled` flipped true.
-  const [hovered, setHovered] = createSignal(false);
-  const open = () => hovered() && !props.disabled;
-
   return (
     <Show when={!isTouchDevice()} fallback={props.children}>
-      <KobalteTooltip
-        open={open()}
-        onOpenChange={setHovered}
+      <CoreHoverCard
+        trigger={props.children}
+        content={
+          <Surface
+            class={cn(
+              'flex items-center justify-center p-2 text-ink-muted text-xs wrap-break-word bg-tooltip',
+              props.contentClass
+            )}
+            depth={3}
+          >
+            {props.content}
+          </Surface>
+        }
         placement={props.placement ?? 'bottom'}
         overflowPadding={16}
         fitViewport={true}
@@ -45,27 +55,12 @@ export function HoverCard(props: HoverCardProps) {
         openDelay={250}
         flip={true}
         gutter={4}
-      >
-        <KobalteTooltip.Trigger
-          class={cn('inline-flex items-center', props.triggerClass)}
-          as={props.as ?? 'div'}
-        >
-          {props.children}
-        </KobalteTooltip.Trigger>
-        <KobalteTooltip.Portal>
-          <KobalteTooltip.Content class="z-tool-tip max-w-[calc(100vw-32px)]">
-            <Surface
-              class={cn(
-                'flex items-center justify-center p-2 text-ink-muted text-xs wrap-break-word bg-tooltip',
-                props.contentClass
-              )}
-              depth={3}
-            >
-              {props.content}
-            </Surface>
-          </KobalteTooltip.Content>
-        </KobalteTooltip.Portal>
-      </KobalteTooltip>
+        contentClass="max-w-[calc(100vw-32px)]"
+        triggerClass={cn('inline-flex items-center', props.triggerClass)}
+        triggerAs={props.as ?? 'div'}
+        disabled={props.disabled}
+        chokeGroup={props.chokeGroup}
+      />
     </Show>
   );
 }

--- a/apps/web/src/features/property/extractors/PropertyIcon.tsx
+++ b/apps/web/src/features/property/extractors/PropertyIcon.tsx
@@ -39,7 +39,13 @@ export function PropertyIcon(props: Props): JSX.Element {
     return (
       <Show when={userId()}>
         {(id) => (
-          <UserIcon id={id()} size="sm" suppressClick class={cn(props.class)} />
+          <UserIcon
+            id={id()}
+            size="sm"
+            suppressClick
+            showTooltip={false}
+            class={cn(props.class)}
+          />
         )}
       </Show>
     );

--- a/apps/web/src/features/property/extractors/PropertyTooltip.tsx
+++ b/apps/web/src/features/property/extractors/PropertyTooltip.tsx
@@ -25,6 +25,7 @@ export function PropertyTooltip(props: Props) {
     <HoverCard
       content={<CorePropertyTooltip property={props.property} />}
       disabled={ctx?.editorOpen() ?? false}
+      contentClass='rounded-xl p-1.5 px-3 bg-menu shadow-menu'
     >
       {props.children}
     </HoverCard>

--- a/apps/web/src/features/property/extractors/PropertyTooltip.tsx
+++ b/apps/web/src/features/property/extractors/PropertyTooltip.tsx
@@ -25,7 +25,7 @@ export function PropertyTooltip(props: Props) {
     <HoverCard
       content={<CorePropertyTooltip property={props.property} />}
       disabled={ctx?.editorOpen() ?? false}
-      contentClass='rounded-xl p-1.5 px-3 bg-menu shadow-menu'
+      contentClass="rounded-xl p-1.5 px-3 bg-menu shadow-menu"
     >
       {props.children}
     </HoverCard>

--- a/apps/web/src/lib/core/component/HoverCard.tsx
+++ b/apps/web/src/lib/core/component/HoverCard.tsx
@@ -180,12 +180,15 @@ export function HoverCard(props: HoverCardComponentProps) {
     );
     if (deeperTriggerIsOpen) return false;
 
+    // Register before closing competitors so their `unregister` calls cannot
+    // remove this group's set from the map during the handoff.
+    entries.add(entry);
+    entry.registeredGroup = group;
+
     for (const openEntry of competitors) {
       openEntry.close();
     }
 
-    entries.add(entry);
-    entry.registeredGroup = group;
     return true;
   };
 

--- a/apps/web/src/lib/core/component/HoverCard.tsx
+++ b/apps/web/src/lib/core/component/HoverCard.tsx
@@ -16,18 +16,38 @@ import {
 type NestedHoverCardContext = {
   count: () => number;
   setCount: Setter<number>;
+  entry: HoverCardEntry;
 };
 
 const HoverCardPortalNestedPreviewOpenContext = createContext<
   NestedHoverCardContext | undefined
 >(undefined);
 
-// Top-level open cards. When a new card opens, close any already-open siblings
-// so only one card is visible at a time — Kobalte instances are independent
-// and a missed pointerleave (common during scroll) can leave multiple stranded.
-const openTopLevelHoverCards = new Set<() => void>();
+type HoverCardEntry = {
+  parent?: HoverCardEntry;
+  close: () => void;
+  registeredGroup?: string;
+  trigger?: HTMLElement;
+};
 
-type HoverCardComponentProps = {
+const DEFAULT_CHOKE_GROUP = 'hover-card';
+
+// Kobalte hover-card instances do not coordinate with each other. Keep one
+// open branch per group: a card opened from another card's *content* preserves
+// its ancestors, while every unrelated card (including one whose trigger is
+// merely inside another trigger) is closed.
+const openHoverCardsByGroup = new Map<string, Set<HoverCardEntry>>();
+
+function isAncestor(candidate: HoverCardEntry, entry: HoverCardEntry) {
+  let parent = entry.parent;
+  while (parent) {
+    if (parent === candidate) return true;
+    parent = parent.parent;
+  }
+  return false;
+}
+
+export type HoverCardComponentProps = {
   /** The trigger content to hover over */
   trigger: JSX.Element;
   /** The content to show in the hover card */
@@ -55,10 +75,19 @@ type HoverCardComponentProps = {
   triggerAriaLabel?: string;
   /** Class applied to the underlying trigger element. */
   triggerClass?: string;
+  /** Receives the underlying Kobalte trigger element. */
+  triggerRef?: (element: HTMLElement) => void;
   /** Tab index for the trigger element. Use -1 to remove from tab order. */
   triggerTabIndex?: number;
   /** Whether to disable the hover card */
   disabled?: boolean;
+  /**
+   * Cards in the same choke group share one open branch. Opening an unrelated
+   * card closes the current branch; opening a card rendered inside another
+   * card's content preserves its ancestors. Defaults to the app-wide rich
+   * hover-card group. Pass false to opt out of coordination.
+   */
+  chokeGroup?: string | false;
   /**
    * Don't open from the synthetic pointerenter fired when the trigger mounts
    * under a stationary cursor (e.g. a chip inserted via keyboard); require
@@ -77,6 +106,12 @@ type HoverCardComponentProps = {
   portalMount?: HTMLElement;
   /** Placement of the hover card */
   placement?: HoverCardRootProps['placement'];
+  /** Whether the card should flip when it would overflow. */
+  flip?: HoverCardRootProps['flip'];
+  /** Whether the card should be constrained to the viewport. */
+  fitViewport?: HoverCardRootProps['fitViewport'];
+  /** Minimum distance between the card and the viewport edge. */
+  overflowPadding?: HoverCardRootProps['overflowPadding'];
 };
 
 /**
@@ -92,12 +127,86 @@ export function HoverCard(props: HoverCardComponentProps) {
   const [isHoverCardOpen, setIsHoverCardOpen] = createSignal(false);
   let contentEl: HTMLElement | undefined;
 
+  let entry: HoverCardEntry;
+
+  const unregister = () => {
+    const group = entry.registeredGroup;
+    if (group === undefined) return;
+
+    const entries = openHoverCardsByGroup.get(group);
+    entries?.delete(entry);
+    if (entries?.size === 0) openHoverCardsByGroup.delete(group);
+    entry.registeredGroup = undefined;
+  };
+
+  const closeSelf = () => {
+    unregister();
+    setIsHoverCardOpen(false);
+    props.onOpenChange?.(false);
+  };
+
+  entry = {
+    parent: parentNestedContext?.entry,
+    close: closeSelf,
+  };
+
+  const register = (): boolean => {
+    const group = props.chokeGroup ?? DEFAULT_CHOKE_GROUP;
+    if (group === false) {
+      unregister();
+      return true;
+    }
+
+    if (entry.registeredGroup !== group) unregister();
+
+    let entries = openHoverCardsByGroup.get(group);
+    if (!entries) {
+      entries = new Set();
+      openHoverCardsByGroup.set(group, entries);
+    }
+
+    const competitors = [...entries].filter(
+      (openEntry) => openEntry !== entry && !isAncestor(openEntry, entry)
+    );
+
+    // When triggers contain each other, the deepest trigger is the user's
+    // actual target. Keep it even if a broader ancestor trigger's longer open
+    // delay expires afterward.
+    const deeperTriggerIsOpen = competitors.some(
+      (openEntry) =>
+        entry.trigger &&
+        openEntry.trigger &&
+        entry.trigger.contains(openEntry.trigger)
+    );
+    if (deeperTriggerIsOpen) return false;
+
+    for (const openEntry of competitors) {
+      openEntry.close();
+    }
+
+    entries.add(entry);
+    entry.registeredGroup = group;
+    return true;
+  };
+
+  const isDisabled = () => props.disabled || isTouchDevice();
+
   // Keep the internal open signal in sync with controlled `open` so the
-  // nested-card tracking effect below still fires when consumers control state.
+  // nested-card tracking and choke group still work when consumers control state.
   createEffect(() => {
     if (props.open !== undefined) {
-      setIsHoverCardOpen(props.open);
+      const open = props.open && !isDisabled();
+      const accepted = open ? register() : false;
+      if (!open) unregister();
+      setIsHoverCardOpen(accepted);
+      if (open && !accepted) props.onOpenChange?.(false);
     }
+  });
+
+  // `disabled` is reactive (property cards use it while their editor popover
+  // is open), so an already-open uncontrolled card must close immediately.
+  createEffect(() => {
+    if (isDisabled() && isHoverCardOpen()) closeSelf();
   });
 
   createEffect(() => {
@@ -108,13 +217,6 @@ export function HoverCard(props: HoverCardComponentProps) {
       });
     }
   });
-
-  const closeSelf = () => {
-    setIsHoverCardOpen(false);
-    props.onOpenChange?.(false);
-  };
-
-  const isTopLevel = parentNestedContext === undefined;
 
   // Distinguish real hovers from the synthetic pointerenter browsers fire
   // when the trigger mounts under a stationary cursor: only coordinate
@@ -143,7 +245,10 @@ export function HoverCard(props: HoverCardComponentProps) {
   }
 
   const handleOpenChange = (open: boolean) => {
-    if (open && props.requirePointerMovement && !pointerMoved) {
+    if (
+      open &&
+      (isDisabled() || (props.requirePointerMovement && !pointerMoved))
+    ) {
       return;
     }
 
@@ -151,24 +256,18 @@ export function HoverCard(props: HoverCardComponentProps) {
       return;
     }
 
-    if (open && isTopLevel) {
-      for (const close of openTopLevelHoverCards) {
-        if (close !== closeSelf) close();
-      }
-      openTopLevelHoverCards.add(closeSelf);
-    } else if (!open && isTopLevel) {
-      openTopLevelHoverCards.delete(closeSelf);
+    if (open && !register()) {
+      setIsHoverCardOpen(false);
+      props.onOpenChange?.(false);
+      return;
     }
+    if (!open) unregister();
 
     setIsHoverCardOpen(open);
     props.onOpenChange?.(open);
   };
 
-  onCleanup(() => {
-    if (isTopLevel) openTopLevelHoverCards.delete(closeSelf);
-  });
-
-  const isDisabled = () => props.disabled || isTouchDevice();
+  onCleanup(unregister);
 
   const shouldForceMount = () => nestedOpenCount() > 0;
 
@@ -203,14 +302,21 @@ export function HoverCard(props: HoverCardComponentProps) {
         })
       }
       placement={props.placement ?? 'bottom-start'}
+      flip={props.flip}
+      fitViewport={props.fitViewport}
+      overflowPadding={props.overflowPadding}
       openDelay={props.openDelay ?? 100}
       closeDelay={props.closeDelay ?? 150}
       gutter={props.gutter ?? 8}
-      open={props.open ?? isHoverCardOpen()}
+      open={!isDisabled() && isHoverCardOpen()}
       onOpenChange={handleOpenChange}
       forceMount={shouldForceMount()}
     >
       <KobalteHoverCard.Trigger
+        ref={(element) => {
+          entry.trigger = element;
+          props.triggerRef?.(element);
+        }}
         as={props.triggerAs ?? 'span'}
         aria-label={props.triggerAriaLabel}
         class={props.triggerClass}
@@ -232,7 +338,11 @@ export function HoverCard(props: HoverCardComponentProps) {
           )}
         >
           <HoverCardPortalNestedPreviewOpenContext.Provider
-            value={{ count: nestedOpenCount, setCount: setNestedOpenCount }}
+            value={{
+              count: nestedOpenCount,
+              setCount: setNestedOpenCount,
+              entry,
+            }}
           >
             {props.content}
           </HoverCardPortalNestedPreviewOpenContext.Provider>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes global hover-card open/close coordination and trigger nesting behavior across the app; bugs could strand cards open or dismiss nested previews incorrectly, but no auth or data paths are touched.
> 
> **Overview**
> **Rich hover cards now share one open “branch” per choke group** instead of only closing unrelated top-level cards. Opening a card from another card’s content keeps ancestor cards open; opening any other card in the group closes competing branches. Nested triggers are handled so the deepest target wins when open delays race.
> 
> The **core `HoverCard`** implements this via registrable `HoverCardEntry` objects (parent chain + trigger refs), optional `chokeGroup` (default `hover-card`, `false` to opt out), reactive **`disabled`** (forces an open card closed), and choke-aware **controlled `open`**. It also forwards **`flip` / `fitViewport` / `overflowPadding`** and **`triggerRef`**.
> 
> The **UI `HoverCard`** stops using Kobalte **Tooltip** directly and wraps the core component (same `Surface` styling, passes `chokeGroup` and `disabled`). **`PropertyTooltip`** gets menu-like content classes; **`PropertyIcon`** turns off **`UserIcon`** tooltips inside property hovers to avoid stacked hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3971c940c3e79759d4f02f7c75c642605d5a3afb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->