### PR TITLE
feat(tasks): edit task proerties from task preview

### DIFF
--- a/apps/web/src/features/block-md/component/InlinePropertyValue.tsx
+++ b/apps/web/src/features/block-md/component/InlinePropertyValue.tsx
@@ -7,6 +7,8 @@ import { type Component, type JSX, Match, Switch } from 'solid-js';
 
 type InlinePropertyValueProps = {
   property: PropertyT;
+  /** Owning entity ID, when the pill is rendered outside its entity block. */
+  entityId?: string;
   /** Label rendered when the property is empty. Defaults to "None". */
   emptyLabel?: JSX.Element;
   class?: string;
@@ -67,7 +69,10 @@ export const InlinePropertyValue: Component<InlinePropertyValueProps> = (
         </Property.Pill>
       </Property.Tooltip>
       <Property.PopoverEditor
-        entitySelfFilter={{ entityType: ctx.entityType, blockId }}
+        entitySelfFilter={{
+          entityType: ctx.entityType,
+          blockId: props.entityId ?? blockId,
+        }}
       />
     </Property.Root>
   );

--- a/apps/web/src/features/property/core/Root.tsx
+++ b/apps/web/src/features/property/core/Root.tsx
@@ -1,3 +1,4 @@
+import { useHoldParentHoverCardOpen } from '@core/component/HoverCard';
 import { virtualKeyboardVisible } from '@core/mobile/virtualKeyboard';
 import { cn, Dropdown } from '@ui';
 import { createSignal, type JSX, splitProps } from 'solid-js';
@@ -33,6 +34,8 @@ export function Root(props: PropertyRootProps) {
   const [editorAnchor, setEditorAnchor] = createSignal<HTMLElement | undefined>(
     undefined
   );
+
+  useHoldParentHoverCardOpen(editorOpen);
 
   // Focus restoration helper - used by both closeEditor and onOpenChange
   // When a value is saved, the component may remount (due to reactive updates),

--- a/apps/web/src/features/property/editors/popover/EditorPopover.tsx
+++ b/apps/web/src/features/property/editors/popover/EditorPopover.tsx
@@ -1,3 +1,4 @@
+import { useIsInsideHoverCard } from '@core/component/HoverCard';
 import { cn, Dropdown } from '@ui';
 import { type JSX, onCleanup, onMount } from 'solid-js';
 import { useProperty } from '../../core/context';
@@ -28,6 +29,7 @@ type EditorPopoverProps = {
  */
 export function EditorPopover(props: EditorPopoverProps) {
   const ctx = useProperty();
+  const isInsideHoverCard = useIsInsideHoverCard();
 
   const close = () => {
     if (props.onClose) props.onClose();
@@ -92,6 +94,7 @@ export function EditorPopover(props: EditorPopoverProps) {
     <Dropdown.Content
       class={cn(
         'max-h-96 overflow-hidden flex flex-col w-full max-w-70 p-0 text-sm',
+        isInsideHoverCard && 'z-nested-action-menu!',
         props.class
       )}
       onInteractOutside={handleInteractOutside}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -440,6 +440,9 @@ body.tauri-ios {
 
   /* ---- 200-299: always on top ------------------------------------------ */
   --z-index-tool-tip:      200;
+  /* Portaled controls opened from a tooltip/hover card must stack above the
+     surface that owns them. */
+  --z-index-nested-action-menu: 205;
   /* The PDF custom cursor dot must never hide under a hover tooltip. */
   --z-index-custom-cursor-tooltip: 210;
   /* Toasts sit above everything (incl. full-screen modals) so they stay visible. */

--- a/apps/web/src/lib/core/component/DocumentPreview.tsx
+++ b/apps/web/src/lib/core/component/DocumentPreview.tsx
@@ -42,10 +42,6 @@ import SparkleIcon from '@phosphor/sparkle.svg';
 import LoadingSpinner from '@phosphor/spinner.svg';
 import TrashSimple from '@phosphor/trash-simple.svg';
 import UsersIcon from '@phosphor/users.svg';
-import { Property } from '@property';
-import { SYSTEM_PROPERTY_IDS } from '@property/constants';
-import { useEntityProperties } from '@property/hooks';
-import { getEntityValues, hasValue } from '@property/utils';
 import {
   isAccessiblePreviewItem,
   isCalendarEventPreviewItem,
@@ -58,13 +54,12 @@ import { blockNameToItemType } from '@service-storage/client';
 import { fetchBinary } from '@service-storage/util/fetchBinary';
 import { createCallback } from '@solid-primitives/rootless';
 import { useNavigate } from '@solidjs/router';
-import { Badge, cn, Layer, Surface, Tooltip } from '@ui';
+import { cn, Surface, Tooltip } from '@ui';
 import type { Component, JSX } from 'solid-js';
 import {
   createEffect,
   createMemo,
   createSignal,
-  For,
   Match,
   onCleanup,
   Show,
@@ -76,6 +71,7 @@ import { formatDate } from '../util/date';
 import NotFound from './AccessErrorViews/NotFound';
 import Unauthorized from './AccessErrorViews/Unauthorized';
 import { useItemPreviewData } from './ItemPreview';
+import { TaskPropertiesPreview } from './TaskPropertiesPreview';
 
 /**
  * Container for displaying mentions with optional collapsing
@@ -380,84 +376,6 @@ function ImageCoverStrip(props: {
         </Show>
       </Suspense>
     </div>
-  );
-}
-
-const TASK_PREVIEW_PROPERTIES = [
-  SYSTEM_PROPERTY_IDS.STATUS,
-  SYSTEM_PROPERTY_IDS.PRIORITY,
-  SYSTEM_PROPERTY_IDS.ASSIGNEES,
-];
-
-export function TaskPropertiesPreview(props: { taskId: string }) {
-  const { properties, isLoading } = useEntityProperties(
-    props.taskId,
-    'TASK',
-    false
-  );
-
-  const previewProperties = createMemo(() =>
-    TASK_PREVIEW_PROPERTIES.flatMap((id) => {
-      const p = properties().find((p) => p.propertyDefinitionId === id);
-      return p && hasValue(p) ? [p] : [];
-    })
-  );
-
-  return (
-    <Show when={!isLoading() && previewProperties().length > 0}>
-      <div class="px-2 pb-2 flex flex-row flex-wrap gap-1 text-xs justify-start">
-        <For each={previewProperties()}>
-          {(property) => <PreviewPropertyPill property={property} />}
-        </For>
-      </div>
-    </Show>
-  );
-}
-
-/**
- * Compact read-only pill for the document preview popup. The popup itself is
- * already a tooltip-like surface, so there's no edit trigger or hover-card.
- * Visually matches the side-panel Properties pills.
- */
-function PreviewPropertyPill(props: {
-  property: import('@property/types').Property;
-}) {
-  const isMultiUser = () =>
-    props.property.valueType === 'ENTITY' &&
-    props.property.specificEntityType === 'USER' &&
-    getEntityValues(props.property).length > 1;
-
-  const isUserEntity = () =>
-    props.property.valueType === 'ENTITY' &&
-    props.property.specificEntityType === 'USER';
-
-  return (
-    <Property.Root property={props.property}>
-      <Layer depth={2}>
-        <Badge
-          variant="ghost"
-          size="sm"
-          class="min-w-0 max-w-full gap-1.5 text-left"
-        >
-          <Switch
-            fallback={
-              <Property.Icon
-                property={props.property}
-                class="size-3 shrink-0"
-              />
-            }
-          >
-            <Match when={isMultiUser()}>
-              <Property.UserStack property={props.property} maxUsers={2} />
-            </Match>
-            <Match when={isUserEntity()}>
-              <Property.Icon property={props.property} />
-            </Match>
-          </Switch>
-          <Property.Text property={props.property} class="truncate" />
-        </Badge>
-      </Layer>
-    </Property.Root>
   );
 }
 
@@ -961,7 +879,10 @@ export function DocumentPreviewContent(props: DocumentPreviewContentProps) {
               {/* Task properties: status, priority, assignees */}
               <Show when={props.documentInfo.type === 'task'}>
                 <Suspense fallback={<div class="w-full bg-active h-4 m-2" />}>
-                  <TaskPropertiesPreview taskId={props.documentInfo.id} />
+                  <TaskPropertiesPreview
+                    taskId={props.documentInfo.id}
+                    taskName={accessibleItem().name}
+                  />
                 </Suspense>
               </Show>
 

--- a/apps/web/src/lib/core/component/HoverCard.tsx
+++ b/apps/web/src/lib/core/component/HoverCard.tsx
@@ -4,7 +4,7 @@ import {
   HoverCard as KobalteHoverCard,
 } from '@kobalte/core/hover-card';
 import { cn } from '@ui/utils/classname';
-import type { JSX, Setter } from 'solid-js';
+import type { Accessor, JSX, Setter } from 'solid-js';
 import {
   createContext,
   createEffect,
@@ -22,6 +22,26 @@ type NestedHoverCardContext = {
 const HoverCardPortalNestedPreviewOpenContext = createContext<
   NestedHoverCardContext | undefined
 >(undefined);
+
+/**
+ * Keeps the nearest parent hover card mounted while a portaled child surface
+ * is active. Use this for menus and editors whose content leaves the hover
+ * card's DOM subtree when it opens.
+ */
+export function useHoldParentHoverCardOpen(active: Accessor<boolean>) {
+  const parentContext = useContext(HoverCardPortalNestedPreviewOpenContext);
+
+  createEffect(() => {
+    if (!parentContext || !active()) return;
+    parentContext.setCount((count) => count + 1);
+    onCleanup(() => parentContext.setCount((count) => count - 1));
+  });
+}
+
+/** Returns whether the calling component is rendered inside a hover card. */
+export function useIsInsideHoverCard() {
+  return useContext(HoverCardPortalNestedPreviewOpenContext) !== undefined;
+}
 
 type HoverCardEntry = {
   parent?: HoverCardEntry;

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/DocumentCard.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/DocumentCard.tsx
@@ -58,7 +58,7 @@ import {
 } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
 import { formatDate } from '../../../../util/date';
-import { TaskPropertiesPreview } from '../../../DocumentPreview';
+import { TaskPropertiesPreview } from '../../../TaskPropertiesPreview';
 import { LexicalWrapperContext } from '../../context/LexicalWrapperContext';
 import { floatWithElement } from '../../directive/floatWithElement';
 import { UPDATE_DOCUMENT_NAME_COMMAND } from '../../plugins';

--- a/apps/web/src/lib/core/component/TaskPropertiesPreview.tsx
+++ b/apps/web/src/lib/core/component/TaskPropertiesPreview.tsx
@@ -1,0 +1,92 @@
+import { InlinePropertyValue } from '@block-md/component/InlinePropertyValue';
+import {
+  getPermissions,
+  hasPermissions,
+  Permissions,
+} from '@core/component/SharePermissions';
+import { Modals } from '@property/component/modal';
+import { SYSTEM_PROPERTY_IDS } from '@property/constants';
+import {
+  PropertiesProvider,
+  type PropertySaveHandler,
+} from '@property/context/PropertiesContext';
+import { useEntityProperties } from '@property/hooks';
+import type { Property, PropertyApiValues } from '@property/types';
+import { useBulkSaveEntityPropertiesMutation } from '@queries/properties/entity';
+import { useDocumentAccessLevelQuery } from '@queries/storage/document-metadata';
+import { createMemo, For, Show } from 'solid-js';
+
+const TASK_PREVIEW_PROPERTIES = [
+  SYSTEM_PROPERTY_IDS.STATUS,
+  SYSTEM_PROPERTY_IDS.PRIORITY,
+  SYSTEM_PROPERTY_IDS.ASSIGNEES,
+];
+
+/** Status, priority, and assignee editors for a task preview card. */
+export function TaskPropertiesPreview(props: {
+  taskId: string;
+  taskName?: string;
+}) {
+  const { properties, isLoading, refetch } = useEntityProperties(
+    props.taskId,
+    'TASK',
+    false
+  );
+  const accessQuery = useDocumentAccessLevelQuery(() => props.taskId);
+  const saveMutation = useBulkSaveEntityPropertiesMutation();
+
+  const previewProperties = createMemo(() =>
+    TASK_PREVIEW_PROPERTIES.flatMap((id) => {
+      const property = properties().find(
+        (candidate) => candidate.propertyDefinitionId === id
+      );
+      return property ? [property] : [];
+    })
+  );
+
+  const canEdit = () =>
+    accessQuery.isSuccess &&
+    hasPermissions(getPermissions(accessQuery.data), Permissions.CAN_EDIT);
+
+  const saveOne = (property: Property, apiValues: PropertyApiValues) =>
+    saveMutation.mutateAsync({
+      properties: [
+        { entityId: props.taskId, entityType: 'TASK', property, apiValues },
+      ],
+    });
+
+  const saveHandler: PropertySaveHandler = {
+    saveProperty: (property, value) => saveOne(property, value),
+    saveDate: (property, date) =>
+      saveOne(property, { valueType: 'DATE', value: date }),
+  };
+
+  return (
+    <Show when={!isLoading() && previewProperties().length > 0}>
+      <PropertiesProvider
+        entityId={props.taskId}
+        entityType="TASK"
+        canEdit={canEdit()}
+        documentName={props.taskName}
+        properties={previewProperties}
+        onRefresh={refetch}
+        onPropertyAdded={refetch}
+        onPropertyDeleted={refetch}
+        saveHandler={saveHandler}
+      >
+        <div class="px-2 pb-2 flex flex-row flex-wrap gap-1 text-xs justify-start">
+          <For each={previewProperties()}>
+            {(property) => (
+              <InlinePropertyValue
+                property={property}
+                entityId={props.taskId}
+                class="bg-surface-2 border border-edge"
+              />
+            )}
+          </For>
+        </div>
+        <Modals />
+      </PropertiesProvider>
+    </Show>
+  );
+}

--- a/apps/web/src/lib/queries/storage/document-metadata.ts
+++ b/apps/web/src/lib/queries/storage/document-metadata.ts
@@ -1,5 +1,6 @@
 import { storageServiceClient } from '@service-storage/client';
 import type { DocumentMetadata } from '@service-storage/generated/schemas';
+import type { AccessLevel } from '@service-storage/generated/schemas/accessLevel';
 import { useQuery } from '@tanstack/solid-query';
 import type { Accessor } from 'solid-js';
 import { entityKeys } from './keys';
@@ -17,10 +18,31 @@ async function fetchDocumentMetadata(
   return result.value.documentMetadata;
 }
 
+async function fetchDocumentAccessLevel(
+  documentId: string
+): Promise<AccessLevel> {
+  const result = await storageServiceClient.getDocumentMetadata({ documentId });
+  if (result.isErr()) {
+    throw new Error('Failed to fetch document access level');
+  }
+  return result.value.userAccessLevel;
+}
+
 export function useDocumentMetadataQuery(documentId: Accessor<string>) {
   return useQuery(() => ({
     queryKey: entityKeys.documentMetadata(documentId()).queryKey,
     queryFn: () => fetchDocumentMetadata(documentId()),
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+    enabled: !!documentId(),
+  }));
+}
+
+/** Loads the current user's access level for a document. */
+export function useDocumentAccessLevelQuery(documentId: Accessor<string>) {
+  return useQuery(() => ({
+    queryKey: entityKeys.documentAccessLevel(documentId()).queryKey,
+    queryFn: () => fetchDocumentAccessLevel(documentId()),
     staleTime: STALE_TIME,
     gcTime: GC_TIME,
     enabled: !!documentId(),

--- a/apps/web/src/lib/queries/storage/keys.ts
+++ b/apps/web/src/lib/queries/storage/keys.ts
@@ -67,6 +67,9 @@ export const entityKeys = createQueryKeys('entity', {
   documentMetadata: (documentId: string) => ({
     queryKey: [documentId],
   }),
+  documentAccessLevel: (documentId: string) => ({
+    queryKey: [documentId, 'accessLevel'],
+  }),
   projectData: (projectId: string) => ({
     queryKey: [projectId],
   }),

--- a/docs/AGENT_GUIDE/tasks.md
+++ b/docs/AGENT_GUIDE/tasks.md
@@ -25,6 +25,14 @@ New accounts are seeded with three sample tasks (`Intro to tasks`, `Advanced tas
 Tasks are documents under the hood (creation hits `POST /dss/documents/create_task`), so they
 also show up in Files/`All` and in AI-chat document listings.
 
+## View and edit task properties
+
+An open task shows Status, Priority, and Assignees as property pills below its title. Task
+mentions and document references also show the same three pills in their hover-card preview,
+including properties that do not have a value yet. Click a preview pill to edit it without
+opening the task; the property picker keeps the preview open while you make a selection.
+Users with view or comment access see the same pills read-only.
+
 ## Messages as tasks
 
 In any channel composer, toggle the `Task` switch before sending to create a task from the


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes property persistence and permission checks from preview surfaces and hover-card stacking; mistakes could allow edits without rights or dismiss previews mid-edit.
> 
> **Overview**
> Task mention and document preview cards now show **status, priority, and assignee** as interactive property pills (including empty values), not read-only badges. Editing uses the shared `InlinePropertyValue` / property popover stack, gated by a new document **access-level** query so view/comment users stay read-only.
> 
> **Hover-card UX:** `Property.Root` keeps the parent preview open while a portaled editor is open; popovers inside hover cards get a higher stacking token (`z-nested-action-menu`). `InlinePropertyValue` accepts an optional `entityId` so self-filters work when the pill is not in the task block.
> 
> `TaskPropertiesPreview` is extracted from `DocumentPreview` and wired through document preview, Lexical task cards, and property modals. Agent docs describe preview editing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f16e7f7d00e6a65f0f13682b07bf95d466445f47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->