### PR TITLE
feat(agent): send next queued message on enter

### DIFF
--- a/apps/web/src/features/block-agent/component/AgentComposer.tsx
+++ b/apps/web/src/features/block-agent/component/AgentComposer.tsx
@@ -76,6 +76,7 @@ export function AgentComposer() {
         placeholder="Message the agent, @mention anything"
         autofocus={autofocus}
         busy={composer.busy()}
+        hasQueuedMessages={queuedItems().length > 0}
         // Prompts go straight to the service, so sending needs a session to
         // post to — a block whose create is still on the wire can be typed
         // into, but not sent from, until the id lands.

--- a/apps/web/src/features/block-agent/ui/AgentInput.test.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentInput.test.tsx
@@ -83,7 +83,7 @@ describe('queued message advancement', () => {
     const sendNext = screen.getByRole('button', {
       name: 'Send next queued message',
     });
-    expect(screen.getByTestId('enter-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('enter-icon')).toBeTruthy();
 
     fireEvent.click(sendNext);
     expect(onStop).toHaveBeenCalledTimes(1);
@@ -113,7 +113,7 @@ describe('queued message advancement', () => {
 
     render(() => <AgentInput busy onSend={vi.fn()} onStop={onStop} />);
 
-    expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Stop' })).toBeTruthy();
     editor.enter?.();
     expect(onStop).not.toHaveBeenCalled();
   });

--- a/apps/web/src/features/block-agent/ui/AgentInput.test.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentInput.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { fireEvent, render, screen } from '@solidjs/testing-library';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentInput } from './AgentInput';
+
+const editor = vi.hoisted(() => ({
+  clear: vi.fn(),
+  enter: undefined as (() => boolean) | undefined,
+  change: undefined as ((markdown: string) => void) | undefined,
+}));
+
+vi.mock(
+  '@core/component/LexicalMarkdown/builder/MarkdownConfigBuilder',
+  () => ({
+    buildConfig: () => {
+      const builder = {
+        namespace: () => builder,
+        withMentions: () => builder,
+        withEmojis: () => builder,
+        withLinks: () => builder,
+        withHistory: () => builder,
+        withCode: () => builder,
+        withRestoreFocus: () => builder,
+        withAgentCommands: () => builder,
+        onEnter: (callback: () => boolean) => {
+          editor.enter = callback;
+          return builder;
+        },
+        onFocusLeave: () => builder,
+        onChange: (callback: (markdown: string) => void) => {
+          editor.change = callback;
+          return builder;
+        },
+        controls: {
+          clear: editor.clear,
+          focus: vi.fn(),
+        },
+        lexical: {
+          update: vi.fn(),
+        },
+      };
+      return builder;
+    },
+  })
+);
+
+vi.mock('@core/component/LexicalMarkdown/builder/MarkdownShell', () => ({
+  MarkdownShell: () => <div data-testid="agent-input-editor" />,
+}));
+
+vi.mock('@phosphor/arrow-up.svg', () => ({
+  default: () => <span data-testid="send-icon" />,
+}));
+
+vi.mock('@phosphor/spinner-gap.svg', () => ({
+  default: () => <span data-testid="spinner-icon" />,
+}));
+
+vi.mock(
+  '@phosphor-icons/core/regular/arrow-bend-down-left.svg?component-solid',
+  () => ({
+    default: () => <span data-testid="enter-icon" />,
+  })
+);
+
+beforeEach(() => {
+  editor.clear.mockClear();
+  editor.enter = undefined;
+  editor.change = undefined;
+});
+
+describe('queued message advancement', () => {
+  it('shows a pressable Enter action that advances the next queued message', () => {
+    const onStop = vi.fn();
+
+    render(() => (
+      <AgentInput busy hasQueuedMessages onSend={vi.fn()} onStop={onStop} />
+    ));
+
+    const sendNext = screen.getByRole('button', {
+      name: 'Send next queued message',
+    });
+    expect(screen.getByTestId('enter-icon')).toBeInTheDocument();
+
+    fireEvent.click(sendNext);
+    expect(onStop).toHaveBeenCalledTimes(1);
+
+    editor.enter?.();
+    expect(onStop).toHaveBeenCalledTimes(2);
+  });
+
+  it('sends typed text instead of advancing past it', () => {
+    const onSend = vi.fn();
+    const onStop = vi.fn();
+
+    render(() => (
+      <AgentInput busy hasQueuedMessages onSend={onSend} onStop={onStop} />
+    ));
+
+    editor.change?.('  another request  ');
+    editor.enter?.();
+
+    expect(onSend).toHaveBeenCalledWith('another request');
+    expect(onStop).not.toHaveBeenCalled();
+    expect(editor.clear).toHaveBeenCalledOnce();
+  });
+
+  it('keeps Enter inert when there is no queued message or draft', () => {
+    const onStop = vi.fn();
+
+    render(() => <AgentInput busy onSend={vi.fn()} onStop={onStop} />);
+
+    expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument();
+    editor.enter?.();
+    expect(onStop).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/block-agent/ui/AgentInput.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentInput.tsx
@@ -11,6 +11,7 @@ import { buildConfig } from '@core/component/LexicalMarkdown/builder/MarkdownCon
 import { MarkdownShell } from '@core/component/LexicalMarkdown/builder/MarkdownShell';
 import type { AgentCommandItem } from '@core/component/LexicalMarkdown/plugins';
 import { $insertReferencedPaste } from '@macro-inc/lexical-core';
+import EnterIcon from '@phosphor-icons/core/regular/arrow-bend-down-left.svg?component-solid';
 import { Button, SendButton, Surface } from '@ui';
 import { createSignal, type JSX, onCleanup, onMount, Show } from 'solid-js';
 
@@ -21,6 +22,11 @@ export interface AgentInputProps {
   placeholder?: string;
   /** The agent is working: the send button becomes a stop square. */
   busy?: boolean;
+  /**
+   * A waiting action can be advanced by ending the current turn. While the
+   * input is empty, Enter and the matching button do exactly that.
+   */
+  hasQueuedMessages?: boolean;
   disabled?: boolean;
   autofocus?: boolean;
   /**
@@ -77,6 +83,20 @@ export function AgentInput(props: AgentInputProps) {
     props.onSend(content);
   };
 
+  const canSendNext = () =>
+    markdown().trim().length === 0 &&
+    props.busy &&
+    props.hasQueuedMessages &&
+    !props.disabled &&
+    props.onStop !== undefined;
+
+  const sendNext = () => {
+    if (!canSendNext()) return;
+    // Stop bypasses the server queue. The cancelled turn ending immediately
+    // dispatches its oldest waiting action, so the queue remains FIFO.
+    props.onStop?.();
+  };
+
   const editor = buildConfig('chat')
     .namespace('agent-input')
     .withMentions({
@@ -90,7 +110,8 @@ export function AgentInput(props: AgentInputProps) {
     .withRestoreFocus()
     .withAgentCommands({ commands: () => props.commands?.() ?? [] })
     .onEnter(() => {
-      send();
+      if (canSend()) send();
+      else sendNext();
       return true;
     })
     .onFocusLeave({
@@ -162,15 +183,28 @@ export function AgentInput(props: AgentInputProps) {
                 />
               }
             >
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                label="Stop"
-                onClick={() => props.onStop?.()}
-                class="rounded-[11px] size-7.5 text-ink-extra-muted not-disabled:bg-ink/5 not-disabled:hover:bg-ink/10"
+              <Show
+                when={canSendNext()}
+                fallback={
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    label="Stop"
+                    onClick={() => props.onStop?.()}
+                    class="rounded-[11px] size-7.5 text-ink-extra-muted not-disabled:bg-ink/5 not-disabled:hover:bg-ink/10"
+                  >
+                    <div class="size-3.5 rounded-sm bg-current" />
+                  </Button>
+                }
               >
-                <div class="size-3.5 rounded-sm bg-current" />
-              </Button>
+                <SendButton
+                  tooltip="Send next queued message"
+                  shortcut="Enter"
+                  onClick={sendNext}
+                >
+                  <EnterIcon />
+                </SendButton>
+              </Show>
             </Show>
           </div>
         </div>

--- a/apps/web/src/features/block-agent/ui/AgentInput.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentInput.tsx
@@ -198,6 +198,7 @@ export function AgentInput(props: AgentInputProps) {
                 }
               >
                 <SendButton
+                  aria-label="Send next queued message"
                   tooltip="Send next queued message"
                   shortcut="Enter"
                   onClick={sendNext}

--- a/docs/AGENT_GUIDE/ai-chat.md
+++ b/docs/AGENT_GUIDE/ai-chat.md
@@ -67,7 +67,11 @@ transcript (and in the originating channel thread).
   user message in the transcript.
 - Keyboard: Up at the very start of the composer input moves focus into the
   bottom (next-to-send) queue row; further Up presses walk toward newer entries, Down
-  walks back and past the bottom row returns to the input.
+  walks back and past the bottom row returns to the input. When the composer is empty
+  and a prompt is queued, its action becomes `Send next queued message` (an Enter
+  symbol); pressing Enter or clicking that button cancels the current turn so the next
+  queued prompt starts immediately. Typed composer text still takes priority and Enter
+  queues that new prompt normally.
 - The stop button cancels only the **current** turn. The queue keeps draining: the next
   queued prompt starts a new turn. To fully quiesce a session, remove the queued
   entries, then stop.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Replace the stop control with a pressable Enter action when the agent composer is empty and messages are queued
- Make keyboard Enter cancel the current turn so the oldest queued message dispatches immediately
- Preserve normal Enter-to-send behavior when the composer contains a draft
- Give the action an explicit accessible label and Enter shortcut hint
- Document the new agent-session queue interaction and cover the action states with component tests

## Testing

- Focused component tests: 3 passed
- Frontend TypeScript check: passed
- Biome check for changed frontend files: passed
- Browser walkthrough: queued a second coding-agent prompt, clicked the bent-Enter action, verified the current turn stopped and the queued prompt ran successfully

[agent_send_next_queued_message.mp4](https://cursor.com/agents/bc-d06090be-6c4b-407a-b309-0527a31292e7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_send_next_queued_message.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d06090be-6c4b-407a-b309-0527a31292e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d06090be-6c4b-407a-b309-0527a31292e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

