### PR TITLE
chore(agents): good mobile UI

### DIFF
--- a/apps/web/src/components/app/split-layout/components/SplitLabel.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitLabel.tsx
@@ -32,8 +32,6 @@ import {
   createSignal,
   For,
   type JSX,
-  onCleanup,
-  onMount,
   type ParentProps,
   Show,
 } from 'solid-js';
@@ -53,26 +51,19 @@ export function StaticSplitLabel(props: {
   class?: string;
   colorIcon?: boolean;
   /** Enables double-click renaming while retaining the split title/menu
-   * chrome. On touch, tapping the title opens the dropdown instead —
-   * callers that want a Rename item should drive it through
-   * `registerStartRename`. */
+   * chrome. */
   onRename?: (name: string) => void;
   renameAriaLabel?: string;
-  /** Receives a function that starts inline rename (and `undefined` on
-   *  unmount), so the title menu can offer Rename without a tap on the
-   *  name itself stealing the dropdown. */
-  registerStartRename?: (start: (() => void) | undefined) => void;
 }) {
   const panel = useSplitPanelOrThrow();
   const [renaming, setRenaming] = createSignal(false);
   createEffect(() => {
     panel.handle.setDisplayName(props.label);
   });
-  const beginRename = () => setRenaming(true);
   const startRename = (event: MouseEvent) => {
     event.preventDefault();
     event.stopPropagation();
-    beginRename();
+    setRenaming(true);
   };
   const openTitleFileMenu = (e: MouseEvent) => {
     if (!isTouchDevice()) return;
@@ -82,10 +73,6 @@ export function StaticSplitLabel(props: {
     e.stopPropagation();
     trigger();
   };
-  onMount(() => {
-    props.registerStartRename?.(beginRename);
-    onCleanup(() => props.registerStartRename?.(undefined));
-  });
   return (
     <SplitLabelContextMenu>
       <HeaderIsland class="shrink" onClick={openTitleFileMenu}>
@@ -122,11 +109,9 @@ export function StaticSplitLabel(props: {
                   fallback={
                     <span
                       class="inline-block truncate text-sm font-semibold"
-                      onDblClick={(event) => {
-                        // Touch uses the title menu's Rename item; a second
-                        // tap must not steal that into an inline edit.
-                        if (isTouchDevice()) return;
-                        startRename(event);
+                      onDblClick={startRename}
+                      onClick={(event) => {
+                        if (isTouchDevice()) startRename(event);
                       }}
                     >
                       {props.label}

--- a/apps/web/src/components/app/split-layout/components/SplitLabel.tsx
+++ b/apps/web/src/components/app/split-layout/components/SplitLabel.tsx
@@ -32,6 +32,8 @@ import {
   createSignal,
   For,
   type JSX,
+  onCleanup,
+  onMount,
   type ParentProps,
   Show,
 } from 'solid-js';
@@ -51,19 +53,26 @@ export function StaticSplitLabel(props: {
   class?: string;
   colorIcon?: boolean;
   /** Enables double-click renaming while retaining the split title/menu
-   * chrome. */
+   * chrome. On touch, tapping the title opens the dropdown instead —
+   * callers that want a Rename item should drive it through
+   * `registerStartRename`. */
   onRename?: (name: string) => void;
   renameAriaLabel?: string;
+  /** Receives a function that starts inline rename (and `undefined` on
+   *  unmount), so the title menu can offer Rename without a tap on the
+   *  name itself stealing the dropdown. */
+  registerStartRename?: (start: (() => void) | undefined) => void;
 }) {
   const panel = useSplitPanelOrThrow();
   const [renaming, setRenaming] = createSignal(false);
   createEffect(() => {
     panel.handle.setDisplayName(props.label);
   });
+  const beginRename = () => setRenaming(true);
   const startRename = (event: MouseEvent) => {
     event.preventDefault();
     event.stopPropagation();
-    setRenaming(true);
+    beginRename();
   };
   const openTitleFileMenu = (e: MouseEvent) => {
     if (!isTouchDevice()) return;
@@ -73,6 +82,10 @@ export function StaticSplitLabel(props: {
     e.stopPropagation();
     trigger();
   };
+  onMount(() => {
+    props.registerStartRename?.(beginRename);
+    onCleanup(() => props.registerStartRename?.(undefined));
+  });
   return (
     <SplitLabelContextMenu>
       <HeaderIsland class="shrink" onClick={openTitleFileMenu}>
@@ -109,9 +122,11 @@ export function StaticSplitLabel(props: {
                   fallback={
                     <span
                       class="inline-block truncate text-sm font-semibold"
-                      onDblClick={startRename}
-                      onClick={(event) => {
-                        if (isTouchDevice()) startRename(event);
+                      onDblClick={(event) => {
+                        // Touch uses the title menu's Rename item; a second
+                        // tap must not steal that into an inline edit.
+                        if (isTouchDevice()) return;
+                        startRename(event);
                       }}
                     >
                       {props.label}

--- a/apps/web/src/features/block-agent/component/AgentMessage.tsx
+++ b/apps/web/src/features/block-agent/component/AgentMessage.tsx
@@ -61,7 +61,8 @@ function AgentMessagePart(props: {
 function UserMessage(props: { message: FoldedMessage }) {
   return (
     <div class="flex w-full">
-      <div class="relative w-full overflow-hidden rounded-lg border border-edge-muted bg-hover px-3 py-2 text-ink">
+      {/* Phone: a full-width card. Desktop: hugs the text, right-aligned. */}
+      <div class="relative w-full overflow-hidden rounded-lg border border-edge-muted bg-hover px-3 py-2 text-ink md:ml-auto md:w-auto md:max-w-[calc(100%-8rem)]">
         <For each={props.message.parts}>
           {(part, index) => (
             <AgentMessagePart

--- a/apps/web/src/features/block-agent/component/AgentMessage.tsx
+++ b/apps/web/src/features/block-agent/component/AgentMessage.tsx
@@ -61,7 +61,7 @@ function AgentMessagePart(props: {
 function UserMessage(props: { message: FoldedMessage }) {
   return (
     <div class="flex w-full">
-      <div class="relative ml-auto max-w-[calc(100%-8rem)] overflow-hidden rounded-lg border border-edge-muted bg-hover px-3 py-2 text-ink">
+      <div class="relative w-full overflow-hidden rounded-lg border border-edge-muted bg-hover px-3 py-2 text-ink">
         <For each={props.message.parts}>
           {(part, index) => (
             <AgentMessagePart

--- a/apps/web/src/features/block-agent/component/AgentRenameModal.tsx
+++ b/apps/web/src/features/block-agent/component/AgentRenameModal.tsx
@@ -1,0 +1,116 @@
+/**
+ * Rename dialog for an agent session. Same chrome as the automation
+ * rename modal — agent sessions are not DSS entities, so they cannot use
+ * the generic bulk-edit rename view.
+ */
+
+import {
+  EntityModalActionFooter,
+  EntityModalTitle,
+} from '@app/features/entity/entity-modal/EntityModal';
+import { getSplitPanelRef } from '@components/app/split-layout/layoutUtils';
+import clickOutside from '@core/directive/clickOutside';
+import { Dialog } from '@kobalte/core/dialog';
+import {
+  type Accessor,
+  createSignal,
+  onMount,
+  type Setter,
+  Show,
+} from 'solid-js';
+import { Portal } from 'solid-js/web';
+
+false && clickOutside;
+
+export function AgentRenameModal(props: {
+  isOpen: Accessor<boolean>;
+  setIsOpen: Setter<boolean>;
+  name: string;
+  onRename: (newName: string) => void;
+}) {
+  return (
+    <Show when={props.isOpen()}>
+      <AgentRenameModalContent
+        isOpen={props.isOpen}
+        setIsOpen={props.setIsOpen}
+        name={props.name}
+        onRename={props.onRename}
+      />
+    </Show>
+  );
+}
+
+function AgentRenameModalContent(props: {
+  isOpen: Accessor<boolean>;
+  setIsOpen: Setter<boolean>;
+  name: string;
+  onRename: (newName: string) => void;
+}) {
+  let inputRef: HTMLInputElement | undefined;
+  const [editValue, setEditValue] = createSignal(props.name);
+
+  const close = () => props.setIsOpen(false);
+
+  const finishEditing = () => {
+    const newValue = editValue().trim();
+    if (newValue) {
+      props.onRename(newValue);
+    }
+    close();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      finishEditing();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    }
+  };
+
+  return (
+    <Dialog open={props.isOpen()} onOpenChange={props.setIsOpen} modal={true}>
+      <Portal mount={getSplitPanelRef() ?? undefined}>
+        <Dialog.Overlay
+          as="div"
+          class="absolute z-modal inset-px bg-modal-overlay"
+          use:clickOutside={close}
+          on:click={close}
+        />
+        <div class="absolute z-modal pointer-events-none px-2 inset-px">
+          <Dialog.Content class="pointer-events-none!">
+            <div class="pointer-events-auto w-full max-w-[min(36rem,calc(100%-1rem))] mx-auto mt-16 bg-surface border border-edge h-fit p-2">
+              <div class="w-full my-1">
+                <EntityModalTitle title="Rename" />
+                <div class="w-full">
+                  <input
+                    ref={(el) => {
+                      inputRef = el;
+                      onMount(() => {
+                        setTimeout(() => {
+                          inputRef?.focus();
+                          inputRef?.select();
+                        });
+                      });
+                    }}
+                    value={editValue()}
+                    onInput={(e) => setEditValue(e.currentTarget.value)}
+                    onKeyDown={handleKeyDown}
+                    class="w-full p-2 text-sm border border-edge bg-surface text-ink placeholder:text-ink-placeholder focus:outline-none focus:bg-active selection:bg-ink selection:text-surface"
+                    placeholder="Enter title..."
+                  />
+                </div>
+                <EntityModalActionFooter
+                  onCancel={close}
+                  onConfirm={finishEditing}
+                  confirmText="Rename"
+                />
+              </div>
+            </div>
+          </Dialog.Content>
+        </div>
+      </Portal>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/block-agent/component/AgentSplitHeader.tsx
+++ b/apps/web/src/features/block-agent/component/AgentSplitHeader.tsx
@@ -11,11 +11,13 @@ import {
 import { StaticSplitLabel } from '@components/app/split-layout/components/SplitLabel';
 import { toast } from '@core/component/Toast/Toast';
 import { useUserId } from '@core/context/user';
+import { TOKENS } from '@core/hotkey/tokens';
 import { isMobile } from '@core/mobile/isMobile';
 import { buildSimpleEntityUrl, openExternalUrl } from '@core/util/url';
 import ArrowSquareOut from '@phosphor/arrow-square-out.svg';
 import GitBranch from '@phosphor/git-branch.svg';
 import LinkIcon from '@phosphor/link.svg';
+import RenameIcon from '@phosphor/pencil-line.svg';
 import { handleAgentSessionRenamed } from '@queries/agent-session/session-metadata-sync';
 import { agentHarnessServiceClient } from '@service-agent-harness/client';
 import type { AgentSessionResponse } from '@service-agent-harness/generated/schemas';
@@ -75,6 +77,18 @@ export function AgentSplitHeader(props: {
     toast.success('Link copied to clipboard');
   };
 
+  const canRename = () => props.session?.ownerId === userId();
+  let startRename: (() => void) | undefined;
+
+  const renameTool: BlockTool = {
+    group: 'file',
+    label: 'Rename',
+    icon: RenameIcon,
+    hotkeyToken: TOKENS.entity.action.rename,
+    action: () => startRename?.(),
+    condition: canRename,
+  };
+
   const tools: BlockTool[] = [
     {
       label: () => {
@@ -115,8 +129,11 @@ export function AgentSplitHeader(props: {
         <StaticSplitLabel
           iconType="agent"
           label={title()}
-          onRename={props.session?.ownerId === userId() ? rename : undefined}
+          onRename={canRename() ? rename : undefined}
           renameAriaLabel="Agent session name"
+          registerStartRename={(start) => {
+            startRename = start;
+          }}
         />
       </SplitHeaderLeft>
 
@@ -140,7 +157,7 @@ export function AgentSplitHeader(props: {
 
       <ResponsiveBlockToolbar
         tools={[]}
-        menuTools={tools}
+        menuTools={[renameTool, ...tools]}
         ops={ops}
         id={sessionId() ?? ''}
         itemType="foreign"

--- a/apps/web/src/features/block-agent/component/AgentSplitHeader.tsx
+++ b/apps/web/src/features/block-agent/component/AgentSplitHeader.tsx
@@ -21,8 +21,9 @@ import RenameIcon from '@phosphor/pencil-line.svg';
 import { handleAgentSessionRenamed } from '@queries/agent-session/session-metadata-sync';
 import { agentHarnessServiceClient } from '@service-agent-harness/client';
 import type { AgentSessionResponse } from '@service-agent-harness/generated/schemas';
-import { For, Show } from 'solid-js';
+import { createSignal, For, Show } from 'solid-js';
 import { useAgentSession } from '../context/AgentSessionContext';
+import { AgentRenameModal } from './AgentRenameModal';
 
 /** 'claude-code' → 'Claude Code'; the fallback when the fold has no title. */
 export function harnessTitle(harness: string | undefined): string {
@@ -39,6 +40,10 @@ export function harnessTitle(harness: string | undefined): string {
  * toolbar, matching the PR block's shape for non-document blocks: static
  * label (names the split tab), copy-link tool, and a file menu with the
  * session's repository.
+ *
+ * Rename lives on the title menu (channel / automation), not on a tap of
+ * the name — `StaticSplitLabel` without `onRename` so a touch tap opens
+ * the dropdown instead of an inline editor.
  */
 export function AgentSplitHeader(props: {
   session: AgentSessionResponse | undefined;
@@ -50,6 +55,7 @@ export function AgentSplitHeader(props: {
   // block id is the one thing here that is not a shareable session id.
   const { sessionId } = useAgentSession();
   const userId = useUserId();
+  const [renameOpen, setRenameOpen] = createSignal(false);
   const title = () => {
     const persistedName = props.session?.name;
     if (persistedName && persistedName !== 'Agent Session')
@@ -78,14 +84,13 @@ export function AgentSplitHeader(props: {
   };
 
   const canRename = () => props.session?.ownerId === userId();
-  let startRename: (() => void) | undefined;
 
   const renameTool: BlockTool = {
     group: 'file',
     label: 'Rename',
     icon: RenameIcon,
     hotkeyToken: TOKENS.entity.action.rename,
-    action: () => startRename?.(),
+    action: () => setRenameOpen(true),
     condition: canRename,
   };
 
@@ -126,15 +131,7 @@ export function AgentSplitHeader(props: {
   return (
     <>
       <SplitHeaderLeft>
-        <StaticSplitLabel
-          iconType="agent"
-          label={title()}
-          onRename={canRename() ? rename : undefined}
-          renameAriaLabel="Agent session name"
-          registerStartRename={(start) => {
-            startRename = start;
-          }}
-        />
+        <StaticSplitLabel iconType="agent" label={title()} />
       </SplitHeaderLeft>
 
       {/* Tools live on the header row itself — `ResponsiveBlockToolbar`
@@ -162,6 +159,12 @@ export function AgentSplitHeader(props: {
         id={sessionId() ?? ''}
         itemType="foreign"
         name={title()}
+      />
+      <AgentRenameModal
+        isOpen={renameOpen}
+        setIsOpen={setRenameOpen}
+        name={title()}
+        onRename={(name) => void rename(name)}
       />
     </>
   );

--- a/apps/web/src/features/block-agent/component/Block.tsx
+++ b/apps/web/src/features/block-agent/component/Block.tsx
@@ -66,7 +66,7 @@ function AgentBlockContent() {
                 {/* Home/chat: re-enable pointer events on the accessory
                     contribution — the float host is pointer-transparent. */}
                 <div class="flex w-full justify-center shrink-0 px-4 pb-4 pointer-events-auto touch:px-(--mobile-chrome-gutter) touch:pb-0">
-                  <div class="w-1/2">
+                  <div class="w-1/2 mx-auto">
                     <AgentComposer />
                   </div>
                 </div>

--- a/apps/web/src/features/block-agent/component/Block.tsx
+++ b/apps/web/src/features/block-agent/component/Block.tsx
@@ -1,3 +1,4 @@
+import { FloatRegionOrInline } from '@components/app/mobile/float-regions/FloatRegion';
 import { SidePanel } from '@components/app/side-panel';
 import { SplitPanelContext } from '@components/app/split-layout/context';
 import { useBlockId } from '@core/block';
@@ -59,9 +60,15 @@ function AgentBlockContent() {
             />
             <div class="size-full min-w-0 flex flex-col">
               <Transcript />
-              <div class="shrink-0 w-full max-w-3xl mx-auto px-4 pb-4">
-                <AgentComposer />
-              </div>
+              {/* Full-frame mobile: composer + queue float in the bottom
+                  accessory region above the dock; desktop stays inline. */}
+              <FloatRegionOrInline region="accessory">
+                <div class="flex w-full justify-center shrink-0 px-4 pb-4 touch:px-(--mobile-chrome-gutter) touch:pb-0 touch:pointer-events-auto">
+                  <div class="w-full max-w-3xl">
+                    <AgentComposer />
+                  </div>
+                </div>
+              </FloatRegionOrInline>
             </div>
             <Show when={sessionOriginThread(session())}>
               {(origin) => (

--- a/apps/web/src/features/block-agent/component/Block.tsx
+++ b/apps/web/src/features/block-agent/component/Block.tsx
@@ -66,7 +66,7 @@ function AgentBlockContent() {
                 {/* Home/chat: re-enable pointer events on the accessory
                     contribution — the float host is pointer-transparent. */}
                 <div class="flex w-full justify-center shrink-0 px-4 pb-4 pointer-events-auto touch:px-(--mobile-chrome-gutter) touch:pb-0">
-                  <div class="w-full md:w-1/2">
+                  <div class="w-1/2">
                     <AgentComposer />
                   </div>
                 </div>

--- a/apps/web/src/features/block-agent/component/Block.tsx
+++ b/apps/web/src/features/block-agent/component/Block.tsx
@@ -66,7 +66,7 @@ function AgentBlockContent() {
                 {/* Home/chat: re-enable pointer events on the accessory
                     contribution — the float host is pointer-transparent. */}
                 <div class="flex w-full justify-center shrink-0 px-4 pb-4 pointer-events-auto touch:px-(--mobile-chrome-gutter) touch:pb-0">
-                  <div class="w-full max-w-3xl">
+                  <div class="w-full md:w-1/2">
                     <AgentComposer />
                   </div>
                 </div>

--- a/apps/web/src/features/block-agent/component/Block.tsx
+++ b/apps/web/src/features/block-agent/component/Block.tsx
@@ -63,7 +63,9 @@ function AgentBlockContent() {
               {/* Full-frame mobile: composer + queue float in the bottom
                   accessory region above the dock; desktop stays inline. */}
               <FloatRegionOrInline region="accessory">
-                <div class="flex w-full justify-center shrink-0 px-4 pb-4 touch:px-(--mobile-chrome-gutter) touch:pb-0 touch:pointer-events-auto">
+                {/* Home/chat: re-enable pointer events on the accessory
+                    contribution — the float host is pointer-transparent. */}
+                <div class="flex w-full justify-center shrink-0 px-4 pb-4 pointer-events-auto touch:px-(--mobile-chrome-gutter) touch:pb-0">
                   <div class="w-full max-w-3xl">
                     <AgentComposer />
                   </div>

--- a/apps/web/src/features/block-agent/component/Block.tsx
+++ b/apps/web/src/features/block-agent/component/Block.tsx
@@ -66,7 +66,7 @@ function AgentBlockContent() {
                 {/* Home/chat: re-enable pointer events on the accessory
                     contribution — the float host is pointer-transparent. */}
                 <div class="flex w-full justify-center shrink-0 px-4 pb-4 pointer-events-auto touch:px-(--mobile-chrome-gutter) touch:pb-0">
-                  <div class="w-1/2 mx-auto">
+                  <div class="w-full md:w-1/2 mx-auto">
                     <AgentComposer />
                   </div>
                 </div>

--- a/apps/web/src/features/block-agent/component/Transcript.tsx
+++ b/apps/web/src/features/block-agent/component/Transcript.tsx
@@ -202,9 +202,9 @@ export function Transcript() {
               }}
             >
               {(message) => (
-                // Half-pane on desktop so expanding the side panel does
-                // not yank a max-w-3xl column. Mobile stays full-bleed.
-                <div class="w-full md:w-1/2 mx-auto px-4 pb-4 min-w-0">
+                // Always half the pane so expanding Context grows down,
+                // not out. Same width on phone and desktop.
+                <div class="w-1/2 mx-auto px-2 pb-4 min-w-0">
                   <Message message={message} />
                 </div>
               )}

--- a/apps/web/src/features/block-agent/component/Transcript.tsx
+++ b/apps/web/src/features/block-agent/component/Transcript.tsx
@@ -19,6 +19,7 @@
 
 import { ScrollToBottomOverlay } from '@channel/Channel/ScrollToBottomOverlay';
 import type { ThreadListScrollState } from '@channel/Channel/ThreadList';
+import { createMobileKeyboardScrollPin } from '@core/component/AI/component/message/create-mobile-keyboard-scroll-pin';
 import { Scroll } from '@ui';
 import { createSignal, onCleanup } from 'solid-js';
 import { Virtualizer, type VirtualizerHandle } from 'virtua/solid';
@@ -42,6 +43,7 @@ export function Transcript() {
   let growthObserver: ResizeObserver | undefined;
   let viewportObserver: ResizeObserver | undefined;
   const [transcriptEl, setTranscriptEl] = createSignal<HTMLDivElement>();
+  const [contentEl, setContentEl] = createSignal<HTMLDivElement>();
 
   onCleanup(() => {
     cancelPin?.();
@@ -158,11 +160,21 @@ export function Transcript() {
     viewportObserver.observe(el);
   };
 
+  // Full-frame mobile: keep pinned to the bottom across virtual-keyboard
+  // show/hide when the reader was already at the bottom — same recipe as
+  // the AI chat, now that the composer lives in the accessory float.
+  createMobileKeyboardScrollPin({
+    scrollEl: () => scrollRef,
+    wrapperEl: contentEl,
+    scrollToBottom: () => pinToBottom(),
+  });
+
   return (
     <div class="relative flex-1 min-h-0" ref={setTranscriptEl}>
       <Scroll scrollRef={attachScroller}>
         <div
-          class="flex flex-col [overflow-anchor:none]"
+          ref={setContentEl}
+          class="flex flex-col [overflow-anchor:none] touch:pt-[calc(var(--mobile-content-inset-top,0)+0.5rem)] touch:pb-(--mobile-content-inset-bottom)"
           style={{ 'min-height': `${viewportHeight()}px` }}
         >
           {/* Bottom-align short transcripts, chat-style. */}
@@ -201,6 +213,7 @@ export function Transcript() {
       <ScrollToBottomOverlay
         scrollState={scrollState}
         onScrollToBottom={pinToBottom}
+        class="touch:top-[calc(var(--mobile-content-inset-top,0)+1rem)]"
       />
       <ReplyToSelection container={transcriptEl()} onReply={quoteSelection} />
     </div>

--- a/apps/web/src/features/block-agent/component/Transcript.tsx
+++ b/apps/web/src/features/block-agent/component/Transcript.tsx
@@ -202,9 +202,9 @@ export function Transcript() {
               }}
             >
               {(message) => (
-                // Always half the pane so expanding Context grows down,
-                // not out. Same width on phone and desktop.
-                <div class="w-1/2 mx-auto px-2 pb-4 min-w-0">
+                // Half the pane on desktop so expanding Context grows
+                // down, not out. A phone is full-bleed.
+                <div class="w-full md:w-1/2 mx-auto px-4 pb-4 min-w-0">
                   <Message message={message} />
                 </div>
               )}

--- a/apps/web/src/features/block-agent/component/Transcript.tsx
+++ b/apps/web/src/features/block-agent/component/Transcript.tsx
@@ -202,7 +202,9 @@ export function Transcript() {
               }}
             >
               {(message) => (
-                <div class="w-full max-w-3xl mx-auto px-4 pb-4 min-w-0">
+                // Half-pane on desktop so expanding the side panel does
+                // not yank a max-w-3xl column. Mobile stays full-bleed.
+                <div class="w-full md:w-1/2 mx-auto px-4 pb-4 min-w-0">
                   <Message message={message} />
                 </div>
               )}

--- a/apps/web/src/features/block-agent/debug/Gallery.tsx
+++ b/apps/web/src/features/block-agent/debug/Gallery.tsx
@@ -7,6 +7,7 @@
 import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
 import type {
   FoldedMessage,
+  ModelOption,
   ToolStatus,
 } from '@service-agent-fold/generated/types';
 import { createSignal, type JSX, onCleanup } from 'solid-js';
@@ -15,6 +16,7 @@ import { ReplyToSelection } from '../component/ReplyToSelection';
 import {
   ActionLine,
   AgentInput,
+  AgentModelSelector,
   AnimatedNumber,
   ComposerNotice,
   CountSummary,
@@ -29,6 +31,87 @@ import {
   ToolErrorCard,
   ToolStatusTitle,
 } from '../ui';
+
+/** A Cursor-shaped catalog: long enough to scroll, with one grouped tail. */
+const FIXTURE_MODELS: ModelOption[] = [
+  { id: 'auto', name: 'Auto', description: null, group: null },
+  {
+    id: 'grok-4.6-high-fast',
+    name: 'Cursor Grok 4.6 High Fast',
+    description: null,
+    group: null,
+  },
+  { id: 'composer-2.5', name: 'Composer 2.5', description: null, group: null },
+  {
+    id: 'opus-5-high',
+    name: 'Claude Opus 5 High',
+    description: null,
+    group: null,
+  },
+  {
+    id: 'opus-5-high-fast',
+    name: 'Claude Opus 5 High Fast',
+    description: null,
+    group: null,
+  },
+  { id: 'sol-high', name: 'GPT-5.6 Sol High', description: null, group: null },
+  {
+    id: 'sol-high-fast',
+    name: 'GPT-5.6 Sol High Fast',
+    description: null,
+    group: null,
+  },
+  {
+    id: 'sol-xhigh',
+    name: 'GPT-5.6 Sol Extra High',
+    description: null,
+    group: null,
+  },
+  {
+    id: 'fable-5-high',
+    name: 'Claude Fable 5 High',
+    description: null,
+    group: null,
+  },
+  {
+    id: 'gemini-3.7-flash-high',
+    name: 'Gemini 3.7 Flash High',
+    description: null,
+    group: null,
+  },
+  {
+    id: 'sonnet-5-high',
+    name: 'Claude Sonnet 5 High',
+    description: null,
+    group: null,
+  },
+  {
+    id: 'luna-high',
+    name: 'GPT-5.6 Luna High',
+    description: null,
+    group: 'Legacy',
+  },
+];
+
+/** The composer as the block mounts it, with the model control wired. */
+function ModelSelectorDemo() {
+  const [model, setModel] = createSignal<string | null>('grok-4.6-high-fast');
+  return (
+    <AgentInput
+      onSend={(content) => console.info('[gallery] send', content)}
+      modelControl={
+        <AgentModelSelector
+          model={model()}
+          options={FIXTURE_MODELS}
+          onSelect={(id) => {
+            console.info('[gallery] model', id);
+            setModel(id);
+          }}
+        />
+      }
+    />
+  );
+}
 
 function Item(props: { label: string; children: JSX.Element }) {
   return (
@@ -421,6 +504,10 @@ export default function AgentUiGallery() {
               onSend={() => {}}
               onStop={() => console.info('[gallery] stop')}
             />
+          </Item>
+
+          <Item label="AgentInput with model selector">
+            <ModelSelectorDemo />
           </Item>
 
           <Item label="AgentMessage (end-to-end)">

--- a/apps/web/src/features/block-agent/debug/replay/Replay.tsx
+++ b/apps/web/src/features/block-agent/debug/replay/Replay.tsx
@@ -260,7 +260,7 @@ export default function AgentReplay() {
               <div class="flex-1 min-h-0 flex flex-col">
                 <SessionChrome />
                 <Transcript />
-                <div class="shrink-0 w-full max-w-3xl mx-auto px-4 pb-4">
+                <div class="shrink-0 w-full md:w-1/2 mx-auto px-4 pb-4">
                   <AgentComposer />
                 </div>
               </div>

--- a/apps/web/src/features/block-agent/debug/replay/Replay.tsx
+++ b/apps/web/src/features/block-agent/debug/replay/Replay.tsx
@@ -260,7 +260,7 @@ export default function AgentReplay() {
               <div class="flex-1 min-h-0 flex flex-col">
                 <SessionChrome />
                 <Transcript />
-                <div class="shrink-0 w-full md:w-1/2 mx-auto px-4 pb-4">
+                <div class="shrink-0 w-1/2 mx-auto px-2 pb-4">
                   <AgentComposer />
                 </div>
               </div>

--- a/apps/web/src/features/block-agent/debug/replay/Replay.tsx
+++ b/apps/web/src/features/block-agent/debug/replay/Replay.tsx
@@ -260,7 +260,7 @@ export default function AgentReplay() {
               <div class="flex-1 min-h-0 flex flex-col">
                 <SessionChrome />
                 <Transcript />
-                <div class="shrink-0 w-1/2 mx-auto px-2 pb-4">
+                <div class="shrink-0 w-full md:w-1/2 mx-auto px-4 pb-4">
                   <AgentComposer />
                 </div>
               </div>

--- a/apps/web/src/features/block-agent/ui/AgentInput.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentInput.tsx
@@ -11,6 +11,7 @@ import { buildConfig } from '@core/component/LexicalMarkdown/builder/MarkdownCon
 import { MarkdownShell } from '@core/component/LexicalMarkdown/builder/MarkdownShell';
 import type { AgentCommandItem } from '@core/component/LexicalMarkdown/plugins';
 import { isMobile } from '@core/mobile/isMobile';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { useTouchOutsideToDismissKeyboard } from '@core/mobile/useTouchOutsideToDismissKeyboard';
 import { $insertReferencedPaste } from '@macro-inc/lexical-core';
 import EnterIcon from '@phosphor-icons/core/regular/arrow-bend-down-left.svg?component-solid';
@@ -39,7 +40,7 @@ export interface AgentInputProps {
   /** Receives the composed markdown, including any `<m-document-mention>` tags. */
   onSend: (markdown: string) => void;
   onStop?: () => void;
-  /** Model control: right of the text on desktop, footer-left on touch. */
+  /** Model control: a pill above the box on desktop, footer-left on touch. */
   modelControl?: JSX.Element;
   /**
    * Ref-style: receives the quote-insert function once the editor mounts
@@ -155,12 +156,16 @@ export function AgentInput(props: AgentInputProps) {
 
   return (
     <div ref={containerRef} data-keep-keyboard class="flex flex-col gap-1.5">
+      {/* Desktop: the model pill sits above the box, as it always has. */}
+      <Show when={!isTouchDevice() && props.modelControl}>
+        <div class="flex items-center px-0.5">{props.modelControl}</div>
+      </Show>
       {/* h-auto beats Surface's size-full so the in-flow controls are not
           clipped over the editor (that was Auto sitting on the placeholder). */}
       <Surface class="rounded-xl touch:rounded-2xl h-auto" depth={2} solid>
-        {/* Desktop: one row, controls right of the text. Touch: the text
-            gets the whole width and the controls drop to a footer row
-            (model left, send right) — the chat-tall / channel footer shape. */}
+        {/* Desktop: one row, send right of the text. Touch: the text gets
+            the whole width and the controls drop to a footer row (model
+            left, send right) — the chat-tall / channel footer shape. */}
         <div
           class="flex items-end gap-1 px-2 py-1.5 touch:flex-col touch:items-stretch touch:gap-1.5 touch:px-3 touch:pt-2.5 touch:pb-2"
           onPointerDown={focusEditor}
@@ -192,9 +197,9 @@ export function AgentInput(props: AgentInputProps) {
 
           {/* In-flow — never absolute over the text. */}
           <div class="flex shrink-0 items-center gap-1 pb-0.5 touch:pb-0">
-            <div class="min-w-0">
-              <Show when={props.modelControl}>{props.modelControl}</Show>
-            </div>
+            <Show when={isTouchDevice() && props.modelControl}>
+              <div class="min-w-0">{props.modelControl}</div>
+            </Show>
             <div class="ml-auto shrink-0">
               <Show
                 when={props.busy && props.onStop}

--- a/apps/web/src/features/block-agent/ui/AgentInput.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentInput.tsx
@@ -39,7 +39,7 @@ export interface AgentInputProps {
   /** Receives the composed markdown, including any `<m-document-mention>` tags. */
   onSend: (markdown: string) => void;
   onStop?: () => void;
-  /** Model pill in the composer footer, opposite send. */
+  /** Model pill on the same row as send, after the editor. */
   modelControl?: JSX.Element;
   /**
    * Ref-style: receives the quote-insert function once the editor mounts
@@ -155,14 +155,19 @@ export function AgentInput(props: AgentInputProps) {
 
   return (
     <div ref={containerRef} data-keep-keyboard class="flex flex-col gap-1.5">
-      <Surface class="rounded-xl touch:rounded-3xl" depth={2} solid>
-        <div class="flex flex-col px-2 py-1.5" onPointerDown={focusEditor}>
+      {/* h-auto beats Surface's size-full so the in-flow controls are not
+          clipped over the editor (that was Auto sitting on the placeholder). */}
+      <Surface class="rounded-xl touch:rounded-3xl h-auto" depth={2} solid>
+        <div
+          class="flex items-end gap-1 px-2 py-1.5"
+          onPointerDown={focusEditor}
+        >
           {/* No vertical padding of its own: the shell is min-h-8 and editor
             paragraphs carry my-1.5, so the row's py-1.5 is the whole frame —
             the same 44px single-line height as ChatInput. */}
           <div
             ref={bodyRef}
-            class="pl-1 text-sm text-ink"
+            class="min-w-0 flex-1 pl-1 text-sm text-ink"
             classList={{
               // While empty only the placeholder renders; keep it to one clipped
               // line so it doesn't wrap into the single-line height.
@@ -182,48 +187,43 @@ export function AgentInput(props: AgentInputProps) {
             />
           </div>
 
-          {/* Channel / chat-tall: model and send live in the bar, not
-              absolutely over the editor or the mobile dock. */}
-          <div class="flex items-center justify-between gap-1 pt-0.5">
-            <div class="min-w-0">
-              <Show when={props.modelControl}>{props.modelControl}</Show>
-            </div>
-            <div class="shrink-0">
+          {/* In-flow next to the editor — never absolute over the text. */}
+          <div class="flex shrink-0 items-center gap-1 pb-0.5">
+            <Show when={props.modelControl}>{props.modelControl}</Show>
+            <Show
+              when={props.busy && props.onStop}
+              fallback={
+                <SendButton
+                  tooltip="Send"
+                  disabled={!canSend()}
+                  onClick={send}
+                />
+              }
+            >
               <Show
-                when={props.busy && props.onStop}
+                when={canSendNext()}
                 fallback={
-                  <SendButton
-                    tooltip="Send"
-                    disabled={!canSend()}
-                    onClick={send}
-                  />
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    label="Stop"
+                    onClick={() => props.onStop?.()}
+                    class="rounded-[11px] size-7.5 text-ink-extra-muted not-disabled:bg-ink/5 not-disabled:hover:bg-ink/10"
+                  >
+                    <div class="size-3.5 rounded-sm bg-current" />
+                  </Button>
                 }
               >
-                <Show
-                  when={canSendNext()}
-                  fallback={
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      label="Stop"
-                      onClick={() => props.onStop?.()}
-                      class="rounded-[11px] size-7.5 text-ink-extra-muted not-disabled:bg-ink/5 not-disabled:hover:bg-ink/10"
-                    >
-                      <div class="size-3.5 rounded-sm bg-current" />
-                    </Button>
-                  }
+                <SendButton
+                  aria-label="Send next queued message"
+                  tooltip="Send next queued message"
+                  shortcut="Enter"
+                  onClick={sendNext}
                 >
-                  <SendButton
-                    aria-label="Send next queued message"
-                    tooltip="Send next queued message"
-                    shortcut="Enter"
-                    onClick={sendNext}
-                  >
-                    <EnterIcon />
-                  </SendButton>
-                </Show>
+                  <EnterIcon />
+                </SendButton>
               </Show>
-            </div>
+            </Show>
           </div>
         </div>
       </Surface>

--- a/apps/web/src/features/block-agent/ui/AgentInput.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentInput.tsx
@@ -10,6 +10,7 @@
 import { buildConfig } from '@core/component/LexicalMarkdown/builder/MarkdownConfigBuilder';
 import { MarkdownShell } from '@core/component/LexicalMarkdown/builder/MarkdownShell';
 import type { AgentCommandItem } from '@core/component/LexicalMarkdown/plugins';
+import { isMobile } from '@core/mobile/isMobile';
 import { $insertReferencedPaste } from '@macro-inc/lexical-core';
 import EnterIcon from '@phosphor-icons/core/regular/arrow-bend-down-left.svg?component-solid';
 import { Button, SendButton, Surface } from '@ui';
@@ -146,7 +147,7 @@ export function AgentInput(props: AgentInputProps) {
       <Show when={props.modelControl}>
         <div class="flex items-center px-0.5">{props.modelControl}</div>
       </Show>
-      <Surface class="rounded-xl" depth={2} solid>
+      <Surface class="rounded-xl touch:rounded-3xl" depth={2} solid>
         <div class="relative px-2 py-1.5">
           {/* No vertical padding of its own: the shell is min-h-8 and editor
             paragraphs carry my-1.5, so the row's py-1.5 is the whole frame —
@@ -161,6 +162,9 @@ export function AgentInput(props: AgentInputProps) {
               // line so it doesn't wrap into the single-line height.
               'overflow-hidden whitespace-nowrap':
                 markdown().trim().length === 0,
+              // Long drafts must not eat the mobile viewport above the dock.
+              'max-h-[calc(32*var(--dvh,1dvh))] overflow-y-auto':
+                isMultiline() && isMobile(),
             }}
           >
             <MarkdownShell

--- a/apps/web/src/features/block-agent/ui/AgentInput.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentInput.tsx
@@ -39,7 +39,7 @@ export interface AgentInputProps {
   /** Receives the composed markdown, including any `<m-document-mention>` tags. */
   onSend: (markdown: string) => void;
   onStop?: () => void;
-  /** Model pill on the same row as send, after the editor. */
+  /** Model control: right of the text on desktop, footer-left on touch. */
   modelControl?: JSX.Element;
   /**
    * Ref-style: receives the quote-insert function once the editor mounts
@@ -157,9 +157,12 @@ export function AgentInput(props: AgentInputProps) {
     <div ref={containerRef} data-keep-keyboard class="flex flex-col gap-1.5">
       {/* h-auto beats Surface's size-full so the in-flow controls are not
           clipped over the editor (that was Auto sitting on the placeholder). */}
-      <Surface class="rounded-xl touch:rounded-3xl h-auto" depth={2} solid>
+      <Surface class="rounded-xl touch:rounded-2xl h-auto" depth={2} solid>
+        {/* Desktop: one row, controls right of the text. Touch: the text
+            gets the whole width and the controls drop to a footer row
+            (model left, send right) — the chat-tall / channel footer shape. */}
         <div
-          class="flex items-end gap-1 px-2 py-1.5"
+          class="flex items-end gap-1 px-2 py-1.5 touch:flex-col touch:items-stretch touch:gap-1.5 touch:px-3 touch:pt-2.5 touch:pb-2"
           onPointerDown={focusEditor}
         >
           {/* No vertical padding of its own: the shell is min-h-8 and editor
@@ -167,7 +170,7 @@ export function AgentInput(props: AgentInputProps) {
             the same 44px single-line height as ChatInput. */}
           <div
             ref={bodyRef}
-            class="min-w-0 flex-1 pl-1 text-sm text-ink"
+            class="min-w-0 flex-1 pl-1 text-sm text-ink touch:pl-0 touch:text-base"
             classList={{
               // While empty only the placeholder renders; keep it to one clipped
               // line so it doesn't wrap into the single-line height.
@@ -187,43 +190,47 @@ export function AgentInput(props: AgentInputProps) {
             />
           </div>
 
-          {/* In-flow next to the editor — never absolute over the text. */}
-          <div class="flex shrink-0 items-center gap-1 pb-0.5">
-            <Show when={props.modelControl}>{props.modelControl}</Show>
-            <Show
-              when={props.busy && props.onStop}
-              fallback={
-                <SendButton
-                  tooltip="Send"
-                  disabled={!canSend()}
-                  onClick={send}
-                />
-              }
-            >
+          {/* In-flow — never absolute over the text. */}
+          <div class="flex shrink-0 items-center gap-1 pb-0.5 touch:pb-0">
+            <div class="min-w-0">
+              <Show when={props.modelControl}>{props.modelControl}</Show>
+            </div>
+            <div class="ml-auto shrink-0">
               <Show
-                when={canSendNext()}
+                when={props.busy && props.onStop}
                 fallback={
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    label="Stop"
-                    onClick={() => props.onStop?.()}
-                    class="rounded-[11px] size-7.5 text-ink-extra-muted not-disabled:bg-ink/5 not-disabled:hover:bg-ink/10"
-                  >
-                    <div class="size-3.5 rounded-sm bg-current" />
-                  </Button>
+                  <SendButton
+                    tooltip="Send"
+                    disabled={!canSend()}
+                    onClick={send}
+                  />
                 }
               >
-                <SendButton
-                  aria-label="Send next queued message"
-                  tooltip="Send next queued message"
-                  shortcut="Enter"
-                  onClick={sendNext}
+                <Show
+                  when={canSendNext()}
+                  fallback={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      label="Stop"
+                      onClick={() => props.onStop?.()}
+                      class="rounded-[11px] size-7.5 text-ink-extra-muted not-disabled:bg-ink/5 not-disabled:hover:bg-ink/10"
+                    >
+                      <div class="size-3.5 rounded-sm bg-current" />
+                    </Button>
+                  }
                 >
-                  <EnterIcon />
-                </SendButton>
+                  <SendButton
+                    aria-label="Send next queued message"
+                    tooltip="Send next queued message"
+                    shortcut="Enter"
+                    onClick={sendNext}
+                  >
+                    <EnterIcon />
+                  </SendButton>
+                </Show>
               </Show>
-            </Show>
+            </div>
           </div>
         </div>
       </Surface>

--- a/apps/web/src/features/block-agent/ui/AgentInput.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentInput.tsx
@@ -11,6 +11,7 @@ import { buildConfig } from '@core/component/LexicalMarkdown/builder/MarkdownCon
 import { MarkdownShell } from '@core/component/LexicalMarkdown/builder/MarkdownShell';
 import type { AgentCommandItem } from '@core/component/LexicalMarkdown/plugins';
 import { isMobile } from '@core/mobile/isMobile';
+import { useTouchOutsideToDismissKeyboard } from '@core/mobile/useTouchOutsideToDismissKeyboard';
 import { $insertReferencedPaste } from '@macro-inc/lexical-core';
 import EnterIcon from '@phosphor-icons/core/regular/arrow-bend-down-left.svg?component-solid';
 import { Button, SendButton, Surface } from '@ui';
@@ -63,7 +64,9 @@ const SINGLE_LINE_HEIGHT = 40;
 
 export function AgentInput(props: AgentInputProps) {
   const [markdown, setMarkdown] = createSignal('');
+  let containerRef: HTMLDivElement | undefined;
   let bodyRef: HTMLDivElement | undefined;
+  useTouchOutsideToDismissKeyboard(() => containerRef);
 
   // Sending while busy is allowed — the service queues prompts behind the
   // running turn.
@@ -139,16 +142,21 @@ export function AgentInput(props: AgentInputProps) {
     onCleanup(() => props.registerQuoteInsert?.(undefined));
   });
 
+  // MarkdownShell only focuses on click when !isMobile(), so padding taps
+  // on a phone miss the empty contenteditable. Focus from this gesture
+  // (channel EditorShell / chat surface) so the whole box is tappable,
+  // including on touch — pointerdown stays inside the user gesture that
+  // iOS needs to raise the keyboard.
+  const focusEditor = (event: Event) => {
+    const target = event.target as HTMLElement | null;
+    if (target?.closest('button')) return;
+    editor.controls.focus();
+  };
+
   return (
-    <div class="flex flex-col gap-1.5">
-      {/* Above the surface rather than inside it: the pill belongs to the
-          composer, not to the outlined field, so it must not eat into the
-          editor's frame or sit within its border. */}
-      <Show when={props.modelControl}>
-        <div class="flex items-center px-0.5">{props.modelControl}</div>
-      </Show>
+    <div ref={containerRef} data-keep-keyboard class="flex flex-col gap-1.5">
       <Surface class="rounded-xl touch:rounded-3xl" depth={2} solid>
-        <div class="relative px-2 py-1.5">
+        <div class="relative px-2 py-1.5" onPointerDown={focusEditor}>
           {/* No vertical padding of its own: the shell is min-h-8 and editor
             paragraphs carry my-1.5, so the row's py-1.5 is the whole frame —
             the same 44px single-line height as ChatInput. */}
@@ -156,8 +164,10 @@ export function AgentInput(props: AgentInputProps) {
             ref={bodyRef}
             class="pl-1 text-sm text-ink"
             classList={{
-              'pr-10': !isMultiline(),
-              'pb-8': isMultiline(),
+              // Room for model + send on one line (chat's right-controls inset).
+              'pr-28': !isMultiline() && !!props.modelControl,
+              'pr-10': !isMultiline() && !props.modelControl,
+              'pb-10': isMultiline(),
               // While empty only the placeholder renders; keep it to one clipped
               // line so it doesn't wrap into the single-line height.
               'overflow-hidden whitespace-nowrap':
@@ -176,7 +186,8 @@ export function AgentInput(props: AgentInputProps) {
             />
           </div>
 
-          <div class="absolute right-1.5 bottom-1.5">
+          <div class="absolute right-1.5 bottom-1.5 flex items-center gap-1">
+            <Show when={props.modelControl}>{props.modelControl}</Show>
             <Show
               when={props.busy && props.onStop}
               fallback={

--- a/apps/web/src/features/block-agent/ui/AgentInput.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentInput.tsx
@@ -39,7 +39,7 @@ export interface AgentInputProps {
   /** Receives the composed markdown, including any `<m-document-mention>` tags. */
   onSend: (markdown: string) => void;
   onStop?: () => void;
-  /** Sits as a pill above the input box, e.g. the session's model selector. */
+  /** Model pill in the composer footer, opposite send. */
   modelControl?: JSX.Element;
   /**
    * Ref-style: receives the quote-insert function once the editor mounts
@@ -59,7 +59,7 @@ export interface AgentInputProps {
   registerFocus?: (focus: (() => void) | undefined) => void;
 }
 
-/** Past this height the controls drop below the text instead of overlaying it. */
+/** Past this height a phone draft is scroll-capped so it cannot eat the dock. */
 const SINGLE_LINE_HEIGHT = 40;
 
 export function AgentInput(props: AgentInputProps) {
@@ -72,8 +72,8 @@ export function AgentInput(props: AgentInputProps) {
   // running turn.
   const canSend = () => markdown().trim().length > 0 && !props.disabled;
 
-  // Same content-driven switch as ChatInput: once the editor body wraps past
-  // one line, the send button stops overlaying the text and sits below it.
+  // Caps tall drafts on a phone so the editor cannot eat the viewport
+  // above the dock. Controls live in a footer row, not over the text.
   const isMultiline = () => {
     if (markdown().trim().length === 0) return false;
     if (!bodyRef) return false;
@@ -156,7 +156,7 @@ export function AgentInput(props: AgentInputProps) {
   return (
     <div ref={containerRef} data-keep-keyboard class="flex flex-col gap-1.5">
       <Surface class="rounded-xl touch:rounded-3xl" depth={2} solid>
-        <div class="relative px-2 py-1.5" onPointerDown={focusEditor}>
+        <div class="flex flex-col px-2 py-1.5" onPointerDown={focusEditor}>
           {/* No vertical padding of its own: the shell is min-h-8 and editor
             paragraphs carry my-1.5, so the row's py-1.5 is the whole frame —
             the same 44px single-line height as ChatInput. */}
@@ -164,10 +164,6 @@ export function AgentInput(props: AgentInputProps) {
             ref={bodyRef}
             class="pl-1 text-sm text-ink"
             classList={{
-              // Room for model + send on one line (chat's right-controls inset).
-              'pr-28': !isMultiline() && !!props.modelControl,
-              'pr-10': !isMultiline() && !props.modelControl,
-              'pb-10': isMultiline(),
               // While empty only the placeholder renders; keep it to one clipped
               // line so it doesn't wrap into the single-line height.
               'overflow-hidden whitespace-nowrap':
@@ -186,42 +182,48 @@ export function AgentInput(props: AgentInputProps) {
             />
           </div>
 
-          <div class="absolute right-1.5 bottom-1.5 flex items-center gap-1">
-            <Show when={props.modelControl}>{props.modelControl}</Show>
-            <Show
-              when={props.busy && props.onStop}
-              fallback={
-                <SendButton
-                  tooltip="Send"
-                  disabled={!canSend()}
-                  onClick={send}
-                />
-              }
-            >
+          {/* Channel / chat-tall: model and send live in the bar, not
+              absolutely over the editor or the mobile dock. */}
+          <div class="flex items-center justify-between gap-1 pt-0.5">
+            <div class="min-w-0">
+              <Show when={props.modelControl}>{props.modelControl}</Show>
+            </div>
+            <div class="shrink-0">
               <Show
-                when={canSendNext()}
+                when={props.busy && props.onStop}
                 fallback={
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    label="Stop"
-                    onClick={() => props.onStop?.()}
-                    class="rounded-[11px] size-7.5 text-ink-extra-muted not-disabled:bg-ink/5 not-disabled:hover:bg-ink/10"
-                  >
-                    <div class="size-3.5 rounded-sm bg-current" />
-                  </Button>
+                  <SendButton
+                    tooltip="Send"
+                    disabled={!canSend()}
+                    onClick={send}
+                  />
                 }
               >
-                <SendButton
-                  aria-label="Send next queued message"
-                  tooltip="Send next queued message"
-                  shortcut="Enter"
-                  onClick={sendNext}
+                <Show
+                  when={canSendNext()}
+                  fallback={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      label="Stop"
+                      onClick={() => props.onStop?.()}
+                      class="rounded-[11px] size-7.5 text-ink-extra-muted not-disabled:bg-ink/5 not-disabled:hover:bg-ink/10"
+                    >
+                      <div class="size-3.5 rounded-sm bg-current" />
+                    </Button>
+                  }
                 >
-                  <EnterIcon />
-                </SendButton>
+                  <SendButton
+                    aria-label="Send next queued message"
+                    tooltip="Send next queued message"
+                    shortcut="Enter"
+                    onClick={sendNext}
+                  >
+                    <EnterIcon />
+                  </SendButton>
+                </Show>
               </Show>
-            </Show>
+            </div>
           </div>
         </div>
       </Surface>

--- a/apps/web/src/features/block-agent/ui/AgentModelSelector.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentModelSelector.tsx
@@ -78,7 +78,7 @@ export function AgentModelSelector(props: AgentModelSelectorProps) {
             <Dropdown.Trigger
               variant="ghost"
               size="sm"
-              class="h-6 gap-1 rounded-full bg-ink/5 px-2 text-xs text-ink-muted hover:bg-ink/10"
+              class="h-6 gap-1 rounded-full bg-ink/5 px-2 text-xs text-ink-muted hover:bg-ink/10 touch:h-8"
               disabled={props.disabled || props.changingTo !== undefined}
             >
               <TextShimmer
@@ -134,7 +134,7 @@ export function AgentModelSelector(props: AgentModelSelectorProps) {
             disabled={props.disabled || props.changingTo !== undefined}
             ariaLabel="Agent model"
             searchPlaceholder="Search models"
-            triggerClass="h-6 rounded-full bg-ink/5 px-2 text-xs text-ink-muted hover:bg-ink/10"
+            triggerClass="h-6 rounded-full bg-ink/5 px-2 text-xs text-ink-muted hover:bg-ink/10 touch:h-8"
             contentClass="overflow-hidden"
             placement="top-start"
           />

--- a/apps/web/src/features/block-agent/ui/AgentModelSelector.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentModelSelector.tsx
@@ -6,19 +6,28 @@
  * projection of them, so this component never needs a model registry of its
  * own. Renders nothing until the harness has advertised its models.
  *
- * Harnesses advertise as many models as they like, so the list scrolls rather
- * than growing without bound: it shows at most `MAX_VISIBLE_ROWS` (or fewer,
- * when the popper has less room than that), leaving the next row half-cut
- * under a gradient so the overflow is visible rather than merely scrollable.
+ * Touch devices get a bottom sheet (`MobileDrawer`, the same chrome as the
+ * split title menu) listing every model with a check on the current one.
+ * Desktop keeps a popover: a compact scrolling list for short catalogs, the
+ * searchable `ModelCatalogPicker` for long ones.
+ *
+ * Harnesses advertise as many models as they like, so the desktop list
+ * scrolls rather than growing without bound: it shows at most
+ * `MAX_VISIBLE_ROWS` (or fewer, when the popper has less room than that),
+ * leaving the next row half-cut under a gradient so the overflow is visible
+ * rather than merely scrollable.
  */
 
+import { MobileDrawer } from '@components/app/mobile/MobileDrawer';
 import { ModelCatalogPicker } from '@core/component/AI/component/input/ModelCatalogPicker';
 import { isLargeModelCatalog } from '@core/component/AI/component/input/modelCatalog';
 import { ScrollIndicators } from '@core/component/VerticalScrollIndicators';
+import { isTouchDevice } from '@core/mobile/isTouchDevice';
+import Check from '@phosphor/check.svg';
 import CaretDown from '@phosphor-icons/core/regular/caret-down.svg?component-solid';
 import type { ModelOption } from '@service-agent-fold/generated/types';
-import { cn, Dropdown } from '@ui';
-import { createSignal, For, Show } from 'solid-js';
+import { Button, cn, Dropdown } from '@ui';
+import { createMemo, createSignal, For, Show } from 'solid-js';
 import { TextShimmer } from './TextShimmer';
 
 /** Compact ghost pill — same size as the short-list trigger and chat's selector. */
@@ -57,8 +66,23 @@ export interface AgentModelSelectorProps {
   onSelect: (model: string) => void;
 }
 
+/** Consecutive options under one harness heading (`null` = no heading). */
+type ModelGroup = { label: string | null; options: ModelOption[] };
+
+function groupOptions(options: ModelOption[]): ModelGroup[] {
+  const groups: ModelGroup[] = [];
+  for (const option of options) {
+    const label = option.group ?? null;
+    const last = groups[groups.length - 1];
+    if (last && last.label === label) last.options.push(option);
+    else groups.push({ label, options: [option] });
+  }
+  return groups;
+}
+
 export function AgentModelSelector(props: AgentModelSelectorProps) {
   const [listRef, setListRef] = createSignal<HTMLElement>();
+  const [sheetOpen, setSheetOpen] = createSignal(false);
   const shown = () => props.changingTo ?? props.model;
   const label = () =>
     props.options.find((option) => option.id === shown())?.name ??
@@ -72,75 +96,144 @@ export function AgentModelSelector(props: AgentModelSelectorProps) {
       group: option.group ?? undefined,
     }));
   const useCatalog = () => isLargeModelCatalog(catalogOptions());
+  const groups = createMemo(() => groupOptions(props.options));
+  const disabled = () => props.disabled || props.changingTo !== undefined;
+
+  const pick = (id: string) => {
+    setSheetOpen(false);
+    if (id !== props.model) props.onSelect(id);
+  };
+
+  const sheet = (
+    <MobileDrawer
+      side="bottom"
+      open={sheetOpen()}
+      onOpenChange={setSheetOpen}
+      preventScroll={false}
+      preventScrollbarShift={false}
+    >
+      {/* Plain text + caret, like the reference composer — no pill. */}
+      <MobileDrawer.Trigger
+        as={Button}
+        variant="ghost"
+        size="sm"
+        aria-label="Agent model"
+        disabled={disabled()}
+        class="h-8 max-w-[60vw] min-w-0 justify-start gap-1 rounded-lg border-none bg-transparent px-1.5 text-left text-sm text-ink-muted hover:bg-hover"
+      >
+        <TextShimmer
+          text={label()}
+          active={props.changingTo !== undefined}
+          class="min-w-0 truncate"
+        />
+        <CaretDown class="size-3.5 shrink-0" />
+      </MobileDrawer.Trigger>
+      <MobileDrawer.Portal>
+        <MobileDrawer.Overlay class="fixed inset-0 z-modal-overlay bg-modal-overlay pattern-diagonal-4 pattern-edge-muted" />
+        <MobileDrawer.Content aria-label="Choose a model">
+          <MobileDrawer.Handle />
+          <MobileDrawer.ScrollBody>
+            <For each={groups()}>
+              {(group) => (
+                <>
+                  <Show when={group.label}>
+                    {(heading) => (
+                      <MobileDrawer.Label>{heading()}</MobileDrawer.Label>
+                    )}
+                  </Show>
+                  <MobileDrawer.Section
+                    role="radiogroup"
+                    aria-label={group.label ?? 'Models'}
+                    class="mb-3 flex shrink-0 flex-col"
+                  >
+                    <For each={group.options}>
+                      {(option) => (
+                        <button
+                          type="button"
+                          role="radio"
+                          aria-checked={option.id === shown()}
+                          title={option.description ?? undefined}
+                          class="flex w-full items-center gap-3 bg-surface px-4 py-3 text-left text-sm text-ink hover:bg-hover hover-transition-bg not-last:mb-px"
+                          onClick={() => pick(option.id)}
+                        >
+                          <span class="min-w-0 flex-1 truncate">
+                            {option.name}
+                          </span>
+                          <Show when={option.id === shown()}>
+                            <Check class="size-3.5 shrink-0 text-accent" />
+                          </Show>
+                        </button>
+                      )}
+                    </For>
+                  </MobileDrawer.Section>
+                </>
+              )}
+            </For>
+          </MobileDrawer.ScrollBody>
+        </MobileDrawer.Content>
+      </MobileDrawer.Portal>
+    </MobileDrawer>
+  );
+
+  const shortList = (
+    <Dropdown placement="top-start">
+      <Dropdown.Trigger
+        variant="ghost"
+        size="sm"
+        class={PILL_TRIGGER_CLASS}
+        disabled={disabled()}
+      >
+        <TextShimmer text={label()} active={props.changingTo !== undefined} />
+        <CaretDown />
+      </Dropdown.Trigger>
+      <Dropdown.Content class="overflow-hidden">
+        {/* The gradients anchor here, outside the scrolling box, and read
+            the menu background through `--color-surface`. */}
+        <div class="relative [--color-surface:var(--color-menu)]">
+          <Dropdown.Group
+            ref={setListRef}
+            class="overflow-y-auto overscroll-contain p-0"
+            style={{ 'max-height': LIST_MAX_HEIGHT }}
+          >
+            <div class="flex flex-col p-1.5">
+              <For each={props.options}>
+                {(option) => (
+                  <Dropdown.Item
+                    class={cn(
+                      'h-7 shrink-0 gap-2',
+                      option.id === shown() && 'text-ink font-medium'
+                    )}
+                    title={option.description ?? undefined}
+                    onSelect={() => pick(option.id)}
+                  >
+                    <span class="flex-1 truncate text-xs">{option.name}</span>
+                  </Dropdown.Item>
+                )}
+              </For>
+            </div>
+          </Dropdown.Group>
+          <ScrollIndicators scrollRef={listRef} appearance="gradient" />
+        </div>
+      </Dropdown.Content>
+    </Dropdown>
+  );
 
   return (
     <Show when={props.options.length > 0}>
-      <Show
-        when={useCatalog()}
-        fallback={
-          <Dropdown placement="top-start">
-            <Dropdown.Trigger
-              variant="ghost"
-              size="sm"
-              class={PILL_TRIGGER_CLASS}
-              disabled={props.disabled || props.changingTo !== undefined}
-            >
-              <TextShimmer
-                text={label()}
-                active={props.changingTo !== undefined}
-              />
-              <CaretDown />
-            </Dropdown.Trigger>
-            <Dropdown.Content class="overflow-hidden">
-              {/* The gradients anchor here, outside the scrolling box, and read
-                  the menu background through `--color-surface`. */}
-              <div class="relative [--color-surface:var(--color-menu)]">
-                <Dropdown.Group
-                  ref={setListRef}
-                  class="overflow-y-auto overscroll-contain p-0"
-                  style={{ 'max-height': LIST_MAX_HEIGHT }}
-                >
-                  <div class="flex flex-col p-1.5">
-                    <For each={props.options}>
-                      {(option) => (
-                        <Dropdown.Item
-                          class={cn(
-                            'h-7 shrink-0 gap-2',
-                            option.id === shown() && 'text-ink font-medium'
-                          )}
-                          title={option.description ?? undefined}
-                          onSelect={() => {
-                            if (option.id !== props.model)
-                              props.onSelect(option.id);
-                          }}
-                        >
-                          <span class="flex-1 truncate text-xs">
-                            {option.name}
-                          </span>
-                        </Dropdown.Item>
-                      )}
-                    </For>
-                  </div>
-                </Dropdown.Group>
-                <ScrollIndicators scrollRef={listRef} appearance="gradient" />
-              </div>
-            </Dropdown.Content>
-          </Dropdown>
-        }
-      >
-        <ModelCatalogPicker
-          value={shown()}
-          options={catalogOptions()}
-          onSelect={(id) => {
-            if (id !== props.model) props.onSelect(id);
-          }}
-          disabled={props.disabled || props.changingTo !== undefined}
-          ariaLabel="Agent model"
-          searchPlaceholder="Search models"
-          triggerClass={PILL_TRIGGER_CLASS}
-          contentClass="overflow-hidden"
-          placement="top-start"
-        />
+      <Show when={!isTouchDevice()} fallback={sheet}>
+        <Show when={useCatalog()} fallback={shortList}>
+          <ModelCatalogPicker
+            value={shown()}
+            options={catalogOptions()}
+            onSelect={pick}
+            disabled={disabled()}
+            ariaLabel="Agent model"
+            searchPlaceholder="Search models"
+            triggerClass={PILL_TRIGGER_CLASS}
+            contentClass="overflow-hidden"
+            placement="top-start"
+          />
+        </Show>
       </Show>
     </Show>
   );

--- a/apps/web/src/features/block-agent/ui/AgentModelSelector.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentModelSelector.tsx
@@ -21,6 +21,10 @@ import { cn, Dropdown } from '@ui';
 import { createSignal, For, Show } from 'solid-js';
 import { TextShimmer } from './TextShimmer';
 
+/** Compact ghost pill — same size as the short-list trigger and chat's selector. */
+const PILL_TRIGGER_CLASS =
+  'h-6 w-auto max-w-[9rem] min-w-0 justify-start gap-1 rounded-full border-transparent bg-ink/5 px-2 text-left text-xs text-ink-muted hover:bg-ink/10';
+
 /** Height of one model row — `h-7` on the item, so the cap is exact. */
 const ROW_HEIGHT_PX = 28;
 /** Rows shown in full before the list starts scrolling. */
@@ -78,7 +82,7 @@ export function AgentModelSelector(props: AgentModelSelectorProps) {
             <Dropdown.Trigger
               variant="ghost"
               size="sm"
-              class="h-6 gap-1 rounded-full bg-ink/5 px-2 text-xs text-ink-muted hover:bg-ink/10 touch:h-8"
+              class={PILL_TRIGGER_CLASS}
               disabled={props.disabled || props.changingTo !== undefined}
             >
               <TextShimmer
@@ -124,21 +128,19 @@ export function AgentModelSelector(props: AgentModelSelectorProps) {
           </Dropdown>
         }
       >
-        <div class="min-w-44">
-          <ModelCatalogPicker
-            value={shown()}
-            options={catalogOptions()}
-            onSelect={(id) => {
-              if (id !== props.model) props.onSelect(id);
-            }}
-            disabled={props.disabled || props.changingTo !== undefined}
-            ariaLabel="Agent model"
-            searchPlaceholder="Search models"
-            triggerClass="h-6 rounded-full bg-ink/5 px-2 text-xs text-ink-muted hover:bg-ink/10 touch:h-8"
-            contentClass="overflow-hidden"
-            placement="top-start"
-          />
-        </div>
+        <ModelCatalogPicker
+          value={shown()}
+          options={catalogOptions()}
+          onSelect={(id) => {
+            if (id !== props.model) props.onSelect(id);
+          }}
+          disabled={props.disabled || props.changingTo !== undefined}
+          ariaLabel="Agent model"
+          searchPlaceholder="Search models"
+          triggerClass={PILL_TRIGGER_CLASS}
+          contentClass="overflow-hidden"
+          placement="top-start"
+        />
       </Show>
     </Show>
   );

--- a/docs/AGENT_GUIDE/ai-chat.md
+++ b/docs/AGENT_GUIDE/ai-chat.md
@@ -60,8 +60,8 @@ sits on top and a footer row holds the model name (left, e.g. `Auto ⌄`) and
 **Send** (right). Tapping the model name opens a bottom sheet listing every
 model with a check on the current one — pick a row to switch. On desktop the
 transcript and composer are half the pane wide so expanding **Context** only
-grows vertically; the model control is a small pill next to Send. Tap the
-session title
+grows vertically; your messages are right-aligned bubbles and the model pill
+sits above the box. Tap the session title
 to open the title menu (caret), then **Rename** — that opens the same style of
 rename dialog automations use. Do not expect a tap on the name itself to start
 an inline edit.

--- a/docs/AGENT_GUIDE/ai-chat.md
+++ b/docs/AGENT_GUIDE/ai-chat.md
@@ -55,10 +55,13 @@ transcript (and in the originating channel thread).
 
 On mobile the composer (and any queued prompts above it) floats in the bottom
 accessory region above the dock — same placement as channel and AI chat — so it
-stays tappable and clear of the home indicator. Tap the box to type; the model
-pill sits in the composer on the same row as send (right of the text, not over
-the placeholder). Transcript messages stay at half pane width so expanding
-**Context** only grows vertically. Tap the session title
+stays tappable and clear of the home indicator. The box is full width; the text
+sits on top and a footer row holds the model name (left, e.g. `Auto ⌄`) and
+**Send** (right). Tapping the model name opens a bottom sheet listing every
+model with a check on the current one — pick a row to switch. On desktop the
+transcript and composer are half the pane wide so expanding **Context** only
+grows vertically; the model control is a small pill next to Send. Tap the
+session title
 to open the title menu (caret), then **Rename** — that opens the same style of
 rename dialog automations use. Do not expect a tap on the name itself to start
 an inline edit.

--- a/docs/AGENT_GUIDE/ai-chat.md
+++ b/docs/AGENT_GUIDE/ai-chat.md
@@ -56,7 +56,8 @@ transcript (and in the originating channel thread).
 On mobile the composer (and any queued prompts above it) floats in the bottom
 accessory region above the dock — same placement as channel and AI chat — so it
 stays tappable and clear of the home indicator. Tap the box to type; the model
-pill sits inside the composer next to send, like AI chat. Tap the session title
+pill sits in the composer footer opposite send (not overlaid on the bar). Tap
+the session title
 to open the title menu (caret), then **Rename** — that opens the same style of
 rename dialog automations use. Do not expect a tap on the name itself to start
 an inline edit.

--- a/docs/AGENT_GUIDE/ai-chat.md
+++ b/docs/AGENT_GUIDE/ai-chat.md
@@ -55,9 +55,11 @@ transcript (and in the originating channel thread).
 
 On mobile the composer (and any queued prompts above it) floats in the bottom
 accessory region above the dock — same placement as channel and AI chat — so it
-stays tappable and clear of the home indicator. Tap the session title to open
-the title menu (caret), then **Rename**; do not expect a tap on the name itself
-to start an inline edit. Desktop still double-clicks the title to rename.
+stays tappable and clear of the home indicator. Tap the box to type; the model
+pill sits inside the composer next to send, like AI chat. Tap the session title
+to open the title menu (caret), then **Rename** — that opens the same style of
+rename dialog automations use. Do not expect a tap on the name itself to start
+an inline edit.
 
 - Sending is never blocked by a running turn. A prompt sent mid-turn is queued
   **server-side** and dispatches automatically when the current turn ends, one per turn.

--- a/docs/AGENT_GUIDE/ai-chat.md
+++ b/docs/AGENT_GUIDE/ai-chat.md
@@ -53,6 +53,12 @@ used in chat and channels; they serialize as `<m-document-mention>` tags in the 
 the agent sees. Agent replies that emit those tags render as clickable chips in the
 transcript (and in the originating channel thread).
 
+On mobile the composer (and any queued prompts above it) floats in the bottom
+accessory region above the dock — same placement as channel and AI chat — so it
+stays tappable and clear of the home indicator. Tap the session title to open
+the title menu (caret), then **Rename**; do not expect a tap on the name itself
+to start an inline edit. Desktop still double-clicks the title to rename.
+
 - Sending is never blocked by a running turn. A prompt sent mid-turn is queued
   **server-side** and dispatches automatically when the current turn ends, one per turn.
   The queue holds at most 50 entries; past that a send is refused with an error rather

--- a/docs/AGENT_GUIDE/ai-chat.md
+++ b/docs/AGENT_GUIDE/ai-chat.md
@@ -56,8 +56,9 @@ transcript (and in the originating channel thread).
 On mobile the composer (and any queued prompts above it) floats in the bottom
 accessory region above the dock — same placement as channel and AI chat — so it
 stays tappable and clear of the home indicator. Tap the box to type; the model
-pill sits in the composer footer opposite send (not overlaid on the bar). Tap
-the session title
+pill sits in the composer on the same row as send (right of the text, not over
+the placeholder). Transcript messages stay at half pane width so expanding
+**Context** only grows vertically. Tap the session title
 to open the title menu (caret), then **Rename** — that opens the same style of
 rename dialog automations use. Do not expect a tap on the name itself to start
 an inline edit.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the coding-agent session usable on a phone and matches the existing web/mobile patterns.

- **Title rename:** on touch, tapping the session name opens the title menu with **Rename** instead of inline edit.
- **Composer placement:** the composer floats in the mobile dock region (`FloatRegionOrInline`) so it is tappable and clears the home indicator.
- **Composer layout:** full width on phones; text on top, footer row with the model name (left) and Send (right). Desktop keeps a single row with controls to the right of the text. Nothing is absolutely positioned over the placeholder anymore.
- **Model selector:** on touch, the model name is plain text + caret that opens a `MobileDrawer` bottom sheet (drag handle, every model, check on the current one, harness group labels). Desktop keeps the pill + popover / `ModelCatalogPicker`.
- **Column width:** transcript and composer are `w-full` below `md` and half the pane above it, so expanding **Context** grows down, not out, on desktop.
- Gallery (`/component/agent-ui`) gained an "AgentInput with model selector" fixture so the sheet can be exercised without a live harness.
- `docs/AGENT_GUIDE/ai-chat.md` updated.

## Verification (iPhone 12 Pro emulation)

[mobile_agent_composer_and_model_sheet.mp4](https://cursor.com/agents/bc-e4d2ffbd-6f18-488f-b228-f3e2e1dcc784/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_agent_composer_and_model_sheet.mp4)

Agent session composer, full width above the dock, then typed:

[Mobile agent composer, full width](https://cursor.com/agents/bc-e4d2ffbd-6f18-488f-b228-f3e2e1dcc784/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_agent_composer_full_width.webp)
[Mobile agent composer with typed text](https://cursor.com/agents/bc-e4d2ffbd-6f18-488f-b228-f3e2e1dcc784/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_agent_composer_typed.webp)

Model footer, bottom sheet, and the footer after picking Claude Opus 5 High:

[Model name in composer footer](https://cursor.com/agents/bc-e4d2ffbd-6f18-488f-b228-f3e2e1dcc784/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_composer_model_footer.webp)
[Model bottom sheet](https://cursor.com/agents/bc-e4d2ffbd-6f18-488f-b228-f3e2e1dcc784/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_model_bottom_sheet.webp)
[Footer after selecting a model](https://cursor.com/agents/bc-e4d2ffbd-6f18-488f-b228-f3e2e1dcc784/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_model_selected_opus.webp)

`bun type-check` and biome pass. Vitest cannot run in this Nix sandbox (`EINVAL scandir /proc`), so verification is browser-based.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4d2ffbd-6f18-488f-b228-f3e2e1dcc784?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4d2ffbd-6f18-488f-b228-f3e2e1dcc784&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

