### PR TITLE
chore(documents): highlight last document outline heading when scrolled to the bottom

### DIFF
--- a/apps/web/src/features/block-md/component/MarkdownOutline.test.ts
+++ b/apps/web/src/features/block-md/component/MarkdownOutline.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { getActiveHeadingIndex, shouldShowOutline } from './MarkdownOutline';
+import {
+  getActiveHeadingIndex,
+  isScrolledToBottom,
+  shouldShowOutline,
+} from './MarkdownOutline';
 
 describe('getActiveHeadingIndex', () => {
   it('selects the first heading before the document reaches it', () => {
@@ -10,8 +14,24 @@ describe('getActiveHeadingIndex', () => {
     expect(getActiveHeadingIndex([20, 100, 300], 150)).toBe(1);
   });
 
+  it('selects the last heading when scrolled to the bottom', () => {
+    expect(getActiveHeadingIndex([20, 100, 400], 80, true)).toBe(2);
+  });
+
   it('returns no selection when the document has no headings', () => {
     expect(getActiveHeadingIndex([], 150)).toBe(-1);
+    expect(getActiveHeadingIndex([], 150, true)).toBe(-1);
+  });
+});
+
+describe('isScrolledToBottom', () => {
+  it('is true at and just past the last pixel', () => {
+    expect(isScrolledToBottom(920, 800, 1720)).toBe(true);
+    expect(isScrolledToBottom(918.5, 800, 1720)).toBe(true);
+  });
+
+  it('is false when more than the threshold remains', () => {
+    expect(isScrolledToBottom(900, 800, 1720)).toBe(false);
   });
 });
 

--- a/apps/web/src/features/block-md/component/MarkdownOutline.tsx
+++ b/apps/web/src/features/block-md/component/MarkdownOutline.tsx
@@ -16,6 +16,7 @@ type OutlineHeading = {
 };
 
 const ACTIVE_HEADING_OFFSET = 80;
+const BOTTOM_SCROLL_THRESHOLD = 2;
 const MIN_OUTLINE_HEADINGS = 3;
 export const MARKDOWN_OUTLINE_WIDTH = 40;
 
@@ -26,11 +27,22 @@ export function shouldShowOutline(
   return enabled && headingCount >= MIN_OUTLINE_HEADINGS;
 }
 
+export function isScrolledToBottom(
+  scrollTop: number,
+  clientHeight: number,
+  scrollHeight: number,
+  threshold = BOTTOM_SCROLL_THRESHOLD
+): boolean {
+  return scrollTop + clientHeight >= scrollHeight - threshold;
+}
+
 export function getActiveHeadingIndex(
   headingTops: number[],
-  activeLine: number
+  activeLine: number,
+  atBottom = false
 ): number {
   if (headingTops.length === 0) return -1;
+  if (atBottom) return headingTops.length - 1;
 
   let activeIndex = 0;
   for (const [index, top] of headingTops.entries()) {
@@ -164,7 +176,16 @@ export function MarkdownOutline(props: {
           editor.getElementByKey(heading.key)?.getBoundingClientRect().top ??
           Number.POSITIVE_INFINITY
       );
-      const activeIndex = getActiveHeadingIndex(headingTops, activeLine);
+      const atBottom = isScrolledToBottom(
+        scrollContainer.scrollTop,
+        scrollContainer.clientHeight,
+        scrollContainer.scrollHeight
+      );
+      const activeIndex = getActiveHeadingIndex(
+        headingTops,
+        activeLine,
+        atBottom
+      );
       setActiveHeadingKey(currentHeadings[activeIndex]?.key);
     };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The left-side document outline (the small accent dashes) tracks the heading that has crossed an 80px line near the top of the viewport. If the last section is short, that last heading never crosses the line — even when you are scrolled all the way to the bottom — so the orange dash sits on the previous heading.

## Fix

When the document scroller is at the bottom (within 2px), select the last heading.

## Testing

- Unit tests for `isScrolledToBottom` and last-heading selection
- Browser: created a 5-heading doc with a short last section, scrolled to the bottom; last dash had `bg-accent` (`activeIndexes: [4]`)

[Last outline dash active at document bottom](https://cursor.com/agents/bc-f8902555-18f4-40bb-ae4c-8830fba05511/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foutline_last_dash_active_debug.webp)
[outline_indicator_scrolls_to_last_heading.mp4](https://cursor.com/agents/bc-f8902555-18f4-40bb-ae4c-8830fba05511/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foutline_indicator_scrolls_to_last_heading.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8902555-18f4-40bb-ae4c-8830fba05511?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8902555-18f4-40bb-ae4c-8830fba05511&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

