### PR TITLE
feat(web): create out-of-office events from the calendar composer

### DIFF
--- a/apps/web/src/features/calendar/calendar.css
+++ b/apps/web/src/features/calendar/calendar.css
@@ -525,6 +525,41 @@
 	--fc-event-text-color: var(--color-ink-muted);
 }
 
+/* Out-of-office chips fill solid with their calendar color, matching how
+   Google Calendar renders the type. */
+.calendar-view .fc .fc-event.calendar-event-out-of-office {
+	--fc-event-bg-color: var(--event-calendar-color, var(--color-calendar));
+	--fc-event-text-color: var(--color-surface);
+}
+
+/* The month grid's dot treatment sets its colors directly rather than
+   through the event variables, so the solid fill must too. A selected chip
+   keeps its usual accent rendering. */
+.calendar-view
+	.fc
+	.fc-dayGridMonth-view
+	.fc-daygrid-dot-event.calendar-event-out-of-office:not(
+		:has(.calendar-event-content-selected)
+	) {
+	background-color: var(--fc-event-bg-color);
+	color: var(--fc-event-text-color);
+}
+
+/* A color bar and response dot carry no signal on a chip already filled
+   with the calendar color. */
+.calendar-view .fc .calendar-event-out-of-office .calendar-event-color-bar,
+.calendar-view .fc .calendar-event-out-of-office .calendar-event-response-dot {
+	display: none;
+}
+
+.calendar-view
+	.fc
+	.calendar-event-out-of-office
+	.calendar-event-content-with-color-bar
+	.calendar-event-content-layout {
+	padding-left: 3px;
+}
+
 .calendar-view .fc .fc-event:hover {
 	z-index: 4;
 }
