### PR TITLE
chore(agent): keep magic chip replies inside the channel column

### DIFF
--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/core/StaticMarkdown.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/core/StaticMarkdown.tsx
@@ -546,7 +546,7 @@ const MagicChip: TypedRenderableEntity<MagicChipNode> = {
   guard: (node: LexicalNode): node is MagicChipNode =>
     node.__type === 'magic-chip',
   render: (props) => (
-    <div class="max-w-full">
+    <div class="min-w-0 max-w-full overflow-x-hidden">
       <MagicChipDecorator
         {...props.node.exportComponentProps()}
         key={props.node.getKey()}

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { render, screen } from '@solidjs/testing-library';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock(
+  '@core/component/LexicalMarkdown/component/core/StaticMarkdown',
+  () => ({
+    StaticMarkdownContext: (props: { children: unknown }) => props.children,
+    StaticMarkdown: (props: { markdown: string }) => <p>{props.markdown}</p>,
+  })
+);
+
+import { MagicChipView } from './MagicChipView';
+
+const LONG_PATH =
+  '/home/ubuntu/.cursor/projects/workspace/terminals/261831.txt'.repeat(8);
+
+describe('MagicChipView', () => {
+  it('keeps a streaming thought inside the message column', () => {
+    const { container } = render(() => (
+      <div style={{ width: '320px' }}>
+        <MagicChipView
+          agentSessionId="session-1"
+          presentation={{
+            kind: 'working',
+            activity: {
+              label: 'Thinking',
+              detail: LONG_PATH,
+              busy: true,
+            },
+          }}
+        />
+      </div>
+    ));
+
+    const chip = container.querySelector('[data-magic-chip="session-1"]');
+    expect(chip?.className).toContain('min-w-0');
+    expect(chip?.className).toContain('max-w-full');
+    expect(chip?.className).toContain('overflow-x-hidden');
+    expect(screen.getByText('Thinking')).toBeTruthy();
+    expect(screen.getByText(LONG_PATH).className).toContain('truncate');
+  });
+
+  it('keeps a streaming answer inside the message column', () => {
+    const { container } = render(() => (
+      <div style={{ width: '320px' }}>
+        <MagicChipView
+          agentSessionId="session-2"
+          presentation={{
+            kind: 'answering',
+            markdown: `Inspecting \`${LONG_PATH}\``,
+            activity: {
+              label: 'Reading files',
+              detail: LONG_PATH,
+              busy: true,
+            },
+          }}
+        />
+      </div>
+    ));
+
+    const chip = container.querySelector('[data-magic-chip="session-2"]');
+    expect(chip?.className).toContain('grid-cols-[minmax(0,1fr)]');
+    expect(chip?.className).toContain('overflow-x-hidden');
+    expect(screen.getByText('Reading files')).toBeTruthy();
+  });
+});

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -6,6 +6,15 @@ import { channelTheme } from '@core/component/LexicalMarkdown/theme';
 import { type Component, Match, Show, Switch } from 'solid-js';
 import type { MagicChipActivity, MagicChipPresentation } from './presentation';
 
+/**
+ * Keep the chip inside the message column. A default grid track sizes to
+ * min-content, so a streaming thought, path, or unbreakable token can grow
+ * the chip past the chat edge — the reply is still in the DOM, just off
+ * screen, which looks like the agent never answered.
+ */
+const CHIP_BOUNDS = 'w-full min-w-0 max-w-full overflow-x-hidden';
+const CHIP_STACK = `grid ${CHIP_BOUNDS} grid-cols-[minmax(0,1fr)] gap-1`;
+
 function working(presentation: MagicChipPresentation) {
   return presentation.kind === 'working' ? presentation : undefined;
 }
@@ -26,7 +35,7 @@ const ActivityLine: Component<{
 }> = (props) => (
   <button
     type="button"
-    class="flex h-6 w-full min-w-0 items-center gap-2 text-left"
+    class={`flex h-6 ${CHIP_BOUNDS} items-center gap-2 text-left`}
     data-magic-chip={props.agentSessionId}
     data-message-reply-preview={`${props.activity.label}${
       props.activity.detail ? ` ${props.activity.detail}` : ''
@@ -47,7 +56,7 @@ const ActivityLine: Component<{
     </span>
     <Show when={props.activity.detail}>
       {(detail) => (
-        <span class="min-w-0 truncate text-xs text-ink-extra-muted">
+        <span class="min-w-0 flex-1 truncate text-xs text-ink-extra-muted">
           {detail()}
         </span>
       )}
@@ -58,7 +67,7 @@ const ActivityLine: Component<{
 /** The response, quoted as if the agent had answered inline. */
 const AnswerBody: Component<{ markdown: string }> = (props) => (
   <div
-    class="w-full border-l-2 border-accent pl-3 text-left text-sm leading-6"
+    class={`${CHIP_BOUNDS} wrap-break-word border-l-2 border-accent pl-3 text-left text-sm leading-6`}
     data-message-reply-preview
   >
     <StaticMarkdownContext theme={channelTheme}>
@@ -80,12 +89,9 @@ const StreamingAnswer: Component<{
   activity: MagicChipActivity;
   onOpen?: () => void;
 }> = (props) => (
-  <div
-    class="grid w-full min-w-0 justify-items-start gap-1"
-    data-magic-chip={props.agentSessionId}
-  >
+  <div class={CHIP_STACK} data-magic-chip={props.agentSessionId}>
     <AnswerBody markdown={props.markdown} />
-    <div class="w-full pl-3">
+    <div class={`${CHIP_BOUNDS} pl-3`}>
       <ActivityLine
         agentSessionId={props.agentSessionId}
         activity={props.activity}
@@ -101,10 +107,7 @@ const SettledAnswer: Component<{
   markdown: string;
   onOpen?: () => void;
 }> = (props) => (
-  <div
-    class="grid w-full min-w-0 justify-items-start gap-1"
-    data-magic-chip={props.agentSessionId}
-  >
+  <div class={CHIP_STACK} data-magic-chip={props.agentSessionId}>
     <AnswerBody markdown={props.markdown} />
     <button
       type="button"

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -45,6 +45,9 @@ an agent session; follow-up
 `@` mentions of that bot in the same thread route to it.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention.
+The Magic Chip that streams the agent's reply stays inside the message column: long
+thoughts, file paths, and unbreakable tokens wrap or truncate instead of expanding the
+thread past the chat's right edge.
 
 ## Channel tabs
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What was going on

In production the agent *was* answering. The Magic Chip that streams the reply grew sideways as it typed.

A default CSS grid track sizes to `min-content`. While the agent streams a thought, a file path, or any other unbreakable token, that min-content width keeps growing. The quoted answer (and the “Thinking” / “Reading files” line) paint off the right edge of the chat column. The reply is still in the DOM — you just cannot see it — so the session looks like it never responded.

That matches the channel chips that sit on “Starting session” / mid-tool activity with a sliver of orange gutter, and the ones that “go totally off the screen to the right as it is typing.”

## Fix

- Pin the chip to `minmax(0, 1fr)` with `min-w-0 max-w-full overflow-x-hidden` so long content wraps or truncates in the message column.
- Truncate the activity detail with `flex-1` so a streaming thought cannot expand the row.
- Clamp the static-markdown wrapper the same way.

Frontend-only. No backend / authz change; hexagonal boundaries were not touched.

## Test plan

- [x] Vitest: `MagicChipView` working + answering states keep containment classes on a long path
- [x] Existing presentation + model tests still pass
- [x] Browser: 320px preview with an unbreakable path wraps inside the column instead of overflowing

[Magic chip stays in column](https://cursor.com/agents/bc-677fbf30-c118-422f-8298-7389a3620243/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmagic_chip_stays_in_column.webp)
[magic_chip_stays_in_column.mp4](https://cursor.com/agents/bc-677fbf30-c118-422f-8298-7389a3620243/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmagic_chip_stays_in_column.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-677fbf30-c118-422f-8298-7389a3620243?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-677fbf30-c118-422f-8298-7389a3620243&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

