### PR TITLE
feat(activity): name bots and the system principal instead of "Automation"

### DIFF
--- a/apps/web/src/features/activity/context/activity-context.test.tsx
+++ b/apps/web/src/features/activity/context/activity-context.test.tsx
@@ -29,6 +29,7 @@ describe('appActivityContext.botName', () => {
   beforeEach(() => {
     useBotsQuery.mockReset();
     useBotsQuery.mockReturnValue({
+      isPending: false,
       isSuccess: true,
       data: [
         { id: TEAM_BOT, name: 'Triage' },
@@ -47,6 +48,31 @@ describe('appActivityContext.botName', () => {
       expect(second()).toBe('Digest');
       expect(first()).toBe('Triage');
       expect(useBotsQuery).toHaveBeenCalledTimes(1);
+      dispose();
+    });
+  });
+
+  it('is undefined while the list loads and `Bot` once it has failed', () => {
+    useBotsQuery.mockReturnValue({
+      isPending: true,
+      isSuccess: false,
+      data: undefined,
+    });
+    createRoot((dispose) => {
+      const context = useActivityContext();
+      expect(context.botName(() => TEAM_BOT)()).toBeUndefined();
+      dispose();
+    });
+
+    useBotsQuery.mockReturnValue({
+      isPending: false,
+      isSuccess: false,
+      isError: true,
+      data: undefined,
+    });
+    createRoot((dispose) => {
+      const context = useActivityContext();
+      expect(context.botName(() => TEAM_BOT)()).toBe('Bot');
       dispose();
     });
   });

--- a/apps/web/src/features/activity/context/activity-context.test.tsx
+++ b/apps/web/src/features/activity/context/activity-context.test.tsx
@@ -1,0 +1,64 @@
+import { MACRO_SYSTEM_BOT_ID } from '@core/constant/macroSystem';
+import { createRoot } from 'solid-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useBotsQuery = vi.fn();
+
+vi.mock('@queries/bots/bots', () => ({
+  useBotsQuery: () => useBotsQuery(),
+}));
+vi.mock('@core/context/user', () => ({ useUserId: () => () => 'me' }));
+vi.mock('@core/user', () => ({
+  tryMacroId: () => undefined,
+  useDisplayName: () => [() => ''],
+}));
+vi.mock('@property/editor/hooks/useAllProperties', () => ({
+  useAllProperties: () => () => [],
+}));
+vi.mock('@property/hooks', () => ({ usePropertyEntityDisplay: () => ({}) }));
+vi.mock('@service-storage/graphql-soup', () => ({
+  getGraphqlSoupClient: () => ({}),
+}));
+
+const { useActivityContext } = await import('./activity-context');
+
+const TEAM_BOT = '11111111-1111-4111-8111-111111111111';
+const OTHER_BOT = '22222222-2222-4222-8222-222222222222';
+
+describe('appActivityContext.botName', () => {
+  beforeEach(() => {
+    useBotsQuery.mockReset();
+    useBotsQuery.mockReturnValue({
+      isSuccess: true,
+      data: [
+        { id: TEAM_BOT, name: 'Triage' },
+        { id: OTHER_BOT, name: 'Digest' },
+      ],
+    });
+  });
+
+  it('subscribes to the bots list once per consumer, however many bot rows it names', () => {
+    createRoot((dispose) => {
+      const context = useActivityContext();
+      const first = context.botName(() => TEAM_BOT);
+      const second = context.botName(() => OTHER_BOT);
+
+      expect(first()).toBe('Triage');
+      expect(second()).toBe('Digest');
+      expect(first()).toBe('Triage');
+      expect(useBotsQuery).toHaveBeenCalledTimes(1);
+      dispose();
+    });
+  });
+
+  it('never fetches the bots list for first-party bots', () => {
+    createRoot((dispose) => {
+      const context = useActivityContext();
+      const name = context.botName(() => MACRO_SYSTEM_BOT_ID);
+
+      expect(name()).toBe('System');
+      expect(useBotsQuery).not.toHaveBeenCalled();
+      dispose();
+    });
+  });
+});

--- a/apps/web/src/features/activity/context/activity-context.tsx
+++ b/apps/web/src/features/activity/context/activity-context.tsx
@@ -3,6 +3,11 @@ import { tryMacroId, useDisplayName } from '@core/user';
 import { useAllProperties } from '@property/editor/hooks/useAllProperties';
 import { usePropertyEntityDisplay } from '@property/hooks';
 import type { PropertyDefinitionDomain } from '@property/types';
+import { useBotsQuery } from '@queries/bots/bots';
+import {
+  firstPartyBotName,
+  getBotDisplayName,
+} from '@queries/channel/message-sender';
 import type { EntityType } from '@service-properties/generated/schemas/entityType';
 import { getGraphqlSoupClient } from '@service-storage/graphql-soup';
 import type { Client } from '@urql/core';
@@ -39,10 +44,16 @@ export type ActivityContext = {
   /** The signed-in user, so their own rows read "You". */
   currentUserId: Accessor<string>;
   /**
-   * Display name for an actor id. Resolves to `undefined` when the id is
-   * not a user (automation rows), `''` while loading, else the name.
+   * Display name for a user actor id. Resolves to `undefined` when the id
+   * is not a user, `''` while loading, else the name.
    */
   displayName: (actorId: Accessor<string>) => Accessor<string | undefined>;
+  /**
+   * Display name for a bot by bare UUID. First-party bots resolve at once
+   * from constants; team bots resolve from the bots list, `undefined` while
+   * it loads, `Bot` when the list does not know the id.
+   */
+  botName: (botId: Accessor<string>) => Accessor<string | undefined>;
   /** Name, icon, and link target for a referenced entity. */
   entityDisplay: (
     entityId: Accessor<string>,
@@ -73,6 +84,16 @@ function appActivityContext(): ActivityContext {
       if (!id) return () => undefined;
       const [name] = useDisplayName(id, { emailFallback: 'local-part' });
       return name;
+    },
+    botName: (botId) => {
+      const bots = useBotsQuery();
+      return () => {
+        const id = botId();
+        const firstParty = firstPartyBotName(id);
+        if (firstParty) return firstParty;
+        if (!bots.isSuccess) return undefined;
+        return getBotDisplayName(`bot|${id}`, undefined, bots.data);
+      };
     },
     entityDisplay: (entityId, entityType) =>
       usePropertyEntityDisplay(entityId, entityType),

--- a/apps/web/src/features/activity/context/activity-context.tsx
+++ b/apps/web/src/features/activity/context/activity-context.tsx
@@ -11,7 +11,14 @@ import {
 import type { EntityType } from '@service-properties/generated/schemas/entityType';
 import { getGraphqlSoupClient } from '@service-storage/graphql-soup';
 import type { Client } from '@urql/core';
-import { type Accessor, createContext, type JSX, useContext } from 'solid-js';
+import {
+  type Accessor,
+  createContext,
+  getOwner,
+  type JSX,
+  runWithOwner,
+  useContext,
+} from 'solid-js';
 
 /** Resolved display for one referenced entity: name, icon, and link target. */
 export type EntityDisplay = {
@@ -76,6 +83,13 @@ export function useActivityContext(): ActivityContext {
 
 function appActivityContext(): ActivityContext {
   const userId = useUserId();
+  // One bots subscription per consumer, made under the consumer's owner the
+  // first time a bot row asks for a name and reused after that, so it is not
+  // rebuilt each time a recycled row changes actor and user-only surfaces
+  // never fetch the list at all.
+  const owner = getOwner();
+  let bots: ReturnType<typeof useBotsQuery> | undefined;
+  const botsQuery = () => (bots ??= runWithOwner(owner, useBotsQuery));
   return {
     graphql: () => getGraphqlSoupClient(),
     currentUserId: () => userId() ?? '',
@@ -85,15 +99,13 @@ function appActivityContext(): ActivityContext {
       const [name] = useDisplayName(id, { emailFallback: 'local-part' });
       return name;
     },
-    botName: (botId) => {
-      const bots = useBotsQuery();
-      return () => {
-        const id = botId();
-        const firstParty = firstPartyBotName(id);
-        if (firstParty) return firstParty;
-        if (!bots.isSuccess) return undefined;
-        return getBotDisplayName(`bot|${id}`, undefined, bots.data);
-      };
+    botName: (botId) => () => {
+      const id = botId();
+      const firstParty = firstPartyBotName(id);
+      if (firstParty) return firstParty;
+      const list = botsQuery();
+      if (!list?.isSuccess) return undefined;
+      return getBotDisplayName(`bot|${id}`, undefined, list.data);
     },
     entityDisplay: (entityId, entityType) =>
       usePropertyEntityDisplay(entityId, entityType),

--- a/apps/web/src/features/activity/context/activity-context.tsx
+++ b/apps/web/src/features/activity/context/activity-context.tsx
@@ -58,7 +58,7 @@ export type ActivityContext = {
   /**
    * Display name for a bot by bare UUID. First-party bots resolve at once
    * from constants; team bots resolve from the bots list, `undefined` while
-   * it loads, `Bot` when the list does not know the id.
+   * it loads, `Bot` when the list does not know the id or failed to load.
    */
   botName: (botId: Accessor<string>) => Accessor<string | undefined>;
   /** Name, icon, and link target for a referenced entity. */
@@ -104,8 +104,8 @@ function appActivityContext(): ActivityContext {
       const firstParty = firstPartyBotName(id);
       if (firstParty) return firstParty;
       const list = botsQuery();
-      if (!list?.isSuccess) return undefined;
-      return getBotDisplayName(`bot|${id}`, undefined, list.data);
+      if (!list || list.isPending) return undefined;
+      return getBotDisplayName(`bot|${id}`, undefined, list.data ?? []);
     },
     entityDisplay: (entityId, entityType) =>
       usePropertyEntityDisplay(entityId, entityType),

--- a/apps/web/src/features/activity/core/actor.test.ts
+++ b/apps/web/src/features/activity/core/actor.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { parseActor } from './actor';
+
+describe('parseActor', () => {
+  it('parses users from macro ids', () => {
+    expect(parseActor('macro|sarah@example.com')).toEqual({
+      kind: 'user',
+      id: 'macro|sarah@example.com',
+    });
+  });
+
+  it('parses bots from bot principals', () => {
+    expect(parseActor('bot|00000000-0000-0000-0000-00000000a1a1')).toEqual({
+      kind: 'bot',
+      botId: '00000000-0000-0000-0000-00000000a1a1',
+    });
+  });
+
+  it('keeps anything else raw', () => {
+    expect(parseActor('system:nightly')).toEqual({
+      kind: 'unknown',
+      raw: 'system:nightly',
+    });
+    expect(parseActor('bot|')).toEqual({ kind: 'unknown', raw: 'bot|' });
+    expect(parseActor('macro|no-at-sign')).toEqual({
+      kind: 'unknown',
+      raw: 'macro|no-at-sign',
+    });
+  });
+});

--- a/apps/web/src/features/activity/core/actor.ts
+++ b/apps/web/src/features/activity/core/actor.ts
@@ -1,0 +1,24 @@
+import { type MacroId, tryMacroId } from '@core/user/macroId';
+
+/**
+ * Who performed an activity event, parsed once from the wire `actorId`.
+ * The backend emits `macro|<email>` for users and `bot|<uuid>` for bots
+ * (first-party agents, team bots, and the system principal). Anything else
+ * is preserved raw so the row can still say something honest.
+ */
+export type Actor =
+  | { kind: 'user'; id: MacroId }
+  | { kind: 'bot'; botId: string }
+  | { kind: 'unknown'; raw: string };
+
+const BOT_PREFIX = 'bot|';
+
+export function parseActor(actorId: string): Actor {
+  const user = tryMacroId(actorId);
+  if (user) return { kind: 'user', id: user };
+  if (actorId.startsWith(BOT_PREFIX)) {
+    const botId = actorId.slice(BOT_PREFIX.length);
+    if (botId.length > 0) return { kind: 'bot', botId };
+  }
+  return { kind: 'unknown', raw: actorId };
+}

--- a/apps/web/src/features/activity/primitives/actor-name.test.ts
+++ b/apps/web/src/features/activity/primitives/actor-name.test.ts
@@ -1,3 +1,6 @@
+import { MACRO_AGENT_PRINCIPAL_ID } from '@core/constant/macroAgent';
+import { MACRO_SYSTEM_PRINCIPAL_ID } from '@core/constant/macroSystem';
+import { createRoot } from 'solid-js';
 import { describe, expect, it } from 'vitest';
 import {
   createMockActivityContext,
@@ -5,22 +8,52 @@ import {
 } from '../tests/mock-context';
 import { createActorName } from './actor-name';
 
+function nameOf(
+  context: ReturnType<typeof createMockActivityContext>,
+  actorId: string
+): string {
+  return createRoot((dispose) => {
+    const name = createActorName(context, () => actorId)();
+    dispose();
+    return name;
+  });
+}
+
 describe('createActorName', () => {
   const context = createMockActivityContext();
 
   it('names the viewer "You"', () => {
-    expect(createActorName(context, () => MOCK_VIEWER_ID)()).toBe('You');
+    expect(nameOf(context, MOCK_VIEWER_ID)).toBe('You');
   });
 
   it('resolves other users through displayName', () => {
-    expect(createActorName(context, () => 'macro|sarah@example.com')()).toBe(
-      'sarah'
+    expect(nameOf(context, 'macro|sarah@example.com')).toBe('sarah');
+  });
+
+  it('names the system principal "System"', () => {
+    expect(nameOf(context, MACRO_SYSTEM_PRINCIPAL_ID)).toBe('System');
+  });
+
+  it('names first-party bots from their constants', () => {
+    expect(nameOf(context, MACRO_AGENT_PRINCIPAL_ID)).toBe('Macro');
+  });
+
+  it('resolves team bots through botName', () => {
+    expect(nameOf(context, 'bot|deadbeef-0000-0000-0000-000000000001')).toBe(
+      'Bot deadbeef'
     );
   });
 
-  it('labels non-user actors as automation', () => {
-    expect(createActorName(context, () => 'system:nightly')()).toBe(
-      'Automation'
+  it('reads empty while a team bot name is still loading', () => {
+    const loading = createMockActivityContext({
+      botName: () => () => undefined,
+    });
+    expect(nameOf(loading, 'bot|deadbeef-0000-0000-0000-000000000001')).toBe(
+      ''
     );
+  });
+
+  it('never says "Automation" for ids it cannot parse', () => {
+    expect(nameOf(context, 'system:nightly')).toBe('Unknown');
   });
 });

--- a/apps/web/src/features/activity/primitives/actor-name.ts
+++ b/apps/web/src/features/activity/primitives/actor-name.ts
@@ -1,16 +1,33 @@
-import type { Accessor } from 'solid-js';
+import { type Accessor, createMemo } from 'solid-js';
+import { match } from 'ts-pattern';
 import type { ActivityContext } from '../context/activity-context';
+import { parseActor } from '../core/actor';
 
-/** "You" for the viewer, "Automation" for non-user actors, else the name. */
+/**
+ * The name an activity row shows for its actor. The viewer reads "You",
+ * other users read their display name, bots read their bot name (the
+ * system principal reads "System"), and ids the app cannot parse read
+ * "Unknown". Resolvers are created lazily per actor kind so a user row
+ * never subscribes to the bots list.
+ */
 export function createActorName(
-  context: Pick<ActivityContext, 'currentUserId' | 'displayName'>,
+  context: Pick<ActivityContext, 'currentUserId' | 'displayName' | 'botName'>,
   actorId: Accessor<string>
 ): Accessor<string> {
-  const remote = context.displayName(actorId);
-  return () => {
-    const name = remote();
-    if (name === undefined) return 'Automation';
-    if (actorId() === context.currentUserId()) return 'You';
-    return name;
-  };
+  const resolver = createMemo<Accessor<string>>(() => {
+    const id = actorId();
+    if (id === context.currentUserId()) return () => 'You';
+    return match(parseActor(id))
+      .with({ kind: 'user' }, (actor) => {
+        const remote = context.displayName(() => actor.id);
+        return () => remote() ?? 'Unknown';
+      })
+      .with({ kind: 'bot' }, (actor) => {
+        const remote = context.botName(() => actor.botId);
+        return () => remote() ?? '';
+      })
+      .with({ kind: 'unknown' }, () => () => 'Unknown')
+      .exhaustive();
+  });
+  return () => resolver()();
 }

--- a/apps/web/src/features/activity/tests/mock-context.ts
+++ b/apps/web/src/features/activity/tests/mock-context.ts
@@ -1,3 +1,4 @@
+import { firstPartyBotName } from '@queries/channel/message-sender';
 import type { Client } from '@urql/core';
 import type { ActivityContext } from '../context/activity-context';
 import { createMockGraphql, type MockGraphql } from './mock-graphql';
@@ -11,7 +12,8 @@ export type MockActivityContext = ActivityContext & {
 /**
  * In-memory implementations of every activity dependency. Entities resolve
  * to `Entity <id>` and link as markdown blocks; actor ids of the form
- * `macro|name@…` resolve to `name`, anything else reads as automation.
+ * `macro|name@…` resolve to `name`; bot ids resolve to their first-party
+ * name or `Bot <first uuid group>`.
  */
 export function createMockActivityContext(
   overrides: Partial<ActivityContext> = {}
@@ -25,6 +27,10 @@ export function createMockActivityContext(
       const id = actorId();
       if (!id.startsWith('macro|')) return () => undefined;
       return () => id.slice('macro|'.length).split('@')[0] ?? '';
+    },
+    botName: (botId) => () => {
+      const id = botId();
+      return firstPartyBotName(id) ?? `Bot ${id.split('-')[0]}`;
     },
     entityDisplay: (entityId) => ({
       name: () => `Entity ${entityId()}`,

--- a/apps/web/src/lib/core/constant/macroSystem.ts
+++ b/apps/web/src/lib/core/constant/macroSystem.ts
@@ -1,0 +1,25 @@
+/**
+ * Identity for the autonomous Macro platform principal. Mirrors
+ * `bot_id::MACRO_SYSTEM_BOT_ID` on the backend, which attributes actions the
+ * platform takes on its own (onboarding seeds, scheduled jobs) to this bot.
+ */
+export const MACRO_SYSTEM_BOT_ID = '00000000-0000-0000-0000-000000005759';
+
+/**
+ * Canonical principal id for the system bot, matching the `bot|<uuid>` form
+ * used for bot senders, participants, and activity actors everywhere else.
+ */
+export const MACRO_SYSTEM_PRINCIPAL_ID = `bot|${MACRO_SYSTEM_BOT_ID}`;
+
+/** Display name for the system principal. */
+export const MACRO_SYSTEM_NAME = 'System';
+
+/**
+ * Whether an id refers to the system bot. Accepts both the bare UUID and the
+ * `bot|<uuid>` participant/sender form.
+ */
+export function isMacroSystemId(id: string | undefined): boolean {
+  if (!id) return false;
+  const bare = id.startsWith('bot|') ? id.slice('bot|'.length) : id;
+  return bare === MACRO_SYSTEM_BOT_ID;
+}

--- a/apps/web/src/lib/queries/channel/message-sender.ts
+++ b/apps/web/src/lib/queries/channel/message-sender.ts
@@ -2,6 +2,7 @@ import { CURSOR_BOT_NAME, isCursorBotId } from '@core/constant/cursorAgent';
 import { isMacroAgentId, MACRO_AGENT_NAME } from '@core/constant/macroAgent';
 import { isMacroCoderId, MACRO_CODER_NAME } from '@core/constant/macroCoder';
 import { isMacroNewId, MACRO_NEW_NAME } from '@core/constant/macroNew';
+import { isMacroSystemId, MACRO_SYSTEM_NAME } from '@core/constant/macroSystem';
 import type {
   ApiChannelMessage,
   ApiThreadReply,
@@ -35,11 +36,16 @@ export function senderFromStorageId(senderId: string): ApiMessageSender {
   return { type: 'user', id: senderId };
 }
 
-function systemBotDisplayName(id: string): string | undefined {
+/**
+ * Display name for a first-party bot (bare UUID or `bot|<uuid>`), resolved
+ * from constants so it never waits on the bots list. Undefined for team bots.
+ */
+export function firstPartyBotName(id: string): string | undefined {
   if (isMacroAgentId(id)) return MACRO_AGENT_NAME;
   if (isMacroCoderId(id)) return MACRO_CODER_NAME;
   if (isMacroNewId(id)) return MACRO_NEW_NAME;
   if (isCursorBotId(id)) return CURSOR_BOT_NAME;
+  if (isMacroSystemId(id)) return MACRO_SYSTEM_NAME;
   return undefined;
 }
 
@@ -51,7 +57,7 @@ export function getBotDisplayName(
 ): string | undefined {
   const parsed = sender ?? senderFromStorageId(senderId);
   const systemName =
-    systemBotDisplayName(parsed.id) ?? systemBotDisplayName(senderId);
+    firstPartyBotName(parsed.id) ?? firstPartyBotName(senderId);
 
   if (parsed.type !== 'bot' && !systemName) return undefined;
 

--- a/apps/web/src/lib/queries/channel/tests/message-sender.test.ts
+++ b/apps/web/src/lib/queries/channel/tests/message-sender.test.ts
@@ -2,9 +2,15 @@ import {
   MACRO_CODER_NAME,
   MACRO_CODER_PRINCIPAL_ID,
 } from '@core/constant/macroCoder';
+import {
+  MACRO_SYSTEM_BOT_ID,
+  MACRO_SYSTEM_NAME,
+  MACRO_SYSTEM_PRINCIPAL_ID,
+} from '@core/constant/macroSystem';
 import { describe, expect, it } from 'vitest';
 import {
   type ChannelMessageWithMaybeSender,
+  firstPartyBotName,
   getBotDisplayName,
   normalizeChannelMessageSender,
   senderFromStorageId,
@@ -100,6 +106,16 @@ describe('message sender normalization', () => {
 
   it('resolves built-in agent names without channel bot data', () => {
     expect(getBotDisplayName(MACRO_CODER_PRINCIPAL_ID)).toBe(MACRO_CODER_NAME);
+  });
+
+  it('names the system principal without channel bot data', () => {
+    expect(getBotDisplayName(MACRO_SYSTEM_PRINCIPAL_ID)).toBe(
+      MACRO_SYSTEM_NAME
+    );
+    expect(firstPartyBotName(MACRO_SYSTEM_BOT_ID)).toBe(MACRO_SYSTEM_NAME);
+    expect(firstPartyBotName('00000000-0000-0000-0000-000000000002')).toBe(
+      undefined
+    );
   });
 
   it('uses a generic label rather than exposing an unknown bot UUID', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Every non-user actor in the activity feed and the entity side panel read `Automation`. Rows written by the platform now read `System`, rows by an agent read the bot's name (`Macro`, `Macro Coder`, `Cursor`, or a team bot's name), and the word `Automation` is gone.

## Demo

Before (`main`) then after (this PR) for a fresh user whose onboarding rows were written by the system principal. `main` renders 18 `Automation` rows; this branch renders the same 18 rows as `System` and `document.body.innerText` contains no `Automation`.

[a5_attribution_before_after.mp4](https://cursor.com/agents/bc-be408f63-be6f-4984-9d7e-8488650b6fe8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fa5_attribution_before_after.mp4)

## How

- `core/actor.ts` parses the wire `actorId` once into `{ kind: 'user' } | { kind: 'bot' } | { kind: 'unknown' }`. `bot|<uuid>` is the only non-user prefix the backend emits (`Actor = ChannelSender`).
- `@core/constant/macroSystem.ts` mirrors `bot_id::MACRO_SYSTEM_BOT_ID` (`…5759`), the principal the backend uses for autonomous platform actions (onboarding seeds and the like). It joins `firstPartyBotName` in `message-sender.ts` (renamed from the private `systemBotDisplayName` and exported), so channels stop showing `Bot` for it too.
- `ActivityContext` gains `botName(botId)`. The app implementation resolves first-party bots from constants immediately and team bots from the bots list once it succeeds (`undefined` while loading, `Bot` for unknown ids). The `useBotsQuery()` subscription is created once per context consumer, lazily under the consumer's owner the first time a team-bot row asks for a name, and reused for every later call; first-party bots and user-only surfaces never create it.
- `createActorName` is a `ts-pattern` table over the parsed actor: viewer `You`, user via `displayName`, bot via `botName`, unknown `Unknown`.

## Tests

- `core/actor.test.ts`: user, bot, and raw fallbacks (`bot|`, `macro|no-at-sign`, `system:nightly`).
- `primitives/actor-name.test.ts`: viewer, user, system, first-party bot, team bot, loading team bot, unparseable.
- `context/activity-context.test.tsx`: two team-bot rows share one `useBotsQuery()` subscription; a first-party bot never creates it.
- `message-sender.test.ts`: the system principal resolves without channel bot data.

Part 3 of the activity feed polish program.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be408f63-be6f-4984-9d7e-8488650b6fe8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be408f63-be6f-4984-9d7e-8488650b6fe8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

