### PR TITLE
feat(activity): most-active entities as an inline chip row under the graph

### DIFF
--- a/apps/web/src/features/activity/components/top-entities.tsx
+++ b/apps/web/src/features/activity/components/top-entities.tsx
@@ -1,63 +1,60 @@
-import { SoupSectionHeader } from '@app/features/next-soup/soup-view/section-header';
 import { type JSX, Show } from 'solid-js';
 import type { EntityDisplay } from '../context/activity-context';
 import type { ActivityTopEntity } from '../core/event';
-import { EntityMention } from './entity-mention';
 
-/** The "Most active" section chrome; the view supplies the rows. */
-export function TopEntitiesSection(props: {
-  empty: boolean;
-  children: JSX.Element;
-}) {
+/**
+ * The "Most active" chips as one wrapping row under the graph card, with a
+ * muted lead-in label. The view supplies the chips and hides the row when
+ * there are none.
+ */
+export function TopEntitiesSection(props: { children: JSX.Element }) {
   return (
-    <section class="min-w-0" aria-label="Most active">
-      <SoupSectionHeader>Most active</SoupSectionHeader>
-      <Show
-        when={!props.empty}
-        fallback={
-          <p class="px-2 py-2 text-ink-muted text-sm">No entities yet.</p>
-        }
-      >
-        {props.children}
-      </Show>
+    <section
+      class="flex min-w-0 flex-wrap items-center gap-1.5 px-1"
+      aria-label="Most active"
+    >
+      <span class="mr-0.5 shrink-0 text-ink-extra-muted text-xs">
+        Most active
+      </span>
+      {props.children}
     </section>
   );
 }
 
 /**
- * One most-active row sharing the feed's row chrome: mention on the left,
- * action count on the right. Without a resolved display the entity kind is
- * not linkable and the row reads "Item".
+ * One most-active entity as a pill: icon, name, action count. Without a
+ * resolved display the entity kind is not linkable and the chip reads
+ * "Item". `rowProps` carry the host's click-to-open handlers.
  */
-export function TopEntityRow(props: {
+export function TopEntityChip(props: {
   entity: ActivityTopEntity;
   display?: EntityDisplay;
   rowProps?: JSX.HTMLAttributes<HTMLDivElement>;
 }) {
   return (
-    <div class="mx-1 flex w-[calc(100%-0.5rem)] items-stretch px-2 text-sm">
-      <div
-        {...props.rowProps}
-        class="flex min-h-10 min-w-0 flex-1 items-center gap-1.5 rounded-lg px-2 py-0.5 hover:bg-hover/30"
+    <div
+      {...props.rowProps}
+      class="inline-flex max-w-full cursor-default items-center gap-1.5 rounded-full border border-edge-muted bg-surface px-2.5 py-1 text-xs hover:bg-hover/30"
+      data-activity-top-entity
+    >
+      <Show
+        when={props.display}
+        fallback={<span class="text-ink-extra-muted">Item</span>}
       >
-        <span class="min-w-0 truncate">
-          <Show
-            when={props.display}
-            fallback={<span class="text-ink-extra-muted">Item</span>}
-          >
-            {(display) => (
-              <EntityMention
-                entityId={props.entity.entityId}
-                display={display()}
-              />
-            )}
-          </Show>
-        </span>
-        <span class="ml-auto shrink-0 text-right font-medium text-ink-extra-muted text-xs tabular-nums">
-          {props.entity.count.toLocaleString()}{' '}
-          {props.entity.count === 1 ? 'action' : 'actions'}
-        </span>
-      </div>
+        {(display) => (
+          <>
+            <span class="flex shrink-0 items-center [&_svg]:size-3.5">
+              {display().icon()}
+            </span>
+            <span class="max-w-[24ch] truncate text-ink">
+              {display().name()}
+            </span>
+          </>
+        )}
+      </Show>
+      <span class="shrink-0 text-ink-extra-muted tabular-nums">
+        {props.entity.count.toLocaleString()}
+      </span>
     </div>
   );
 }

--- a/apps/web/src/features/activity/components/top-entities.tsx
+++ b/apps/web/src/features/activity/components/top-entities.tsx
@@ -1,22 +1,25 @@
+import { SoupSectionHeader } from '@app/features/next-soup/soup-view/section-header';
 import { type JSX, Show } from 'solid-js';
 import type { EntityDisplay } from '../context/activity-context';
 import type { ActivityTopEntity } from '../core/event';
 
 /**
- * The "Most active" chips as one wrapping row under the graph card, with a
- * muted lead-in label. The view supplies the chips and hides the row when
- * there are none.
+ * The "Most active" chips as one wrapping row under the graph card, headed
+ * like the feed's day sections. The view supplies the chips and hides the
+ * section when there are none.
  */
 export function TopEntitiesSection(props: { children: JSX.Element }) {
   return (
     <section
-      class="flex min-w-0 flex-wrap items-center gap-1.5 px-1"
-      aria-label="Most active"
+      class="flex min-w-0 flex-col gap-1.5"
+      aria-labelledby="activity-most-active-heading"
     >
-      <span class="mr-0.5 shrink-0 text-ink-extra-muted text-xs">
-        Most active
-      </span>
-      {props.children}
+      <SoupSectionHeader class="mx-0 my-0 w-full">
+        <h2 id="activity-most-active-heading">Most active</h2>
+      </SoupSectionHeader>
+      <div class="flex min-w-0 flex-wrap items-center gap-1.5 px-1">
+        {props.children}
+      </div>
     </section>
   );
 }

--- a/apps/web/src/features/activity/views/my-activity-view.test.tsx
+++ b/apps/web/src/features/activity/views/my-activity-view.test.tsx
@@ -107,22 +107,34 @@ describe('MyActivityView', () => {
     expect(container.textContent).toContain('No activity yet.');
   });
 
-  it('lists the most active entities and opens them', () => {
+  it('renders the most active entities as chips under the graph and opens them', () => {
     const { container, onOpen, graphql } = renderView();
     graphql.latest('MyActivityOverview').resolve(
       overviewPage({
-        total: 4,
-        topEntities: [{ entityType: 'DOCUMENT', entityId: 'doc-7', count: 4 }],
+        total: 7,
+        topEntities: [
+          { entityType: 'DOCUMENT', entityId: 'doc-7', count: 4 },
+          { entityType: 'DOCUMENT', entityId: 'doc-8', count: 3 },
+        ],
       })
     );
 
-    expect(container.textContent).toContain('Most active');
-    expect(container.textContent).toContain('4 actions');
-
     const section = screen.getByLabelText('Most active');
-    const body = section.querySelector('.hover\\:bg-hover\\/30');
-    if (!body) throw new Error('top entity body not rendered');
-    fireEvent.click(body);
+    const chips = section.querySelectorAll('[data-activity-top-entity]');
+    expect(chips).toHaveLength(2);
+    expect(chips[0]?.textContent).toContain('4');
+    expect(section.textContent).not.toContain('actions');
+
+    const graph = container.querySelector(
+      '[aria-labelledby="activity-actions-heading"]'
+    );
+    expect(graph?.closest('[data-layer]')?.parentElement).toBe(
+      section.parentElement
+    );
+
+    const chip = chips[0];
+    if (!chip) throw new Error('top entity chip not rendered');
+    fireEvent.click(chip);
 
     expect(onOpen).toHaveBeenCalledExactlyOnceWith({
       block: 'md',
@@ -130,5 +142,12 @@ describe('MyActivityView', () => {
       params: undefined,
       newSplit: false,
     });
+  });
+
+  it('renders no most-active row when the overview has no top entities', () => {
+    const { container, graphql } = renderView();
+    graphql.latest('MyActivityOverview').resolve(overviewPage({ total: 0 }));
+    expect(screen.queryByLabelText('Most active')).toBeNull();
+    expect(container.textContent).not.toContain('No entities yet.');
   });
 });

--- a/apps/web/src/features/activity/views/my-activity-view.tsx
+++ b/apps/web/src/features/activity/views/my-activity-view.tsx
@@ -4,7 +4,7 @@ import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component
 import { Button } from '@ui';
 import { For, type JSX, Match, Show, Switch } from 'solid-js';
 import { ActionGraph } from '../components/action-graph';
-import { TopEntitiesSection, TopEntityRow } from '../components/top-entities';
+import { TopEntitiesSection, TopEntityChip } from '../components/top-entities';
 import {
   type OpenEntityTarget,
   useActivityContext,
@@ -70,23 +70,21 @@ export function MyActivityView(props: {
               }
             >
               {(overview) => (
-                <>
-                  <OverviewInset>
-                    <ActionGraph overview={overview()} />
-                  </OverviewInset>
-                  <TopEntitiesSection
-                    empty={overview().topEntities.length === 0}
-                  >
-                    <For each={overview().topEntities}>
-                      {(entity) => (
-                        <OpenableTopEntityRow
-                          entity={entity}
-                          onOpen={props.onOpen}
-                        />
-                      )}
-                    </For>
-                  </TopEntitiesSection>
-                </>
+                <OverviewInset>
+                  <ActionGraph overview={overview()} />
+                  <Show when={overview().topEntities.length > 0}>
+                    <TopEntitiesSection>
+                      <For each={overview().topEntities}>
+                        {(entity) => (
+                          <OpenableTopEntityChip
+                            entity={entity}
+                            onOpen={props.onOpen}
+                          />
+                        )}
+                      </For>
+                    </TopEntitiesSection>
+                  </Show>
+                </OverviewInset>
               )}
             </Show>
             <Switch>
@@ -156,7 +154,7 @@ function NamedActivityRow(props: {
   );
 }
 
-function OpenableTopEntityRow(props: {
+function OpenableTopEntityChip(props: {
   entity: ActivityTopEntity;
   onOpen: (target: OpenEntityTarget) => void;
 }) {
@@ -168,7 +166,7 @@ function OpenableTopEntityRow(props: {
     props.onOpen
   );
   return (
-    <TopEntityRow
+    <TopEntityChip
       entity={props.entity}
       display={opener()?.display}
       rowProps={opener()?.handlers}

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -77,7 +77,9 @@ Board/List views, `Company` create button. Requires a team ("Join a team to enab
 ## Activity — `/app/component/activity`
 
 GitHub-style actions heatmap (one a11y node per day — makes snapshots huge; prefer saving the
-snapshot to a file) plus a feed of "You edited/created X" entries.
+snapshot to a file), then a `Most active` row of pill chips directly under the card (entity
+icon, name, action count; click opens the entity, shift-click opens a new split; the row is
+absent when there are no entities), then a feed of "You edited/created X" entries.
 
 ## Home — `/app/component/home`
 

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -77,9 +77,10 @@ Board/List views, `Company` create button. Requires a team ("Join a team to enab
 ## Activity — `/app/component/activity`
 
 GitHub-style actions heatmap (one a11y node per day — makes snapshots huge; prefer saving the
-snapshot to a file), then a `Most active` row of pill chips directly under the card (entity
-icon, name, action count; click opens the entity, shift-click opens a new split; the row is
-absent when there are no entities), then a feed of "You edited/created X" entries.
+snapshot to a file), then a `Most active` section header (styled like the feed's day headers)
+over a wrapping row of pill chips (entity icon, name, action count; click opens the entity,
+shift-click opens a new split; the section is absent when there are no entities), then a feed
+of "You edited/created X" entries.
 
 ## Home — `/app/component/home`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The `Most active` list on `/activity` rendered one full-width row per entity under a soup section header, pushing the feed a screen down for six entries. It is now a wrapping row of pills directly under the actions card, headed by a `Most active` section header in the same style as the feed's day headers (`Today`).

## Demo

Before (`main`) then after (this PR), same user and data. The eight-row list becomes one wrapping chip row under a `Most active` header and the `Today` header moves up the page.

[a2_top_entities_chips_before_after.mp4](https://cursor.com/agents/bc-be408f63-be6f-4984-9d7e-8488650b6fe8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fa2_top_entities_chips_before_after.mp4)

The header sits above the chips, aligned with the actions card and the `Today` header:

[Most active section header over a wrapping row of entity chips, followed by the Today day header](https://cursor.com/agents/bc-be408f63-be6f-4984-9d7e-8488650b6fe8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fa2-most-active-header.png)

## How

- `TopEntitiesSection` renders a `SoupSectionHeader` (`Most active`, an `h2` the section is labelled by) over a `flex flex-wrap` row of chips. The header drops the soup header's own `mx-1` because `OverviewInset` already applies that inset, so it lines up with the card and the day headers.
- `TopEntityRow` becomes `TopEntityChip`: entity icon, name truncated at `24ch`, action count, in a rounded-full pill. The chip keeps the host's split-aware click handlers so click / shift-click still open the entity.
- `MyActivityView` moves the section inside `OverviewInset` under the graph and hides it entirely when `topEntities` is empty (the `No entities yet.` copy is gone).
- `docs/AGENT_GUIDE/surfaces.md` describes the header and chip row.

## Tests

`my-activity-view.test.tsx`: chips render with counts and no `actions` suffix, the chip row is a sibling of the graph card, click opens the entity, and an empty overview renders no `Most active` section.

Part 2 of the activity feed polish program.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be408f63-be6f-4984-9d7e-8488650b6fe8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be408f63-be6f-4984-9d7e-8488650b6fe8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

