### PR TITLE
feat(activity): same-geometry skeleton while the actions graph loads

### DIFF
--- a/apps/web/src/features/activity/components/action-graph.tsx
+++ b/apps/web/src/features/activity/components/action-graph.tsx
@@ -1,6 +1,6 @@
 import { cn, Layer, Tooltip } from '@ui';
 import { format } from 'date-fns';
-import { createMemo, For, type JSX } from 'solid-js';
+import { createMemo, For, type JSX, Show } from 'solid-js';
 import { match } from 'ts-pattern';
 import { OVERVIEW_TZ, parseOverviewDate } from '../core/activity-dates';
 import {
@@ -47,8 +47,15 @@ function dayStat(date: string | null): string {
  * The actions heatmap as a side-panel-style card: a titled header row, the
  * year of day cells, and a compact stats row, divided like `SidePanel.Card`
  * so it reads as list chrome rather than a dashboard tile.
+ *
+ * With `skeleton`, the same layout renders shimmer placeholders in place of
+ * the numbers and day cells. Pass a `placeholderOverview` so the geometry
+ * matches the card that replaces it.
  */
-export function ActionGraph(props: { overview: ActivityOverview }) {
+export function ActionGraph(props: {
+  overview: ActivityOverview;
+  skeleton?: boolean;
+}) {
   const grid = createMemo(() => buildContributionGrid(props.overview));
   const monthLabels = createMemo(
     () =>
@@ -60,27 +67,46 @@ export function ActionGraph(props: { overview: ActivityOverview }) {
       )
   );
   const stats = createMemo(() => summarizeActivity(props.overview));
+  const skeleton = () => props.skeleton === true;
 
   return (
     <Layer depth={2}>
       <section
         class="overflow-hidden rounded-lg border border-edge-muted bg-surface"
         aria-labelledby="activity-actions-heading"
+        aria-busy={skeleton() || undefined}
+        data-activity-graph-skeleton={skeleton() || undefined}
       >
         <div class="divide-y divide-edge-muted text-xs">
-          <ActionGraphHeader total={props.overview.total} />
+          <ActionGraphHeader
+            total={props.overview.total}
+            skeleton={skeleton()}
+          />
           <ContributionHeatmap
             weeks={grid().weeks}
             monthLabels={monthLabels()}
+            skeleton={skeleton()}
           />
-          <ActionGraphStats stats={stats()} />
+          <ActionGraphStats stats={stats()} skeleton={skeleton()} />
         </div>
       </section>
     </Layer>
   );
 }
 
-function ActionGraphHeader(props: { total: number }) {
+function SkeletonText(props: { class?: string }) {
+  return (
+    <span
+      aria-hidden
+      class={cn(
+        'skeleton-shimmer inline-block h-3 rounded bg-skeleton align-middle',
+        props.class
+      )}
+    />
+  );
+}
+
+function ActionGraphHeader(props: { total: number; skeleton: boolean }) {
   return (
     <header class="flex min-h-7 items-center gap-2 px-4 py-2">
       <h2
@@ -88,9 +114,11 @@ function ActionGraphHeader(props: { total: number }) {
         class="font-semibold text-ink-muted text-xs"
       >
         Actions{' '}
-        <span class="text-ink-extra-muted tabular-nums">
-          ({props.total.toLocaleString()})
-        </span>
+        <Show when={!props.skeleton} fallback={<SkeletonText class="w-8" />}>
+          <span class="text-ink-extra-muted tabular-nums">
+            ({props.total.toLocaleString()})
+          </span>
+        </Show>
       </h2>
       <IntensityLegend />
     </header>
@@ -114,6 +142,7 @@ function IntensityLegend() {
 function ContributionHeatmap(props: {
   weeks: ContributionWeek[];
   monthLabels: Map<number, string>;
+  skeleton: boolean;
 }) {
   return (
     <div class="overflow-x-auto px-4 py-3 scrollbar-hidden">
@@ -129,7 +158,7 @@ function ContributionHeatmap(props: {
           <WeekdayGutter />
           <WeekRow>
             <For each={props.weeks}>
-              {(week) => <HeatmapWeek week={week} />}
+              {(week) => <HeatmapWeek week={week} skeleton={props.skeleton} />}
             </For>
           </WeekRow>
         </div>
@@ -152,10 +181,12 @@ function WeekdayGutter() {
   );
 }
 
-function HeatmapWeek(props: { week: ContributionWeek }) {
+function HeatmapWeek(props: { week: ContributionWeek; skeleton: boolean }) {
   return (
     <WeekColumn class="flex flex-col gap-[3px]">
-      <For each={props.week}>{(day) => <DaySquare day={day} />}</For>
+      <For each={props.week}>
+        {(day) => <DaySquare day={day} skeleton={props.skeleton} />}
+      </For>
     </WeekColumn>
   );
 }
@@ -168,7 +199,7 @@ function MonthLetter(props: { label?: string }) {
   );
 }
 
-function DaySquare(props: { day: ContributionDay | null }) {
+function DaySquare(props: { day: ContributionDay | null; skeleton: boolean }) {
   const day = props.day;
   if (!day) {
     return <span class="aspect-square w-full shrink-0" />;
@@ -176,18 +207,30 @@ function DaySquare(props: { day: ContributionDay | null }) {
 
   const label = actionLabel(day);
   return (
-    <Tooltip
-      as="span"
-      placement="top"
-      class="aspect-square w-full shrink-0"
-      label={label}
+    <Show
+      when={!props.skeleton}
+      fallback={
+        <span
+          aria-hidden
+          data-activity-day
+          class="skeleton-shimmer block aspect-square w-full shrink-0 rounded-[3px] bg-skeleton"
+        />
+      }
     >
-      <IntensitySwatch
-        level={day.intensity}
-        class="block size-full rounded-[3px]"
-        aria-label={label}
-      />
-    </Tooltip>
+      <Tooltip
+        as="span"
+        placement="top"
+        class="aspect-square w-full shrink-0"
+        label={label}
+      >
+        <IntensitySwatch
+          level={day.intensity}
+          class="block size-full rounded-[3px]"
+          aria-label={label}
+          data-activity-day
+        />
+      </Tooltip>
+    </Show>
   );
 }
 
@@ -195,10 +238,12 @@ function IntensitySwatch(props: {
   level: ActivityIntensity;
   class?: string;
   'aria-label'?: string;
+  'data-activity-day'?: boolean;
 }) {
   return (
     <span
       aria-label={props['aria-label']}
+      data-activity-day={props['data-activity-day'] || undefined}
       class={cn(
         match(props.level)
           .with(0, () => 'bg-ink/10')
@@ -234,35 +279,41 @@ function WeekRow(props: { class?: string; children?: JSX.Element }) {
   );
 }
 
-function ActionGraphStats(props: { stats: ActivityStats }) {
+function ActionGraphStats(props: { stats: ActivityStats; skeleton: boolean }) {
   return (
     <dl class="flex flex-wrap items-center gap-x-4 gap-y-1 px-4 py-2">
       <Stat
         label="Most active month"
         value={monthStat(props.stats.mostActiveMonth)}
+        skeleton={props.skeleton}
       />
       <Stat
         label="Most active day"
         value={dayStat(props.stats.mostActiveDay)}
+        skeleton={props.skeleton}
       />
       <Stat
         label="Longest streak"
         value={formatStreak(props.stats.longestStreak)}
+        skeleton={props.skeleton}
       />
       <Stat
         label="Current streak"
         value={formatStreak(props.stats.currentStreak)}
+        skeleton={props.skeleton}
       />
     </dl>
   );
 }
 
-function Stat(props: { label: string; value: string }) {
+function Stat(props: { label: string; value: string; skeleton: boolean }) {
   return (
     <div class="flex min-w-0 items-center gap-1.5">
       <dt class="shrink-0 text-ink-extra-muted">{props.label}</dt>
       <dd class="min-w-0 truncate font-medium text-ink tabular-nums">
-        {props.value}
+        <Show when={!props.skeleton} fallback={<SkeletonText class="w-12" />}>
+          {props.value}
+        </Show>
       </dd>
     </div>
   );

--- a/apps/web/src/features/activity/core/placeholder-overview.test.ts
+++ b/apps/web/src/features/activity/core/placeholder-overview.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { buildContributionGrid } from './contribution-grid';
+import { placeholderOverview } from './placeholder-overview';
+
+describe('placeholderOverview', () => {
+  it('spans the 365 local dates ending after today', () => {
+    const overview = placeholderOverview(new Date(2026, 8, 6, 15, 30));
+    expect(overview.to).toBe('2026-09-07');
+    expect(overview.from).toBe('2025-09-07');
+    expect(overview.days).toEqual([]);
+    expect(overview.total).toBe(0);
+  });
+
+  it('lays out the same week columns as a real overview of that window', () => {
+    const now = new Date(2026, 8, 6);
+    const placeholder = placeholderOverview(now);
+    const real = {
+      ...placeholder,
+      days: [{ date: '2026-09-01', count: 3 }],
+      total: 3,
+    };
+    expect(buildContributionGrid(placeholder).weeks).toHaveLength(
+      buildContributionGrid(real).weeks.length
+    );
+  });
+});

--- a/apps/web/src/features/activity/core/placeholder-overview.ts
+++ b/apps/web/src/features/activity/core/placeholder-overview.ts
@@ -1,0 +1,26 @@
+import { addDays, format } from 'date-fns';
+import { formatOverviewDate, parseOverviewDate } from './activity-dates';
+import type { ActivityOverview } from './event';
+
+/** Days in the server's trailing-year overview window. */
+const WINDOW_DAYS = 365;
+
+/**
+ * An empty overview spanning the same window the server will return: the
+ * 365 local dates ending after the viewer's current date. Feeding it to the
+ * graph while the real overview loads yields the exact final geometry, so
+ * the skeleton cannot drift from the ready card.
+ */
+export function placeholderOverview(now: Date): ActivityOverview {
+  const today = parseOverviewDate(format(now, 'yyyy-MM-dd'));
+  const to = addDays(today, 1);
+  const from = addDays(to, -WINDOW_DAYS);
+  return {
+    from: formatOverviewDate(from),
+    to: formatOverviewDate(to),
+    timeZone: 'UTC',
+    total: 0,
+    days: [],
+    topEntities: [],
+  };
+}

--- a/apps/web/src/features/activity/views/my-activity-view.test.tsx
+++ b/apps/web/src/features/activity/views/my-activity-view.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ActivityContextProvider } from '../context/activity-context';
+import { placeholderOverview } from '../core/placeholder-overview';
 import { createdEvent, messagedEvent } from '../queries/fixtures';
 import { createMockActivityContext } from '../tests/mock-context';
 import { feedPage, overviewPage } from '../tests/wire';
@@ -49,10 +50,39 @@ function renderView() {
 const rows = () => document.querySelectorAll('[data-activity-row]');
 
 describe('MyActivityView', () => {
-  it('shows loading copy for both the overview and the feed', () => {
-    const { container } = renderView();
-    expect(container.textContent).toContain('Loading activity overview…');
+  it('shows a same-shape graph skeleton and loading copy for the feed', () => {
+    const { container, graphql } = renderView();
+    const skeleton = container.querySelector('[data-activity-graph-skeleton]');
+    if (!skeleton) throw new Error('graph skeleton not rendered');
+    const skeletonDays = skeleton.querySelectorAll(
+      '[data-activity-day]'
+    ).length;
+    expect(skeletonDays).toBeGreaterThan(300);
+    expect(container.textContent).not.toContain('Loading activity overview');
     expect(container.textContent).toContain('Loading…');
+
+    const placeholder = placeholderOverview(new Date());
+    graphql
+      .latest('MyActivityOverview')
+      .resolve(overviewPage({ from: placeholder.from, to: placeholder.to }));
+
+    expect(
+      container.querySelector('[data-activity-graph-skeleton]')
+    ).toBeNull();
+    expect(container.querySelectorAll('[data-activity-day]').length).toBe(
+      skeletonDays
+    );
+  });
+
+  it('shows unavailable copy when the overview fails', () => {
+    const { container, graphql } = renderView();
+    graphql.latest('MyActivityOverview').fail('boom');
+    expect(
+      container.querySelector('[data-activity-graph-skeleton]')
+    ).toBeNull();
+    expect(container.textContent).toContain(
+      'Activity overview is unavailable right now.'
+    );
   });
 
   it('renders grouped rows with actor names and pages on Show more', async () => {

--- a/apps/web/src/features/activity/views/my-activity-view.tsx
+++ b/apps/web/src/features/activity/views/my-activity-view.tsx
@@ -10,6 +10,7 @@ import {
   useActivityContext,
 } from '../context/activity-context';
 import type { ActivityEvent, ActivityTopEntity } from '../core/event';
+import { placeholderOverview } from '../core/placeholder-overview';
 import { createActorName } from '../primitives/actor-name';
 import { createEntityOpener } from '../primitives/entity-opener';
 import { createMyActivityState } from '../primitives/my-activity';
@@ -61,11 +62,19 @@ export function MyActivityView(props: {
               when={overview()}
               fallback={
                 <OverviewInset>
-                  <p class="px-2 py-1 text-ink-extra-muted text-xs">
-                    {state.overview().t === 'error'
-                      ? 'Activity overview is unavailable right now.'
-                      : 'Loading activity overview…'}
-                  </p>
+                  <Show
+                    when={state.overview().t === 'error'}
+                    fallback={
+                      <ActionGraph
+                        overview={placeholderOverview(new Date())}
+                        skeleton
+                      />
+                    }
+                  >
+                    <p class="px-2 py-1 text-ink-extra-muted text-xs">
+                      Activity overview is unavailable right now.
+                    </p>
+                  </Show>
                 </OverviewInset>
               }
             >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The `/activity` overview used to show a line of loading copy that snapped into a ~200px card once the overview query landed. `ActionGraph` now takes a `skeleton` flag and renders its own layout with shimmer day cells and stat placeholders.

## Demo

Before (`main`) then after (this PR), with the `MyActivityOverview` response held for 5s so the loading state is visible. On `main` the feed jumps down when the card lands; on this branch the skeleton already occupies the card's geometry and the feed does not move.

[a1_graph_loading_before_after.mp4](https://cursor.com/agents/bc-be408f63-be6f-4984-9d7e-8488650b6fe8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fa1_graph_loading_before_after.mp4)

## How

- `core/placeholder-overview.ts` builds an empty `ActivityOverview` whose window mirrors the server's `trailing_year` (365 local dates ending after today), so the skeleton lays out the same week columns the ready card will.
- `ActionGraph` in skeleton mode swaps the total, the day cells, and the stat values for `skeleton-shimmer bg-skeleton` blocks. Same DOM, same classes, so the height matches by construction instead of by a hand-tuned pixel count.
- `MyActivityView` renders `<ActionGraph overview={placeholderOverview(new Date())} skeleton />` while the overview is loading. The error copy is unchanged.

`createUrqlQuery` is store-based and never suspends, so this is a `Show` fallback rather than a Solid `<Suspense>` boundary.

## Tests

- `placeholder-overview.test.ts` checks the window and that it lays out the same week count as a populated overview of the same window.
- `my-activity-view.test.tsx` asserts the skeleton renders the same number of `[data-activity-day]` cells as the ready graph, and that the overview error path still shows its copy.

Part 1 of the activity feed polish program (skeleton, inline top entities, attribution, virtualized feed, timeline restyle, narrow viewports).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be408f63-be6f-4984-9d7e-8488650b6fe8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be408f63-be6f-4984-9d7e-8488650b6fe8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

