### PR TITLE
feat(web): magic chip as a fixed-height expandable card; fix duplicate-folded prompts

### DIFF
--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 
-import { cleanup, fireEvent, render } from '@solidjs/testing-library';
+import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MagicChipView } from './MagicChipView';
 
@@ -22,8 +22,15 @@ vi.mock('@core/component/LexicalMarkdown/theme', () => ({
 
 afterEach(cleanup);
 
+const LONG_PATH =
+  '/home/ubuntu/.cursor/projects/workspace/terminals/261831.txt'.repeat(8);
+
+function answerArea(container: HTMLElement) {
+  return container.querySelector('[data-magic-chip-answer]');
+}
+
 describe('MagicChipView', () => {
-  it('shows the card with the activity row before any answer arrives', () => {
+  it('reserves the answer height and shows the activity row while working', () => {
     const onOpen = vi.fn();
     const { container } = render(() => (
       <MagicChipView
@@ -39,11 +46,14 @@ describe('MagicChipView', () => {
     const card = container.querySelector('[data-magic-chip-preview]');
     expect(card?.className).toContain('rounded-lg');
     expect(card?.className).not.toContain('border-accent');
+
+    expect(answerArea(container)?.className).toContain('h-32');
     expect(container.querySelector('[data-testid="chip-markdown"]')).toBeNull();
+    expect(container.querySelectorAll('.bg-skeleton')).toHaveLength(3);
+    expect(container.querySelectorAll('.skeleton-shimmer')).toHaveLength(3);
 
     const footer = card?.querySelector('button');
     expect(footer?.textContent).toContain('Booting agent');
-    expect(footer?.className).not.toContain('border-t');
     expect(footer?.getAttribute('data-message-reply-preview')).toBe(
       'Booting agent'
     );
@@ -52,7 +62,7 @@ describe('MagicChipView', () => {
     expect(onOpen).toHaveBeenCalledTimes(1);
   });
 
-  it('clips the answer above the activity row while streaming', () => {
+  it('keeps the same answer height once the answer streams in', () => {
     const onOpen = vi.fn();
     const { container } = render(() => (
       <MagicChipView
@@ -66,14 +76,14 @@ describe('MagicChipView', () => {
       />
     ));
 
-    const card = container.querySelector('[data-magic-chip-preview]');
-    const body = card?.querySelector('[data-message-reply-preview]');
-    expect(body?.className).toContain('max-h-32');
+    expect(answerArea(container)?.className).toContain('h-32');
+    expect(container.querySelector('.bg-skeleton')).toBeNull();
+
+    const body = container.querySelector('[data-message-reply-preview]');
     expect(body?.className).toContain('overflow-hidden');
     expect(body?.textContent).toBe('Hello from the agent');
 
-    const footer = card?.querySelector('button');
-    expect(footer?.className).toContain('border-t');
+    const footer = container.querySelector('[data-magic-chip-preview] button');
     expect(footer?.textContent).toContain('Writing response');
     expect(footer?.textContent).not.toContain('Open session');
 
@@ -92,9 +102,31 @@ describe('MagicChipView', () => {
       />
     ));
 
+    expect(answerArea(container)?.className).toContain('h-32');
     const footer = container.querySelector('[data-magic-chip-preview] button');
     expect(footer?.textContent).toContain('Open session');
     fireEvent.click(footer!);
     expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a long activity detail inside the message column', () => {
+    const { container } = render(() => (
+      <div style={{ width: '320px' }}>
+        <MagicChipView
+          agentSessionId="session-1"
+          presentation={{
+            kind: 'working',
+            activity: { label: 'Thinking', detail: LONG_PATH, busy: true },
+          }}
+        />
+      </div>
+    ));
+
+    const card = container.querySelector('[data-magic-chip="session-1"]');
+    expect(card?.className).toContain('min-w-0');
+    expect(card?.className).toContain('max-w-full');
+    expect(card?.className).toContain('overflow-hidden');
+    expect(screen.getByText('Thinking')).toBeTruthy();
+    expect(screen.getByText(LONG_PATH).className).toContain('truncate');
   });
 });

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -107,14 +107,17 @@ describe('MagicChipView', () => {
 
     const area = answerArea(container)!;
     const clip = () => container.querySelector('[data-magic-chip-clip]');
+    const fade = () => container.querySelector('[data-magic-chip-fade]');
     expect(area.getAttribute('aria-expanded')).toBe('false');
     expect(area.className).toContain('h-22');
-    expect(area.textContent).not.toContain('Show less');
+    expect(fade()).toBeTruthy();
+    expect(area.textContent).toContain('Show more');
 
     fireEvent.click(area);
     expect(area.getAttribute('aria-expanded')).toBe('true');
     expect(area.className).not.toContain('h-22');
     expect(clip()?.className).not.toContain('overflow-hidden');
+    expect(fade()).toBeNull();
     expect(area.textContent).toContain('Show less');
     expect(onOpen).not.toHaveBeenCalled();
 
@@ -122,7 +125,8 @@ describe('MagicChipView', () => {
     expect(area.getAttribute('aria-expanded')).toBe('false');
     expect(area.className).toContain('h-22');
     expect(clip()?.className).toContain('overflow-hidden');
-    expect(area.textContent).not.toContain('Show less');
+    expect(fade()).toBeTruthy();
+    expect(area.textContent).toContain('Show more');
     expect(onOpen).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -47,10 +47,10 @@ describe('MagicChipView', () => {
     expect(card?.className).toContain('rounded-lg');
     expect(card?.className).not.toContain('border-accent');
 
-    expect(answerArea(container)?.className).toContain('h-32');
+    expect(answerArea(container)?.className).toContain('h-22');
     expect(container.querySelector('[data-testid="chip-markdown"]')).toBeNull();
-    expect(container.querySelectorAll('.bg-skeleton')).toHaveLength(3);
-    expect(container.querySelectorAll('.skeleton-shimmer')).toHaveLength(3);
+    expect(container.querySelector('[data-magic-chip-pending]')).toBeTruthy();
+    expect(container.querySelector('.bg-skeleton')).toBeNull();
 
     const footer = card?.querySelector('button');
     expect(footer?.textContent).toContain('Booting agent');
@@ -76,8 +76,8 @@ describe('MagicChipView', () => {
       />
     ));
 
-    expect(answerArea(container)?.className).toContain('h-32');
-    expect(container.querySelector('.bg-skeleton')).toBeNull();
+    expect(answerArea(container)?.className).toContain('h-22');
+    expect(container.querySelector('[data-magic-chip-pending]')).toBeNull();
 
     const body = container.querySelector('[data-message-reply-preview]');
     expect(body?.className).toContain('overflow-hidden');
@@ -102,7 +102,7 @@ describe('MagicChipView', () => {
       />
     ));
 
-    expect(answerArea(container)?.className).toContain('h-32');
+    expect(answerArea(container)?.className).toContain('h-22');
     const footer = container.querySelector('[data-magic-chip-preview] button');
     expect(footer?.textContent).toContain('Open session');
     fireEvent.click(footer!);

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -2,69 +2,110 @@
  * @vitest-environment jsdom
  */
 
-import { render, screen } from '@solidjs/testing-library';
-import { describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@solidjs/testing-library';
+import { createSignal } from 'solid-js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MagicChipView } from './MagicChipView';
 
 vi.mock(
   '@core/component/LexicalMarkdown/component/core/StaticMarkdown',
   () => ({
     StaticMarkdownContext: (props: { children: unknown }) => props.children,
-    StaticMarkdown: (props: { markdown: string }) => <p>{props.markdown}</p>,
+    StaticMarkdown: (props: { markdown: string }) => (
+      <div data-testid="chip-markdown">{props.markdown}</div>
+    ),
   })
 );
 
-import { MagicChipView } from './MagicChipView';
+vi.mock('@core/component/LexicalMarkdown/theme', () => ({
+  channelTheme: {},
+}));
 
-const LONG_PATH =
-  '/home/ubuntu/.cursor/projects/workspace/terminals/261831.txt'.repeat(8);
+afterEach(cleanup);
 
 describe('MagicChipView', () => {
-  it('keeps a streaming thought inside the message column', () => {
+  it('keeps working state as a single activity line', () => {
     const { container } = render(() => (
-      <div style={{ width: '320px' }}>
-        <MagicChipView
-          agentSessionId="session-1"
-          presentation={{
-            kind: 'working',
-            activity: {
-              label: 'Thinking',
-              detail: LONG_PATH,
-              busy: true,
-            },
-          }}
-        />
-      </div>
+      <MagicChipView
+        agentSessionId="session"
+        presentation={{
+          kind: 'working',
+          activity: { label: 'Booting agent', busy: true },
+        }}
+      />
     ));
 
-    const chip = container.querySelector('[data-magic-chip="session-1"]');
-    expect(chip?.className).toContain('min-w-0');
-    expect(chip?.className).toContain('max-w-full');
-    expect(chip?.className).toContain('overflow-x-hidden');
-    expect(screen.getByText('Thinking')).toBeTruthy();
-    expect(screen.getByText(LONG_PATH).className).toContain('truncate');
+    expect(container.querySelector('[data-magic-chip-preview]')).toBeNull();
+    expect(container.textContent).toContain('Booting agent');
   });
 
-  it('keeps a streaming answer inside the message column', () => {
+  it('caps the answering preview and opens the session on click', () => {
+    const onOpen = vi.fn();
     const { container } = render(() => (
-      <div style={{ width: '320px' }}>
-        <MagicChipView
-          agentSessionId="session-2"
-          presentation={{
-            kind: 'answering',
-            markdown: `Inspecting \`${LONG_PATH}\``,
-            activity: {
-              label: 'Reading files',
-              detail: LONG_PATH,
-              busy: true,
-            },
-          }}
-        />
-      </div>
+      <MagicChipView
+        agentSessionId="session"
+        presentation={{
+          kind: 'answering',
+          markdown: 'Hello from the agent',
+          activity: { label: 'Writing response', busy: false },
+        }}
+        onOpen={onOpen}
+      />
     ));
 
-    const chip = container.querySelector('[data-magic-chip="session-2"]');
-    expect(chip?.className).toContain('grid-cols-[minmax(0,1fr)]');
-    expect(chip?.className).toContain('overflow-x-hidden');
-    expect(screen.getByText('Reading files')).toBeTruthy();
+    const preview = container.querySelector('[data-magic-chip-preview]');
+    expect(preview).toBeTruthy();
+    expect(preview?.className).toContain('h-36');
+    expect(preview?.className).toContain('overflow-auto');
+    expect(container.textContent).toContain('Hello from the agent');
+    expect(container.textContent).toContain('Writing response');
+
+    fireEvent.click(preview!);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the settled preview the same height and clickable', () => {
+    const onOpen = vi.fn();
+    const { container } = render(() => (
+      <MagicChipView
+        agentSessionId="session"
+        presentation={{
+          kind: 'settled',
+          markdown: 'All done',
+        }}
+        onOpen={onOpen}
+      />
+    ));
+
+    const preview = container.querySelector('[data-magic-chip-preview]');
+    expect(preview?.className).toContain('h-36');
+    fireEvent.click(preview!);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('pins the preview to the bottom as the answer grows', () => {
+    const [markdown, setMarkdown] = createSignal('first');
+    const { container } = render(() => (
+      <MagicChipView
+        agentSessionId="session"
+        presentation={{
+          kind: 'answering',
+          markdown: markdown(),
+          activity: { label: 'Writing response', busy: true },
+        }}
+      />
+    ));
+
+    const preview = container.querySelector(
+      '[data-magic-chip-preview]'
+    ) as HTMLDivElement;
+    Object.defineProperty(preview, 'scrollHeight', {
+      configurable: true,
+      get: () => 400,
+    });
+    preview.scrollTop = 0;
+
+    setMarkdown('first\n\nsecond paragraph of the answer');
+    expect(preview.scrollTop).toBe(400);
   });
 });

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -3,7 +3,6 @@
  */
 
 import { cleanup, fireEvent, render } from '@solidjs/testing-library';
-import { createSignal } from 'solid-js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MagicChipView } from './MagicChipView';
 
@@ -39,7 +38,7 @@ describe('MagicChipView', () => {
     expect(container.textContent).toContain('Booting agent');
   });
 
-  it('caps the answering preview and opens the session on click', () => {
+  it('clips the answering card and shows the activity in its footer', () => {
     const onOpen = vi.fn();
     const { container } = render(() => (
       <MagicChipView
@@ -53,59 +52,54 @@ describe('MagicChipView', () => {
       />
     ));
 
-    const preview = container.querySelector('[data-magic-chip-preview]');
-    expect(preview).toBeTruthy();
-    expect(preview?.className).toContain('h-36');
-    expect(preview?.className).toContain('overflow-auto');
-    expect(container.textContent).toContain('Hello from the agent');
-    expect(container.textContent).toContain('Writing response');
+    const card = container.querySelector('[data-magic-chip-preview]');
+    expect(card?.className).toContain('rounded-lg');
+    expect(card?.className).not.toContain('border-accent');
 
-    fireEvent.click(preview!);
-    expect(onOpen).toHaveBeenCalledTimes(1);
+    const body = card?.querySelector('[data-message-reply-preview]');
+    expect(body?.className).toContain('max-h-32');
+    expect(body?.className).toContain('overflow-hidden');
+    expect(body?.textContent).toContain('Hello from the agent');
+
+    const footer = card?.querySelector('button');
+    expect(footer?.textContent).toContain('Writing response');
+    expect(footer?.textContent).not.toContain('Open session');
+
+    fireEvent.click(body!);
+    fireEvent.click(footer!);
+    expect(onOpen).toHaveBeenCalledTimes(2);
   });
 
-  it('keeps the settled preview the same height and clickable', () => {
+  it('labels the settled footer Open session', () => {
     const onOpen = vi.fn();
     const { container } = render(() => (
       <MagicChipView
         agentSessionId="session"
-        presentation={{
-          kind: 'settled',
-          markdown: 'All done',
-        }}
+        presentation={{ kind: 'settled', markdown: 'All done' }}
         onOpen={onOpen}
       />
     ));
 
-    const preview = container.querySelector('[data-magic-chip-preview]');
-    expect(preview?.className).toContain('h-36');
-    fireEvent.click(preview!);
+    const card = container.querySelector('[data-magic-chip-preview]');
+    const footer = card?.querySelector('button');
+    expect(footer?.textContent).toContain('Open session');
+    fireEvent.click(footer!);
     expect(onOpen).toHaveBeenCalledTimes(1);
   });
 
-  it('pins the preview to the bottom as the answer grows', () => {
-    const [markdown, setMarkdown] = createSignal('first');
+  it('uses the rendered answer as the reply preview, not the footer', () => {
     const { container } = render(() => (
       <MagicChipView
         agentSessionId="session"
         presentation={{
           kind: 'answering',
-          markdown: markdown(),
+          markdown: 'Answer text',
           activity: { label: 'Writing response', busy: true },
         }}
       />
     ));
 
-    const preview = container.querySelector(
-      '[data-magic-chip-preview]'
-    ) as HTMLDivElement;
-    Object.defineProperty(preview, 'scrollHeight', {
-      configurable: true,
-      get: () => 400,
-    });
-    preview.scrollTop = 0;
-
-    setMarkdown('first\n\nsecond paragraph of the answer');
-    expect(preview.scrollTop).toBe(400);
+    const preview = container.querySelector('[data-message-reply-preview]');
+    expect(preview?.textContent).toBe('Answer text');
   });
 });

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -58,8 +58,11 @@ describe('MagicChipView', () => {
       'Booting agent'
     );
 
+    // Nothing to expand yet, so the answer area leads to the session too.
+    expect(answerArea(container)?.getAttribute('aria-expanded')).toBeNull();
+    fireEvent.click(answerArea(container)!);
     fireEvent.click(footer!);
-    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen).toHaveBeenCalledTimes(2);
   });
 
   it('keeps the same answer height once the answer streams in', () => {
@@ -79,17 +82,63 @@ describe('MagicChipView', () => {
     expect(answerArea(container)?.className).toContain('h-22');
     expect(container.querySelector('[data-magic-chip-pending]')).toBeNull();
 
-    const body = container.querySelector('[data-message-reply-preview]');
-    expect(body?.className).toContain('overflow-hidden');
-    expect(body?.textContent).toBe('Hello from the agent');
+    const clip = container.querySelector('[data-magic-chip-clip]');
+    expect(clip?.className).toContain('overflow-hidden');
+    const preview = container.querySelector('[data-message-reply-preview]');
+    expect(preview?.textContent).toBe('Hello from the agent');
 
     const footer = container.querySelector('[data-magic-chip-preview] button');
     expect(footer?.textContent).toContain('Writing response');
     expect(footer?.textContent).not.toContain('Open session');
 
-    fireEvent.click(body!);
     fireEvent.click(footer!);
-    expect(onOpen).toHaveBeenCalledTimes(2);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('expands the answer in place on click and collapses again', () => {
+    const onOpen = vi.fn();
+    const { container } = render(() => (
+      <MagicChipView
+        agentSessionId="session"
+        presentation={{ kind: 'settled', markdown: 'All done' }}
+        onOpen={onOpen}
+      />
+    ));
+
+    const area = answerArea(container)!;
+    const clip = () => container.querySelector('[data-magic-chip-clip]');
+    expect(area.getAttribute('aria-expanded')).toBe('false');
+    expect(area.className).toContain('h-22');
+    expect(area.textContent).not.toContain('Show less');
+
+    fireEvent.click(area);
+    expect(area.getAttribute('aria-expanded')).toBe('true');
+    expect(area.className).not.toContain('h-22');
+    expect(clip()?.className).not.toContain('overflow-hidden');
+    expect(area.textContent).toContain('Show less');
+    expect(onOpen).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(area, { key: 'Enter' });
+    expect(area.getAttribute('aria-expanded')).toBe('false');
+    expect(area.className).toContain('h-22');
+    expect(clip()?.className).toContain('overflow-hidden');
+    expect(area.textContent).not.toContain('Show less');
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('keeps the disclosure hint out of the reply preview text', () => {
+    const { container } = render(() => (
+      <MagicChipView
+        agentSessionId="session"
+        presentation={{ kind: 'settled', markdown: 'All done' }}
+      />
+    ));
+
+    fireEvent.click(answerArea(container)!);
+    expect(answerArea(container)?.textContent).toContain('Show less');
+    expect(
+      container.querySelector('[data-message-reply-preview]')?.textContent
+    ).toBe('All done');
   });
 
   it('labels the settled footer Open session', () => {

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -23,7 +23,8 @@ vi.mock('@core/component/LexicalMarkdown/theme', () => ({
 afterEach(cleanup);
 
 describe('MagicChipView', () => {
-  it('keeps working state as a single activity line', () => {
+  it('shows the card with the activity row before any answer arrives', () => {
+    const onOpen = vi.fn();
     const { container } = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -31,14 +32,27 @@ describe('MagicChipView', () => {
           kind: 'working',
           activity: { label: 'Booting agent', busy: true },
         }}
+        onOpen={onOpen}
       />
     ));
 
-    expect(container.querySelector('[data-magic-chip-preview]')).toBeNull();
-    expect(container.textContent).toContain('Booting agent');
+    const card = container.querySelector('[data-magic-chip-preview]');
+    expect(card?.className).toContain('rounded-lg');
+    expect(card?.className).not.toContain('border-accent');
+    expect(container.querySelector('[data-testid="chip-markdown"]')).toBeNull();
+
+    const footer = card?.querySelector('button');
+    expect(footer?.textContent).toContain('Booting agent');
+    expect(footer?.className).not.toContain('border-t');
+    expect(footer?.getAttribute('data-message-reply-preview')).toBe(
+      'Booting agent'
+    );
+
+    fireEvent.click(footer!);
+    expect(onOpen).toHaveBeenCalledTimes(1);
   });
 
-  it('clips the answering card and shows the activity in its footer', () => {
+  it('clips the answer above the activity row while streaming', () => {
     const onOpen = vi.fn();
     const { container } = render(() => (
       <MagicChipView
@@ -53,15 +67,13 @@ describe('MagicChipView', () => {
     ));
 
     const card = container.querySelector('[data-magic-chip-preview]');
-    expect(card?.className).toContain('rounded-lg');
-    expect(card?.className).not.toContain('border-accent');
-
     const body = card?.querySelector('[data-message-reply-preview]');
     expect(body?.className).toContain('max-h-32');
     expect(body?.className).toContain('overflow-hidden');
-    expect(body?.textContent).toContain('Hello from the agent');
+    expect(body?.textContent).toBe('Hello from the agent');
 
     const footer = card?.querySelector('button');
+    expect(footer?.className).toContain('border-t');
     expect(footer?.textContent).toContain('Writing response');
     expect(footer?.textContent).not.toContain('Open session');
 
@@ -80,26 +92,9 @@ describe('MagicChipView', () => {
       />
     ));
 
-    const card = container.querySelector('[data-magic-chip-preview]');
-    const footer = card?.querySelector('button');
+    const footer = container.querySelector('[data-magic-chip-preview] button');
     expect(footer?.textContent).toContain('Open session');
     fireEvent.click(footer!);
     expect(onOpen).toHaveBeenCalledTimes(1);
-  });
-
-  it('uses the rendered answer as the reply preview, not the footer', () => {
-    const { container } = render(() => (
-      <MagicChipView
-        agentSessionId="session"
-        presentation={{
-          kind: 'answering',
-          markdown: 'Answer text',
-          activity: { label: 'Writing response', busy: true },
-        }}
-      />
-    ));
-
-    const preview = container.querySelector('[data-message-reply-preview]');
-    expect(preview?.textContent).toBe('Answer text');
   });
 });

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -7,13 +7,7 @@ import { PulsingStar } from '@entity/components/PulsingStar';
 import ArrowUpRight from '@phosphor/arrow-up-right.svg';
 import CaretRight from '@phosphor/caret-right.svg';
 import { Layer } from '@ui';
-import {
-  type Component,
-  createSignal,
-  onCleanup,
-  onMount,
-  Show,
-} from 'solid-js';
+import { type Component, createSignal, Show } from 'solid-js';
 import type { MagicChipActivity, MagicChipPresentation } from './presentation';
 
 function answerMarkdown(presentation: MagicChipPresentation) {
@@ -76,55 +70,41 @@ const AnswerPending: Component<{ busy: boolean }> = (props) => (
 );
 
 /**
- * The answer: clipped to four lines with a fade while collapsed, whole once
- * expanded. The fade only shows when the text is actually taller than the
- * clip, so short answers read whole either way.
+ * The answer: clipped to the fixed answer area with a fade while collapsed,
+ * whole once expanded.
  */
 const AnswerBody: Component<{ markdown: string; expanded: boolean }> = (
   props
-) => {
-  const [overflowing, setOverflowing] = createSignal(false);
-  let clip: HTMLDivElement | undefined;
-
-  onMount(() => {
-    const el = clip;
-    if (!el) return;
-    const measure = () => setOverflowing(el.scrollHeight > el.clientHeight + 1);
-    measure();
-    if (typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(measure);
-    observer.observe(el);
-    if (el.firstElementChild) observer.observe(el.firstElementChild);
-    onCleanup(() => observer.disconnect());
-  });
-
-  return (
+) => (
+  <div
+    class="relative"
+    classList={{ 'h-full overflow-hidden': !props.expanded }}
+    data-magic-chip-clip
+  >
     <div
-      ref={(el) => {
-        clip = el;
-      }}
-      class="relative"
-      classList={{ 'h-full overflow-hidden': !props.expanded }}
-      data-magic-chip-clip
+      class="pointer-events-none min-w-0 max-w-full wrap-break-word"
+      data-message-reply-preview
     >
-      <div
-        class="pointer-events-none min-w-0 max-w-full wrap-break-word"
-        data-message-reply-preview
-      >
-        <StaticMarkdownContext theme={channelTheme}>
-          <StaticMarkdown markdown={props.markdown} target="external" />
-        </StaticMarkdownContext>
-      </div>
-      <Show when={overflowing() && !props.expanded}>
-        <div class="pointer-events-none absolute inset-x-0 top-1/2 bottom-0 bg-linear-to-b from-transparent via-surface/80 to-surface group-hover/answer:via-hover/80 group-hover/answer:to-hover" />
-        <ExpandHint expanded={false} />
-      </Show>
-      <Show when={props.expanded}>
-        <ExpandHint expanded />
-      </Show>
+      <StaticMarkdownContext theme={channelTheme}>
+        <StaticMarkdown markdown={props.markdown} target="external" />
+      </StaticMarkdownContext>
     </div>
-  );
-};
+    <Show
+      when={props.expanded}
+      fallback={
+        <>
+          <div
+            class="pointer-events-none absolute inset-x-0 top-1/2 bottom-0 bg-linear-to-b from-transparent via-surface/80 to-surface group-hover/answer:via-hover/80 group-hover/answer:to-hover"
+            data-magic-chip-fade
+          />
+          <ExpandHint expanded={false} />
+        </>
+      }
+    >
+      <ExpandHint expanded />
+    </Show>
+  </div>
+);
 
 /**
  * The disclosure cue: `Show more` over the fade, `Show less` under the text.

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -116,7 +116,7 @@ const AnswerBody: Component<{ markdown: string; expanded: boolean }> = (
         </StaticMarkdownContext>
       </div>
       <Show when={overflowing() && !props.expanded}>
-        <div class="pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-linear-to-b from-transparent via-surface/80 to-surface group-hover/answer:via-hover/80 group-hover/answer:to-hover" />
+        <div class="pointer-events-none absolute inset-x-0 top-1/2 bottom-0 bg-linear-to-b from-transparent via-surface/80 to-surface group-hover/answer:via-hover/80 group-hover/answer:to-hover" />
         <ExpandHint expanded={false} />
       </Show>
       <Show when={props.expanded}>
@@ -126,12 +126,17 @@ const AnswerBody: Component<{ markdown: string; expanded: boolean }> = (
   );
 };
 
-/** The disclosure cue: `Show more` over the fade, `Show less` under the text. */
+/**
+ * The disclosure cue: `Show more` over the fade, `Show less` under the text.
+ * The collapsed cue steps aside while the area is hovered so it never sits
+ * on top of the text the hover is inviting you to read.
+ */
 const ExpandHint: Component<{ expanded: boolean }> = (props) => (
   <span
-    class="pointer-events-none flex items-center gap-1 text-xs text-ink-extra-muted group-hover/answer:text-ink-muted"
+    class="pointer-events-none flex items-center gap-1 text-xs text-ink-extra-muted transition-opacity motion-reduce:transition-none"
     classList={{
-      'absolute right-0 bottom-0 pb-0.5': !props.expanded,
+      'absolute right-0 bottom-0 pb-0.5 group-hover/answer:opacity-0':
+        !props.expanded,
       'pt-1 pb-0.5': props.expanded,
     }}
     aria-hidden="true"

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -8,31 +8,26 @@ import { Layer } from '@ui';
 import {
   type Component,
   createSignal,
-  Match,
   onCleanup,
   onMount,
   Show,
-  Switch,
 } from 'solid-js';
 import type { MagicChipActivity, MagicChipPresentation } from './presentation';
 
-function working(presentation: MagicChipPresentation) {
-  return presentation.kind === 'working' ? presentation : undefined;
+function answerMarkdown(presentation: MagicChipPresentation) {
+  return presentation.kind === 'working' ? undefined : presentation.markdown;
 }
 
-function answering(presentation: MagicChipPresentation) {
-  return presentation.kind === 'answering' ? presentation : undefined;
+function currentActivity(presentation: MagicChipPresentation) {
+  return presentation.kind === 'settled' ? undefined : presentation.activity;
 }
 
-function settled(presentation: MagicChipPresentation) {
-  return presentation.kind === 'settled' ? presentation : undefined;
-}
-
-function replyPreview(activity: MagicChipActivity) {
+function replyPreview(activity: MagicChipActivity | undefined) {
+  if (!activity) return 'Open session';
   return `${activity.label}${activity.detail ? ` ${activity.detail}` : ''}`;
 }
 
-/** The shimmering label plus its muted detail, shared by every activity row. */
+/** The shimmering label plus its muted detail. */
 const ActivityText: Component<{ activity: MagicChipActivity }> = (props) => (
   <>
     <span
@@ -59,36 +54,11 @@ const ActivityText: Component<{ activity: MagicChipActivity }> = (props) => (
   </>
 );
 
-/** Fixed-height activity line — no box, just a shimmering label in the flow. */
-const ActivityLine: Component<{
-  agentSessionId: string;
-  activity: MagicChipActivity;
-  onOpen?: () => void;
-}> = (props) => (
-  <button
-    type="button"
-    class="flex h-6 w-full min-w-0 items-center gap-1.5 text-left text-xs"
-    data-magic-chip={props.agentSessionId}
-    data-message-reply-preview={replyPreview(props.activity)}
-    disabled={!props.onOpen}
-    onMouseDown={(event) => event.preventDefault()}
-    onClick={props.onOpen}
-  >
-    <ActivityText activity={props.activity} />
-  </button>
-);
-
 /**
- * The answer as a card: the opening of the response, clipped to six lines
- * and faded out, with a footer that says what the agent is doing (or that it
- * is done). Clicking anywhere opens the session for the rest.
+ * The opening of the answer, clipped to six lines. The fade only shows once
+ * the text is actually taller than the clip, so short answers read whole.
  */
-const AnswerCard: Component<{
-  agentSessionId: string;
-  markdown: string;
-  activity?: MagicChipActivity;
-  onOpen?: () => void;
-}> = (props) => {
+const AnswerBody: Component<{ markdown: string }> = (props) => {
   const [overflowing, setOverflowing] = createSignal(false);
   let clip: HTMLDivElement | undefined;
 
@@ -105,6 +75,40 @@ const AnswerCard: Component<{
   });
 
   return (
+    <div
+      ref={(el) => {
+        clip = el;
+      }}
+      class="relative max-h-32 overflow-hidden px-3 py-1"
+      data-message-reply-preview
+    >
+      <div class="pointer-events-none min-w-0 max-w-full wrap-break-word">
+        <StaticMarkdownContext theme={channelTheme}>
+          <StaticMarkdown markdown={props.markdown} target="external" />
+        </StaticMarkdownContext>
+      </div>
+      <Show when={overflowing()}>
+        <div class="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-linear-to-b from-transparent to-surface" />
+      </Show>
+    </div>
+  );
+};
+
+/**
+ * One card for the whole turn, so the chrome is there from the first
+ * moment: a status row while the agent works, the opening of the answer
+ * above that row as it is written, and `Open session` once the turn ends.
+ * Clicking anywhere opens the session.
+ */
+export const MagicChipView: Component<{
+  agentSessionId: string;
+  presentation: MagicChipPresentation;
+  onOpen?: () => void;
+}> = (props) => {
+  const markdown = () => answerMarkdown(props.presentation);
+  const activity = () => currentActivity(props.presentation);
+
+  return (
     <Layer depth={2}>
       <div
         class="my-2 w-full overflow-hidden rounded-lg border border-edge-muted bg-surface"
@@ -113,33 +117,24 @@ const AnswerCard: Component<{
         onMouseDown={(event) => event.preventDefault()}
         onClick={props.onOpen}
       >
-        <div
-          ref={(el) => {
-            clip = el;
-          }}
-          class="relative max-h-32 overflow-hidden px-3 py-1"
-          data-message-reply-preview
-        >
-          <div class="pointer-events-none min-w-0 max-w-full wrap-break-word">
-            <StaticMarkdownContext theme={channelTheme}>
-              <StaticMarkdown markdown={props.markdown} target="external" />
-            </StaticMarkdownContext>
-          </div>
-          <Show when={overflowing()}>
-            <div class="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-linear-to-b from-transparent to-surface" />
-          </Show>
-        </div>
+        <Show when={markdown()}>
+          {(answer) => <AnswerBody markdown={answer()} />}
+        </Show>
         <button
           type="button"
-          class="flex min-h-9 w-full items-center gap-1.5 border-t border-edge-muted px-3 py-2 text-left text-xs leading-5 text-ink-extra-muted hover:bg-hover"
+          class="flex min-h-9 w-full items-center gap-1.5 px-3 py-2 text-left text-xs leading-5 text-ink-extra-muted hover:bg-hover"
+          classList={{ 'border-t border-edge-muted': Boolean(markdown()) }}
+          data-message-reply-preview={
+            markdown() ? undefined : replyPreview(activity())
+          }
           disabled={!props.onOpen}
         >
           <span class="flex min-w-0 flex-1 items-center gap-1.5">
             <Show
-              when={props.activity}
+              when={activity()}
               fallback={<span class="text-ink-muted">Open session</span>}
             >
-              {(activity) => <ActivityText activity={activity()} />}
+              {(current) => <ActivityText activity={current()} />}
             </Show>
           </span>
           <ArrowUpRight aria-hidden="true" class="size-3 shrink-0" />
@@ -148,41 +143,3 @@ const AnswerCard: Component<{
     </Layer>
   );
 };
-
-/** Render an already-derived Magic Chip presentation. */
-export const MagicChipView: Component<{
-  agentSessionId: string;
-  presentation: MagicChipPresentation;
-  onOpen?: () => void;
-}> = (props) => (
-  <Switch>
-    <Match when={working(props.presentation)}>
-      {(presentation) => (
-        <ActivityLine
-          agentSessionId={props.agentSessionId}
-          activity={presentation().activity}
-          onOpen={props.onOpen}
-        />
-      )}
-    </Match>
-    <Match when={answering(props.presentation)}>
-      {(presentation) => (
-        <AnswerCard
-          agentSessionId={props.agentSessionId}
-          markdown={presentation().markdown}
-          activity={presentation().activity}
-          onOpen={props.onOpen}
-        />
-      )}
-    </Match>
-    <Match when={settled(props.presentation)}>
-      {(presentation) => (
-        <AnswerCard
-          agentSessionId={props.agentSessionId}
-          markdown={presentation().markdown}
-          onOpen={props.onOpen}
-        />
-      )}
-    </Match>
-  </Switch>
-);

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -3,11 +3,12 @@ import {
   StaticMarkdownContext,
 } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
 import { channelTheme } from '@core/component/LexicalMarkdown/theme';
+import ArrowUpRight from '@phosphor/arrow-up-right.svg';
+import { Layer } from '@ui';
 import {
   type Component,
-  createEffect,
+  createSignal,
   Match,
-  on,
   onCleanup,
   onMount,
   Show,
@@ -27,6 +28,37 @@ function settled(presentation: MagicChipPresentation) {
   return presentation.kind === 'settled' ? presentation : undefined;
 }
 
+function replyPreview(activity: MagicChipActivity) {
+  return `${activity.label}${activity.detail ? ` ${activity.detail}` : ''}`;
+}
+
+/** The shimmering label plus its muted detail, shared by every activity row. */
+const ActivityText: Component<{ activity: MagicChipActivity }> = (props) => (
+  <>
+    <span
+      class="shrink-0"
+      classList={{
+        'magic-chip-shimmer': props.activity.busy,
+        'text-ink-muted': !props.activity.busy,
+      }}
+    >
+      {props.activity.label}
+    </span>
+    <Show when={props.activity.detail}>
+      {(detail) => (
+        <>
+          <span aria-hidden="true" class="shrink-0 text-ink-placeholder">
+            ·
+          </span>
+          <span class="min-w-0 truncate text-ink-extra-muted" title={detail()}>
+            {detail()}
+          </span>
+        </>
+      )}
+    </Show>
+  </>
+);
+
 /** Fixed-height activity line — no box, just a shimmering label in the flow. */
 const ActivityLine: Component<{
   agentSessionId: string;
@@ -35,140 +67,87 @@ const ActivityLine: Component<{
 }> = (props) => (
   <button
     type="button"
-    class="flex h-6 w-full min-w-0 items-center gap-2 text-left"
+    class="flex h-6 w-full min-w-0 items-center gap-1.5 text-left text-xs"
     data-magic-chip={props.agentSessionId}
-    data-message-reply-preview={`${props.activity.label}${
-      props.activity.detail ? ` ${props.activity.detail}` : ''
-    }`}
+    data-message-reply-preview={replyPreview(props.activity)}
     disabled={!props.onOpen}
     onMouseDown={(event) => event.preventDefault()}
     onClick={props.onOpen}
   >
-    <span
-      class="shrink-0 text-xs font-semibold"
-      classList={{
-        'magic-chip-shimmer': props.activity.busy,
-        'text-ink-muted': !props.activity.busy,
-      }}
-      aria-live="polite"
-    >
-      {props.activity.label}
-    </span>
-    <Show when={props.activity.detail}>
-      {(detail) => (
-        <span class="min-w-0 truncate text-xs text-ink-extra-muted">
-          {detail()}
-        </span>
-      )}
-    </Show>
+    <ActivityText activity={props.activity} />
   </button>
 );
 
-function pinToBottom(el: HTMLElement) {
-  el.scrollTop = el.scrollHeight;
-}
-
 /**
- * Quoted answer preview. Fixed height so the thread does not grow as the
- * agent writes; the latest text stays in view, and a click opens the session.
+ * The answer as a card: the opening of the response, clipped to six lines
+ * and faded out, with a footer that says what the agent is doing (or that it
+ * is done). Clicking anywhere opens the session for the rest.
  */
-const AnswerBody: Component<{
+const AnswerCard: Component<{
+  agentSessionId: string;
   markdown: string;
+  activity?: MagicChipActivity;
   onOpen?: () => void;
 }> = (props) => {
-  let scroller: HTMLDivElement | undefined;
+  const [overflowing, setOverflowing] = createSignal(false);
+  let clip: HTMLDivElement | undefined;
 
   onMount(() => {
-    const el = scroller;
+    const el = clip;
     if (!el) return;
-    pinToBottom(el);
-    const inner = el.firstElementChild;
-    if (!inner || typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(() => pinToBottom(el));
-    observer.observe(inner);
+    const measure = () => setOverflowing(el.scrollHeight > el.clientHeight + 1);
+    measure();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    if (el.firstElementChild) observer.observe(el.firstElementChild);
     onCleanup(() => observer.disconnect());
   });
 
-  createEffect(
-    on(
-      () => props.markdown,
-      () => {
-        const el = scroller;
-        if (el) pinToBottom(el);
-      }
-    )
-  );
-
   return (
-    <div
-      ref={(el) => {
-        scroller = el;
-      }}
-      class="h-36 w-full min-w-0 max-w-full overflow-auto overscroll-contain border-l-2 border-accent pl-3 text-left text-sm leading-6"
-      data-magic-chip-preview
-      data-message-reply-preview
-      onMouseDown={(event) => event.preventDefault()}
-      onClick={props.onOpen}
-    >
-      <div class="pointer-events-none min-w-0 max-w-full wrap-break-word">
-        <StaticMarkdownContext theme={channelTheme}>
-          <StaticMarkdown markdown={props.markdown} target="external" />
-        </StaticMarkdownContext>
+    <Layer depth={2}>
+      <div
+        class="my-2 w-full overflow-hidden rounded-lg border border-edge-muted bg-surface"
+        data-magic-chip={props.agentSessionId}
+        data-magic-chip-preview
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={props.onOpen}
+      >
+        <div
+          ref={(el) => {
+            clip = el;
+          }}
+          class="relative max-h-32 overflow-hidden px-3 py-1"
+          data-message-reply-preview
+        >
+          <div class="pointer-events-none min-w-0 max-w-full wrap-break-word">
+            <StaticMarkdownContext theme={channelTheme}>
+              <StaticMarkdown markdown={props.markdown} target="external" />
+            </StaticMarkdownContext>
+          </div>
+          <Show when={overflowing()}>
+            <div class="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-linear-to-b from-transparent to-surface" />
+          </Show>
+        </div>
+        <button
+          type="button"
+          class="flex min-h-9 w-full items-center gap-1.5 border-t border-edge-muted px-3 py-2 text-left text-xs leading-5 text-ink-extra-muted hover:bg-hover"
+          disabled={!props.onOpen}
+        >
+          <span class="flex min-w-0 flex-1 items-center gap-1.5">
+            <Show
+              when={props.activity}
+              fallback={<span class="text-ink-muted">Open session</span>}
+            >
+              {(activity) => <ActivityText activity={activity()} />}
+            </Show>
+          </span>
+          <ArrowUpRight aria-hidden="true" class="size-3 shrink-0" />
+        </button>
       </div>
-    </div>
+    </Layer>
   );
 };
-
-/**
- * The answer as it is being written, with the activity line beneath it.
- *
- * The same quoted body the settled state uses, so the turn ending changes
- * only what is under the answer, not the answer itself — no reflow at the
- * moment the agent stops.
- */
-const StreamingAnswer: Component<{
-  agentSessionId: string;
-  markdown: string;
-  activity: MagicChipActivity;
-  onOpen?: () => void;
-}> = (props) => (
-  <div
-    class="grid w-full min-w-0 justify-items-start gap-1"
-    data-magic-chip={props.agentSessionId}
-  >
-    <AnswerBody markdown={props.markdown} onOpen={props.onOpen} />
-    <div class="w-full pl-3">
-      <ActivityLine
-        agentSessionId={props.agentSessionId}
-        activity={props.activity}
-        onOpen={props.onOpen}
-      />
-    </div>
-  </div>
-);
-
-/** The settled response, quoted as if the agent had answered inline. */
-const SettledAnswer: Component<{
-  agentSessionId: string;
-  markdown: string;
-  onOpen?: () => void;
-}> = (props) => (
-  <div
-    class="grid w-full min-w-0 justify-items-start gap-1"
-    data-magic-chip={props.agentSessionId}
-  >
-    <AnswerBody markdown={props.markdown} onOpen={props.onOpen} />
-    <button
-      type="button"
-      class="pl-3.5 mb-2 text-xs text-ink-extra-muted hover:text-ink"
-      onMouseDown={(event) => event.preventDefault()}
-      onClick={props.onOpen}
-      disabled={!props.onOpen}
-    >
-      Open session
-    </button>
-  </div>
-);
 
 /** Render an already-derived Magic Chip presentation. */
 export const MagicChipView: Component<{
@@ -188,7 +167,7 @@ export const MagicChipView: Component<{
     </Match>
     <Match when={answering(props.presentation)}>
       {(presentation) => (
-        <StreamingAnswer
+        <AnswerCard
           agentSessionId={props.agentSessionId}
           markdown={presentation().markdown}
           activity={presentation().activity}
@@ -198,7 +177,7 @@ export const MagicChipView: Component<{
     </Match>
     <Match when={settled(props.presentation)}>
       {(presentation) => (
-        <SettledAnswer
+        <AnswerCard
           agentSessionId={props.agentSessionId}
           markdown={presentation().markdown}
           onOpen={props.onOpen}

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -36,6 +36,7 @@ const ActivityText: Component<{ activity: MagicChipActivity }> = (props) => (
         'magic-chip-shimmer': props.activity.busy,
         'text-ink-muted': !props.activity.busy,
       }}
+      aria-live="polite"
     >
       {props.activity.label}
     </span>
@@ -45,13 +46,34 @@ const ActivityText: Component<{ activity: MagicChipActivity }> = (props) => (
           <span aria-hidden="true" class="shrink-0 text-ink-placeholder">
             ·
           </span>
-          <span class="min-w-0 truncate text-ink-extra-muted" title={detail()}>
+          <span
+            class="min-w-0 flex-1 truncate text-ink-extra-muted"
+            title={detail()}
+          >
             {detail()}
           </span>
         </>
       )}
     </Show>
   </>
+);
+
+/** Placeholder lines that hold the answer's space until the agent writes. */
+const AnswerSkeleton: Component<{ busy: boolean }> = (props) => (
+  <div class="flex flex-col gap-3 pt-2" aria-hidden="true">
+    <div
+      class="h-3 w-11/12 rounded-full bg-skeleton"
+      classList={{ 'skeleton-shimmer': props.busy }}
+    />
+    <div
+      class="h-3 w-4/5 rounded-full bg-skeleton"
+      classList={{ 'skeleton-shimmer': props.busy }}
+    />
+    <div
+      class="h-3 w-3/5 rounded-full bg-skeleton"
+      classList={{ 'skeleton-shimmer': props.busy }}
+    />
+  </div>
 );
 
 /**
@@ -79,7 +101,7 @@ const AnswerBody: Component<{ markdown: string }> = (props) => {
       ref={(el) => {
         clip = el;
       }}
-      class="relative max-h-32 overflow-hidden px-3 py-1"
+      class="relative h-full overflow-hidden"
       data-message-reply-preview
     >
       <div class="pointer-events-none min-w-0 max-w-full wrap-break-word">
@@ -95,10 +117,10 @@ const AnswerBody: Component<{ markdown: string }> = (props) => {
 };
 
 /**
- * One card for the whole turn, so the chrome is there from the first
- * moment: a status row while the agent works, the opening of the answer
- * above that row as it is written, and `Open session` once the turn ends.
- * Clicking anywhere opens the session.
+ * One card, one height, for the whole turn: the answer area is reserved from
+ * the first moment (skeleton lines while the agent works, the opening of the
+ * answer once it writes) so the thread never jumps, and the bottom row reads
+ * the current activity or `Open session`. Clicking anywhere opens the session.
  */
 export const MagicChipView: Component<{
   agentSessionId: string;
@@ -111,19 +133,23 @@ export const MagicChipView: Component<{
   return (
     <Layer depth={2}>
       <div
-        class="my-2 w-full overflow-hidden rounded-lg border border-edge-muted bg-surface"
+        class="my-2 w-full min-w-0 max-w-full overflow-hidden rounded-lg border border-edge-muted bg-surface"
         data-magic-chip={props.agentSessionId}
         data-magic-chip-preview
         onMouseDown={(event) => event.preventDefault()}
         onClick={props.onOpen}
       >
-        <Show when={markdown()}>
-          {(answer) => <AnswerBody markdown={answer()} />}
-        </Show>
+        <div class="h-32 px-3 py-1" data-magic-chip-answer>
+          <Show
+            when={markdown()}
+            fallback={<AnswerSkeleton busy={activity()?.busy ?? false} />}
+          >
+            {(answer) => <AnswerBody markdown={answer()} />}
+          </Show>
+        </div>
         <button
           type="button"
-          class="flex min-h-9 w-full items-center gap-1.5 px-3 py-2 text-left text-xs leading-5 text-ink-extra-muted hover:bg-hover"
-          classList={{ 'border-t border-edge-muted': Boolean(markdown()) }}
+          class="flex min-h-9 w-full items-center gap-1.5 border-t border-edge-muted px-3 py-2 text-left text-xs leading-5 text-ink-extra-muted hover:bg-hover"
           data-message-reply-preview={
             markdown() ? undefined : replyPreview(activity())
           }

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -5,6 +5,7 @@ import {
 import { channelTheme } from '@core/component/LexicalMarkdown/theme';
 import { PulsingStar } from '@entity/components/PulsingStar';
 import ArrowUpRight from '@phosphor/arrow-up-right.svg';
+import CaretRight from '@phosphor/caret-right.svg';
 import { Layer } from '@ui';
 import {
   type Component,
@@ -75,10 +76,13 @@ const AnswerPending: Component<{ busy: boolean }> = (props) => (
 );
 
 /**
- * The opening of the answer, clipped to four lines. The fade only shows once
- * the text is actually taller than the clip, so short answers read whole.
+ * The answer: clipped to four lines with a fade while collapsed, whole once
+ * expanded. The fade only shows when the text is actually taller than the
+ * clip, so short answers read whole either way.
  */
-const AnswerBody: Component<{ markdown: string }> = (props) => {
+const AnswerBody: Component<{ markdown: string; expanded: boolean }> = (
+  props
+) => {
   const [overflowing, setOverflowing] = createSignal(false);
   let clip: HTMLDivElement | undefined;
 
@@ -99,26 +103,53 @@ const AnswerBody: Component<{ markdown: string }> = (props) => {
       ref={(el) => {
         clip = el;
       }}
-      class="relative h-full overflow-hidden"
-      data-message-reply-preview
+      class="relative"
+      classList={{ 'h-full overflow-hidden': !props.expanded }}
+      data-magic-chip-clip
     >
-      <div class="pointer-events-none min-w-0 max-w-full wrap-break-word">
+      <div
+        class="pointer-events-none min-w-0 max-w-full wrap-break-word"
+        data-message-reply-preview
+      >
         <StaticMarkdownContext theme={channelTheme}>
           <StaticMarkdown markdown={props.markdown} target="external" />
         </StaticMarkdownContext>
       </div>
-      <Show when={overflowing()}>
-        <div class="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-linear-to-b from-transparent to-surface" />
+      <Show when={overflowing() && !props.expanded}>
+        <div class="pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-linear-to-b from-transparent via-surface/80 to-surface group-hover/answer:via-hover/80 group-hover/answer:to-hover" />
+        <ExpandHint expanded={false} />
+      </Show>
+      <Show when={props.expanded}>
+        <ExpandHint expanded />
       </Show>
     </div>
   );
 };
 
+/** The disclosure cue: `Show more` over the fade, `Show less` under the text. */
+const ExpandHint: Component<{ expanded: boolean }> = (props) => (
+  <span
+    class="pointer-events-none flex items-center gap-1 text-xs text-ink-extra-muted group-hover/answer:text-ink-muted"
+    classList={{
+      'absolute right-0 bottom-0 pb-0.5': !props.expanded,
+      'pt-1 pb-0.5': props.expanded,
+    }}
+    aria-hidden="true"
+  >
+    <CaretRight
+      class="size-3 shrink-0 transition-transform motion-reduce:transition-none"
+      classList={{ 'rotate-90': props.expanded }}
+    />
+    {props.expanded ? 'Show less' : 'Show more'}
+  </span>
+);
+
 /**
- * One card, one height, for the whole turn: the answer area is reserved from
- * the first moment (a pulsing star while the agent works, the opening of the
- * answer once it writes) so the thread never jumps, and the bottom row reads
- * the current activity or `Open session`. Clicking anywhere opens the session.
+ * One card for the whole turn: the answer area is reserved from the first
+ * moment (a pulsing star while the agent works, the opening of the answer
+ * once it writes) so the thread never jumps, and the bottom row reads the
+ * current activity or `Open session`. Clicking the answer expands it in
+ * place; clicking the row opens the session.
  */
 export const MagicChipView: Component<{
   agentSessionId: string;
@@ -127,6 +158,14 @@ export const MagicChipView: Component<{
 }> = (props) => {
   const markdown = () => answerMarkdown(props.presentation);
   const activity = () => currentActivity(props.presentation);
+  const [expanded, setExpanded] = createSignal(false);
+
+  // Before there is an answer there is nothing to expand, so the whole card
+  // leads to the session.
+  const onAnswerClick = () => {
+    if (markdown()) setExpanded((open) => !open);
+    else props.onOpen?.();
+  };
 
   return (
     <Layer depth={2}>
@@ -135,14 +174,28 @@ export const MagicChipView: Component<{
         data-magic-chip={props.agentSessionId}
         data-magic-chip-preview
         onMouseDown={(event) => event.preventDefault()}
-        onClick={props.onOpen}
       >
-        <div class="h-22 px-3 py-1" data-magic-chip-answer>
+        <div
+          role="button"
+          tabIndex={0}
+          aria-expanded={markdown() ? expanded() : undefined}
+          class="group/answer px-3 py-1 text-left hover:bg-hover"
+          classList={{ 'h-22': !expanded() }}
+          data-magic-chip-answer
+          onClick={onAnswerClick}
+          onKeyDown={(event) => {
+            if (event.key !== 'Enter' && event.key !== ' ') return;
+            event.preventDefault();
+            onAnswerClick();
+          }}
+        >
           <Show
             when={markdown()}
             fallback={<AnswerPending busy={activity()?.busy ?? false} />}
           >
-            {(answer) => <AnswerBody markdown={answer()} />}
+            {(answer) => (
+              <AnswerBody markdown={answer()} expanded={expanded()} />
+            )}
           </Show>
         </div>
         <button
@@ -152,6 +205,7 @@ export const MagicChipView: Component<{
             markdown() ? undefined : replyPreview(activity())
           }
           disabled={!props.onOpen}
+          onClick={props.onOpen}
         >
           <span class="flex min-w-0 flex-1 items-center gap-1.5">
             <Show

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -3,17 +3,17 @@ import {
   StaticMarkdownContext,
 } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
 import { channelTheme } from '@core/component/LexicalMarkdown/theme';
-import { type Component, Match, Show, Switch } from 'solid-js';
+import {
+  type Component,
+  createEffect,
+  Match,
+  on,
+  onCleanup,
+  onMount,
+  Show,
+  Switch,
+} from 'solid-js';
 import type { MagicChipActivity, MagicChipPresentation } from './presentation';
-
-/**
- * Keep the chip inside the message column. A default grid track sizes to
- * min-content, so a streaming thought, path, or unbreakable token can grow
- * the chip past the chat edge — the reply is still in the DOM, just off
- * screen, which looks like the agent never answered.
- */
-const CHIP_BOUNDS = 'w-full min-w-0 max-w-full overflow-x-hidden';
-const CHIP_STACK = `grid ${CHIP_BOUNDS} grid-cols-[minmax(0,1fr)] gap-1`;
 
 function working(presentation: MagicChipPresentation) {
   return presentation.kind === 'working' ? presentation : undefined;
@@ -35,7 +35,7 @@ const ActivityLine: Component<{
 }> = (props) => (
   <button
     type="button"
-    class={`flex h-6 ${CHIP_BOUNDS} items-center gap-2 text-left`}
+    class="flex h-6 w-full min-w-0 items-center gap-2 text-left"
     data-magic-chip={props.agentSessionId}
     data-message-reply-preview={`${props.activity.label}${
       props.activity.detail ? ` ${props.activity.detail}` : ''
@@ -56,7 +56,7 @@ const ActivityLine: Component<{
     </span>
     <Show when={props.activity.detail}>
       {(detail) => (
-        <span class="min-w-0 flex-1 truncate text-xs text-ink-extra-muted">
+        <span class="min-w-0 truncate text-xs text-ink-extra-muted">
           {detail()}
         </span>
       )}
@@ -64,17 +64,60 @@ const ActivityLine: Component<{
   </button>
 );
 
-/** The response, quoted as if the agent had answered inline. */
-const AnswerBody: Component<{ markdown: string }> = (props) => (
-  <div
-    class={`${CHIP_BOUNDS} wrap-break-word border-l-2 border-accent pl-3 text-left text-sm leading-6`}
-    data-message-reply-preview
-  >
-    <StaticMarkdownContext theme={channelTheme}>
-      <StaticMarkdown markdown={props.markdown} target="external" />
-    </StaticMarkdownContext>
-  </div>
-);
+function pinToBottom(el: HTMLElement) {
+  el.scrollTop = el.scrollHeight;
+}
+
+/**
+ * Quoted answer preview. Fixed height so the thread does not grow as the
+ * agent writes; the latest text stays in view, and a click opens the session.
+ */
+const AnswerBody: Component<{
+  markdown: string;
+  onOpen?: () => void;
+}> = (props) => {
+  let scroller: HTMLDivElement | undefined;
+
+  onMount(() => {
+    const el = scroller;
+    if (!el) return;
+    pinToBottom(el);
+    const inner = el.firstElementChild;
+    if (!inner || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(() => pinToBottom(el));
+    observer.observe(inner);
+    onCleanup(() => observer.disconnect());
+  });
+
+  createEffect(
+    on(
+      () => props.markdown,
+      () => {
+        const el = scroller;
+        if (el) pinToBottom(el);
+      }
+    )
+  );
+
+  return (
+    <div
+      ref={(el) => {
+        scroller = el;
+      }}
+      class="h-36 w-full min-w-0 max-w-full overflow-auto overscroll-contain border-l-2 border-accent pl-3 text-left text-sm leading-6"
+      data-magic-chip-preview
+      data-message-reply-preview
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={props.onOpen}
+    >
+      <div class="pointer-events-none min-w-0 max-w-full wrap-break-word">
+        <StaticMarkdownContext theme={channelTheme}>
+          <StaticMarkdown markdown={props.markdown} target="external" />
+        </StaticMarkdownContext>
+      </div>
+    </div>
+  );
+};
 
 /**
  * The answer as it is being written, with the activity line beneath it.
@@ -89,9 +132,12 @@ const StreamingAnswer: Component<{
   activity: MagicChipActivity;
   onOpen?: () => void;
 }> = (props) => (
-  <div class={CHIP_STACK} data-magic-chip={props.agentSessionId}>
-    <AnswerBody markdown={props.markdown} />
-    <div class={`${CHIP_BOUNDS} pl-3`}>
+  <div
+    class="grid w-full min-w-0 justify-items-start gap-1"
+    data-magic-chip={props.agentSessionId}
+  >
+    <AnswerBody markdown={props.markdown} onOpen={props.onOpen} />
+    <div class="w-full pl-3">
       <ActivityLine
         agentSessionId={props.agentSessionId}
         activity={props.activity}
@@ -107,8 +153,11 @@ const SettledAnswer: Component<{
   markdown: string;
   onOpen?: () => void;
 }> = (props) => (
-  <div class={CHIP_STACK} data-magic-chip={props.agentSessionId}>
-    <AnswerBody markdown={props.markdown} />
+  <div
+    class="grid w-full min-w-0 justify-items-start gap-1"
+    data-magic-chip={props.agentSessionId}
+  >
+    <AnswerBody markdown={props.markdown} onOpen={props.onOpen} />
     <button
       type="button"
       class="pl-3.5 mb-2 text-xs text-ink-extra-muted hover:text-ink"

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -3,6 +3,7 @@ import {
   StaticMarkdownContext,
 } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
 import { channelTheme } from '@core/component/LexicalMarkdown/theme';
+import { PulsingStar } from '@entity/components/PulsingStar';
 import ArrowUpRight from '@phosphor/arrow-up-right.svg';
 import { Layer } from '@ui';
 import {
@@ -58,26 +59,23 @@ const ActivityText: Component<{ activity: MagicChipActivity }> = (props) => (
   </>
 );
 
-/** Placeholder lines that hold the answer's space until the agent writes. */
-const AnswerSkeleton: Component<{ busy: boolean }> = (props) => (
-  <div class="flex flex-col gap-3 pt-2" aria-hidden="true">
-    <div
-      class="h-3 w-11/12 rounded-full bg-skeleton"
-      classList={{ 'skeleton-shimmer': props.busy }}
-    />
-    <div
-      class="h-3 w-4/5 rounded-full bg-skeleton"
-      classList={{ 'skeleton-shimmer': props.busy }}
-    />
-    <div
-      class="h-3 w-3/5 rounded-full bg-skeleton"
-      classList={{ 'skeleton-shimmer': props.busy }}
-    />
+/**
+ * Holds the answer's space until the agent writes: the chat's own waiting
+ * glyph, pulsing while the agent is busy and still while it is not (a
+ * disconnected session, a turn that ended without prose).
+ */
+const AnswerPending: Component<{ busy: boolean }> = (props) => (
+  <div
+    class="flex h-full items-center justify-center"
+    data-magic-chip-pending
+    aria-hidden="true"
+  >
+    <PulsingStar kind="streamIndicator" animate={props.busy} />
   </div>
 );
 
 /**
- * The opening of the answer, clipped to six lines. The fade only shows once
+ * The opening of the answer, clipped to four lines. The fade only shows once
  * the text is actually taller than the clip, so short answers read whole.
  */
 const AnswerBody: Component<{ markdown: string }> = (props) => {
@@ -118,7 +116,7 @@ const AnswerBody: Component<{ markdown: string }> = (props) => {
 
 /**
  * One card, one height, for the whole turn: the answer area is reserved from
- * the first moment (skeleton lines while the agent works, the opening of the
+ * the first moment (a pulsing star while the agent works, the opening of the
  * answer once it writes) so the thread never jumps, and the bottom row reads
  * the current activity or `Open session`. Clicking anywhere opens the session.
  */
@@ -139,10 +137,10 @@ export const MagicChipView: Component<{
         onMouseDown={(event) => event.preventDefault()}
         onClick={props.onOpen}
       >
-        <div class="h-32 px-3 py-1" data-magic-chip-answer>
+        <div class="h-22 px-3 py-1" data-magic-chip-answer>
           <Show
             when={markdown()}
-            fallback={<AnswerSkeleton busy={activity()?.busy ?? false} />}
+            fallback={<AnswerPending busy={activity()?.busy ?? false} />}
           >
             {(answer) => <AnswerBody markdown={answer()} />}
           </Show>

--- a/apps/web/src/lib/queries/agent-session/session-fold.test.ts
+++ b/apps/web/src/lib/queries/agent-session/session-fold.test.ts
@@ -78,6 +78,36 @@ describe('buffer overlap', () => {
     ).toEqual([]);
     expect(dropOverlap([frame(1)], [frame(1), frame(1)])).toEqual([frame(1)]);
   });
+
+  it('matches one entry whose object keys came back in another order', () => {
+    // The persisted log is read from jsonb, which reorders keys; the
+    // realtime frame for the same row keeps the runtime's order.
+    const stored = {
+      createdAt: '2026-08-13T00:00:05Z',
+      direction: 'to_server',
+      content: {
+        type: 'acp',
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'session/prompt',
+        params: { prompt: [{ text: 'hi', type: 'text' }], sessionId: 's' },
+      },
+    } as unknown as AgentSessionLogEntryDto;
+    const live = {
+      content: {
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'session/prompt',
+        params: { sessionId: 's', prompt: [{ type: 'text', text: 'hi' }] },
+        type: 'acp',
+      },
+      direction: 'to_server',
+      createdAt: '2026-08-13T00:00:05Z',
+    } as unknown as AgentSessionLogEntryDto;
+
+    expect(JSON.stringify(stored)).not.toBe(JSON.stringify(live));
+    expect(dropOverlap([stored], [live])).toEqual([]);
+  });
 });
 
 describe('shared session folds', () => {
@@ -108,6 +138,26 @@ describe('shared session folds', () => {
       frame(3),
     ]);
     (await acquired).release();
+  });
+
+  it('skips a late realtime frame the fetched log already held', async () => {
+    harness.getLog.mockResolvedValue(
+      ok({ bot, entries: [frame(1), frame(2)] })
+    );
+    const acquired = await acquireAgentSessionFold({
+      agentSessionId: 'session-a',
+    });
+
+    // The gateway delivers the second row after the HTTP fetch returned it.
+    handleAgentSessionLog(event('session-a', 2));
+    handleAgentSessionLog(event('session-a', 3));
+    await Promise.resolve();
+
+    expect(fold.pushSessionEntries).toHaveBeenCalledTimes(1);
+    expect(fold.pushSessionEntries).toHaveBeenCalledWith('session-a', [
+      frame(3),
+    ]);
+    acquired.release();
   });
 
   it('isolates raw and folded events by session', async () => {

--- a/apps/web/src/lib/queries/agent-session/session-fold.ts
+++ b/apps/web/src/lib/queries/agent-session/session-fold.ts
@@ -31,6 +31,8 @@ type SessionState = {
   foldedSinks: Set<FoldedMessageSink>;
   metadataSinks: Set<SessionMetadataSink>;
   opening?: Promise<void>;
+  /** Drops realtime frames the fetched log already contained. */
+  overlap?: OverlapFilter;
   ready: boolean;
   references: number;
 };
@@ -127,17 +129,16 @@ async function open(state: SessionState): Promise<void> {
     }
 
     state.bot = result.value.bot;
+    state.overlap = createOverlapFilter(result.value.entries);
     await openSession(state.agentSessionId, result.value.entries);
     machineOpen = true;
 
     // Frames can continue arriving while each worker request is in flight.
     // Drain until an empty check and `ready` assignment can happen together.
-    let fetched = result.value.entries;
     while (state.buffered.length > 0) {
       const buffered = state.buffered;
       state.buffered = [];
-      const replay = dropOverlap(fetched, buffered);
-      fetched = [];
+      const replay = state.overlap(buffered);
       if (replay.length > 0) await push(state, replay);
     }
     state.ready = true;
@@ -172,7 +173,11 @@ export function handleAgentSessionLog(event: AgentSessionLogEvent): void {
     state.buffered.push(entry);
     return;
   }
-  void push(state, [entry]).catch((error: unknown) => {
+  // The gateway can deliver a frame after the HTTP log that already held it
+  // was fetched; folding it again would open a second turn for one prompt.
+  const fresh = state.overlap?.([entry]) ?? [entry];
+  if (fresh.length === 0) return;
+  void push(state, fresh).catch((error: unknown) => {
     console.error('[agent-fold] live frame could not be folded', error);
   });
 }
@@ -195,24 +200,62 @@ async function push(
   for (const sink of state.foldedSinks) sink(messages);
 }
 
+type OverlapFilter = (
+  entries: AgentSessionLogEntryDto[]
+) => AgentSessionLogEntryDto[];
+
+/**
+ * A key under which the same log row compares equal however it travelled.
+ *
+ * The fetched log comes out of a jsonb column, which stores object keys in
+ * its own order; realtime frames are serialized from memory in insertion
+ * order. `JSON.stringify` therefore differs for one and the same entry, so
+ * keys are sorted before comparing.
+ */
+function canonical(value: unknown): string {
+  return JSON.stringify(value, (_key, inner: unknown) => {
+    if (!inner || typeof inner !== 'object' || Array.isArray(inner)) {
+      return inner;
+    }
+    return Object.fromEntries(
+      Object.entries(inner as Record<string, unknown>).sort(([a], [b]) =>
+        a < b ? -1 : a > b ? 1 : 0
+      )
+    );
+  });
+}
+
+/**
+ * Build a filter that drops each fetched occurrence once, so realtime frames
+ * that duplicate the snapshot are skipped whenever they arrive, while a
+ * genuinely new frame with the same content later still passes.
+ */
+export function createOverlapFilter(
+  fetched: AgentSessionLogEntryDto[]
+): OverlapFilter {
+  const remaining = new Map<string, number>();
+  for (const entry of fetched) {
+    const key = canonical(entry);
+    remaining.set(key, (remaining.get(key) ?? 0) + 1);
+  }
+
+  return (entries) => {
+    if (remaining.size === 0) return entries;
+    return entries.filter((entry) => {
+      const key = canonical(entry);
+      const count = remaining.get(key);
+      if (!count) return true;
+      if (count === 1) remaining.delete(key);
+      else remaining.set(key, count - 1);
+      return false;
+    });
+  };
+}
+
 /** Return buffered frame occurrences not already present in the snapshot. */
 export function dropOverlap(
   fetched: AgentSessionLogEntryDto[],
   buffered: AgentSessionLogEntryDto[]
 ): AgentSessionLogEntryDto[] {
-  if (buffered.length === 0 || fetched.length === 0) return buffered;
-
-  const fetchedCounts = new Map<string, number>();
-  for (const entry of fetched) {
-    const key = JSON.stringify(entry);
-    fetchedCounts.set(key, (fetchedCounts.get(key) ?? 0) + 1);
-  }
-
-  return buffered.filter((entry) => {
-    const key = JSON.stringify(entry);
-    const remaining = fetchedCounts.get(key) ?? 0;
-    if (remaining === 0) return true;
-    fetchedCounts.set(key, remaining - 1);
-    return false;
-  });
+  return createOverlapFilter(fetched)(buffered);
 }

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -43,9 +43,10 @@ own time zone (their primary calendar's), so it resolves relative times ("tomorr
 bot asks before scheduling a specific clock time. `@macro-new` / `@coder` / `@cursor` open
 an agent session; follow-up
 `@` mentions of that bot in the same thread route to it.
-While the agent works, the reply shows a Magic Chip: a fixed-height scrollable
-preview of the answer, pinned to the latest text. Click the preview (or the
-activity / Open session line under it) to open the agent session.
+While the agent works, the reply shows a Magic Chip: a rounded card with the
+opening of the answer clipped to a fixed height and faded out, and a footer row
+that reads the current activity (or `Open session` once done). Click the card
+body or its footer to open the agent session and read the rest.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention.
 The Magic Chip that streams the agent's reply stays inside the message column: long

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -47,9 +47,9 @@ The reply renders a Magic Chip: a rounded card of constant height that is presen
 from the moment the session boots. Its answer area shows a pulsing star while the
 agent works, then the opening of the answer clipped to four lines and faded out; its
 bottom row reads the current activity (`Booting agent`, `Writing response`, ...) and
-`Open session` once the turn ends. A `Show more` cue sits over the fade when the
-answer is longer than the clip: click the answer text to expand it in place (`Show
-less` collapses it again); click the bottom row to open the agent session. Before an
+`Open session` once the turn ends. A `Show more` cue sits over the fade: click the
+answer text to expand it in place (`Show less` collapses it again); click the
+bottom row to open the agent session. Before an
 answer exists, clicking the answer area also opens the session.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention.

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -43,10 +43,12 @@ own time zone (their primary calendar's), so it resolves relative times ("tomorr
 bot asks before scheduling a specific clock time. `@macro-new` / `@coder` / `@cursor` open
 an agent session; follow-up
 `@` mentions of that bot in the same thread route to it.
-While the agent works, the reply shows a Magic Chip: a rounded card with the
-opening of the answer clipped to a fixed height and faded out, and a footer row
-that reads the current activity (or `Open session` once done). Click the card
-body or its footer to open the agent session and read the rest.
+The reply renders a Magic Chip: a rounded card that is present from the moment
+the session boots. Its bottom row reads the current activity (`Booting agent`,
+`Writing response`, ...); as the answer is written, its opening appears above
+that row, clipped to six lines and faded out; once the turn ends the row reads
+`Open session`. Click anywhere on the card to open the agent session and read
+the rest.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention.
 The Magic Chip that streams the agent's reply stays inside the message column: long

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -43,12 +43,12 @@ own time zone (their primary calendar's), so it resolves relative times ("tomorr
 bot asks before scheduling a specific clock time. `@macro-new` / `@coder` / `@cursor` open
 an agent session; follow-up
 `@` mentions of that bot in the same thread route to it.
-The reply renders a Magic Chip: a rounded card that is present from the moment
-the session boots. Its bottom row reads the current activity (`Booting agent`,
-`Writing response`, ...); as the answer is written, its opening appears above
-that row, clipped to six lines and faded out; once the turn ends the row reads
-`Open session`. Click anywhere on the card to open the agent session and read
-the rest.
+The reply renders a Magic Chip: a rounded card of constant height that is present
+from the moment the session boots. Its answer area shows skeleton lines while the
+agent works, then the opening of the answer clipped to six lines and faded out; its
+bottom row reads the current activity (`Booting agent`, `Writing response`, ...) and
+`Open session` once the turn ends. Click anywhere on the card to open the agent
+session and read the rest.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention.
 The Magic Chip that streams the agent's reply stays inside the message column: long

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -47,8 +47,10 @@ The reply renders a Magic Chip: a rounded card of constant height that is presen
 from the moment the session boots. Its answer area shows a pulsing star while the
 agent works, then the opening of the answer clipped to four lines and faded out; its
 bottom row reads the current activity (`Booting agent`, `Writing response`, ...) and
-`Open session` once the turn ends. Click anywhere on the card to open the agent
-session and read the rest.
+`Open session` once the turn ends. A `Show more` cue sits over the fade when the
+answer is longer than the clip: click the answer text to expand it in place (`Show
+less` collapses it again); click the bottom row to open the agent session. Before an
+answer exists, clicking the answer area also opens the session.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention.
 The Magic Chip that streams the agent's reply stays inside the message column: long

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -43,6 +43,9 @@ own time zone (their primary calendar's), so it resolves relative times ("tomorr
 bot asks before scheduling a specific clock time. `@macro-new` / `@coder` / `@cursor` open
 an agent session; follow-up
 `@` mentions of that bot in the same thread route to it.
+While the agent works, the reply shows a Magic Chip: a fixed-height scrollable
+preview of the answer, pinned to the latest text. Click the preview (or the
+activity / Open session line under it) to open the agent session.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention.
 The Magic Chip that streams the agent's reply stays inside the message column: long

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -44,8 +44,8 @@ bot asks before scheduling a specific clock time. `@macro-new` / `@coder` / `@cu
 an agent session; follow-up
 `@` mentions of that bot in the same thread route to it.
 The reply renders a Magic Chip: a rounded card of constant height that is present
-from the moment the session boots. Its answer area shows skeleton lines while the
-agent works, then the opening of the answer clipped to six lines and faded out; its
+from the moment the session boots. Its answer area shows a pulsing star while the
+agent works, then the opening of the answer clipped to four lines and faded out; its
 bottom row reads the current activity (`Booting agent`, `Writing response`, ...) and
 `Open session` once the turn ends. Click anywhere on the card to open the agent
 session and read the rest.


### PR DESCRIPTION
Cap the streamed/settled answer at h-36, pin scroll to the latest text, and open the agent session when the preview is clicked so the chip no longer grows the channel thread.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI behavior and accessibility for agent replies change broadly; session-fold dedup touches realtime vs snapshot reconciliation and could drop or retain frames incorrectly if canonical matching is wrong.
> 
> **Overview**
> **Magic Chip** is reworked from separate working/streaming/settled layouts into one **fixed-height rounded card** so the thread does not jump as the agent progresses. The answer slot stays at **`h-22`**: a **pulsing star** while there is no prose, then clipped markdown with a **fade** and **Show more / Show less** expand-in-place (keyboard via Enter). The **footer row** shows live activity (or **Open session** when settled) and opens the session; with no answer yet, tapping the answer area also opens the session. Reply-preview attributes are split so disclosure text does not pollute the quoted answer.
> 
> **Agent session folding** fixes duplicate turns when the HTTP snapshot and realtime gateway deliver the same log row. Overlap detection now uses **canonical JSON** (sorted object keys) via `createOverlapFilter`, reused for buffered replay on open and for **late** frames after `ready`; `dropOverlap` delegates to the same filter. Tests cover jsonb key reordering and post-fetch duplicates.
> 
> **Channels agent guide** documents the new Magic Chip interaction model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a27b5dd6aa830d77bdad0c5d77fe45b7dc6c4aac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->