### PR TITLE
fix(calendar): name a shared calendar organizer instead of its address

### DIFF
--- a/apps/web/src/features/entity/composed/list-entity/calendar.test.tsx
+++ b/apps/web/src/features/entity/composed/list-entity/calendar.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@solidjs/testing-library';
+import { describe, expect, it, vi } from 'vitest';
+import type { CalendarEventEntity } from '../../types/entity';
+import { CalendarEventWhen } from './calendar';
+
+vi.mock('@core/user', () => ({
+  emailToMacroId: (email: string) =>
+    email.includes('@') ? `macro|${email}` : undefined,
+  getDisplayName: (id: string) =>
+    id === 'macro|jacob@macro.com'
+      ? 'Jacob Beckerman'
+      : id.replace(/^macro\|/, ''),
+}));
+vi.mock('@core/component/UserIcon', () => ({ UserIcon: () => null }));
+vi.mock('../../entity', () => ({ Entity: {} }));
+
+function event(
+  organizer: CalendarEventEntity['organizer']
+): CalendarEventEntity {
+  return {
+    id: 'event',
+    name: 'Out of office',
+    ownerId: 'macro|gab@macro.com',
+    type: 'calendar_event',
+    status: 'confirmed',
+    isReadOnly: false,
+    organizer,
+    time: {
+      kind: 'timed',
+      startsAt: '2026-08-14T04:00:00Z',
+      endsAt: '2026-08-15T04:00:00Z',
+    },
+  };
+}
+
+describe('CalendarEventWhen organizer', () => {
+  it('names a shared calendar by the name the source supplied, not its address', () => {
+    render(() => (
+      <CalendarEventWhen
+        entity={event({
+          name: 'Macro Vacation',
+          email: 'c_03728f99@group.calendar.google.com',
+        })}
+      />
+    ));
+
+    expect(screen.getByText('Macro Vacation')).toBeTruthy();
+    expect(screen.queryByText(/group\.calendar\.google\.com/)).toBeNull();
+  });
+
+  it('prefers the Macro profile name when the organizer has one', () => {
+    render(() => (
+      <CalendarEventWhen
+        entity={event({ name: 'jacob', email: 'jacob@macro.com' })}
+      />
+    ));
+
+    expect(screen.getByText('Jacob Beckerman')).toBeTruthy();
+  });
+
+  it('falls back to the email when the organizer has neither a profile nor a name', () => {
+    render(() => (
+      <CalendarEventWhen entity={event({ email: 'someone@example.com' })} />
+    ));
+
+    expect(screen.getByText('someone@example.com')).toBeTruthy();
+  });
+});

--- a/apps/web/src/features/entity/composed/list-entity/calendar.tsx
+++ b/apps/web/src/features/entity/composed/list-entity/calendar.tsx
@@ -96,12 +96,15 @@ function organizerIconProps(
 
 /** Organizer display: the Macro profile name when resolved, else the source's
  * own name, else the email. Read reactively so it fills in when the user's
- * name cache resolves. */
+ * name cache resolves. The profile lookup falls back to the email for an
+ * address without a profile, such as a shared calendar's, so that fallback
+ * must not win over the name the source supplied. */
 function organizerName(entity: CalendarEventEntity): string {
   const email = entity.organizer?.email;
   const macroId = email ? emailToMacroId(email) : undefined;
   const resolved = macroId ? getDisplayName(macroId).trim() : '';
-  return resolved || entity.organizer?.name || email || '';
+  const profileName = resolved && resolved !== email ? resolved : '';
+  return profileName || entity.organizer?.name || email || '';
 }
 
 const Dot = () => <span class="shrink-0 text-ink/30">·</span>;


### PR DESCRIPTION
A calendar row shows its organizer as the Macro profile name when the address resolves to one, otherwise the name the source supplied, otherwise the email. The profile lookup returns the email itself for an address without a profile, so a shared calendar's organizer, a `c_…@group.calendar.google.com` address whose display name is the calendar's, rendered as the raw address in search and soup rows. The fallback no longer counts as a resolved profile, so those rows read `Macro Vacation`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display logic for calendar organizer labels with new unit tests; no auth, data, or API changes.
> 
> **Overview**
> Calendar list rows were showing **shared Google calendar organizers** as raw `group.calendar.google.com` addresses because `getDisplayName` echoes the email when there is no Macro profile, and that value was treated as a successful profile resolution—blocking the calendar source’s display name.
> 
> **`organizerName`** now only uses the profile lookup when the resolved string is **not** the organizer email; otherwise it keeps the prior order: source-supplied name, then email. **`CalendarEventWhen`** / wide rows pick up the fix through the same helper.
> 
> Adds **`calendar.test.tsx`** covering shared-calendar naming, Macro profile preference, and email-only fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22a0bb1e6f60846cb90b6fa45dbad6434939a894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->