### PR TITLE
feat(activity): virtualize the feed and page on scroll

### DIFF
--- a/apps/web/src/features/activity/core/feed-rows.test.ts
+++ b/apps/web/src/features/activity/core/feed-rows.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { decodeActivityEvent } from '../queries/decode';
+import { createdEvent, editedEvent } from '../queries/fixtures';
+import { flattenFeed, reuseRows, shouldFetchMore } from './feed-rows';
+
+const created = decodeActivityEvent(createdEvent);
+const edited = decodeActivityEvent(editedEvent);
+
+describe('flattenFeed', () => {
+  it('interleaves day headers and events in order and ends with a tail when more pages exist', () => {
+    const rows = flattenFeed(
+      [
+        { key: 'today', label: 'Today', events: [created] },
+        { key: 'yesterday', label: 'Yesterday', events: [edited] },
+      ],
+      { hasMore: true }
+    );
+    expect(rows.map((row) => row.kind)).toEqual([
+      'day',
+      'event',
+      'day',
+      'event',
+      'tail',
+    ]);
+    expect(rows[0]).toEqual({ kind: 'day', key: 'today', label: 'Today' });
+    expect(rows[1]).toEqual({ kind: 'event', event: created });
+  });
+
+  it('omits the tail on the last page', () => {
+    const rows = flattenFeed(
+      [{ key: 'today', label: 'Today', events: [created] }],
+      { hasMore: false }
+    );
+    expect(rows.map((row) => row.kind)).toEqual(['day', 'event']);
+  });
+});
+
+describe('reuseRows', () => {
+  it('keeps previous row objects for matching keys and adds the rest', () => {
+    const previous = flattenFeed(
+      [{ key: 'today', label: 'Today', events: [created] }],
+      { hasMore: true }
+    );
+    const next = flattenFeed(
+      [
+        { key: 'today', label: 'Today', events: [{ ...created }] },
+        { key: 'yesterday', label: 'Yesterday', events: [edited] },
+      ],
+      { hasMore: false }
+    );
+    const reused = reuseRows(previous, next);
+    expect(reused[0]).toBe(previous[0]);
+    expect(reused[1]).toBe(previous[1]);
+    expect(reused[2]).toBe(next[2]);
+    expect(reused[3]).toBe(next[3]);
+    expect(reused.map((row) => row.kind)).toEqual([
+      'day',
+      'event',
+      'day',
+      'event',
+    ]);
+  });
+});
+
+describe('shouldFetchMore', () => {
+  it.each([
+    // [scrollSize, viewportSize, offset, expected]
+    [3000, 800, 0, false],
+    [3000, 800, 1399, false],
+    [3000, 800, 1400, true],
+    [3000, 800, 2200, true],
+    [500, 800, 0, true],
+    [1000, 50, 800, false],
+    [1000, 50, 850, true],
+  ])(
+    'scrollSize %i viewport %i offset %i -> %s',
+    (scrollSize, viewportSize, offset, expected) => {
+      expect(shouldFetchMore({ scrollSize, viewportSize, offset })).toBe(
+        expected
+      );
+    }
+  );
+});

--- a/apps/web/src/features/activity/core/feed-rows.ts
+++ b/apps/web/src/features/activity/core/feed-rows.ts
@@ -1,0 +1,72 @@
+import type { ActivityEvent } from './event';
+import type { FeedGroup } from './group-events';
+
+/**
+ * One virtualized row of the Activity screen. The overview card is row zero
+ * so it scrolls with the feed and the virtualizer needs no start margin.
+ */
+export type FeedRow =
+  | { kind: 'overview' }
+  | { kind: 'day'; key: string; label: string }
+  | { kind: 'event'; event: ActivityEvent }
+  | { kind: 'status'; status: 'loading' | 'error' | 'empty' }
+  | { kind: 'tail' };
+
+/** Day headers and their events in order, plus a tail row while more pages exist. */
+export function flattenFeed(
+  groups: FeedGroup[],
+  options: { hasMore: boolean }
+): FeedRow[] {
+  const rows: FeedRow[] = [];
+  for (const group of groups) {
+    rows.push({ kind: 'day', key: group.key, label: group.label });
+    for (const event of group.events) rows.push({ kind: 'event', event });
+  }
+  if (options.hasMore) rows.push({ kind: 'tail' });
+  return rows;
+}
+
+function rowKey(row: FeedRow): string {
+  switch (row.kind) {
+    case 'overview':
+    case 'tail':
+      return row.kind;
+    case 'day':
+      return `day:${row.key}`;
+    case 'event':
+      return `event:${row.event.id}`;
+    case 'status':
+      return `status:${row.status}`;
+  }
+}
+
+/**
+ * Carry previous row objects forward where the key matches, so the list
+ * keys rows by reference and a refetch or a paging flag flip does not
+ * remount every mounted row. Events are immutable once recorded, so a
+ * matching id is a matching row.
+ */
+export function reuseRows(previous: FeedRow[], next: FeedRow[]): FeedRow[] {
+  if (previous.length === 0) return next;
+  const byKey = new Map(previous.map((row) => [rowKey(row), row]));
+  return next.map((row) => byKey.get(rowKey(row)) ?? row);
+}
+
+/** Floor for the near-bottom threshold so tiny viewports still page. */
+const MIN_FETCH_THRESHOLD = 100;
+
+/**
+ * Whether the scroller is within one viewport of its end, the point at which
+ * the next page should start loading so it usually lands before the user
+ * reaches the bottom.
+ */
+export function shouldFetchMore(metrics: {
+  scrollSize: number;
+  viewportSize: number;
+  offset: number;
+}): boolean {
+  const threshold = Math.max(MIN_FETCH_THRESHOLD, metrics.viewportSize);
+  return (
+    metrics.scrollSize - metrics.viewportSize - metrics.offset <= threshold
+  );
+}

