### PR TITLE
fix channel viewed cursor pagination

### DIFF
--- a/crates/channels/fixtures/channel_list_pagination.sql
+++ b/crates/channels/fixtures/channel_list_pagination.sql
@@ -1,5 +1,6 @@
--- Give user-a's channels different created_at and updated_at orderings so the
--- channel-list cursor regression test exercises both sort methods.
+-- Give user-a's channels different created_at, updated_at, and viewed_at
+-- orderings so the channel-list cursor regression test exercises every simple
+-- sort method. In particular, viewed_at reverses the updated_at ordering.
 UPDATE comms_channels
 SET created_at = '2024-01-01 00:00:00+00',
     updated_at = '2024-01-03 00:00:00+00'
@@ -9,3 +10,9 @@ UPDATE comms_channels
 SET created_at = '2024-01-02 00:00:00+00',
     updated_at = '2024-01-02 00:00:00+00'
 WHERE id = '00000000-0000-0000-0000-000000000c03';
+
+INSERT INTO comms_activity (id, user_id, channel_id, viewed_at) VALUES
+  ('00000000-0000-0000-0000-000000000a01', 'macro|user-a@test.com',
+   '00000000-0000-0000-0000-000000000c01', '2024-01-01 00:00:00+00'),
+  ('00000000-0000-0000-0000-000000000a03', 'macro|user-a@test.com',
+   '00000000-0000-0000-0000-000000000c03', '2024-01-04 00:00:00+00');

--- a/crates/channels/fixtures/channel_list_pagination.sql
+++ b/crates/channels/fixtures/channel_list_pagination.sql
@@ -11,6 +11,20 @@ SET created_at = '2024-01-02 00:00:00+00',
     updated_at = '2024-01-02 00:00:00+00'
 WHERE id = '00000000-0000-0000-0000-000000000c03';
 
+-- This channel intentionally has no comms_activity row, exercising the
+-- ViewedAt epoch fallback and the ViewedUpdated updated_at fallback.
+INSERT INTO comms_channels (
+  id, name, channel_type, org_id, owner_id, created_at, updated_at
+) VALUES (
+  '00000000-0000-0000-0000-000000000c05', 'no-activity', 'public', NULL,
+  'macro|user-a@test.com', '2024-01-01 12:00:00+00', '2024-01-02 12:00:00+00'
+);
+
+INSERT INTO comms_channel_participants (channel_id, user_id, role, joined_at) VALUES (
+  '00000000-0000-0000-0000-000000000c05', 'macro|user-a@test.com', 'owner',
+  '2024-01-01 12:00:00+00'
+);
+
 INSERT INTO comms_activity (id, user_id, channel_id, viewed_at) VALUES
   ('00000000-0000-0000-0000-000000000a01', 'macro|user-a@test.com',
    '00000000-0000-0000-0000-000000000c01', '2024-01-01 00:00:00+00'),

