### PR TITLE
fix(agent-harness): source Redis config from Doppler

### DIFF
--- a/infra/stacks/agent-harness-service/Pulumi.dev.yaml
+++ b/infra/stacks/agent-harness-service/Pulumi.dev.yaml
@@ -3,4 +3,3 @@ config:
   aws:region: us-east-1
   agent-harness-service:github_sync_app_pem: github-sync-app-pem-dev
   agent-harness-service:macro_api_token_private_secret_key: macro-api-token-private-key-dev
-  agent-harness-service:macro_cache_secret_key: macro-cache-dev

--- a/infra/stacks/agent-harness-service/Pulumi.prod.yaml
+++ b/infra/stacks/agent-harness-service/Pulumi.prod.yaml
@@ -3,4 +3,3 @@ config:
   aws:region: us-east-1
   agent-harness-service:github_sync_app_pem: github-sync-app-pem-prod
   agent-harness-service:macro_api_token_private_secret_key: macro-api-token-private-key-prod
-  agent-harness-service:macro_cache_secret_key: macro-cache-prod

--- a/infra/stacks/agent-harness-service/index.ts
+++ b/infra/stacks/agent-harness-service/index.ts
@@ -45,12 +45,6 @@ const macroApiTokenPrivateKeyArn = aws.secretsmanager
 
 const MACRO_API_TOKENS = getMacroApiToken();
 
-const MACRO_CACHE = aws.secretsmanager
-  .getSecretVersionOutput({
-    secretId: config.require('macro_cache_secret_key'),
-  })
-  .apply((secret) => secret.secretString);
-
 // ── AI tools infra ───────────────────────────────────────────────────────────
 
 const aiTools =
@@ -114,10 +108,6 @@ const service = new AgentHarnessService(`agent-harness-service-${stack}`, {
     {
       name: 'ENVIRONMENT',
       value: stack,
-    },
-    {
-      name: 'REDIS_URI',
-      value: pulumi.interpolate`redis://${MACRO_CACHE}`,
     },
     // Datadog
     {

--- a/services/agent_harness_service/Cargo.toml
+++ b/services/agent_harness_service/Cargo.toml
@@ -35,6 +35,7 @@ aws-sdk-kms = { workspace = true }
 cursor_api_key = { path = "../../crates/cursor_api_key" }
 cursor_cloud_agents = { path = "../../crates/cursor_cloud_agents" }
 database_env_vars = { path = "../../crates/database_env_vars" }
+doppler-config = { workspace = true }
 entity_access = { path = "../../crates/entity_access" }
 futures = { workspace = true }
 github = { path = "../../crates/github", default-features = false, features = [

--- a/services/agent_harness_service/Cargo.toml
+++ b/services/agent_harness_service/Cargo.toml
@@ -35,7 +35,6 @@ aws-sdk-kms = { workspace = true }
 cursor_api_key = { path = "../../crates/cursor_api_key" }
 cursor_cloud_agents = { path = "../../crates/cursor_cloud_agents" }
 database_env_vars = { path = "../../crates/database_env_vars" }
-doppler-config = { workspace = true }
 entity_access = { path = "../../crates/entity_access" }
 futures = { workspace = true }
 github = { path = "../../crates/github", default-features = false, features = [


### PR DESCRIPTION
## Summary
- remove the standalone ECS `REDIS_URI` environment variable, which is ignored when `APP_SECRETS_JSON` is present
- remove the now-unused Macro cache Pulumi configuration
- rely on the agent-harness Doppler contract check now present on `main`

## Context
Agent harness tasks failed to start after the Redis command-routing rollout because `macro_config` exclusively reads the Doppler-backed `APP_SECRETS_JSON` when it is present. `REDIS_URI` has been added to the agent-harness `dev` and `prd` Doppler configs without exposing its value.

## Validation
- `cargo metadata --no-deps --format-version 1`
- `cargo test -p agent_harness_service`
- `cargo fmt --all -- --check`
- `cargo clippy -p agent_harness_service --bin agent_harness_service_doppler_config -- -D warnings`
- loaded the agent-harness `dev` and `prd` Doppler configs through the validation binary
- `bun run lint` in `infra/`
- `git diff --check`

Local `bun run check` could not execute because this isolated worktree does not have infra dependencies installed (`tsc: command not found`); CI runs the repository TypeScript check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Redis for agent-harness depends entirely on Doppler `APP_SECRETS_JSON`; a missing or wrong `REDIS_URI` there would prevent tasks from starting or routing correctly.
> 
> **Overview**
> **Stops injecting Redis through Pulumi/ECS** now that agent-harness reads cache settings from Doppler via `APP_SECRETS_JSON`.
> 
> The agent-harness Pulumi stack no longer loads the Macro cache secret from AWS Secrets Manager or sets a `REDIS_URI` container environment variable built from that value. Dev and prod stack configs drop the unused `macro_cache_secret_key` setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86a31a76ab5d62dbfbd864ecf63664afbc751e1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->