--- a/apps/web/src/features/activity/primitives/my-activity.test.ts
+++ b/apps/web/src/features/activity/primitives/my-activity.test.ts
@@ -72,6 +72,49 @@ describe('createMyActivityState', () => {
     expect(feed.hasMore).toBe(false);
   });
 
+  it('exposes the overview as row zero and the flattened feed after it', () => {
+    const { state, graphql } = setup();
+    expect(state.rows().map((row) => row.kind)).toEqual(['overview', 'status']);
+
+    graphql.latest('MyActivity').resolve(feedPage([createdEvent], 'c2'));
+    const ready = state.rows();
+    expect(ready.map((row) => row.kind)).toEqual([
+      'overview',
+      'day',
+      'event',
+      'tail',
+    ]);
+
+    state.loadMore();
+    // The in-flight flag flips but the mounted rows keep their identity.
+    expect(state.rows()[1]).toBe(ready[1]);
+    expect(state.rows()[2]).toBe(ready[2]);
+
+    graphql.latest('MyActivity').resolve(feedPage([editedEvent], null));
+    expect(state.rows().map((row) => row.kind)).toEqual([
+      'overview',
+      'day',
+      'event',
+      'event',
+    ]);
+    expect(state.rows()[2]).toBe(ready[2]);
+  });
+
+  it('ignores loadMore while a page is in flight or none remain', () => {
+    const { state, graphql } = setup();
+    graphql.latest('MyActivity').resolve(feedPage([createdEvent], 'c2'));
+    const requests = () =>
+      graphql.pending.filter((op) => op.name === 'MyActivity').length;
+
+    state.loadMore();
+    state.loadMore();
+    expect(requests()).toBe(2);
+
+    graphql.latest('MyActivity').resolve(feedPage([editedEvent], null));
+    state.loadMore();
+    expect(requests()).toBe(2);
+  });
+
   it('is empty when the first page has no rows', () => {
     const { state, graphql } = setup();
     graphql.latest('MyActivity').resolve(feedPage([]));

--- a/apps/web/src/features/activity/primitives/my-activity.test.ts
+++ b/apps/web/src/features/activity/primitives/my-activity.test.ts
@@ -10,6 +10,8 @@ afterEach(() => {
   for (const dispose of disposals.splice(0)) dispose();
 });
 
+const settle = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
 function setup() {
   const context = createMockActivityContext();
   let state!: MyActivityState;
@@ -113,6 +115,46 @@ describe('createMyActivityState', () => {
     graphql.latest('MyActivity').resolve(feedPage([editedEvent], null));
     state.loadMore();
     expect(requests()).toBe(2);
+  });
+
+  it('stops auto-paging after a failed page until retryMore', async () => {
+    const { state, graphql } = setup();
+    graphql.latest('MyActivity').resolve(feedPage([createdEvent], 'c2'));
+    const requests = () =>
+      graphql.pending.filter((op) => op.name === 'MyActivity').length;
+
+    state.loadMore();
+    expect(requests()).toBe(2);
+    graphql.latest('MyActivity').fail('boom');
+    // The page observer settles its failure a few microtasks after the result.
+    await settle();
+
+    const feed = state.feed();
+    expect(feed.t).toBe('ready');
+    if (feed.t !== 'ready') return;
+    expect(feed.moreFailed).toBe(true);
+    expect(feed.loadingMore).toBe(false);
+    expect(feed.hasMore).toBe(true);
+
+    // The near-end check keeps firing while the user rests at the bottom;
+    // none of those turn into another request.
+    state.loadMore();
+    state.loadMore();
+    expect(requests()).toBe(2);
+
+    state.retryMore();
+    await settle();
+    expect(requests()).toBe(3);
+    expect(graphql.latest('MyActivity').variables).toEqual({
+      input: { limit: 50, cursor: 'c2' },
+    });
+
+    graphql.latest('MyActivity').resolve(feedPage([editedEvent], null));
+    const after = state.feed();
+    if (after.t !== 'ready') throw new Error('feed should stay ready');
+    expect(after.moreFailed).toBe(false);
+    expect(after.hasMore).toBe(false);
+    expect(after.groups.flatMap((g) => g.events)).toHaveLength(2);
   });
 
   it('is empty when the first page has no rows', () => {

--- a/apps/web/src/features/activity/primitives/my-activity.ts
+++ b/apps/web/src/features/activity/primitives/my-activity.ts
@@ -1,6 +1,7 @@
 import { type Accessor, createMemo } from 'solid-js';
 import type { ActivityContext } from '../context/activity-context';
 import type { ActivityOverview } from '../core/event';
+import { type FeedRow, flattenFeed, reuseRows } from '../core/feed-rows';
 import { type FeedGroup, groupEventsByDay } from '../core/group-events';
 import { createMyActivityQuery } from '../queries/feed-query';
 import { createMyActivityOverviewQuery } from '../queries/overview-query';
@@ -19,6 +20,9 @@ export type OverviewView =
 export type MyActivityState = {
   overview: Accessor<OverviewView>;
   feed: Accessor<FeedView>;
+  /** Every virtualized row of the screen: the overview first, then the feed. */
+  rows: Accessor<FeedRow[]>;
+  /** Fetch the next feed page. No-op while one is in flight or none remain. */
   loadMore: () => void;
 };
 
@@ -57,9 +61,22 @@ export function createMyActivityState(
     return { t: 'empty' };
   });
 
+  const rows = createMemo<FeedRow[]>((previous) => {
+    const current = feed();
+    const feedRows: FeedRow[] =
+      current.t === 'ready'
+        ? flattenFeed(current.groups, { hasMore: current.hasMore })
+        : [{ kind: 'status', status: current.t }];
+    return reuseRows(previous, [{ kind: 'overview' }, ...feedRows]);
+  }, []);
+
   return {
     overview,
     feed,
-    loadMore: () => void feedQuery.fetchNextPage(),
+    rows,
+    loadMore: () => {
+      if (!feedQuery.hasNextPage || feedQuery.isFetchingNextPage) return;
+      void feedQuery.fetchNextPage();
+    },
   };
 }

--- a/apps/web/src/features/activity/primitives/my-activity.ts
+++ b/apps/web/src/features/activity/primitives/my-activity.ts
@@ -10,7 +10,14 @@ export type FeedView =
   | { t: 'loading' }
   | { t: 'error' }
   | { t: 'empty' }
-  | { t: 'ready'; groups: FeedGroup[]; hasMore: boolean; loadingMore: boolean };
+  | {
+      t: 'ready';
+      groups: FeedGroup[];
+      hasMore: boolean;
+      loadingMore: boolean;
+      /** The last next-page request failed; auto-paging waits for `retryMore`. */
+      moreFailed: boolean;
+    };
 
 export type OverviewView =
   | { t: 'loading' }
@@ -22,8 +29,14 @@ export type MyActivityState = {
   feed: Accessor<FeedView>;
   /** Every virtualized row of the screen: the overview first, then the feed. */
   rows: Accessor<FeedRow[]>;
-  /** Fetch the next feed page. No-op while one is in flight or none remain. */
+  /**
+   * Fetch the next feed page. No-op while one is in flight, none remain, or
+   * the last attempt failed (so a scroller resting near the end does not
+   * hammer a failing endpoint).
+   */
   loadMore: () => void;
+  /** Retry the failed next page. The one way to page again after a failure. */
+  retryMore: () => void;
 };
 
 /**
@@ -54,6 +67,7 @@ export function createMyActivityState(
         groups: groups(),
         hasMore: feedQuery.hasNextPage,
         loadingMore: feedQuery.isFetchingNextPage,
+        moreFailed: feedQuery.isFetchNextPageError,
       };
     }
     if (feedQuery.isLoading) return { t: 'loading' };
@@ -70,13 +84,19 @@ export function createMyActivityState(
     return reuseRows(previous, [{ kind: 'overview' }, ...feedRows]);
   }, []);
 
+  const fetchNext = () => {
+    if (!feedQuery.hasNextPage || feedQuery.isFetchingNextPage) return;
+    void feedQuery.fetchNextPage();
+  };
+
   return {
     overview,
     feed,
     rows,
     loadMore: () => {
-      if (!feedQuery.hasNextPage || feedQuery.isFetchingNextPage) return;
-      void feedQuery.fetchNextPage();
+      if (feedQuery.isFetchNextPageError) return;
+      fetchNext();
     },
+    retryMore: fetchNext,
   };
 }

--- a/apps/web/src/features/activity/views/my-activity-view.test.tsx
+++ b/apps/web/src/features/activity/views/my-activity-view.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library';
+import type { JSX } from 'solid-js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ActivityContextProvider } from '../context/activity-context';
 import { placeholderOverview } from '../core/placeholder-overview';
@@ -10,6 +11,29 @@ import { MyActivityView } from './my-activity-view';
 vi.mock('@components/app/split-layout/components/SplitHeader', () => ({
   SplitHeaderLeft: (props: { children: unknown }) => props.children,
 }));
+
+// jsdom has no layout, so the virtualizer renders every row and exposes a
+// fake handle plus its scroll callback so tests can drive paging.
+const virtual = vi.hoisted(() => ({
+  onScroll: undefined as ((offset: number) => void) | undefined,
+  handle: { scrollSize: 3000, viewportSize: 800, scrollOffset: 0 },
+}));
+
+vi.mock('virtua/solid', async () => {
+  const { For } = await import('solid-js');
+  return {
+    Virtualizer: (props: {
+      data: readonly unknown[];
+      children: (row: unknown, index: () => number) => JSX.Element;
+      ref?: (handle: unknown) => void;
+      onScroll?: (offset: number) => void;
+    }) => {
+      props.ref?.(virtual.handle);
+      virtual.onScroll = props.onScroll;
+      return <For each={props.data}>{(row, i) => props.children(row, i)}</For>;
+    },
+  };
+});
 
 vi.mock(
   '@core/component/LexicalMarkdown/component/core/StaticMarkdown',
@@ -85,8 +109,8 @@ describe('MyActivityView', () => {
     );
   });
 
-  it('renders grouped rows with actor names and pages on Show more', async () => {
-    const { graphql } = renderView();
+  it('renders grouped rows with actor names and pages when scrolled near the end', () => {
+    const { container, graphql } = renderView();
     graphql
       .latest('MyActivity')
       .resolve(feedPage([createdEvent, messagedEvent], 'cursor-2'));
@@ -95,16 +119,39 @@ describe('MyActivityView', () => {
     expect(rows()[0]?.getAttribute('data-activity-action')).toBe('created');
     expect(rows()[1]?.getAttribute('data-activity-action')).toBe('messaged');
     expect(screen.getAllByText('sarah')).toHaveLength(2);
+    expect(screen.queryByRole('button', { name: 'Show more' })).toBeNull();
+    expect(container.querySelector('[data-activity-feed-tail]')).not.toBeNull();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
+    const scroll = virtual.onScroll;
+    if (!scroll) throw new Error('virtualizer did not register onScroll');
+    const feedRequests = () =>
+      graphql.pending.filter((op) => op.name === 'MyActivity').length;
+    expect(feedRequests()).toBe(1);
+
+    // Far from the end: 3000 - 800 - 0 > max(100, 800).
+    scroll(0);
+    expect(feedRequests()).toBe(1);
+
+    // Within one viewport of the end.
+    scroll(1500);
+    expect(feedRequests()).toBe(2);
     const next = graphql.latest('MyActivity');
     expect(next.variables).toEqual({
       input: { limit: 50, cursor: 'cursor-2' },
     });
+    expect(container.textContent).toContain('Loading…');
+
+    // A second scroll while the page is in flight does not double-fetch.
+    scroll(1600);
+    expect(feedRequests()).toBe(2);
 
     next.resolve(feedPage([{ ...createdEvent, id: 'evt-99' }], null));
     expect(rows()).toHaveLength(3);
-    expect(screen.queryByRole('button', { name: 'Show more' })).toBeNull();
+    expect(container.querySelector('[data-activity-feed-tail]')).toBeNull();
+
+    // No more pages: scrolling to the end fetches nothing.
+    scroll(2200);
+    expect(feedRequests()).toBe(2);
   });
 
   it('asks the host to open the row entity', () => {

--- a/apps/web/src/features/activity/views/my-activity-view.test.tsx
+++ b/apps/web/src/features/activity/views/my-activity-view.test.tsx
@@ -60,6 +60,8 @@ vi.mock('@service-storage/websocket', () => ({
 
 afterEach(cleanup);
 
+const settle = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
 function renderView() {
   const context = createMockActivityContext();
   const onOpen = vi.fn();
@@ -152,6 +154,42 @@ describe('MyActivityView', () => {
     // No more pages: scrolling to the end fetches nothing.
     scroll(2200);
     expect(feedRequests()).toBe(2);
+  });
+
+  it('offers a retry instead of re-paging when the next page fails', async () => {
+    const { container, graphql } = renderView();
+    graphql
+      .latest('MyActivity')
+      .resolve(feedPage([createdEvent, messagedEvent], 'cursor-2'));
+    const scroll = virtual.onScroll;
+    if (!scroll) throw new Error('virtualizer did not register onScroll');
+    const feedRequests = () =>
+      graphql.pending.filter((op) => op.name === 'MyActivity').length;
+
+    scroll(1500);
+    expect(feedRequests()).toBe(2);
+    graphql.latest('MyActivity').fail('boom');
+    await settle();
+
+    const tail = container.querySelector('[data-activity-feed-tail]');
+    expect(tail?.textContent).toContain("Couldn't load more.");
+    expect(tail?.textContent).not.toContain('Loading…');
+
+    // Still resting near the end: no automatic re-fetch.
+    scroll(1500);
+    scroll(1600);
+    expect(feedRequests()).toBe(2);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    await settle();
+    expect(feedRequests()).toBe(3);
+    expect(container.textContent).toContain('Loading…');
+
+    graphql
+      .latest('MyActivity')
+      .resolve(feedPage([{ ...createdEvent, id: 'evt-99' }], null));
+    expect(rows()).toHaveLength(3);
+    expect(container.querySelector('[data-activity-feed-tail]')).toBeNull();
   });
 
   it('asks the host to open the row entity', () => {

--- a/apps/web/src/features/activity/views/my-activity-view.tsx
+++ b/apps/web/src/features/activity/views/my-activity-view.tsx
@@ -1,8 +1,17 @@
 import { SoupSectionHeader } from '@app/features/next-soup/soup-view/section-header';
 import { SplitHeaderLeft } from '@components/app/split-layout/components/SplitHeader';
 import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
-import { Button } from '@ui';
-import { For, type JSX, Match, Show, Switch } from 'solid-js';
+import {
+  createEffect,
+  createSignal,
+  For,
+  type JSX,
+  on,
+  onCleanup,
+  Show,
+} from 'solid-js';
+import { match } from 'ts-pattern';
+import { Virtualizer, type VirtualizerHandle } from 'virtua/solid';
 import { ActionGraph } from '../components/action-graph';
 import { TopEntitiesSection, TopEntityChip } from '../components/top-entities';
 import {
@@ -10,11 +19,18 @@ import {
   useActivityContext,
 } from '../context/activity-context';
 import type { ActivityEvent, ActivityTopEntity } from '../core/event';
+import { type FeedRow, shouldFetchMore } from '../core/feed-rows';
 import { placeholderOverview } from '../core/placeholder-overview';
 import { createActorName } from '../primitives/actor-name';
 import { createEntityOpener } from '../primitives/entity-opener';
-import { createMyActivityState } from '../primitives/my-activity';
+import {
+  createMyActivityState,
+  type MyActivityState,
+} from '../primitives/my-activity';
 import { ActivityTimelineRow } from './activity-timeline-row';
+
+/** Pixels of rows virtua keeps mounted beyond the viewport on each side. */
+const FEED_BUFFER_PX = 400;
 
 function OverviewInset(props: { children: JSX.Element }) {
   return (
@@ -33,22 +49,41 @@ function FeedStatus(props: { children: JSX.Element }) {
 }
 
 /**
- * The user's own activity, newest first. Reads `ActivityContext`;
- * the host decides what a row click opens.
+ * The user's own activity, newest first, as one virtualized list with the
+ * overview card as its first row. Scrolling near the end fetches the next
+ * page. Reads `ActivityContext`; the host decides what a row click opens.
  */
 export function MyActivityView(props: {
   onOpen: (target: OpenEntityTarget) => void;
 }) {
   const context = useActivityContext();
   const state = createMyActivityState(context);
-  const overview = () => {
-    const current = state.overview();
-    return current.t === 'ready' ? current.overview : undefined;
+  const [scroller, setScroller] = createSignal<HTMLDivElement>();
+  let handle: VirtualizerHandle | undefined;
+
+  const fetchMoreIfNearEnd = (offset: number) => {
+    if (!handle) return;
+    if (
+      shouldFetchMore({
+        scrollSize: handle.scrollSize,
+        viewportSize: handle.viewportSize,
+        offset,
+      })
+    ) {
+      state.loadMore();
+    }
   };
-  const feed = () => {
-    const current = state.feed();
-    return current.t === 'ready' ? current : undefined;
-  };
+
+  // A page that does not fill the viewport never scrolls, so re-check once
+  // virtua has laid out the new rows.
+  createEffect(
+    on(state.rows, () => {
+      const frame = requestAnimationFrame(() =>
+        fetchMoreIfNearEnd(handle?.scrollOffset ?? 0)
+      );
+      onCleanup(() => cancelAnimationFrame(frame));
+    })
+  );
 
   return (
     <div class="@container/u-list flex size-full flex-col">
@@ -56,95 +91,121 @@ export function MyActivityView(props: {
         <span class="font-semibold text-sm">Activity</span>
       </SplitHeaderLeft>
       <StaticMarkdownContext>
-        <div class="min-h-0 flex-1 overflow-y-auto py-1">
+        <div ref={setScroller} class="min-h-0 flex-1 overflow-y-auto py-1">
           <div class="mx-auto w-full max-w-[1000px]">
-            <Show
-              when={overview()}
-              fallback={
-                <OverviewInset>
-                  <Show
-                    when={state.overview().t === 'error'}
-                    fallback={
-                      <ActionGraph
-                        overview={placeholderOverview(new Date())}
-                        skeleton
-                      />
-                    }
-                  >
-                    <p class="px-2 py-1 text-ink-extra-muted text-xs">
-                      Activity overview is unavailable right now.
-                    </p>
-                  </Show>
-                </OverviewInset>
-              }
+            <Virtualizer
+              data={state.rows()}
+              scrollRef={scroller()}
+              ref={(next) => {
+                handle = next;
+              }}
+              bufferSize={FEED_BUFFER_PX}
+              onScroll={fetchMoreIfNearEnd}
             >
-              {(overview) => (
-                <OverviewInset>
-                  <ActionGraph overview={overview()} />
-                  <Show when={overview().topEntities.length > 0}>
-                    <TopEntitiesSection>
-                      <For each={overview().topEntities}>
-                        {(entity) => (
-                          <OpenableTopEntityChip
-                            entity={entity}
-                            onOpen={props.onOpen}
-                          />
-                        )}
-                      </For>
-                    </TopEntitiesSection>
-                  </Show>
-                </OverviewInset>
+              {(row) => (
+                <FeedRowView row={row} state={state} onOpen={props.onOpen} />
               )}
-            </Show>
-            <Switch>
-              <Match when={feed()}>
-                {(feed) => (
-                  <>
-                    <For each={feed().groups}>
-                      {(group) => (
-                        <>
-                          <SoupSectionHeader>{group.label}</SoupSectionHeader>
-                          <For each={group.events}>
-                            {(event) => (
-                              <NamedActivityRow
-                                event={event}
-                                onOpen={props.onOpen}
-                              />
-                            )}
-                          </For>
-                        </>
-                      )}
-                    </For>
-                    <Show when={feed().hasMore}>
-                      <div class="flex justify-center py-2">
-                        <Button
-                          variant="ghost"
-                          onClick={state.loadMore}
-                          disabled={feed().loadingMore}
-                        >
-                          {feed().loadingMore ? 'Loading…' : 'Show more'}
-                        </Button>
-                      </div>
-                    </Show>
-                  </>
-                )}
-              </Match>
-              <Match when={state.feed().t === 'loading'}>
-                <FeedStatus>Loading…</FeedStatus>
-              </Match>
-              <Match when={state.feed().t === 'error'}>
-                <FeedStatus>
-                  Activity is unavailable right now. Try again in a moment.
-                </FeedStatus>
-              </Match>
-              <Match when={state.feed().t === 'empty'}>
-                <FeedStatus>No activity yet.</FeedStatus>
-              </Match>
-            </Switch>
+            </Virtualizer>
           </div>
         </div>
       </StaticMarkdownContext>
     </div>
+  );
+}
+
+function FeedRowView(props: {
+  row: FeedRow;
+  state: MyActivityState;
+  onOpen: (target: OpenEntityTarget) => void;
+}) {
+  return match(props.row)
+    .with({ kind: 'overview' }, () => (
+      <OverviewRow state={props.state} onOpen={props.onOpen} />
+    ))
+    .with({ kind: 'day' }, (row) => (
+      <SoupSectionHeader>{row.label}</SoupSectionHeader>
+    ))
+    .with({ kind: 'event' }, (row) => (
+      <NamedActivityRow event={row.event} onOpen={props.onOpen} />
+    ))
+    .with({ kind: 'status', status: 'loading' }, () => (
+      <FeedStatus>Loading…</FeedStatus>
+    ))
+    .with({ kind: 'status', status: 'error' }, () => (
+      <FeedStatus>
+        Activity is unavailable right now. Try again in a moment.
+      </FeedStatus>
+    ))
+    .with({ kind: 'status', status: 'empty' }, () => (
+      <FeedStatus>No activity yet.</FeedStatus>
+    ))
+    .with({ kind: 'tail' }, () => <FeedTail state={props.state} />)
+    .exhaustive();
+}
+
+function FeedTail(props: { state: MyActivityState }) {
+  const loadingMore = () => {
+    const feed = props.state.feed();
+    return feed.t === 'ready' && feed.loadingMore;
+  };
+  return (
+    <div
+      class="flex h-10 items-center justify-center text-ink-muted text-sm"
+      aria-live="polite"
+      data-activity-feed-tail
+    >
+      <Show when={loadingMore()}>Loading…</Show>
+    </div>
+  );
+}
+
+function OverviewRow(props: {
+  state: MyActivityState;
+  onOpen: (target: OpenEntityTarget) => void;
+}) {
+  const overview = () => {
+    const current = props.state.overview();
+    return current.t === 'ready' ? current.overview : undefined;
+  };
+  return (
+    <Show
+      when={overview()}
+      fallback={
+        <OverviewInset>
+          <Show
+            when={props.state.overview().t === 'error'}
+            fallback={
+              <ActionGraph
+                overview={placeholderOverview(new Date())}
+                skeleton
+              />
+            }
+          >
+            <p class="px-2 py-1 text-ink-extra-muted text-xs">
+              Activity overview is unavailable right now.
+            </p>
+          </Show>
+        </OverviewInset>
+      }
+    >
+      {(overview) => (
+        <OverviewInset>
+          <ActionGraph overview={overview()} />
+          <Show when={overview().topEntities.length > 0}>
+            <TopEntitiesSection>
+              <For each={overview().topEntities}>
+                {(entity) => (
+                  <OpenableTopEntityChip
+                    entity={entity}
+                    onOpen={props.onOpen}
+                  />
+                )}
+              </For>
+            </TopEntitiesSection>
+          </Show>
+        </OverviewInset>
+      )}
+    </Show>
   );
 }
 

--- a/apps/web/src/features/activity/views/my-activity-view.tsx
+++ b/apps/web/src/features/activity/views/my-activity-view.tsx
@@ -9,10 +9,12 @@ import {
   on,
   onCleanup,
   Show,
+  Suspense,
 } from 'solid-js';
 import { match } from 'ts-pattern';
 import { Virtualizer, type VirtualizerHandle } from 'virtua/solid';
 import { ActionGraph } from '../components/action-graph';
+import { ActivityTimelineRow as ActivityTimelineRowView } from '../components/activity-timeline-row';
 import { TopEntitiesSection, TopEntityChip } from '../components/top-entities';
 import {
   type OpenEntityTarget,
@@ -209,6 +211,10 @@ function OverviewRow(props: {
   );
 }
 
+// Rows mount as the user scrolls, and a row whose entity preview is still a
+// cold query suspends the nearest boundary. Each row carries its own so the
+// pane boundary never re-inserts the scroller, which would reset its scroll
+// position to the top.
 function NamedActivityRow(props: {
   event: ActivityEvent;
   onOpen: (target: OpenEntityTarget) => void;
@@ -216,15 +222,32 @@ function NamedActivityRow(props: {
   const context = useActivityContext();
   const name = createActorName(context, () => props.event.actorId);
   return (
-    <ActivityTimelineRow
-      event={props.event}
-      actorName={name()}
-      onOpen={props.onOpen}
-    />
+    <Suspense
+      fallback={
+        <ActivityTimelineRowView event={props.event} actorName={name()} />
+      }
+    >
+      <ActivityTimelineRow
+        event={props.event}
+        actorName={name()}
+        onOpen={props.onOpen}
+      />
+    </Suspense>
   );
 }
 
 function OpenableTopEntityChip(props: {
+  entity: ActivityTopEntity;
+  onOpen: (target: OpenEntityTarget) => void;
+}) {
+  return (
+    <Suspense fallback={<TopEntityChip entity={props.entity} />}>
+      <ResolvedTopEntityChip entity={props.entity} onOpen={props.onOpen} />
+    </Suspense>
+  );
+}
+
+function ResolvedTopEntityChip(props: {
   entity: ActivityTopEntity;
   onOpen: (target: OpenEntityTarget) => void;
 }) {

--- a/apps/web/src/features/activity/views/my-activity-view.tsx
+++ b/apps/web/src/features/activity/views/my-activity-view.tsx
@@ -146,17 +146,27 @@ function FeedRowView(props: {
 }
 
 function FeedTail(props: { state: MyActivityState }) {
-  const loadingMore = () => {
+  const ready = () => {
     const feed = props.state.feed();
-    return feed.t === 'ready' && feed.loadingMore;
+    return feed.t === 'ready' ? feed : undefined;
   };
   return (
     <div
-      class="flex h-10 items-center justify-center text-ink-muted text-sm"
+      class="flex h-10 items-center justify-center gap-2 text-ink-muted text-sm"
       aria-live="polite"
       data-activity-feed-tail
     >
-      <Show when={loadingMore()}>Loading…</Show>
+      <Show when={ready()?.loadingMore}>Loading…</Show>
+      <Show when={!ready()?.loadingMore && ready()?.moreFailed}>
+        <span>Couldn't load more.</span>
+        <button
+          type="button"
+          class="text-ink underline-offset-2 hover:underline"
+          onClick={() => props.state.retryMore()}
+        >
+          Retry
+        </button>
+      </Show>
     </div>
   );
 }

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -106,10 +106,12 @@ Board/List views, `Company` create button. Requires a team ("Join a team to enab
 GitHub-style actions heatmap (one a11y node per day — makes snapshots huge; prefer saving the
 snapshot to a file), then a `Most active` section header (styled like the feed's day headers)
 over a wrapping row of pill chips (entity icon, name, action count; click opens the entity,
-shift-click opens a new split; the section is absent when there are no entities), then a feed of "You edited/created X" entries grouped
-under day headers. The whole page is one virtualized list: only rows near the viewport are
-in the DOM, and scrolling near the bottom fetches the next page automatically (a `Loading…`
-tail appears while it lands). There is no `Show more` button.
+shift-click opens a new split; the section is absent when there are no entities), then a feed
+of "You edited/created X" entries grouped under day headers. The whole page is one virtualized
+list: only rows near the viewport are in the DOM, and scrolling near the bottom fetches the
+next page automatically (a `Loading…` tail appears while it lands). If a page fails, the tail
+reads `Couldn't load more.` with a `Retry` button and automatic paging stops until it is
+pressed. There is no `Show more` button.
 
 ## Home — `/app/component/home`
 

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -106,8 +106,10 @@ Board/List views, `Company` create button. Requires a team ("Join a team to enab
 GitHub-style actions heatmap (one a11y node per day — makes snapshots huge; prefer saving the
 snapshot to a file), then a `Most active` section header (styled like the feed's day headers)
 over a wrapping row of pill chips (entity icon, name, action count; click opens the entity,
-shift-click opens a new split; the section is absent when there are no entities), then a feed
-of "You edited/created X" entries.
+shift-click opens a new split; the section is absent when there are no entities), then a feed of "You edited/created X" entries grouped
+under day headers. The whole page is one virtualized list: only rows near the viewport are
+in the DOM, and scrolling near the bottom fetches the next page automatically (a `Loading…`
+tail appears while it lands). There is no `Show more` button.
 
 ## Home — `/app/component/home`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The `/activity` feed rendered every loaded row and paged through a `Show more` button. The screen is now one `virtua/solid` `Virtualizer` (the same primitive `SoupList` and `InboxList` use) over a flat row list, so only rows near the viewport are in the DOM, and scrolling within a viewport of the end fetches the next 50 rows with no button.

## Demo

Before (`main`) then after (this PR), same user with 90 events, wheel scrolling. On `main` the feed stops at `Show more`, nothing loads until the button is clicked, and the click resets the scroll to the top. On this branch the second page is requested as the scroll nears the end, the list keeps extending to the oldest rows, and the scroll position never moves.

[a3_feed_paging_before_after.mp4](https://cursor.com/agents/bc-be408f63-be6f-4984-9d7e-8488650b6fe8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fa3_feed_paging_before_after.mp4)

## How

- `core/feed-rows.ts`: `FeedRow = overview | day | event | status | tail`, `flattenFeed(groups, { hasMore })`, and `shouldFetchMore({ scrollSize, viewportSize, offset })` (threshold is one viewport, floored at 100px, copied from `SoupList`). `reuseRows(previous, next)` carries row objects forward by key (`event:<id>`, `day:<key>`, …) so the virtualizer, which keys by reference, does not remount every mounted row when `loadingMore` flips or a refetch re-decodes the pages.
- `createMyActivityState` exposes `rows` (overview first, so no `startMargin` measurement) and guards `loadMore` on `hasNextPage && !isFetchingNextPage`.
- `MyActivityView` hosts `<Virtualizer data={rows} scrollRef={scroller} onScroll={fetchMoreIfNearEnd} bufferSize={400}>` inside the existing centered scroller, with one `ts-pattern` match over `FeedRow.kind`. The tail row shows `Loading…` while a page is in flight. A `requestAnimationFrame` re-check after rows change covers a first page that does not fill the viewport.
- Each event row and top-entity chip carries its own `<Suspense>` with a same-height fallback (the presentational row without the entity mention, the chip without its icon). A row whose entity preview is a cold TanStack query suspends the nearest boundary; with rows now mounting on every scroll, the pane-level boundary was re-inserting the scroller and resetting `scrollTop` to 0 on every page. Found in the live lane, see below.
- `docs/AGENT_GUIDE/surfaces.md` notes the virtualized list, auto paging, and the removed button.

## Tests

- `feed-rows.test.ts`: flatten order and tail, `reuseRows` identity, a `shouldFetchMore` table.
- `my-activity.test.ts`: rows shape across loading → ready → paged, row identity survives `loadMore`, and `loadMore` ignores in-flight / exhausted states.
- `my-activity-view.test.tsx` mocks `virtua/solid` (jsdom has no layout) and drives the registered `onScroll`: far from the end fetches nothing, near the end issues `MyActivity` with `cursor-2`, a second scroll in flight does not double-fetch, and the tail disappears on the last page.

## Live evidence

Local stack, user with 90 events (70 seeded documents plus onboarding), 1280×860, driven with Playwright over CDP and wheel scrolling.

- `MyActivity` was requested exactly twice: `{cursor: null, limit: 50}` on load, then `{cursor: "eyJpZCI6…", limit: 50}` as the scroll came within one viewport of the end. No `Show more` text anywhere.
- `[data-activity-row]` count while scrolling all 90 rows: 23 at the top, 30 at the bottom, 42 peak during a range change. Never 90.
- Scroll position survives every row mount after the Suspense fix (before it, `scrollTop` snapped to 0 on every wheel step that mounted new rows because the pane boundary detached the scroller).
- rAF frame deltas over 60 wheel steps down and back up: p50 16.7ms, p95 16.8ms, max mounted rows 32.

[Bottom of the feed after the second page landed](https://cursor.com/agents/bc-be408f63-be6f-4984-9d7e-8488650b6fe8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fa3_autofetch_bottom_page2.png)

## Stacking

Branched from `main` with #6235 (graph skeleton) and #6236 (inline chips) merged in, since all three edit the overview block of `my-activity-view.tsx`. Until those merge, this diff includes their commits; after they merge only the virtualization commits remain.

Part 4 of the activity feed polish program.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be408f63-be6f-4984-9d7e-8488650b6fe8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be408f63-be6f-4984-9d7e-8488650b6fe8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