--- a/crates/channels/src/outbound/pg_channels_repo.rs
+++ b/crates/channels/src/outbound/pg_channels_repo.rs
@@ -744,9 +744,10 @@ fn id_to_display_name(user_id: &MacroUserIdStr<'static>, name_lookup: &NameLooku
 #[cfg(feature = "list")]
 static CHANNEL_LIST_PREFIX: &str = r#"
     WITH user_channels AS (
-        SELECT c.*
+        SELECT c.*, a.viewed_at
         FROM comms_channels c
         INNER JOIN comms_channel_participants cp ON cp.channel_id = c.id
+        LEFT JOIN comms_activity a ON a.channel_id = c.id AND a.user_id = $1
         WHERE cp.user_id = $1 AND cp.left_at IS NULL
 "#;
 
@@ -756,8 +757,9 @@ static CHANNEL_LIST_PREFIX: &str = r#"
 #[cfg(feature = "list")]
 static CHANNEL_LIST_PREFIX_WITH_TEAM_CHANNELS: &str = r#"
     WITH user_channels AS (
-        SELECT c.*
+        SELECT c.*, a.viewed_at
         FROM comms_channels c
+        LEFT JOIN comms_activity a ON a.channel_id = c.id AND a.user_id = $1
         WHERE (
             EXISTS (
                 SELECT 1
@@ -787,8 +789,18 @@ static CHANNEL_LIST_SELECT: &str = r#"
         WHERE
             ($4::timestamptz IS NULL)
             OR
-            ((CASE $2 WHEN 'created_at' THEN uc.created_at ELSE uc.updated_at END), uc.id::text) < ($4, $5)
-        ORDER BY (CASE $2 WHEN 'created_at' THEN uc.created_at ELSE uc.updated_at END) DESC, uc.id::text DESC
+            ((CASE $2
+                WHEN 'created_at' THEN uc.created_at
+                WHEN 'viewed_at' THEN COALESCE(uc.viewed_at, '1970-01-01 00:00:00+00')
+                WHEN 'viewed_updated' THEN COALESCE(uc.viewed_at, uc.updated_at)
+                ELSE uc.updated_at
+            END), uc.id::text) < ($4, $5)
+        ORDER BY (CASE $2
+            WHEN 'created_at' THEN uc.created_at
+            WHEN 'viewed_at' THEN COALESCE(uc.viewed_at, '1970-01-01 00:00:00+00')
+            WHEN 'viewed_updated' THEN COALESCE(uc.viewed_at, uc.updated_at)
+            ELSE uc.updated_at
+        END) DESC, uc.id::text DESC
         LIMIT $3
     ),
     channel_participants_json AS (
@@ -828,7 +840,12 @@ static CHANNEL_LIST_SELECT: &str = r#"
         ) as "is_participant"
     FROM paged_channels pc
     LEFT JOIN channel_participants_json cpj ON cpj.channel_id = pc.id
-    ORDER BY (CASE $2 WHEN 'created_at' THEN pc.created_at ELSE pc.updated_at END) DESC, pc.id::text DESC
+    ORDER BY (CASE $2
+        WHEN 'created_at' THEN pc.created_at
+        WHEN 'viewed_at' THEN COALESCE(pc.viewed_at, '1970-01-01 00:00:00+00')
+        WHEN 'viewed_updated' THEN COALESCE(pc.viewed_at, pc.updated_at)
+        ELSE pc.updated_at
+    END) DESC, pc.id::text DESC
 "#;
 
 #[cfg(feature = "list")]

--- a/crates/channels/src/outbound/pg_channels_repo/tests.rs
+++ b/crates/channels/src/outbound/pg_channels_repo/tests.rs
@@ -6,6 +6,7 @@ use crate::domain::models::{
 };
 use crate::domain::ports::{ChannelListRepo, ChannelRepo};
 use crate::outbound::pg_channels_repo::PgChannelsRepo;
+use chrono::{DateTime, Utc};
 use filter_ast::Expr;
 use item_filters::ast::{
     LiteralTree,
@@ -104,6 +105,21 @@ fn channels_params(user_id: &str, filter: LiteralTree<ChannelLiteral>) -> GetCha
 
 fn channel_filter(literal: ChannelLiteral) -> LiteralTree<ChannelLiteral> {
     Some(Arc::new(Expr::val(literal)))
+}
+
+fn channel_list_sort_timestamp(
+    channel: &ChannelWithParticipants,
+    sort: SimpleSortMethod,
+) -> DateTime<Utc> {
+    match sort {
+        SimpleSortMethod::CreatedAt => channel.channel.created_at,
+        SimpleSortMethod::UpdatedAt => channel.channel.updated_at,
+        SimpleSortMethod::ViewedAt | SimpleSortMethod::ViewedUpdated => match channel.channel.id {
+            CH1 => "2024-01-01T00:00:00Z".parse().unwrap(),
+            CH3 => "2024-01-04T00:00:00Z".parse().unwrap(),
+            id => panic!("unexpected channel {id}"),
+        },
+    }
 }
 
 fn participant_roles(channel: &ChannelWithParticipants) -> Vec<(String, ParticipantRole)> {
@@ -268,6 +284,8 @@ async fn channel_list_cursor_pagination_matches_unpaginated_results(pool: Pool<P
     for (sort, expected_ids) in [
         (SimpleSortMethod::CreatedAt, vec![CH3, CH1]),
         (SimpleSortMethod::UpdatedAt, vec![CH1, CH3]),
+        (SimpleSortMethod::ViewedAt, vec![CH3, CH1]),
+        (SimpleSortMethod::ViewedUpdated, vec![CH3, CH1]),
     ] {
         let unpaginated = repo
             .get_user_channels_with_participants(
@@ -312,11 +330,7 @@ async fn channel_list_cursor_pagination_matches_unpaginated_results(pool: Pool<P
                 limit: 1,
                 val: CursorVal {
                     sort_type: sort,
-                    last_val: match sort {
-                        SimpleSortMethod::CreatedAt => last.channel.created_at,
-                        SimpleSortMethod::UpdatedAt => last.channel.updated_at,
-                        _ => unreachable!("channel list test only uses supported sort methods"),
-                    },
+                    last_val: channel_list_sort_timestamp(last, sort),
                 },
                 filter: None,
             });

--- a/crates/channels/src/outbound/pg_channels_repo/tests.rs
+++ b/crates/channels/src/outbound/pg_channels_repo/tests.rs
@@ -37,6 +37,7 @@ const NO_FILTERS: ChannelMessageFilters = ChannelMessageFilters {
 const CH1: Uuid = Uuid::from_u128(0x00000000_0000_0000_0000_000000000c01);
 const CH2: Uuid = Uuid::from_u128(0x00000000_0000_0000_0000_000000000c02);
 const CH3: Uuid = Uuid::from_u128(0x00000000_0000_0000_0000_000000000c03);
+const CH5_NO_ACTIVITY: Uuid = Uuid::from_u128(0x00000000_0000_0000_0000_000000000c05);
 const TEAM_A: Uuid = Uuid::from_u128(0x11111111_1111_1111_1111_111111111111);
 const TEAM_A_AUTO_ACTIVE: Uuid = Uuid::from_u128(0x00000000_0000_0000_0000_000000000c11);
 const TEAM_A_AUTO_LEFT: Uuid = Uuid::from_u128(0x00000000_0000_0000_0000_000000000c12);
@@ -107,6 +108,15 @@ fn channel_filter(literal: ChannelLiteral) -> LiteralTree<ChannelLiteral> {
     Some(Arc::new(Expr::val(literal)))
 }
 
+fn channel_list_fixture_viewed_at(channel_id: Uuid) -> Option<DateTime<Utc>> {
+    match channel_id {
+        CH1 => Some("2024-01-01T00:00:00Z".parse().unwrap()),
+        CH3 => Some("2024-01-04T00:00:00Z".parse().unwrap()),
+        CH5_NO_ACTIVITY => None,
+        id => panic!("unexpected channel {id}"),
+    }
+}
+
 fn channel_list_sort_timestamp(
     channel: &ChannelWithParticipants,
     sort: SimpleSortMethod,
@@ -114,11 +124,12 @@ fn channel_list_sort_timestamp(
     match sort {
         SimpleSortMethod::CreatedAt => channel.channel.created_at,
         SimpleSortMethod::UpdatedAt => channel.channel.updated_at,
-        SimpleSortMethod::ViewedAt | SimpleSortMethod::ViewedUpdated => match channel.channel.id {
-            CH1 => "2024-01-01T00:00:00Z".parse().unwrap(),
-            CH3 => "2024-01-04T00:00:00Z".parse().unwrap(),
-            id => panic!("unexpected channel {id}"),
-        },
+        SimpleSortMethod::ViewedAt => {
+            channel_list_fixture_viewed_at(channel.channel.id).unwrap_or_default()
+        }
+        SimpleSortMethod::ViewedUpdated => {
+            channel_list_fixture_viewed_at(channel.channel.id).unwrap_or(channel.channel.updated_at)
+        }
     }
 }
 
@@ -282,10 +293,13 @@ async fn channel_list_cursor_pagination_matches_unpaginated_results(pool: Pool<P
     let repo = repo(pool);
 
     for (sort, expected_ids) in [
-        (SimpleSortMethod::CreatedAt, vec![CH3, CH1]),
-        (SimpleSortMethod::UpdatedAt, vec![CH1, CH3]),
-        (SimpleSortMethod::ViewedAt, vec![CH3, CH1]),
-        (SimpleSortMethod::ViewedUpdated, vec![CH3, CH1]),
+        (SimpleSortMethod::CreatedAt, vec![CH3, CH5_NO_ACTIVITY, CH1]),
+        (SimpleSortMethod::UpdatedAt, vec![CH1, CH5_NO_ACTIVITY, CH3]),
+        (SimpleSortMethod::ViewedAt, vec![CH3, CH1, CH5_NO_ACTIVITY]),
+        (
+            SimpleSortMethod::ViewedUpdated,
+            vec![CH3, CH5_NO_ACTIVITY, CH1],
+        ),
     ] {
         let unpaginated = repo
             .get_user_channels_with_participants(
@@ -324,6 +338,11 @@ async fn channel_list_cursor_pagination_matches_unpaginated_results(pool: Pool<P
                 break;
             };
             assert_eq!(page.len(), 1);
+            assert_eq!(
+                Some(last.channel.id),
+                expected_ids.get(paginated.len()).copied(),
+                "one-row {sort:?} page was out of order"
+            );
 
             query = Query::Cursor(Cursor {
                 id: last.channel.id,
@@ -360,7 +379,9 @@ async fn channel_list_cursor_pagination_matches_unpaginated_results(pool: Pool<P
                     (USER_B.to_string(), ParticipantRole::Admin),
                     (USER_C.to_string(), ParticipantRole::Member),
                 ],
-                CH3 => vec![(USER_A.to_string(), ParticipantRole::Owner)],
+                CH3 | CH5_NO_ACTIVITY => {
+                    vec![(USER_A.to_string(), ParticipantRole::Owner)]
+                }
                 id => panic!("unexpected channel {id}"),
             };
             assert_eq!(participant_roles(actual), expected_participants);


### PR DESCRIPTION
Fixes an issue with soup channel pagination which could incorrectly surface the same value on multiple cursor pages when sorting by viewed_updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared channel-list SQL and pagination semantics for viewed-based sorts; incorrect fallbacks could still mis-order lists, but scope is limited to list queries and is regression-tested.
> 
> **Overview**
> Fixes **soup channel list** cursor pagination when sorting by **viewed** fields: pages could repeat or skip rows because ordering and cursor comparison ignored per-user `viewed_at` from `comms_activity`.
> 
> The list query now **LEFT JOINs `comms_activity`** and uses the same sort key for **ORDER BY**, **cursor predicates**, and final ordering: `viewed_at` (epoch when missing) and **`viewed_updated`** (`COALESCE(viewed_at, updated_at)`). Fixture and regression tests cover all `SimpleSortMethod` variants, including a channel with no activity row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1954b03a61a9208ee77914718ef067b3c329c3b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->