@@ -548,13 +583,31 @@
 		.fc
 		.fc-event:hover:not(.fc-event-mirror):not(
 			.calendar-multi-day-selection-preview-event
-		):not(:has(.calendar-event-content-selected)) {
+		):not(.calendar-event-out-of-office):not(
+			:has(.calendar-event-content-selected)
+		) {
 		--fc-event-bg-color: color-mix(
 			in oklch,
 			var(--event-calendar-color, var(--color-calendar)) 18%,
 			var(--color-surface)
 		);
 		--fc-event-text-color: var(--color-ink);
+		box-shadow:
+			0 0 0 1px
+			color-mix(
+				in oklch,
+				var(--event-calendar-color, var(--color-calendar)) 55%,
+				transparent
+			);
+	}
+
+	/* A solid out-of-office chip keeps its fill on hover; the ring alone
+	   signals the affordance. */
+	.calendar-view
+		.fc
+		.fc-event.calendar-event-out-of-office:hover:not(
+			:has(.calendar-event-content-selected)
+		) {
 		box-shadow:
 			0 0 0 1px
 			color-mix(
@@ -601,7 +654,9 @@
 	.calendar-view
 		.fc
 		.fc-dayGridMonth-view
-		.fc-daygrid-dot-event:hover:not(:has(.calendar-event-content-selected)) {
+		.fc-daygrid-dot-event:hover:not(.calendar-event-out-of-office):not(
+			:has(.calendar-event-content-selected)
+		) {
 		--fc-event-bg-color: color-mix(
 			in oklch,
 			var(--event-calendar-color, var(--color-calendar)) 16%,

--- a/apps/web/src/features/calendar/components/CalendarGrid.tsx
+++ b/apps/web/src/features/calendar/components/CalendarGrid.tsx
@@ -157,9 +157,15 @@ export function CalendarGrid(props: CalendarGridProps) {
       const emphasized = occurrenceIds.some((id) =>
         props.emphasizedEventIds?.has(id)
       );
+      const classNames = [
+        ...(emphasized ? ['calendar-event-emphasized'] : []),
+        ...(event.eventType === 'out_of_office'
+          ? ['calendar-event-out-of-office']
+          : []),
+      ];
       return {
         ...mapped,
-        classNames: emphasized ? ['calendar-event-emphasized'] : undefined,
+        classNames: classNames.length > 0 ? classNames : undefined,
         startEditable: props.onEventTimeChange ? mapped.startEditable : false,
         durationEditable: props.onEventTimeChange
           ? mapped.durationEditable

--- a/apps/web/src/features/calendar/components/EventDetails.tsx
+++ b/apps/web/src/features/calendar/components/EventDetails.tsx
@@ -9,6 +9,7 @@ import {
 import { plural } from '@core/util/string';
 import { openExternalUrl } from '@core/util/url';
 import { Collapsible } from '@kobalte/core/collapsible';
+import AirplaneTiltIcon from '@phosphor/airplane-tilt.svg';
 import ArrowSquareOutIcon from '@phosphor/arrow-square-out.svg';
 import BellSimpleIcon from '@phosphor/bell-simple.svg';
 import CalendarBlankIcon from '@phosphor/calendar-blank.svg';
@@ -550,6 +551,12 @@ export function EventDetails(props: {
         <div class="select-text text-sm text-ink-muted sm:text-xs">
           {formatEventSchedule(props.event, props.timeFormat)}
         </div>
+        <Show when={props.event.eventType === 'out_of_office'}>
+          <div class="flex select-text items-center gap-1.5 text-sm text-ink-extra-muted sm:text-xs">
+            <AirplaneTiltIcon aria-hidden="true" class="size-4 sm:size-3.5" />
+            Out of office
+          </div>
+        </Show>
         <Show when={recurrenceDescription()}>
           {(description) => (
             <div class="select-text text-sm text-ink-extra-muted sm:text-xs">

--- a/apps/web/src/features/calendar/components/composer/EventForm.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventForm.tsx
@@ -168,32 +168,37 @@ export function EventForm(props: EventFormProps) {
               class="h-9 w-full bg-transparent px-2 text-lg font-semibold leading-snug text-ink outline-none placeholder:text-ink-placeholder"
             />
 
-            <div class="h-12 overflow-y-auto">
-              <MarkdownTextarea
-                type="calendar"
-                initialHtml={calendarDescriptionToEditorHtml(
-                  initialDescription
-                )}
-                editable={() => !fieldIsDisabled('description')}
-                onInitialized={(editor) => {
-                  loadedDescription = exportCalendarDescription(editor);
-                }}
-                onChange={(_markdown, editor) => {
-                  if (!editor) return;
-                  const next = exportCalendarDescription(editor);
-                  controller.setField(
-                    'description',
-                    next === loadedDescription ? initialDescription : next
-                  );
-                }}
-                placeholder="Add description..."
-                portalScope="local"
-                domRef={(element) =>
-                  element.setAttribute('aria-label', 'Description')
-                }
-                class="h-full w-full bg-transparent px-2 text-sm text-ink outline-none"
-              />
-            </div>
+            {/* Google rejects a description on an out-of-office event. The
+                editor re-initializes from the kind switch's reset state, so
+                what it shows always matches what a save submits. */}
+            <Show when={!isOutOfOffice()}>
+              <div class="h-12 overflow-y-auto">
+                <MarkdownTextarea
+                  type="calendar"
+                  initialHtml={calendarDescriptionToEditorHtml(
+                    initialDescription
+                  )}
+                  editable={() => !fieldIsDisabled('description')}
+                  onInitialized={(editor) => {
+                    loadedDescription = exportCalendarDescription(editor);
+                  }}
+                  onChange={(_markdown, editor) => {
+                    if (!editor) return;
+                    const next = exportCalendarDescription(editor);
+                    controller.setField(
+                      'description',
+                      next === loadedDescription ? initialDescription : next
+                    );
+                  }}
+                  placeholder="Add description..."
+                  portalScope="local"
+                  domRef={(element) =>
+                    element.setAttribute('aria-label', 'Description')
+                  }
+                  class="h-full w-full bg-transparent px-2 text-sm text-ink outline-none"
+                />
+              </div>
+            </Show>
           </div>
 
           <div class="flex min-w-0 flex-wrap items-center gap-2">

--- a/apps/web/src/features/calendar/components/composer/EventForm.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventForm.tsx
@@ -1,4 +1,5 @@
 import { MarkdownTextarea } from '@core/component/LexicalMarkdown/component/core/MarkdownTextarea';
+import AirplaneTiltIcon from '@phosphor/airplane-tilt.svg';
 import SpinnerIcon from '@phosphor/spinner.svg';
 import { Button, cn, Layer } from '@ui';
 import { createEffect, createUniqueId, Show } from 'solid-js';
@@ -11,7 +12,10 @@ import { EventDateTimeRangeFields } from './EventDateTimeRangeFields';
 import {
   EventComposerCalendarPill,
   EventComposerConferencePill,
+  EventComposerDeclineMessagePill,
+  EventComposerDeclinePill,
   EventComposerGuestsPill,
+  EventComposerKindPill,
   EventComposerLocationPill,
   EventComposerRecurrencePill,
   EventComposerRemindersPill,
@@ -20,6 +24,7 @@ import type {
   EventEditorDisabledFields,
   EventEditorSubmitValues,
 } from './event-form-model';
+import { outOfOfficeNoticeFor } from './out-of-office';
 import { RecurrenceBuilder } from './RecurrenceBuilder';
 
 export interface EventFormProps {
@@ -61,6 +66,18 @@ export function EventForm(props: EventFormProps) {
     props.disabledFields?.[field] === true;
   const fieldIsDisabled = (field: keyof EventEditorDisabledFields) =>
     formIsDisabled() || fieldIsReadOnly(field);
+
+  const isOutOfOffice = () => controller.isOutOfOffice();
+  // The decline settings of an edited event are unknown until picked, and the
+  // disclosure must not claim behavior nobody chose.
+  const outOfOfficeNotice = () => {
+    const outOfOffice = state().outOfOffice;
+    if (!isOutOfOffice() || !outOfOffice) return undefined;
+    return outOfOfficeNoticeFor(
+      outOfOffice.autoDeclineMode,
+      outOfOffice.declineMessage
+    );
+  };
 
   // The editor cannot hand the provider's string back: Lexical re-serializes
   // whatever it loads. Only content that exports differently from what was
@@ -105,7 +122,12 @@ export function EventForm(props: EventFormProps) {
                 onAllDayChange={controller.setAllDay}
                 startDisabled={fieldIsDisabled('start')}
                 endDisabled={fieldIsDisabled('end')}
-                allDayDisabled={fieldIsDisabled('allDay')}
+                allDayDisabled={
+                  fieldIsDisabled('allDay') ||
+                  // Google requires timed out-of-office events. Leaving
+                  // all-day mode stays possible in case one was seeded.
+                  (isOutOfOffice() && !state().allDay)
+                }
                 invalid={controller.dateRangeError() !== undefined}
                 describedBy={dateRangeDescribedBy()}
               />
@@ -175,6 +197,12 @@ export function EventForm(props: EventFormProps) {
           </div>
 
           <div class="flex min-w-0 flex-wrap items-center gap-2">
+            <EventComposerKindPill
+              eventType={state().eventType}
+              onChange={controller.setEventKind}
+              disabled={formIsDisabled()}
+              readOnly={isEdit()}
+            />
             <EventComposerCalendarPill
               options={controller.calendarOptions()}
               value={controller.selectedCalendarOption()}
@@ -191,28 +219,57 @@ export function EventForm(props: EventFormProps) {
               disabled={formIsDisabled()}
               readOnly={fieldIsReadOnly('recurrence')}
             />
-            <EventComposerGuestsPill
-              options={controller.guestOptions}
-              selected={controller.selectedGuests()}
-              onChange={controller.setSelectedGuests}
-              disabled={formIsDisabled()}
-              readOnly={fieldIsReadOnly('guests')}
-            />
-            <EventComposerConferencePill
-              value={state().conference}
-              canKeepExisting={
-                controller.initialConferenceChoice() === 'existing'
-              }
-              onChange={(conference) =>
-                controller.setField('conference', conference)
-              }
-              disabled={fieldIsDisabled('conference')}
-            />
-            <EventComposerLocationPill
-              value={state().location}
-              onChange={(location) => controller.setField('location', location)}
-              disabled={fieldIsDisabled('location')}
-            />
+            <Show when={!isOutOfOffice()}>
+              <EventComposerGuestsPill
+                options={controller.guestOptions}
+                selected={controller.selectedGuests()}
+                onChange={controller.setSelectedGuests}
+                disabled={formIsDisabled()}
+                readOnly={fieldIsReadOnly('guests')}
+              />
+              <EventComposerConferencePill
+                value={state().conference}
+                canKeepExisting={
+                  controller.initialConferenceChoice() === 'existing'
+                }
+                onChange={(conference) =>
+                  controller.setField('conference', conference)
+                }
+                disabled={fieldIsDisabled('conference')}
+              />
+              <EventComposerLocationPill
+                value={state().location}
+                onChange={(location) =>
+                  controller.setField('location', location)
+                }
+                disabled={fieldIsDisabled('location')}
+              />
+            </Show>
+            <Show when={isOutOfOffice()}>
+              <EventComposerDeclinePill
+                value={state().outOfOffice}
+                onChange={controller.setOutOfOffice}
+                disabled={formIsDisabled()}
+              />
+              <Show
+                when={
+                  state().outOfOffice &&
+                  state().outOfOffice?.autoDeclineMode !== 'decline_none'
+                }
+              >
+                <EventComposerDeclineMessagePill
+                  value={state().outOfOffice?.declineMessage ?? ''}
+                  onChange={(declineMessage) =>
+                    controller.setOutOfOffice({
+                      autoDeclineMode:
+                        state().outOfOffice?.autoDeclineMode ?? 'decline_none',
+                      declineMessage,
+                    })
+                  }
+                  disabled={formIsDisabled()}
+                />
+              </Show>
+            </Show>
             <EventComposerRemindersPill
               minutes={controller.reminderMinutes()}
               usedSlots={
@@ -224,6 +281,29 @@ export function EventForm(props: EventFormProps) {
               disabled={fieldIsDisabled('reminders')}
             />
           </div>
+
+          <Show when={outOfOfficeNotice()}>
+            {(notice) => (
+              <div
+                role="note"
+                aria-label="Out-of-office event"
+                class="flex items-start gap-2 rounded-lg border border-warning/40 bg-warning-bg p-3 text-xs text-warning-ink"
+              >
+                <AirplaneTiltIcon class="mt-px size-4 shrink-0" />
+                <div class="flex min-w-0 flex-col gap-1">
+                  <span class="font-medium">Out-of-office event</span>
+                  <span>{notice().effect}</span>
+                  <Show when={notice().declineMessage}>
+                    {(message) => (
+                      <span class="italic">
+                        Auto-decline reply: “{message()}”
+                      </span>
+                    )}
+                  </Show>
+                </div>
+              </div>
+            )}
+          </Show>
         </div>
 
         <Show when={controller.recurrenceChoice() === 'custom'}>

--- a/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
@@ -20,7 +20,7 @@ import { PropertyCaret } from '@property/extractors/PropertyCaret';
 import { PropertyPill } from '@property/extractors/PropertyPill';
 import type { EntityProperty } from '@property/types';
 import type { EventType } from '@service-storage/generated/schemas/eventType';
-import { cn, Layer, Select, Tooltip } from '@ui';
+import { cn, Layer, Select } from '@ui';
 import { type Accessor, createMemo, createSignal, For, Show } from 'solid-js';
 import {
   formatReminderOffset,
@@ -128,30 +128,26 @@ function ReadOnlyEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
       flip
       slide
     >
-      <Tooltip label="View event guests" placement="bottom">
-        <Popover.Trigger
-          disabled={props.disabled}
-          aria-label="Guests"
-          aria-readonly="true"
-          class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
+      <Popover.Trigger
+        disabled={props.disabled}
+        aria-label="Guests"
+        aria-readonly="true"
+        class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
+      >
+        <Show when={!props.hideIcon}>
+          <UsersIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
+        </Show>
+        <span
+          class={cn(
+            'min-w-0 truncate',
+            PROPERTY_VALUE_CLASS,
+            props.selected.length > 0 ? 'text-current' : 'text-ink-extra-muted'
+          )}
         >
-          <Show when={!props.hideIcon}>
-            <UsersIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
-          </Show>
-          <span
-            class={cn(
-              'min-w-0 truncate',
-              PROPERTY_VALUE_CLASS,
-              props.selected.length > 0
-                ? 'text-current'
-                : 'text-ink-extra-muted'
-            )}
-          >
-            {guestPropertyLabel(props.selected)}
-          </span>
-          <CaretDownIcon class="size-3 shrink-0 text-ink-extra-muted" />
-        </Popover.Trigger>
-      </Tooltip>
+          {guestPropertyLabel(props.selected)}
+        </span>
+        <CaretDownIcon class="size-3 shrink-0 text-ink-extra-muted" />
+      </Popover.Trigger>
       <Popover.Portal>
         <Layer depth={3}>
           <Popover.Content class="z-action-menu w-72 max-w-[calc(100vw-1rem)] rounded-xl border border-edge bg-menu p-1.5 text-sm shadow-menu menu-open-animation">
@@ -227,32 +223,26 @@ function EditableEventComposerGuestsPill(props: EventComposerGuestsPillProps) {
 function GuestsPillTrigger(props: EventComposerGuestsPillProps) {
   const ctx = useProperty();
   return (
-    <Tooltip
-      label="Add guests to this event"
-      placement="bottom"
-      disabled={ctx.editorOpen() || props.disabled}
+    <PropertyPill
+      aria-label="Guests"
+      aria-expanded={ctx.editorOpen()}
+      data-expanded={ctx.editorOpen() ? '' : undefined}
+      class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
     >
-      <PropertyPill
-        aria-label="Guests"
-        aria-expanded={ctx.editorOpen()}
-        data-expanded={ctx.editorOpen() ? '' : undefined}
-        class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
+      <Show when={!props.hideIcon}>
+        <UsersIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
+      </Show>
+      <span
+        class={cn(
+          'min-w-0 truncate',
+          PROPERTY_VALUE_CLASS,
+          props.selected.length > 0 ? 'text-current' : 'text-ink-extra-muted'
+        )}
       >
-        <Show when={!props.hideIcon}>
-          <UsersIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
-        </Show>
-        <span
-          class={cn(
-            'min-w-0 truncate',
-            PROPERTY_VALUE_CLASS,
-            props.selected.length > 0 ? 'text-current' : 'text-ink-extra-muted'
-          )}
-        >
-          {guestPropertyLabel(props.selected)}
-        </span>
-        <PropertyCaret class="text-ink-extra-muted" />
-      </PropertyPill>
-    </Tooltip>
+        {guestPropertyLabel(props.selected)}
+      </span>
+      <PropertyCaret class="text-ink-extra-muted" />
+    </PropertyPill>
   );
 }
 
@@ -326,27 +316,25 @@ export function EventComposerLocationPill(
       flip
       slide
     >
-      <Tooltip label="Set the event location" placement="bottom">
-        <Popover.Trigger
-          disabled={props.disabled}
-          aria-label="Location"
-          class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
+      <Popover.Trigger
+        disabled={props.disabled}
+        aria-label="Location"
+        class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
+      >
+        <Show when={!props.hideIcon}>
+          <MapPinIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
+        </Show>
+        <span
+          class={cn(
+            'min-w-0 truncate',
+            PROPERTY_VALUE_CLASS,
+            props.value ? 'text-current' : 'text-ink-extra-muted'
+          )}
         >
-          <Show when={!props.hideIcon}>
-            <MapPinIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
-          </Show>
-          <span
-            class={cn(
-              'min-w-0 truncate',
-              PROPERTY_VALUE_CLASS,
-              props.value ? 'text-current' : 'text-ink-extra-muted'
-            )}
-          >
-            {props.value || 'Add location'}
-          </span>
-          <CaretDownIcon class="size-3 shrink-0 text-ink-extra-muted" />
-        </Popover.Trigger>
-      </Tooltip>
+          {props.value || 'Add location'}
+        </span>
+        <CaretDownIcon class="size-3 shrink-0 text-ink-extra-muted" />
+      </Popover.Trigger>
       <Popover.Portal>
         <Layer depth={3}>
           <Popover.Content
@@ -420,30 +408,28 @@ export function EventComposerConferencePill(
       optionTextValue="label"
       disabled={props.disabled}
     >
-      <Tooltip label="Set event video conferencing" placement="bottom">
-        <Select.Trigger
-          aria-label="Video conferencing"
-          class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
-        >
-          <VideoCameraIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
-          <Select.Value<EventComposerConferenceOption>>
-            {(selectState) => (
-              <span
-                class={cn(
-                  'truncate',
-                  PROPERTY_VALUE_CLASS,
-                  props.value === 'none' && 'text-ink-extra-muted'
-                )}
-              >
-                {props.value === 'none'
-                  ? 'Add meeting link'
-                  : selectState.selectedOption().label}
-              </span>
-            )}
-          </Select.Value>
-          <Select.Icon />
-        </Select.Trigger>
-      </Tooltip>
+      <Select.Trigger
+        aria-label="Video conferencing"
+        class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
+      >
+        <VideoCameraIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
+        <Select.Value<EventComposerConferenceOption>>
+          {(selectState) => (
+            <span
+              class={cn(
+                'truncate',
+                PROPERTY_VALUE_CLASS,
+                props.value === 'none' && 'text-ink-extra-muted'
+              )}
+            >
+              {props.value === 'none'
+                ? 'Add meeting link'
+                : selectState.selectedOption().label}
+            </span>
+          )}
+        </Select.Value>
+        <Select.Icon />
+      </Select.Trigger>
       <Select.Content>
         <Select.Listbox />
       </Select.Content>
@@ -547,26 +533,24 @@ export function EventComposerRemindersPill(
         </Select.Item>
       )}
     >
-      <Tooltip label="Set event notifications" placement="bottom">
-        <Select.Trigger
-          aria-label="Notifications"
-          class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
-        >
-          <BellSimpleIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
-          <Select.Value<EventComposerSelectOption>>
-            {(selectState) => (
-              <span class={cn('truncate', PROPERTY_VALUE_CLASS)}>
-                {reminderPropertyLabel(
-                  selectState
-                    .selectedOptions()
-                    .map((option) => Number(option.value))
-                )}
-              </span>
-            )}
-          </Select.Value>
-          <Select.Icon />
-        </Select.Trigger>
-      </Tooltip>
+      <Select.Trigger
+        aria-label="Notifications"
+        class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
+      >
+        <BellSimpleIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
+        <Select.Value<EventComposerSelectOption>>
+          {(selectState) => (
+            <span class={cn('truncate', PROPERTY_VALUE_CLASS)}>
+              {reminderPropertyLabel(
+                selectState
+                  .selectedOptions()
+                  .map((option) => Number(option.value))
+              )}
+            </span>
+          )}
+        </Select.Value>
+        <Select.Icon />
+      </Select.Trigger>
       <Select.Content class="w-56 p-0">
         <div class="flex items-center justify-between border-edge-muted border-b px-3 py-2 text-xs text-ink-muted">
           <span>Choose reminders</span>
@@ -607,21 +591,19 @@ export function EventComposerRecurrencePill(
       optionDisabled={() => props.readOnly === true}
       disabled={props.disabled}
     >
-      <Tooltip label="Set how this event repeats" placement="bottom">
-        <Select.Trigger
-          aria-label="Repeats"
-          aria-readonly={props.readOnly || undefined}
-          class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48')}
-        >
-          <Show when={!props.hideIcon}>
-            <RepeatIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
-          </Show>
-          <Select.Value<EventComposerSelectOption>>
-            {(selectState) => selectState.selectedOption().label}
-          </Select.Value>
-          <Select.Icon />
-        </Select.Trigger>
-      </Tooltip>
+      <Select.Trigger
+        aria-label="Repeats"
+        aria-readonly={props.readOnly || undefined}
+        class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48')}
+      >
+        <Show when={!props.hideIcon}>
+          <RepeatIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
+        </Show>
+        <Select.Value<EventComposerSelectOption>>
+          {(selectState) => selectState.selectedOption().label}
+        </Select.Value>
+        <Select.Icon />
+      </Select.Trigger>
       <Select.Content>
         <Select.Listbox />
       </Select.Content>
@@ -653,19 +635,17 @@ export function EventComposerCalendarPill(
       optionDisabled={() => props.readOnly === true}
       disabled={props.disabled}
     >
-      <Tooltip label="Choose the calendar for this event" placement="bottom">
-        <Select.Trigger
-          aria-label="Calendar"
-          aria-readonly={props.readOnly || undefined}
-          class={cn(PROPERTY_TRIGGER_CLASS, 'w-40')}
-        >
-          <CalendarDotsIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
-          <Select.Value<EventEditorCalendarOption>>
-            {(selectState) => selectState.selectedOption().label}
-          </Select.Value>
-          <Select.Icon />
-        </Select.Trigger>
-      </Tooltip>
+      <Select.Trigger
+        aria-label="Calendar"
+        aria-readonly={props.readOnly || undefined}
+        class={cn(PROPERTY_TRIGGER_CLASS, 'w-40')}
+      >
+        <CalendarDotsIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
+        <Select.Value<EventEditorCalendarOption>>
+          {(selectState) => selectState.selectedOption().label}
+        </Select.Value>
+        <Select.Icon />
+      </Select.Trigger>
       <Select.Content>
         <Select.Listbox />
       </Select.Content>
@@ -721,22 +701,17 @@ export function EventComposerKindPill(props: EventComposerKindPillProps) {
       optionDisabled={() => props.readOnly === true}
       disabled={props.disabled}
     >
-      <Tooltip
-        label="Choose between a regular event and marking yourself out of office"
-        placement="bottom"
+      <Select.Trigger
+        aria-label="Event kind"
+        aria-readonly={props.readOnly || undefined}
+        class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48')}
       >
-        <Select.Trigger
-          aria-label="Event kind"
-          aria-readonly={props.readOnly || undefined}
-          class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48')}
-        >
-          <SquaresFourIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
-          <Select.Value<EventComposerKindOption>>
-            {(selectState) => selectState.selectedOption().label}
-          </Select.Value>
-          <Select.Icon />
-        </Select.Trigger>
-      </Tooltip>
+        <SquaresFourIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
+        <Select.Value<EventComposerKindOption>>
+          {(selectState) => selectState.selectedOption().label}
+        </Select.Value>
+        <Select.Icon />
+      </Select.Trigger>
       <Select.Content>
         <Select.Listbox />
       </Select.Content>
@@ -791,25 +766,20 @@ export function EventComposerDeclinePill(props: EventComposerDeclinePillProps) {
       placeholder="Decline settings"
       disabled={props.disabled}
     >
-      <Tooltip
-        label="Choose which conflicting meetings Google declines while you are away"
-        placement="bottom"
+      <Select.Trigger
+        aria-label="Decline meetings"
+        class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
       >
-        <Select.Trigger
-          aria-label="Decline meetings"
-          class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
-        >
-          <CalendarXIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
-          <Select.Value<EventComposerDeclineOption>>
-            {(selectState) => (
-              <span class={cn('truncate', PROPERTY_VALUE_CLASS)}>
-                {selectState.selectedOption().label}
-              </span>
-            )}
-          </Select.Value>
-          <Select.Icon />
-        </Select.Trigger>
-      </Tooltip>
+        <CalendarXIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
+        <Select.Value<EventComposerDeclineOption>>
+          {(selectState) => (
+            <span class={cn('truncate', PROPERTY_VALUE_CLASS)}>
+              {selectState.selectedOption().label}
+            </span>
+          )}
+        </Select.Value>
+        <Select.Icon />
+      </Select.Trigger>
       <Select.Content>
         <Select.Listbox />
       </Select.Content>
@@ -839,28 +809,23 @@ export function EventComposerDeclineMessagePill(
       flip
       slide
     >
-      <Tooltip
-        label="Set the reply sent to declined meeting organizers"
-        placement="bottom"
+      <Popover.Trigger
+        disabled={props.disabled}
+        aria-label="Decline message"
+        class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
       >
-        <Popover.Trigger
-          disabled={props.disabled}
-          aria-label="Decline message"
-          class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
+        <ChatTextIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
+        <span
+          class={cn(
+            'min-w-0 truncate',
+            PROPERTY_VALUE_CLASS,
+            props.value ? 'text-current' : 'text-ink-extra-muted'
+          )}
         >
-          <ChatTextIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
-          <span
-            class={cn(
-              'min-w-0 truncate',
-              PROPERTY_VALUE_CLASS,
-              props.value ? 'text-current' : 'text-ink-extra-muted'
-            )}
-          >
-            {props.value || 'Add decline message'}
-          </span>
-          <CaretDownIcon class="size-3 shrink-0 text-ink-extra-muted" />
-        </Popover.Trigger>
-      </Tooltip>
+          {props.value || 'Add decline message'}
+        </span>
+        <CaretDownIcon class="size-3 shrink-0 text-ink-extra-muted" />
+      </Popover.Trigger>
       <Popover.Portal>
         <Layer depth={3}>
           <Popover.Content

--- a/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventPropertyPills.tsx
@@ -3,9 +3,12 @@ import { type IUser, idToEmail, recipientEntityMapper } from '@core/user';
 import { Popover } from '@kobalte/core/popover';
 import BellSimpleIcon from '@phosphor/bell-simple.svg';
 import CalendarDotsIcon from '@phosphor/calendar-dots.svg';
+import CalendarXIcon from '@phosphor/calendar-x.svg';
 import CaretDownIcon from '@phosphor/caret-down.svg';
+import ChatTextIcon from '@phosphor/chat-text.svg';
 import MapPinIcon from '@phosphor/map-pin.svg';
 import RepeatIcon from '@phosphor/repeat.svg';
+import SquaresFourIcon from '@phosphor/squares-four.svg';
 import UsersIcon from '@phosphor/users.svg';
 import VideoCameraIcon from '@phosphor/video-camera.svg';
 import { useProperty } from '@property/core/context';
@@ -16,6 +19,7 @@ import { PropertyEntitySelector } from '@property/editors/selectors/PropertyEnti
 import { PropertyCaret } from '@property/extractors/PropertyCaret';
 import { PropertyPill } from '@property/extractors/PropertyPill';
 import type { EntityProperty } from '@property/types';
+import type { EventType } from '@service-storage/generated/schemas/eventType';
 import { cn, Layer, Select, Tooltip } from '@ui';
 import { type Accessor, createMemo, createSignal, For, Show } from 'solid-js';
 import {
@@ -30,6 +34,12 @@ import {
   guestEmail,
   type SelectedEventEditorGuest,
 } from './event-form-model';
+import {
+  type EventEditorEventKind,
+  type EventEditorOutOfOffice,
+  eventKindLabel,
+  eventKindOf,
+} from './out-of-office';
 
 const PROPERTY_TRIGGER_CLASS =
   'group flex h-7 items-center justify-between gap-1.5 rounded-full border border-edge-muted bg-surface px-2 py-1 text-left text-xs leading-tight text-ink-muted hover:bg-hover hover:text-ink focus-visible:bg-active focus-visible:text-ink focus-visible:ring-accent/10 data-expanded:bg-hover data-expanded:text-ink';
@@ -660,5 +670,220 @@ export function EventComposerCalendarPill(
         <Select.Listbox />
       </Select.Content>
     </Select>
+  );
+}
+
+interface EventComposerKindOption {
+  value: EventEditorEventKind;
+  label: string;
+}
+
+const EVENT_KIND_OPTIONS: EventComposerKindOption[] = [
+  { value: 'default', label: 'Event' },
+  { value: 'out_of_office', label: 'Out of office' },
+];
+
+export interface EventComposerKindPillProps {
+  eventType: EventType | undefined;
+  onChange: (kind: EventEditorEventKind) => void;
+  disabled?: boolean;
+  /** The provider event type is immutable, so edits show the kind fixed. */
+  readOnly?: boolean;
+}
+
+/** Compact selector for the kind of event being created. */
+export function EventComposerKindPill(props: EventComposerKindPillProps) {
+  // A read-only pill displays whatever type the event has, including
+  // status types the composer cannot create.
+  const options = createMemo<EventComposerKindOption[]>(() =>
+    props.readOnly
+      ? [
+          {
+            value: eventKindOf(props.eventType),
+            label: eventKindLabel(props.eventType),
+          },
+        ]
+      : EVENT_KIND_OPTIONS
+  );
+  const selectedOption = () =>
+    options().find((option) => option.value === eventKindOf(props.eventType)) ??
+    options()[0];
+
+  return (
+    <Select<EventComposerKindOption>
+      options={options()}
+      value={selectedOption()}
+      onChange={(option) => {
+        if (option && !props.readOnly) props.onChange(option.value);
+      }}
+      optionValue="value"
+      optionTextValue="label"
+      optionDisabled={() => props.readOnly === true}
+      disabled={props.disabled}
+    >
+      <Tooltip
+        label="Choose between a regular event and marking yourself out of office"
+        placement="bottom"
+      >
+        <Select.Trigger
+          aria-label="Event kind"
+          aria-readonly={props.readOnly || undefined}
+          class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48')}
+        >
+          <SquaresFourIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
+          <Select.Value<EventComposerKindOption>>
+            {(selectState) => selectState.selectedOption().label}
+          </Select.Value>
+          <Select.Icon />
+        </Select.Trigger>
+      </Tooltip>
+      <Select.Content>
+        <Select.Listbox />
+      </Select.Content>
+    </Select>
+  );
+}
+
+interface EventComposerDeclineOption {
+  value: EventEditorOutOfOffice['autoDeclineMode'];
+  label: string;
+}
+
+const DECLINE_MODE_OPTIONS: EventComposerDeclineOption[] = [
+  { value: 'decline_none', label: "Don't decline meetings" },
+  {
+    value: 'decline_only_new_conflicting_invitations',
+    label: 'Decline new meetings',
+  },
+  {
+    value: 'decline_all_conflicting_invitations',
+    label: 'Decline all meetings',
+  },
+];
+
+export interface EventComposerDeclinePillProps {
+  /** Absent while editing an event whose stored settings are unknown. */
+  value: EventEditorOutOfOffice | undefined;
+  onChange: (value: EventEditorOutOfOffice) => void;
+  disabled?: boolean;
+}
+
+/** Compact selector for how an out-of-office event declines meetings. */
+export function EventComposerDeclinePill(props: EventComposerDeclinePillProps) {
+  const selectedOption = () =>
+    DECLINE_MODE_OPTIONS.find(
+      (option) => option.value === props.value?.autoDeclineMode
+    );
+
+  return (
+    <Select<EventComposerDeclineOption>
+      options={DECLINE_MODE_OPTIONS}
+      value={selectedOption() ?? null}
+      onChange={(option) => {
+        if (!option) return;
+        props.onChange({
+          autoDeclineMode: option.value,
+          declineMessage: props.value?.declineMessage ?? '',
+        });
+      }}
+      optionValue="value"
+      optionTextValue="label"
+      placeholder="Decline settings"
+      disabled={props.disabled}
+    >
+      <Tooltip
+        label="Choose which conflicting meetings Google declines while you are away"
+        placement="bottom"
+      >
+        <Select.Trigger
+          aria-label="Decline meetings"
+          class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
+        >
+          <CalendarXIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
+          <Select.Value<EventComposerDeclineOption>>
+            {(selectState) => (
+              <span class={cn('truncate', PROPERTY_VALUE_CLASS)}>
+                {selectState.selectedOption().label}
+              </span>
+            )}
+          </Select.Value>
+          <Select.Icon />
+        </Select.Trigger>
+      </Tooltip>
+      <Select.Content>
+        <Select.Listbox />
+      </Select.Content>
+    </Select>
+  );
+}
+
+export interface EventComposerDeclineMessagePillProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+/** Compact editable pill for the auto-decline reply message. */
+export function EventComposerDeclineMessagePill(
+  props: EventComposerDeclineMessagePillProps
+) {
+  const [open, setOpen] = createSignal(false);
+  let input: HTMLInputElement | undefined;
+
+  return (
+    <Popover
+      open={open() && !props.disabled}
+      onOpenChange={(nextOpen) => setOpen(!props.disabled && nextOpen)}
+      placement="bottom-start"
+      gutter={4}
+      flip
+      slide
+    >
+      <Tooltip
+        label="Set the reply sent to declined meeting organizers"
+        placement="bottom"
+      >
+        <Popover.Trigger
+          disabled={props.disabled}
+          aria-label="Decline message"
+          class={cn(PROPERTY_TRIGGER_CLASS, 'max-w-48 overflow-hidden')}
+        >
+          <ChatTextIcon class="size-3.5 shrink-0 text-ink-extra-muted" />
+          <span
+            class={cn(
+              'min-w-0 truncate',
+              PROPERTY_VALUE_CLASS,
+              props.value ? 'text-current' : 'text-ink-extra-muted'
+            )}
+          >
+            {props.value || 'Add decline message'}
+          </span>
+          <CaretDownIcon class="size-3 shrink-0 text-ink-extra-muted" />
+        </Popover.Trigger>
+      </Tooltip>
+      <Popover.Portal>
+        <Layer depth={3}>
+          <Popover.Content
+            class="z-action-menu w-72 max-w-[calc(100vw-1rem)] rounded-xl border border-edge bg-menu p-2 shadow-menu menu-open-animation"
+            onOpenAutoFocus={(event) => {
+              event.preventDefault();
+              queueMicrotask(() => input?.focus());
+            }}
+          >
+            <Popover.Title class="sr-only">Decline message</Popover.Title>
+            <input
+              ref={input}
+              type="text"
+              value={props.value}
+              onInput={(event) => props.onChange(event.currentTarget.value)}
+              placeholder="Add decline message..."
+              aria-label="Decline message"
+              disabled={props.disabled}
+              class="h-8 w-full rounded-md border border-edge-muted bg-surface px-2 text-sm text-ink outline-none placeholder:text-ink-placeholder focus:border-accent"
+            />
+          </Popover.Content>
+        </Layer>
+      </Popover.Portal>
+    </Popover>
   );
 }

--- a/apps/web/src/features/calendar/components/composer/create-calendar-event-form-controller.test.ts
+++ b/apps/web/src/features/calendar/components/composer/create-calendar-event-form-controller.test.ts
@@ -200,6 +200,7 @@ describe('out of office', () => {
         title: 'Away',
         guests: 'guest@example.com',
         location: 'HQ',
+        description: 'Send help',
         conference: 'google_meet',
       },
       { calendarOptions: MIXED_CALENDARS }
@@ -217,6 +218,7 @@ describe('out of office', () => {
     });
     expect(values?.guestEmails).toEqual([]);
     expect(values?.location).toBe('');
+    expect(values?.description).toBe('');
     expect(values?.conference).toBeUndefined();
     expect(values?.calendarId).toBe('primary-1');
   });

--- a/apps/web/src/features/calendar/components/composer/create-calendar-event-form-controller.test.ts
+++ b/apps/web/src/features/calendar/components/composer/create-calendar-event-form-controller.test.ts
@@ -44,7 +44,9 @@ afterEach(() => {
  */
 function controllerFor(
   initialValue: Partial<EventEditorInitialValues>,
-  options?: Pick<CreateCalendarEventFormControllerOptions, 'isEdit'>
+  options?: Partial<
+    Pick<CreateCalendarEventFormControllerOptions, 'isEdit' | 'calendarOptions'>
+  >
 ) {
   return createRoot((dispose) => {
     disposers.push(dispose);
@@ -148,5 +150,109 @@ describe('pastEventWarning', () => {
       guests: 'guest@example.com',
     });
     expect(ongoing.pastEventWarning()).toBeUndefined();
+  });
+});
+
+const MIXED_CALENDARS = () => [
+  { id: 'shared-1', label: 'Team', color: '#000000', isPrimary: false },
+  { id: 'primary-1', label: 'Mine', color: '#000000', isPrimary: true },
+];
+
+describe('out of office', () => {
+  it('switching the kind forces a timed range and defaults the decline mode', () => {
+    const today = format(new Date(), 'yyyy-MM-dd');
+    const controller = controllerFor({
+      allDay: true,
+      start: today,
+      end: today,
+      title: 'Away',
+    });
+    controller.setEventKind('out_of_office');
+
+    expect(controller.isOutOfOffice()).toBe(true);
+    expect(controller.state().allDay).toBe(false);
+    expect(controller.state().outOfOffice).toEqual({
+      autoDeclineMode: 'decline_none',
+      declineMessage: '',
+    });
+  });
+
+  it('offers only primary calendars and steers the selection onto one', () => {
+    const controller = controllerFor(
+      { ...timedRange(3), title: 'Away', calendarId: 'shared-1' },
+      { calendarOptions: MIXED_CALENDARS }
+    );
+    controller.setEventKind('out_of_office');
+
+    expect(controller.calendarOptions().map((option) => option.id)).toEqual([
+      'primary-1',
+    ]);
+    expect(controller.effectiveCalendarId()).toBe('primary-1');
+
+    controller.setEventKind('default');
+    expect(controller.effectiveCalendarId()).toBe('shared-1');
+  });
+
+  it('creates with the decline settings and without hidden fields', () => {
+    const controller = controllerFor(
+      {
+        ...timedRange(3),
+        title: 'Away',
+        guests: 'guest@example.com',
+        location: 'HQ',
+        conference: 'google_meet',
+      },
+      { calendarOptions: MIXED_CALENDARS }
+    );
+    controller.setEventKind('out_of_office');
+    controller.setOutOfOffice({
+      autoDeclineMode: 'decline_all_conflicting_invitations',
+      declineMessage: '  Back Monday  ',
+    });
+
+    const values = controller.submitValues();
+    expect(values?.outOfOffice).toEqual({
+      autoDeclineMode: 'decline_all_conflicting_invitations',
+      declineMessage: 'Back Monday',
+    });
+    expect(values?.guestEmails).toEqual([]);
+    expect(values?.location).toBe('');
+    expect(values?.conference).toBeUndefined();
+    expect(values?.calendarId).toBe('primary-1');
+  });
+
+  it('switching back to a regular event restores the hidden fields', () => {
+    const controller = controllerFor({
+      ...timedRange(3),
+      title: 'Sync',
+      guests: 'guest@example.com',
+      location: 'HQ',
+    });
+    controller.setEventKind('out_of_office');
+    controller.setEventKind('default');
+
+    const values = controller.submitValues();
+    expect(values?.outOfOffice).toBeUndefined();
+    expect(values?.guestEmails).toEqual(['guest@example.com']);
+    expect(values?.location).toBe('HQ');
+    expect(controller.isDirty()).toBe(false);
+  });
+
+  it('edits only patch decline settings the user actually picked', () => {
+    const controller = controllerFor(
+      { ...timedRange(3), title: 'Away', eventType: 'out_of_office' },
+      { isEdit: true }
+    );
+    expect(controller.isDirty()).toBe(false);
+    expect(controller.submitValues()?.outOfOffice).toBeUndefined();
+
+    controller.setOutOfOffice({
+      autoDeclineMode: 'decline_only_new_conflicting_invitations',
+      declineMessage: '',
+    });
+    expect(controller.isDirty()).toBe(true);
+    expect(controller.submitValues()?.outOfOffice).toEqual({
+      autoDeclineMode: 'decline_only_new_conflicting_invitations',
+    });
   });
 });

--- a/apps/web/src/features/calendar/components/composer/create-calendar-event-form-controller.test.ts
+++ b/apps/web/src/features/calendar/components/composer/create-calendar-event-form-controller.test.ts
@@ -238,6 +238,24 @@ describe('out of office', () => {
     expect(controller.isDirty()).toBe(false);
   });
 
+  it('edits pass the hidden guest and location values through untouched', () => {
+    const controller = controllerFor(
+      {
+        ...timedRange(3),
+        title: 'Away',
+        eventType: 'out_of_office',
+        guests: 'guest@example.com',
+        location: 'HQ',
+      },
+      { isEdit: true }
+    );
+
+    expect(controller.isDirty()).toBe(false);
+    const values = controller.submitValues();
+    expect(values?.guestEmails).toEqual(['guest@example.com']);
+    expect(values?.location).toBe('HQ');
+  });
+
   it('edits only patch decline settings the user actually picked', () => {
     const controller = controllerFor(
       { ...timedRange(3), title: 'Away', eventType: 'out_of_office' },

--- a/apps/web/src/features/calendar/components/composer/create-calendar-event-form-controller.ts
+++ b/apps/web/src/features/calendar/components/composer/create-calendar-event-form-controller.ts
@@ -286,7 +286,7 @@ export function createCalendarEventFormController(
       ? []
       : selectedGuests().map(guestEmail),
     location: blanksHiddenFields(isOutOfOffice()) ? '' : state().location,
-    description: state().description,
+    description: blanksHiddenFields(isOutOfOffice()) ? '' : state().description,
     conference: blanksHiddenFields(isOutOfOffice())
       ? 'none'
       : state().conference,
@@ -307,7 +307,7 @@ export function createCalendarEventFormController(
       calendarId: initialValue().calendarId ?? options.calendarOptions()[0]?.id,
       guestEmails: blanks ? [] : initialGuestEmails(),
       location: blanks ? '' : initialValue().location,
-      description: initialValue().description,
+      description: blanks ? '' : initialValue().description,
       conference: blanks ? 'none' : initialValue().conference,
       reminderMinutes: normalizedReminderMinutes(initialReminderMinutes()),
       ...outOfOfficeSnapshotFields(initialValue()),
@@ -376,10 +376,13 @@ export function createCalendarEventFormController(
     if (kind === 'out_of_office') {
       // Google requires a timed span, so the switch leaves all-day mode. The
       // hidden guest, location, and conference values stay in state for a
-      // switch back; a save while out of office never submits them.
+      // switch back; a save while out of office never submits them. The
+      // description resets instead: its editor re-initializes from the
+      // initial value when it reappears, so kept edits would be invisible.
       replaceState({
         ...convertTimesForAllDay(state(), false),
         eventType: 'out_of_office',
+        description: initialValue().description,
         outOfOffice: state().outOfOffice ?? {
           autoDeclineMode: 'decline_none',
           declineMessage: '',
@@ -462,7 +465,9 @@ export function createCalendarEventFormController(
         ? []
         : selectedGuests().map(guestEmail),
       location: blanksHiddenFields(isOutOfOffice()) ? '' : current.location,
-      description: current.description,
+      description: blanksHiddenFields(isOutOfOffice())
+        ? ''
+        : current.description,
       ...(conference ? { conference } : {}),
       ...(reminders ? { reminders } : {}),
       ...(outOfOffice ? { outOfOffice } : {}),

--- a/apps/web/src/features/calendar/components/composer/create-calendar-event-form-controller.ts
+++ b/apps/web/src/features/calendar/components/composer/create-calendar-event-form-controller.ts
@@ -1,3 +1,4 @@
+import type { OutOfOfficeProperties } from '@service-email/generated/schemas/outOfOfficeProperties';
 import { type Accessor, batch, createMemo, createSignal } from 'solid-js';
 import {
   buildReminderOverrides,
@@ -25,6 +26,11 @@ import {
   PAST_EVENT_GUESTS_WARNING,
   type SelectedEventEditorGuest,
 } from './event-form-model';
+import {
+  type EventEditorEventKind,
+  type EventEditorOutOfOffice,
+  eventKindOf,
+} from './out-of-office';
 
 interface EventComposerFormSnapshot {
   title: string;
@@ -38,6 +44,9 @@ interface EventComposerFormSnapshot {
   description: string;
   conference: EventEditorConferenceChoice;
   reminderMinutes: readonly number[];
+  eventKind: EventEditorEventKind;
+  autoDeclineMode?: EventEditorOutOfOffice['autoDeclineMode'];
+  declineMessage: string;
 }
 
 function normalizedGuestEmails(emails: readonly string[]) {
@@ -79,6 +88,9 @@ function isEventComposerFormDirty(
     initial.location !== current.location ||
     initial.description !== current.description ||
     initial.conference !== current.conference ||
+    initial.eventKind !== current.eventKind ||
+    initial.autoDeclineMode !== current.autoDeclineMode ||
+    initial.declineMessage !== current.declineMessage ||
     !arraysEqual(
       normalizedGuestEmails(initial.guestEmails),
       normalizedGuestEmails(current.guestEmails)
@@ -110,6 +122,7 @@ function cloneValue(value: EventEditorInitialValues): EventEditorInitialValues {
           })),
         }
       : undefined,
+    outOfOffice: value.outOfOffice ? { ...value.outOfOffice } : undefined,
   };
 }
 
@@ -144,8 +157,34 @@ export function createCalendarEventFormController(
     recurrenceTimeZone: options.recurrenceTimeZone,
   });
 
-  const effectiveCalendarId = () =>
-    state().calendarId ?? options.calendarOptions()[0]?.id;
+  const isOutOfOffice = () => state().eventType === 'out_of_office';
+  const eventKind = () => eventKindOf(state().eventType);
+
+  // Google only accepts out-of-office events on primary calendars, so the
+  // picker offers nothing else while creating one — unless no primary is
+  // writable, where the full list stays and the backend explains the refusal.
+  // An edited event's calendar cannot change, so its single option stays.
+  const primaryCalendarOptions = createMemo(() =>
+    options.calendarOptions().filter((option) => option.isPrimary === true)
+  );
+  const restrictsCalendars = () =>
+    isOutOfOffice() &&
+    options.isEdit !== true &&
+    primaryCalendarOptions().length > 0;
+  const availableCalendarOptions = () =>
+    restrictsCalendars() ? primaryCalendarOptions() : options.calendarOptions();
+
+  const effectiveCalendarId = () => {
+    const chosen = state().calendarId;
+    if (!restrictsCalendars()) {
+      return chosen ?? options.calendarOptions()[0]?.id;
+    }
+    // The restriction also steers a selection made before it applied.
+    const available = availableCalendarOptions();
+    return (
+      available.find((option) => option.id === chosen)?.id ?? available[0]?.id
+    );
+  };
 
   const calendarOptionFor = (calendarId: string | undefined) =>
     options
@@ -155,7 +194,7 @@ export function createCalendarEventFormController(
           option.id === (calendarId ?? options.calendarOptions()[0]?.id)
       ) ?? options.calendarOptions()[0];
 
-  const selectedCalendarOption = () => calendarOptionFor(state().calendarId);
+  const selectedCalendarOption = () => calendarOptionFor(effectiveCalendarId());
 
   const resolvedReminderMinutesFor = (values: EventEditorInitialValues) =>
     normalizedReminderMinutes(
@@ -213,6 +252,20 @@ export function createCalendarEventFormController(
     };
   });
 
+  // An out-of-office event hides guests, location, and conferencing, so the
+  // snapshot zeroes what a save would not submit — a value lingering from
+  // before a kind switch is neither dirty nor saved.
+  const outOfOfficeSnapshotFields = (values: EventEditorInitialValues) => {
+    const eventKind = eventKindOf(values.eventType);
+    const outOfOffice =
+      eventKind === 'out_of_office' ? values.outOfOffice : undefined;
+    return {
+      eventKind,
+      autoDeclineMode: outOfOffice?.autoDeclineMode,
+      declineMessage: outOfOffice?.declineMessage.trim() ?? '',
+    };
+  };
+
   const snapshot = (): EventComposerFormSnapshot => ({
     title: state().title,
     allDay: state().allDay,
@@ -220,26 +273,32 @@ export function createCalendarEventFormController(
     end: state().end,
     recurrenceLines: effectiveRecurrenceLines(),
     calendarId: effectiveCalendarId(),
-    guestEmails: selectedGuests().map(guestEmail),
-    location: state().location,
+    guestEmails: isOutOfOffice() ? [] : selectedGuests().map(guestEmail),
+    location: isOutOfOffice() ? '' : state().location,
     description: state().description,
-    conference: state().conference,
+    conference: isOutOfOffice() ? 'none' : state().conference,
     reminderMinutes: normalizedReminderMinutes(reminderMinutes()),
+    ...outOfOfficeSnapshotFields(state()),
   });
 
-  const initialSnapshot = (): EventComposerFormSnapshot => ({
-    title: initialValue().title,
-    allDay: initialValue().allDay,
-    start: initialValue().start,
-    end: initialValue().end,
-    recurrenceLines: initialValue().recurrenceLines,
-    calendarId: initialValue().calendarId ?? options.calendarOptions()[0]?.id,
-    guestEmails: initialGuestEmails(),
-    location: initialValue().location,
-    description: initialValue().description,
-    conference: initialValue().conference,
-    reminderMinutes: normalizedReminderMinutes(initialReminderMinutes()),
-  });
+  const initialSnapshot = (): EventComposerFormSnapshot => {
+    const initialOutOfOffice =
+      eventKindOf(initialValue().eventType) === 'out_of_office';
+    return {
+      title: initialValue().title,
+      allDay: initialValue().allDay,
+      start: initialValue().start,
+      end: initialValue().end,
+      recurrenceLines: initialValue().recurrenceLines,
+      calendarId: initialValue().calendarId ?? options.calendarOptions()[0]?.id,
+      guestEmails: initialOutOfOffice ? [] : initialGuestEmails(),
+      location: initialOutOfOffice ? '' : initialValue().location,
+      description: initialValue().description,
+      conference: initialOutOfOffice ? 'none' : initialValue().conference,
+      reminderMinutes: normalizedReminderMinutes(initialReminderMinutes()),
+      ...outOfOfficeSnapshotFields(initialValue()),
+    };
+  };
 
   const isDirty = createMemo(() =>
     isEventComposerFormDirty(initialSnapshot(), snapshot())
@@ -298,6 +357,28 @@ export function createCalendarEventFormController(
   const setAllDay = (allDay: boolean) =>
     replaceState(convertTimesForAllDay(state(), allDay));
 
+  const setEventKind = (kind: EventEditorEventKind) => {
+    if (kind === eventKind()) return;
+    if (kind === 'out_of_office') {
+      // Google requires a timed span, so the switch leaves all-day mode. The
+      // hidden guest, location, and conference values stay in state for a
+      // switch back; a save while out of office never submits them.
+      replaceState({
+        ...convertTimesForAllDay(state(), false),
+        eventType: 'out_of_office',
+        outOfOffice: state().outOfOffice ?? {
+          autoDeclineMode: 'decline_none',
+          declineMessage: '',
+        },
+      });
+      return;
+    }
+    replaceState({ ...state(), eventType: undefined, outOfOffice: undefined });
+  };
+
+  const setOutOfOffice = (outOfOffice: EventEditorOutOfOffice) =>
+    setField('outOfOffice', outOfOffice);
+
   const setSelectedGuests = (guests: SelectedEventEditorGuest[]) => {
     batch(() => {
       setSelectedGuestsState(guests);
@@ -319,12 +400,41 @@ export function createCalendarEventFormController(
     notifyChange();
   };
 
+  /**
+   * The decline behavior a save submits. A create always carries it — its
+   * presence is what marks the event out of office. An edit only patches
+   * settings the user actually picked: the readback does not expose the
+   * stored ones, so an untouched pill must leave the provider's alone.
+   */
+  const submittedOutOfOffice = (): OutOfOfficeProperties | undefined => {
+    if (!isOutOfOffice()) return undefined;
+    const current = state().outOfOffice;
+    if (options.isEdit === true) {
+      const initial = initialValue().outOfOffice;
+      if (
+        !current ||
+        (initial &&
+          initial.autoDeclineMode === current.autoDeclineMode &&
+          initial.declineMessage.trim() === current.declineMessage.trim())
+      ) {
+        return undefined;
+      }
+    }
+    const declineMessage = current?.declineMessage.trim();
+    return {
+      autoDeclineMode: current?.autoDeclineMode ?? 'decline_none',
+      ...(declineMessage ? { declineMessage } : {}),
+    };
+  };
+
   const submitValues = (): EventEditorSubmitValues | undefined => {
     const time = recurrence.eventTime();
     if (!time || !recurrence.canSave()) return undefined;
     const current = state();
     const reminders = reminderUpdate();
+    const outOfOffice = submittedOutOfOffice();
     const conference =
+      isOutOfOffice() ||
       current.conference === 'existing' ||
       current.conference === initialValue().conference
         ? undefined
@@ -334,11 +444,12 @@ export function createCalendarEventFormController(
       time,
       recurrenceLines: recurrence.recurrenceLines(),
       calendarId: effectiveCalendarId(),
-      guestEmails: selectedGuests().map(guestEmail),
-      location: current.location,
+      guestEmails: isOutOfOffice() ? [] : selectedGuests().map(guestEmail),
+      location: isOutOfOffice() ? '' : current.location,
       description: current.description,
       ...(conference ? { conference } : {}),
       ...(reminders ? { reminders } : {}),
+      ...(outOfOffice ? { outOfOffice } : {}),
     };
   };
 
@@ -358,7 +469,7 @@ export function createCalendarEventFormController(
   return {
     state,
     value,
-    calendarOptions: options.calendarOptions,
+    calendarOptions: availableCalendarOptions,
     guestOptions: options.guestOptions,
     selectedGuests,
     effectiveCalendarId,
@@ -371,6 +482,10 @@ export function createCalendarEventFormController(
     setField,
     setStart,
     setAllDay,
+    eventKind,
+    isOutOfOffice,
+    setEventKind,
+    setOutOfOffice,
     setSelectedGuests,
     startForRecurrence: recurrence.startForRecurrence,
     recurrenceChoice: recurrence.recurrenceChoice,

--- a/apps/web/src/features/calendar/components/composer/create-calendar-event-form-controller.ts
+++ b/apps/web/src/features/calendar/components/composer/create-calendar-event-form-controller.ts
@@ -196,12 +196,16 @@ export function createCalendarEventFormController(
 
   const selectedCalendarOption = () => calendarOptionFor(effectiveCalendarId());
 
+  // Reminder defaults come from the calendar a save would actually target,
+  // which the out-of-office restriction may have steered away from the
+  // stated `calendarId`.
   const resolvedReminderMinutesFor = (values: EventEditorInitialValues) =>
     normalizedReminderMinutes(
       popupMinutes(
         resolveReminderOverrides(
           values.reminders,
-          calendarOptionFor(values.calendarId)?.defaultReminders,
+          calendarOptionFor(values.calendarId ?? effectiveCalendarId())
+            ?.defaultReminders,
           values.eventType
         )
       )
@@ -252,9 +256,14 @@ export function createCalendarEventFormController(
     };
   });
 
-  // An out-of-office event hides guests, location, and conferencing, so the
-  // snapshot zeroes what a save would not submit — a value lingering from
-  // before a kind switch is neither dirty nor saved.
+  // A new out-of-office event hides guests, location, and conferencing, so a
+  // create blanks them — a value lingering from before a kind switch is
+  // neither dirty nor saved. An edit passes them through untouched instead:
+  // the kind cannot change there, so blanking would patch fields the hidden
+  // pills never let the user edit.
+  const blanksHiddenFields = (outOfOffice: boolean) =>
+    outOfOffice && options.isEdit !== true;
+
   const outOfOfficeSnapshotFields = (values: EventEditorInitialValues) => {
     const eventKind = eventKindOf(values.eventType);
     const outOfOffice =
@@ -273,17 +282,22 @@ export function createCalendarEventFormController(
     end: state().end,
     recurrenceLines: effectiveRecurrenceLines(),
     calendarId: effectiveCalendarId(),
-    guestEmails: isOutOfOffice() ? [] : selectedGuests().map(guestEmail),
-    location: isOutOfOffice() ? '' : state().location,
+    guestEmails: blanksHiddenFields(isOutOfOffice())
+      ? []
+      : selectedGuests().map(guestEmail),
+    location: blanksHiddenFields(isOutOfOffice()) ? '' : state().location,
     description: state().description,
-    conference: isOutOfOffice() ? 'none' : state().conference,
+    conference: blanksHiddenFields(isOutOfOffice())
+      ? 'none'
+      : state().conference,
     reminderMinutes: normalizedReminderMinutes(reminderMinutes()),
     ...outOfOfficeSnapshotFields(state()),
   });
 
   const initialSnapshot = (): EventComposerFormSnapshot => {
-    const initialOutOfOffice =
-      eventKindOf(initialValue().eventType) === 'out_of_office';
+    const blanks = blanksHiddenFields(
+      eventKindOf(initialValue().eventType) === 'out_of_office'
+    );
     return {
       title: initialValue().title,
       allDay: initialValue().allDay,
@@ -291,10 +305,10 @@ export function createCalendarEventFormController(
       end: initialValue().end,
       recurrenceLines: initialValue().recurrenceLines,
       calendarId: initialValue().calendarId ?? options.calendarOptions()[0]?.id,
-      guestEmails: initialOutOfOffice ? [] : initialGuestEmails(),
-      location: initialOutOfOffice ? '' : initialValue().location,
+      guestEmails: blanks ? [] : initialGuestEmails(),
+      location: blanks ? '' : initialValue().location,
       description: initialValue().description,
-      conference: initialOutOfOffice ? 'none' : initialValue().conference,
+      conference: blanks ? 'none' : initialValue().conference,
       reminderMinutes: normalizedReminderMinutes(initialReminderMinutes()),
       ...outOfOfficeSnapshotFields(initialValue()),
     };
@@ -444,8 +458,10 @@ export function createCalendarEventFormController(
       time,
       recurrenceLines: recurrence.recurrenceLines(),
       calendarId: effectiveCalendarId(),
-      guestEmails: isOutOfOffice() ? [] : selectedGuests().map(guestEmail),
-      location: isOutOfOffice() ? '' : current.location,
+      guestEmails: blanksHiddenFields(isOutOfOffice())
+        ? []
+        : selectedGuests().map(guestEmail),
+      location: blanksHiddenFields(isOutOfOffice()) ? '' : current.location,
       description: current.description,
       ...(conference ? { conference } : {}),
       ...(reminders ? { reminders } : {}),

--- a/apps/web/src/features/calendar/components/composer/event-form-model.ts
+++ b/apps/web/src/features/calendar/components/composer/event-form-model.ts
@@ -6,6 +6,7 @@ import {
 import { TZDateMini } from '@date-fns/tz';
 import type { ConferenceChange } from '@service-email/generated/schemas/conferenceChange';
 import type { EventTime } from '@service-email/generated/schemas/eventTime';
+import type { OutOfOfficeProperties } from '@service-email/generated/schemas/outOfOfficeProperties';
 import type { EventReminderOverride } from '@service-storage/generated/schemas/eventReminderOverride';
 import type { EventReminders } from '@service-storage/generated/schemas/eventReminders';
 import type { EventType } from '@service-storage/generated/schemas/eventType';
@@ -30,6 +31,7 @@ import {
   recurrenceConfigsEqual,
   recurrencePresetsFor,
 } from '../../utils/recurrence';
+import type { EventEditorOutOfOffice } from './out-of-office';
 
 /** `<input type="date">` value. */
 const DATE_VALUE = 'yyyy-MM-dd';
@@ -76,6 +78,12 @@ export interface EventEditorInitialValues {
   reminders?: EventReminders;
   /** Provider event type of the edited event; absent for new events. */
   eventType?: EventType;
+  /**
+   * Out-of-office decline behavior. Absent while the event is not out of
+   * office, and on an edited out-of-office event until the user picks decline
+   * settings — the provider readback does not expose the stored ones.
+   */
+  outOfOffice?: EventEditorOutOfOffice;
 }
 
 /** Calendar option displayed by the event editor. */
@@ -85,6 +93,9 @@ export interface EventEditorCalendarOption {
   color: string;
   /** Provider defaults shown until the event's reminders are customized. */
   defaultReminders?: EventReminderOverride[];
+  /** Whether this is its account's primary calendar, the only kind Google
+   * accepts out-of-office events on. */
+  isPrimary?: boolean;
 }
 
 /** Editable fields that a create/edit owner may disable. */
@@ -119,6 +130,12 @@ export interface EventEditorSubmitValues {
   conference?: ConferenceChange;
   /** Present only when the user changed the event's reminder configuration. */
   reminders?: EventReminders;
+  /**
+   * Present when the save is out of office: on create its presence marks the
+   * event as out of office, on edit it patches the decline behavior of an
+   * event that already is.
+   */
+  outOfOffice?: OutOfOfficeProperties;
 }
 
 export function defaultEditorInitialValues(
@@ -138,6 +155,7 @@ export function defaultEditorInitialValues(
     conference: 'none',
     reminders: undefined,
     eventType: undefined,
+    outOfOffice: undefined,
   };
 }
 

--- a/apps/web/src/features/calendar/components/composer/out-of-office.test.ts
+++ b/apps/web/src/features/calendar/components/composer/out-of-office.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { outOfOfficeNoticeFor } from './out-of-office';
+
+describe('outOfOfficeNoticeFor', () => {
+  it('discloses the auto-decline behavior for each mode', () => {
+    expect(
+      outOfOfficeNoticeFor('decline_all_conflicting_invitations').effect
+    ).toContain('decline all conflicting invitations');
+
+    expect(
+      outOfOfficeNoticeFor('decline_only_new_conflicting_invitations').effect
+    ).toContain('newly received conflicting invitations');
+
+    // No decline mode still discloses the away status, without promising declines.
+    const none = outOfOfficeNoticeFor(undefined);
+    expect(none.effect).toContain('away');
+    expect(none.effect).not.toContain('decline all');
+    expect(outOfOfficeNoticeFor('decline_none').effect).toBe(none.effect);
+  });
+
+  it('surfaces a decline message and drops a blank one', () => {
+    expect(
+      outOfOfficeNoticeFor('decline_none', 'On vacation').declineMessage
+    ).toBe('On vacation');
+    expect(
+      outOfOfficeNoticeFor('decline_none', '   ').declineMessage
+    ).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/calendar/components/composer/out-of-office.ts
+++ b/apps/web/src/features/calendar/components/composer/out-of-office.ts
@@ -1,0 +1,64 @@
+import type { OutOfOfficeAutoDeclineMode } from '@service-email/generated/schemas/outOfOfficeAutoDeclineMode';
+import type { EventType } from '@service-storage/generated/schemas/eventType';
+import { match } from 'ts-pattern';
+
+/** The kind of event the composer can create. */
+export type EventEditorEventKind = 'default' | 'out_of_office';
+
+/** Editor state for an out-of-office event's decline behavior. */
+export interface EventEditorOutOfOffice {
+  autoDeclineMode: OutOfOfficeAutoDeclineMode;
+  declineMessage: string;
+}
+
+/** The editor kind an event type maps to; only out-of-office is its own kind. */
+export function eventKindOf(
+  eventType: EventType | undefined
+): EventEditorEventKind {
+  return eventType === 'out_of_office' ? 'out_of_office' : 'default';
+}
+
+/** What the composer's kind pill displays for an event type. */
+export function eventKindLabel(eventType: EventType | undefined) {
+  return match(eventType)
+    .with('out_of_office', () => 'Out of office')
+    .with('focus_time', () => 'Focus time')
+    .with('working_location', () => 'Working location')
+    .with('birthday', () => 'Birthday')
+    .otherwise(() => 'Event');
+}
+
+/**
+ * The consequential side effects of an out-of-office save, so a composer can
+ * disclose them before the user confirms. Without this an event that looks
+ * ordinary would silently write an away block and auto-decline meetings.
+ */
+export type OutOfOfficeNotice = {
+  /** Plain-language description of the away status and auto-decline behavior. */
+  effect: string;
+  /** The reply sent to auto-declined organizers, when one is set. */
+  declineMessage?: string;
+};
+
+/** Describe the away status and auto-decline behavior an OOO save applies. */
+export function outOfOfficeNoticeFor(
+  autoDeclineMode: OutOfOfficeAutoDeclineMode | undefined,
+  declineMessage?: string | null
+): OutOfOfficeNotice {
+  const effect = match(autoDeclineMode ?? 'decline_none')
+    .with(
+      'decline_all_conflicting_invitations',
+      () =>
+        'Google will show you as away and automatically decline all conflicting invitations.'
+    )
+    .with(
+      'decline_only_new_conflicting_invitations',
+      () =>
+        'Google will show you as away and automatically decline newly received conflicting invitations.'
+    )
+    .otherwise(
+      () =>
+        'Google will show you as away for this time; conflicting invitations are left untouched.'
+    );
+  return { effect, declineMessage: declineMessage?.trim() || undefined };
+}

--- a/apps/web/src/features/calendar/hooks/use-event-editor.ts
+++ b/apps/web/src/features/calendar/hooks/use-event-editor.ts
@@ -67,6 +67,7 @@ export function useEventEditor(props: UseEventEditorProps) {
           label: event.calendar.name || 'Calendar',
           color: event.calendar.color,
           defaultReminders: calendar?.defaultReminders,
+          isPrimary: calendar?.isPrimary ?? event.calendar.isPrimary,
         },
       ];
     }
@@ -76,6 +77,7 @@ export function useEventEditor(props: UseEventEditorProps) {
       label: calendarDisplayLabel(calendar, spansInboxes()),
       color: calendar.color ?? DEFAULT_CALENDAR_SOURCE.color,
       defaultReminders: calendar.defaultReminders,
+      isPrimary: calendar.isPrimary,
     }));
   });
 
@@ -120,6 +122,7 @@ export function useEventEditor(props: UseEventEditorProps) {
             : {}),
           ...(values.conference ? { conference: values.conference } : {}),
           ...(values.reminders ? { reminders: values.reminders } : {}),
+          ...(values.outOfOffice ? { outOfOffice: values.outOfOffice } : {}),
         },
       });
       return;
@@ -135,6 +138,7 @@ export function useEventEditor(props: UseEventEditorProps) {
       attendees: values.guestEmails.map((email) => ({ email })),
       ...(values.conference ? { conference: values.conference } : {}),
       ...(values.reminders ? { reminders: values.reminders } : {}),
+      ...(values.outOfOffice ? { outOfOffice: values.outOfOffice } : {}),
     });
   };
 

--- a/apps/web/src/lib/core/component/AI/component/tool/calendar/ChatCompose.tsx
+++ b/apps/web/src/lib/core/component/AI/component/tool/calendar/ChatCompose.tsx
@@ -10,7 +10,6 @@ import { useChatContext } from '@core/component/AI/context';
 import type { AssistantMessagePart } from '@core/component/AI/types';
 import { toast } from '@core/component/Toast/Toast';
 import { recipientEntityMapper, useContacts } from '@core/user';
-import AirplaneTiltIcon from '@phosphor/airplane-tilt.svg';
 import { useVisibleCalendarsQuery } from '@queries/calendar/calendars';
 import { invalidateCalendarOccurrences } from '@queries/calendar/occurrences';
 import { useChatQuery } from '@queries/chat';
@@ -31,7 +30,6 @@ import { CalendarToolEventPreview } from './EventPreview';
 import {
   createCalendarEventToEditorInitialValues,
   editorSubmitValuesToCreateCalendarEvent,
-  outOfOfficeNotice,
 } from './event-form-adapter';
 import { openToolCalendarEvent } from './open-tool-event';
 
@@ -167,6 +165,7 @@ function CalendarChatComposeContent(props: CalendarChatComposeProps) {
       label: calendarDisplayLabel(calendar, calendarsSpanInboxes()),
       color: calendar.color ?? DEFAULT_CALENDAR_SOURCE.color,
       defaultReminders: calendar.defaultReminders,
+      isPrimary: calendar.isPrimary,
     }))
   );
 
@@ -340,28 +339,6 @@ function CalendarChatComposeContent(props: CalendarChatComposeProps) {
               Waiting for the response to finish before this event can be
               edited.
             </p>
-          </Show>
-          <Show when={outOfOfficeNotice(props.initialData)}>
-            {(notice) => (
-              <div
-                role="note"
-                aria-label="Out-of-office event"
-                class="flex items-start gap-2 rounded-lg border border-warning/40 bg-warning-bg p-3 text-xs text-warning-ink"
-              >
-                <AirplaneTiltIcon class="mt-px size-4 shrink-0" />
-                <div class="flex min-w-0 flex-col gap-1">
-                  <span class="font-medium">Out-of-office event</span>
-                  <span>{notice().effect}</span>
-                  <Show when={notice().declineMessage}>
-                    {(message) => (
-                      <span class="italic">
-                        Auto-decline reply: “{message()}”
-                      </span>
-                    )}
-                  </Show>
-                </div>
-              </div>
-            )}
           </Show>
           <EventForm
             controller={controller}

--- a/apps/web/src/lib/core/component/AI/component/tool/calendar/event-form-adapter.test.ts
+++ b/apps/web/src/lib/core/component/AI/component/tool/calendar/event-form-adapter.test.ts
@@ -1,6 +1,10 @@
+import type { EventEditorSubmitValues } from '@app/features/calendar/components/composer/event-form-model';
 import type { CreateCalendarEvent } from '@service-cognition/generated/tools/types';
 import { describe, expect, it } from 'vitest';
-import { outOfOfficeNotice } from './event-form-adapter';
+import {
+  createCalendarEventToEditorInitialValues,
+  editorSubmitValuesToCreateCalendarEvent,
+} from './event-form-adapter';
 
 function event(overrides: Partial<CreateCalendarEvent>): CreateCalendarEvent {
   return {
@@ -14,56 +18,115 @@ function event(overrides: Partial<CreateCalendarEvent>): CreateCalendarEvent {
   } as CreateCalendarEvent;
 }
 
-describe('outOfOfficeNotice', () => {
-  it('returns nothing for a regular event', () => {
-    expect(outOfOfficeNotice(event({}))).toBeUndefined();
-    expect(outOfOfficeNotice(event({ eventType: 'default' }))).toBeUndefined();
+function submitValues(
+  overrides: Partial<EventEditorSubmitValues>
+): EventEditorSubmitValues {
+  return {
+    title: 'Focus',
+    time: {
+      kind: 'timed',
+      startsAt: '2026-08-20T17:00:00Z',
+      endsAt: '2026-08-20T18:00:00Z',
+      timeZone: 'UTC',
+    },
+    guestEmails: [],
+    location: '',
+    description: '',
+    ...overrides,
+  };
+}
+
+describe('createCalendarEventToEditorInitialValues', () => {
+  it('leaves a regular event without out-of-office state', () => {
+    const values = createCalendarEventToEditorInitialValues(event({}));
+    expect(values.eventType).toBeUndefined();
+    expect(values.outOfOffice).toBeUndefined();
   });
 
-  it('discloses the auto-decline behavior for each mode', () => {
-    expect(
-      outOfOfficeNotice(
-        event({
-          eventType: 'out_of_office',
-          outOfOffice: { autoDeclineMode: 'decline_all' },
-        })
-      )?.effect
-    ).toContain('decline all conflicting invitations');
+  it('maps the tool decline modes onto the editor names', () => {
+    const values = createCalendarEventToEditorInitialValues(
+      event({
+        eventType: 'out_of_office',
+        outOfOffice: { autoDeclineMode: 'decline_all', declineMessage: 'Away' },
+      })
+    );
+    expect(values.eventType).toBe('out_of_office');
+    expect(values.outOfOffice).toEqual({
+      autoDeclineMode: 'decline_all_conflicting_invitations',
+      declineMessage: 'Away',
+    });
 
     expect(
-      outOfOfficeNotice(
+      createCalendarEventToEditorInitialValues(
         event({
           eventType: 'out_of_office',
           outOfOffice: { autoDeclineMode: 'decline_new_only' },
         })
-      )?.effect
-    ).toContain('newly received conflicting invitations');
-
-    // No decline mode still discloses the away status, without promising declines.
-    const none = outOfOfficeNotice(
-      event({ eventType: 'out_of_office', outOfOffice: {} })
-    );
-    expect(none?.effect).toContain('away');
-    expect(none?.effect).not.toContain('decline all');
+      ).outOfOffice
+    ).toEqual({
+      autoDeclineMode: 'decline_only_new_conflicting_invitations',
+      declineMessage: '',
+    });
   });
 
-  it('surfaces a decline message and drops a blank one', () => {
-    expect(
-      outOfOfficeNotice(
-        event({
-          eventType: 'out_of_office',
-          outOfOffice: { declineMessage: 'On vacation' },
-        })
-      )?.declineMessage
-    ).toBe('On vacation');
+  it('defaults an out-of-office event without decline settings to none', () => {
+    const values = createCalendarEventToEditorInitialValues(
+      event({ eventType: 'out_of_office' })
+    );
+    expect(values.outOfOffice).toEqual({
+      autoDeclineMode: 'decline_none',
+      declineMessage: '',
+    });
+  });
+});
 
-    expect(
-      outOfOfficeNotice(
-        event({
-          eventType: 'out_of_office',
-          outOfOffice: { declineMessage: '   ' },
-        })
-      )?.declineMessage
-    ).toBeUndefined();
+describe('editorSubmitValuesToCreateCalendarEvent', () => {
+  it('marks the tool args out of office and converts the decline mode back', () => {
+    const merged = editorSubmitValuesToCreateCalendarEvent(
+      submitValues({
+        outOfOffice: {
+          autoDeclineMode: 'decline_only_new_conflicting_invitations',
+          declineMessage: 'On vacation',
+        },
+      }),
+      event({ addGoogleMeet: true })
+    );
+    expect(merged.eventType).toBe('out_of_office');
+    expect(merged.outOfOffice).toEqual({
+      autoDeclineMode: 'decline_new_only',
+      declineMessage: 'On vacation',
+    });
+    expect(merged.addGoogleMeet).toBe(false);
+  });
+
+  it('drops the decline message when it is blank', () => {
+    const merged = editorSubmitValuesToCreateCalendarEvent(
+      submitValues({
+        outOfOffice: { autoDeclineMode: 'decline_all_conflicting_invitations' },
+      }),
+      event({})
+    );
+    expect(merged.outOfOffice).toEqual({ autoDeclineMode: 'decline_all' });
+  });
+
+  it('turns a pending out-of-office create back into a regular event', () => {
+    const merged = editorSubmitValuesToCreateCalendarEvent(
+      submitValues({}),
+      event({
+        eventType: 'out_of_office',
+        outOfOffice: { autoDeclineMode: 'decline_all' },
+      })
+    );
+    expect(merged.eventType).toBe('default');
+    expect(merged.outOfOffice).toBeUndefined();
+  });
+
+  it('keeps a regular event regular', () => {
+    const merged = editorSubmitValuesToCreateCalendarEvent(
+      submitValues({}),
+      event({})
+    );
+    expect(merged.eventType).toBeUndefined();
+    expect(merged.outOfOffice).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/core/component/AI/component/tool/calendar/event-form-adapter.ts
+++ b/apps/web/src/lib/core/component/AI/component/tool/calendar/event-form-adapter.ts
@@ -2,49 +2,32 @@ import type {
   EventEditorInitialValues,
   EventEditorSubmitValues,
 } from '@app/features/calendar/components/composer/event-form-model';
+import type { EventEditorOutOfOffice } from '@app/features/calendar/components/composer/out-of-office';
 import type {
+  AutoDeclineModeInput,
   CreateCalendarEvent,
   EventTimeInput,
 } from '@service-cognition/generated/tools/types';
 import { format, isValid, parseISO, subDays } from 'date-fns';
-import { match } from 'ts-pattern';
 
-/**
- * The consequential side effects of a deferred out-of-office create, so the
- * confirmation composer can disclose them before the user confirms. EventForm
- * does not surface `eventType`/`outOfOffice`, so without this an event that
- * looks ordinary would silently write an away block and auto-decline meetings.
- */
-export type OutOfOfficeNotice = {
-  /** Plain-language description of the away status and auto-decline behavior. */
-  effect: string;
-  /** The reply sent to auto-declined organizers, when one is set. */
-  declineMessage?: string;
+/** The calendar tools abbreviate the email service's decline mode names. */
+const TOOL_TO_EDITOR_DECLINE_MODE: Record<
+  AutoDeclineModeInput,
+  EventEditorOutOfOffice['autoDeclineMode']
+> = {
+  decline_none: 'decline_none',
+  decline_all: 'decline_all_conflicting_invitations',
+  decline_new_only: 'decline_only_new_conflicting_invitations',
 };
 
-/** Describe a deferred create's out-of-office effects, or `undefined` when it is a regular event. */
-export function outOfOfficeNotice(
-  event: CreateCalendarEvent
-): OutOfOfficeNotice | undefined {
-  if (event.eventType !== 'out_of_office') return undefined;
-  const effect = match(event.outOfOffice?.autoDeclineMode ?? 'decline_none')
-    .with(
-      'decline_all',
-      () =>
-        'Google will show you as away and automatically decline all conflicting invitations.'
-    )
-    .with(
-      'decline_new_only',
-      () =>
-        'Google will show you as away and automatically decline newly received conflicting invitations.'
-    )
-    .otherwise(
-      () =>
-        'Google will show you as away for this time; conflicting invitations are left untouched.'
-    );
-  const declineMessage = event.outOfOffice?.declineMessage?.trim() || undefined;
-  return { effect, declineMessage };
-}
+const EDITOR_TO_TOOL_DECLINE_MODE: Record<
+  EventEditorOutOfOffice['autoDeclineMode'],
+  AutoDeclineModeInput
+> = {
+  decline_none: 'decline_none',
+  decline_all_conflicting_invitations: 'decline_all',
+  decline_only_new_conflicting_invitations: 'decline_new_only',
+};
 
 const DATE_VALUE = 'yyyy-MM-dd';
 const DATETIME_VALUE = "yyyy-MM-dd'T'HH:mm";
@@ -73,6 +56,7 @@ function cloneReminders(
 export function createCalendarEventToEditorInitialValues(
   event: CreateCalendarEvent
 ): EventEditorInitialValues {
+  const isOutOfOffice = event.eventType === 'out_of_office';
   const common = {
     title: event.title,
     recurrenceLines: [...(event.recurrenceLines ?? [])],
@@ -86,6 +70,16 @@ export function createCalendarEventToEditorInitialValues(
       ? ('google_meet' as const)
       : ('none' as const),
     reminders: cloneReminders(event.reminders),
+    eventType: isOutOfOffice ? ('out_of_office' as const) : undefined,
+    outOfOffice: isOutOfOffice
+      ? {
+          autoDeclineMode:
+            TOOL_TO_EDITOR_DECLINE_MODE[
+              event.outOfOffice?.autoDeclineMode ?? 'decline_none'
+            ],
+          declineMessage: event.outOfOffice?.declineMessage ?? '',
+        }
+      : undefined,
   };
 
   if (event.time.kind === 'allDay') {
@@ -152,6 +146,9 @@ export function editorSubmitValuesToCreateCalendarEvent(
   values: EventEditorSubmitValues,
   original: CreateCalendarEvent
 ): CreateCalendarEvent {
+  // A create's submit values carry `outOfOffice` exactly while the editor kind
+  // is out of office, so its presence decides the tool's event type.
+  const outOfOffice = values.outOfOffice;
   return {
     ...original,
     title: values.title,
@@ -161,10 +158,27 @@ export function editorSubmitValuesToCreateCalendarEvent(
     attendees: attendees(values.guestEmails, original.attendees),
     recurrenceLines: values.recurrenceLines ?? original.recurrenceLines ?? [],
     calendarId: values.calendarId,
-    addGoogleMeet:
-      values.conference === undefined
+    addGoogleMeet: outOfOffice
+      ? false
+      : values.conference === undefined
         ? original.addGoogleMeet
         : values.conference === 'google_meet',
     reminders: cloneReminders(values.reminders ?? original.reminders),
+    eventType: outOfOffice
+      ? 'out_of_office'
+      : original.eventType === 'out_of_office'
+        ? 'default'
+        : original.eventType,
+    outOfOffice: outOfOffice
+      ? {
+          autoDeclineMode:
+            EDITOR_TO_TOOL_DECLINE_MODE[
+              outOfOffice.autoDeclineMode ?? 'decline_none'
+            ],
+          ...(outOfOffice.declineMessage
+            ? { declineMessage: outOfOffice.declineMessage }
+            : {}),
+        }
+      : undefined,
   };
 }

--- a/apps/web/src/lib/core/component/AI/component/tool/calendar/event-preview-model.ts
+++ b/apps/web/src/lib/core/component/AI/component/tool/calendar/event-preview-model.ts
@@ -68,6 +68,7 @@ export function buildCalendarToolPreviewEvent(
     attendees: [],
     recurrenceLines: input.recurrenceLines ?? input.values.recurrenceLines,
     calendarId: input.calendar?.id ?? input.values.calendarId,
+    eventType: input.values.eventType,
     title: input.values.title.trim() || 'New event',
     calendar,
     location: input.values.location || undefined,

--- a/crates/calendar_events/src/domain/mutations.rs
+++ b/crates/calendar_events/src/domain/mutations.rs
@@ -554,7 +554,7 @@ fn validate_time(time: &EventTime) -> Result<(), CalendarMutationError> {
 
 /// Enforce Google's rules for creating an out-of-office event so the provider
 /// never rejects a write we already accepted: primary calendar only, a timed
-/// span rather than whole days, and no attendees.
+/// span rather than whole days, and no attendees, conference, or description.
 fn validate_out_of_office_create(
     draft: &CalendarEventDraft,
     target: &CalendarCreationTarget,
@@ -578,6 +578,11 @@ fn validate_out_of_office_create(
     if draft.conference.is_some() {
         return Err(CalendarMutationError::InvalidInput(
             "out-of-office events cannot have a video conference".to_string(),
+        ));
+    }
+    if draft.description.as_deref().is_some_and(|d| !d.is_empty()) {
+        return Err(CalendarMutationError::InvalidInput(
+            "out-of-office events cannot have a description".to_string(),
         ));
     }
     Ok(())

--- a/crates/calendar_events/src/domain/mutations/test.rs
+++ b/crates/calendar_events/src/domain/mutations/test.rs
@@ -1268,6 +1268,23 @@ async fn create_out_of_office_rejects_all_day_spans_and_attendees() {
             .await,
         Err(CalendarMutationError::InvalidInput(_))
     ));
+
+    let with_description = service(
+        FakeRepo {
+            creation_target: Some(creation_target(false)),
+            ..FakeRepo::default()
+        },
+        FakeProvider::new(FakeProviderBehavior::Echo),
+        FakeTokens::ok(),
+    );
+    let mut description_draft = out_of_office_draft();
+    description_draft.description = Some("Back Monday".to_string());
+    assert!(matches!(
+        with_description
+            .create_event("macro|user", None, None, description_draft)
+            .await,
+        Err(CalendarMutationError::InvalidInput(_))
+    ));
 }
 
 #[tokio::test]

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -52,7 +52,8 @@ pill to primary calendars, and shows a `Decline meetings` pill (`Don't decline m
 `Decline message` pill; a warning note discloses the away/auto-decline effect before saving.
 When editing an existing event the kind is read-only (Google treats it as immutable), and an
 out-of-office event's decline settings can still be changed — they read as unset because the
-provider does not report the stored ones.
+provider does not report the stored ones. Out-of-office events render on the grid as solid
+chips filled with their calendar color (like Google), unlike regular events' outlined chips.
 
 Teammates' Google Calendar out-of-office events overlay the grid as read-only chips titled
 `<name>: <event title>`. The side panel's `Team out of office` section (shown only when the

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -44,6 +44,16 @@ that account's calendars at once, and the account's calendars listed beneath it 
 name, per-calendar checkbox). Subscribed system calendars (Google holidays, birthdays)
 carry a small RSS icon.
 
+The `New event` composer (also opened by dragging a range on the grid) has an `Event kind`
+pill choosing between `Event` and `Out of office`. Picking `Out of office` hides the guests,
+conferencing, and location pills, forces a timed (not all-day) range, restricts the calendar
+pill to primary calendars, and shows a `Decline meetings` pill (`Don't decline meetings` /
+`Decline new meetings` / `Decline all meetings`) plus, when declining, an optional
+`Decline message` pill; a warning note discloses the away/auto-decline effect before saving.
+When editing an existing event the kind is read-only (Google treats it as immutable), and an
+out-of-office event's decline settings can still be changed — they read as unset because the
+provider does not report the stored ones.
+
 Teammates' Google Calendar out-of-office events overlay the grid as read-only chips titled
 `<name>: <event title>`. The side panel's `Team out of office` section (shown only when the
 user belongs to a team with other members) has a checkbox in its header row toggling the

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -54,7 +54,8 @@ pill to primary calendars, and shows a `Decline meetings` pill (`Don't decline m
 When editing an existing event the kind is read-only (Google treats it as immutable), and an
 out-of-office event's decline settings can still be changed — they read as unset because the
 provider does not report the stored ones. Out-of-office events render on the grid as solid
-chips filled with their calendar color (like Google), unlike regular events' outlined chips.
+chips filled with their calendar color (like Google), unlike regular events' outlined chips,
+and their details card shows an `Out of office` line under the schedule.
 
 Teammates' Google Calendar out-of-office events overlay the grid as read-only chips titled
 `<name>: <event title>`. The side panel's `Team out of office` section (shown only when the

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -46,7 +46,8 @@ carry a small RSS icon.
 
 The `New event` composer (also opened by dragging a range on the grid) has an `Event kind`
 pill choosing between `Event` and `Out of office`. Picking `Out of office` hides the guests,
-conferencing, and location pills, forces a timed (not all-day) range, restricts the calendar
+conferencing, and location pills and the description field (Google rejects them on this
+type), forces a timed (not all-day) range, restricts the calendar
 pill to primary calendars, and shows a `Decline meetings` pill (`Don't decline meetings` /
 `Decline new meetings` / `Decline all meetings`) plus, when declining, an optional
 `Decline message` pill; a warning note discloses the away/auto-decline effect before saving.


### PR DESCRIPTION
Adds an Event / Out of office kind pill to the calendar event composer. Picking Out of office hides guests, location and conferencing, forces a timed range, restricts the calendar picker to primary calendars, and adds decline-mode/decline-message pills plus the same disclosure notice the AI chat composer shows (the copy now lives in one shared module rendered by EventForm on both surfaces). Edit mode shows the kind read-only and only patches decline settings the user actually picks, since the readback does not expose the stored ones.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes calendar create/update payloads and form state for a provider-specific event type; mistakes could strip attendee data on edit or send invalid OOO fields, though coverage includes controller and adapter tests.
> 
> **Overview**
> Adds **out-of-office** as a first-class event kind in the calendar composer (and reuses the same `EventForm` disclosure in AI chat compose via shared `outOfOfficeNoticeFor`).
> 
> Choosing **Out of office** swaps the UI to decline-mode / optional decline-message pills, hides guests, location, conferencing, and description, forces a **timed** range (all-day toggle locked when already timed), and limits new creates to **primary** calendars. Submit/dirty logic strips Google-incompatible fields on create while edits only patch decline settings the user explicitly changes. The grid tags OOO events with `calendar-event-out-of-office` for **solid calendar-color chips** (month dots included); event details show an **Out of office** line.
> 
> Backend create validation now also rejects **non-empty descriptions** on out-of-office drafts. Property pills drop wrapper tooltips; agent guide documents the composer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 708d1764d7860298ecf0a846c30b3f0f4d88f4d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->