### PR TITLE
feat(activity): collapse sequential runs and fold the side panel (A4)

### DIFF
--- a/apps/web/src/features/activity/components/action-phrase.tsx
+++ b/apps/web/src/features/activity/components/action-phrase.tsx
@@ -1,7 +1,7 @@
 import type { PropertyDefinitionDomain } from '@property/types';
 import { Show } from 'solid-js';
 import { describeAction } from '../core/describe-action';
-import type { ActivityEvent } from '../core/event';
+import type { ActivityAction } from '../core/event';
 import { PropertyChangeText } from './property-change';
 
 function capitalize(value: string): string {
@@ -14,21 +14,17 @@ function capitalize(value: string): string {
  * phrase.
  */
 export function ActionPhrase(props: {
-  event: ActivityEvent;
+  action: ActivityAction;
   propertyDefinition?: PropertyDefinitionDomain;
   capitalize?: boolean;
 }) {
   return (
     <Show
-      when={
-        props.event.action.kind === 'property-changed'
-          ? props.event.action
-          : undefined
-      }
+      when={props.action.kind === 'property-changed' ? props.action : undefined}
       fallback={
         props.capitalize
-          ? capitalize(describeAction(props.event.action))
-          : describeAction(props.event.action)
+          ? capitalize(describeAction(props.action))
+          : describeAction(props.action)
       }
     >
       {(change) => (

--- a/apps/web/src/features/activity/components/action-phrase.tsx
+++ b/apps/web/src/features/activity/components/action-phrase.tsx
@@ -11,10 +11,11 @@ function capitalize(value: string): string {
 /**
  * The verb half of an activity row: property changes render their resolved
  * transition ("changed Status from … to …"), everything else the plain verb
- * phrase.
+ * phrase with the run `count` folded in ("made 5 edits").
  */
 export function ActionPhrase(props: {
   action: ActivityAction;
+  count?: number;
   propertyDefinition?: PropertyDefinitionDomain;
   capitalize?: boolean;
 }) {
@@ -23,8 +24,8 @@ export function ActionPhrase(props: {
       when={props.action.kind === 'property-changed' ? props.action : undefined}
       fallback={
         props.capitalize
-          ? capitalize(describeAction(props.action))
-          : describeAction(props.action)
+          ? capitalize(describeAction(props.action, props.count))
+          : describeAction(props.action, props.count)
       }
     >
       {(change) => (

--- a/apps/web/src/features/activity/components/activity-timeline-row.tsx
+++ b/apps/web/src/features/activity/components/activity-timeline-row.tsx
@@ -1,153 +1,156 @@
 import { formatRelativeTimestamp } from '@entity/utils/timestamp';
 import type { PropertyDefinitionDomain } from '@property/types';
+import { cn } from '@ui';
 import { type JSX, Show } from 'solid-js';
 import type { EntityDisplay } from '../context/activity-context';
-import { describeActionForEntity } from '../core/describe-action';
-import type { ActivityEvent } from '../core/event';
+import { entryHead, entrySize, type FeedEntry } from '../core/collapse-runs';
+import { describeActionForEntity, describeRun } from '../core/describe-action';
 import { ActionGlyph } from './action-glyph';
 import { ActionPhrase } from './action-phrase';
 import { ActorName } from './actor-name';
 import { EntityMention } from './entity-mention';
 import { PropertyChangeText } from './property-change';
 
-function Timestamp(props: { event: ActivityEvent }) {
-  return (
-    <time
-      class="ml-auto shrink-0 text-right font-medium text-ink-extra-muted text-xs"
-      dateTime={props.event.occurredAt}
-    >
-      {formatRelativeTimestamp(new Date(props.event.occurredAt), {
-        condensed: true,
-      })}
-    </time>
-  );
-}
-
 function capitalize(value: string): string {
   return value.length === 0 ? value : value[0].toUpperCase() + value.slice(1);
 }
 
+function Separator() {
+  return (
+    <span aria-hidden class="shrink-0 text-ink-extra-muted">
+      ·
+    </span>
+  );
+}
+
 /**
- * Glyph-rail activity row. Mentions and click-to-open handlers are passed
- * in already resolved so this leaf stays presentational.
+ * Glyph-rail activity line for a single event or a collapsed run. Reads
+ * "<actor> <verb> [connector] <entity> [count] · <time>" with the timestamp
+ * inline. Mentions and click-to-open handlers arrive already resolved so
+ * this leaf stays presentational. `compact` is the side panel's density.
  */
 export function ActivityTimelineRow(props: {
-  event: ActivityEvent;
+  entry: FeedEntry;
   actorName?: string;
   showActor?: boolean;
+  compact?: boolean;
   display?: EntityDisplay;
   propertyDefinition?: PropertyDefinitionDomain;
   rowProps?: JSX.HTMLAttributes<HTMLDivElement>;
 }) {
   const showActor = () => props.showActor !== false;
   const actorName = () => props.actorName ?? '';
+  const head = () => entryHead(props.entry);
+  const described = () => describeRun(props.entry);
+  const action = () => described().action;
+  const parts = () => describeActionForEntity(action());
+  const propertyChange = () => {
+    const current = action();
+    return current.kind === 'property-changed' ? current : undefined;
+  };
 
   return (
     <div
-      class="mx-1 flex w-[calc(100%-0.5rem)] items-stretch gap-1 px-2 text-sm"
+      class={cn(
+        'flex items-stretch gap-1',
+        props.compact ? 'text-xs' : 'mx-1 w-[calc(100%-0.5rem)] px-2 text-sm'
+      )}
       data-activity-row
-      data-activity-action={props.event.action.kind}
+      data-activity-action={action().kind}
+      data-activity-run-size={entrySize(props.entry)}
     >
-      <div class="relative flex w-6 shrink-0 items-center justify-center">
-        <div class="absolute inset-y-0 w-px bg-edge-muted" />
-        <span class="relative flex size-5 items-center justify-center rounded-full bg-surface ring ring-edge-muted">
+      <div
+        class={cn(
+          'relative flex shrink-0 items-center justify-center',
+          props.compact ? 'w-5' : 'w-6'
+        )}
+      >
+        <div class="absolute inset-y-0 w-px bg-edge-muted" data-activity-rail />
+        <span
+          class={cn(
+            'relative flex items-center justify-center rounded-full bg-surface ring ring-edge-muted',
+            props.compact ? 'size-4' : 'size-5'
+          )}
+        >
           <ActionGlyph
-            action={props.event.action}
-            class="size-3 text-ink-muted"
+            action={action()}
+            class={cn('text-ink-muted', props.compact ? 'size-2.5' : 'size-3')}
           />
         </span>
       </div>
-      <Show
-        when={props.display}
-        fallback={
-          <RowBody>
-            <Show when={showActor()}>
-              <span class="shrink-0 font-medium">
-                <ActorName name={actorName()} />
-              </span>
-            </Show>
+      <div
+        {...props.rowProps}
+        class={cn(
+          'flex min-w-0 flex-1 items-center rounded-lg py-0.5 hover:bg-hover/30',
+          props.compact ? 'min-h-7 gap-1 px-1.5' : 'min-h-10 gap-1.5 px-2'
+        )}
+      >
+        <Show when={showActor()}>
+          <span class="shrink-0 font-medium">
+            <ActorName name={actorName()} />
+          </span>
+        </Show>
+        <Show
+          when={props.display}
+          fallback={
             <span class="min-w-0 truncate text-ink-muted">
               <ActionPhrase
-                event={props.event}
+                action={action()}
                 propertyDefinition={props.propertyDefinition}
                 capitalize={!showActor()}
               />
             </span>
-            <Timestamp event={props.event} />
-          </RowBody>
-        }
-      >
-        {(display) => (
-          <EntityRow
-            event={props.event}
-            display={display()}
-            showActor={showActor()}
-            actorName={actorName()}
-            propertyDefinition={props.propertyDefinition}
-            rowProps={props.rowProps}
-          />
-        )}
-      </Show>
-    </div>
-  );
-}
-
-function RowBody(props: JSX.HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div
-      {...props}
-      class="flex min-h-10 min-w-0 flex-1 items-center gap-1.5 rounded-lg px-2 py-0.5 hover:bg-hover/30"
-    />
-  );
-}
-
-function EntityRow(props: {
-  event: ActivityEvent;
-  display: EntityDisplay;
-  showActor: boolean;
-  actorName: string;
-  propertyDefinition?: PropertyDefinitionDomain;
-  rowProps?: JSX.HTMLAttributes<HTMLDivElement>;
-}) {
-  const parts = () => describeActionForEntity(props.event.action);
-
-  return (
-    <RowBody {...props.rowProps}>
-      <Show when={props.showActor}>
-        <span class="shrink-0 font-medium">
-          <ActorName name={props.actorName} />
-        </span>
-      </Show>
-      <span class="min-w-0 text-ink-muted">
-        <Show
-          when={
-            props.event.action.kind === 'property-changed'
-              ? props.event.action
-              : undefined
           }
-          fallback={props.showActor ? parts().verb : capitalize(parts().verb)}
         >
-          {(change) => (
-            <PropertyChangeText
-              action={change()}
-              definition={props.propertyDefinition}
-              capitalize={!props.showActor}
-            />
+          {(display) => (
+            <>
+              <span class="min-w-0 text-ink-muted">
+                <Show
+                  when={propertyChange()}
+                  fallback={
+                    showActor() ? parts().verb : capitalize(parts().verb)
+                  }
+                >
+                  {(change) => (
+                    <PropertyChangeText
+                      action={change()}
+                      definition={props.propertyDefinition}
+                      capitalize={!showActor()}
+                    />
+                  )}
+                </Show>
+              </span>
+              <Show when={parts().connector}>
+                {(connector) => (
+                  <span class="shrink-0 text-ink-muted">{connector()}</span>
+                )}
+              </Show>
+              <span class="min-w-0 truncate">
+                <EntityMention entityId={head().entityId} display={display()} />
+              </span>
+            </>
           )}
         </Show>
-      </span>
-      <Show when={parts().connector}>
-        {(connector) => (
-          <span class="shrink-0 text-ink-muted">{connector()}</span>
-        )}
-      </Show>
-      <span class="min-w-0 truncate">
-        <EntityMention
-          entityId={props.event.entityId}
-          display={props.display}
-        />
-      </span>
-      <Timestamp event={props.event} />
-    </RowBody>
+        <Show when={described().countLabel}>
+          {(label) => (
+            <>
+              <Show when={propertyChange()}>
+                <Separator />
+              </Show>
+              <span class="shrink-0 text-ink-muted">{label()}</span>
+            </>
+          )}
+        </Show>
+        <Separator />
+        <time
+          class="shrink-0 text-ink-extra-muted"
+          dateTime={head().occurredAt}
+        >
+          {formatRelativeTimestamp(new Date(head().occurredAt), {
+            condensed: true,
+          })}
+        </time>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/features/activity/components/activity-timeline-row.tsx
+++ b/apps/web/src/features/activity/components/activity-timeline-row.tsx
@@ -1,15 +1,21 @@
-import { formatRelativeTimestamp } from '@entity/utils/timestamp';
+import {
+  formatCompactRelativeTimestamp,
+  formatDateAndTime,
+} from '@entity/utils/timestamp';
 import type { PropertyDefinitionDomain } from '@property/types';
 import { cn } from '@ui';
 import { type JSX, Show } from 'solid-js';
 import type { EntityDisplay } from '../context/activity-context';
 import { entryHead, entrySize, type FeedEntry } from '../core/collapse-runs';
 import { describeActionForEntity, describeRun } from '../core/describe-action';
+import type { RailEnds } from '../core/feed-rows';
 import { ActionGlyph } from './action-glyph';
 import { ActionPhrase } from './action-phrase';
 import { ActorName } from './actor-name';
 import { EntityMention } from './entity-mention';
 import { PropertyChangeText } from './property-change';
+
+const NO_RAIL: RailEnds = { above: false, below: false };
 
 function capitalize(value: string): string {
   return value.length === 0 ? value : value[0].toUpperCase() + value.slice(1);
@@ -25,21 +31,26 @@ function Separator() {
 
 /**
  * Glyph-rail activity line for a single event or a collapsed run. Reads
- * "<actor> <verb> [connector] <entity> [count] · <time>" with the timestamp
- * inline. Mentions and click-to-open handlers arrive already resolved so
- * this leaf stays presentational. `compact` is the side panel's density.
+ * "<actor> <verb> [connector] <entity> [count] · <time>" on one line; long
+ * content truncates. The glyph is a plain icon; `rail` says which connector
+ * segments run from it toward the neighbouring rows, so the rows read as one
+ * line with a gap around each glyph. Mentions and click-to-open handlers
+ * arrive already resolved so this leaf stays presentational. `compact` is
+ * the side panel's density.
  */
 export function ActivityTimelineRow(props: {
   entry: FeedEntry;
   actorName?: string;
   showActor?: boolean;
   compact?: boolean;
+  rail?: RailEnds;
   display?: EntityDisplay;
   propertyDefinition?: PropertyDefinitionDomain;
   rowProps?: JSX.HTMLAttributes<HTMLDivElement>;
 }) {
   const showActor = () => props.showActor !== false;
   const actorName = () => props.actorName ?? '';
+  const rail = () => props.rail ?? NO_RAIL;
   const head = () => entryHead(props.entry);
   const described = () => describeRun(props.entry);
   const action = () => described().action;
@@ -52,8 +63,10 @@ export function ActivityTimelineRow(props: {
   return (
     <div
       class={cn(
-        'flex items-stretch gap-1',
-        props.compact ? 'text-xs' : 'mx-1 w-[calc(100%-0.5rem)] px-2 text-sm'
+        'flex items-stretch',
+        props.compact
+          ? 'gap-1.5 text-xs'
+          : 'mx-1 w-[calc(100%-0.5rem)] gap-2 px-2 text-sm'
       )}
       data-activity-row
       data-activity-action={action().kind}
@@ -61,32 +74,43 @@ export function ActivityTimelineRow(props: {
     >
       <div
         class={cn(
-          'relative flex shrink-0 items-center justify-center',
-          props.compact ? 'w-5' : 'w-6'
+          'flex shrink-0 flex-col items-center',
+          props.compact ? 'w-3.5' : 'w-4'
         )}
       >
-        <div class="absolute inset-y-0 w-px bg-edge-muted" data-activity-rail />
         <span
+          aria-hidden
           class={cn(
-            'relative flex items-center justify-center rounded-full bg-surface ring ring-edge-muted',
-            props.compact ? 'size-4' : 'size-5'
+            'mb-[3px] w-px flex-1 bg-edge-muted',
+            !rail().above && 'invisible'
           )}
-        >
-          <ActionGlyph
-            action={action()}
-            class={cn('text-ink-muted', props.compact ? 'size-2.5' : 'size-3')}
-          />
-        </span>
+          data-activity-rail="above"
+        />
+        <ActionGlyph
+          action={action()}
+          class={cn(
+            'shrink-0 text-ink-muted',
+            props.compact ? 'size-3.5' : 'size-4'
+          )}
+        />
+        <span
+          aria-hidden
+          class={cn(
+            'mt-[3px] w-px flex-1 bg-edge-muted',
+            !rail().below && 'invisible'
+          )}
+          data-activity-rail="below"
+        />
       </div>
       <div
         {...props.rowProps}
         class={cn(
-          'flex min-w-0 flex-1 items-center rounded-lg py-0.5 hover:bg-hover/30',
-          props.compact ? 'min-h-7 gap-1 px-1.5' : 'min-h-10 gap-1.5 px-2'
+          'flex min-w-0 flex-1 items-center whitespace-nowrap rounded-lg hover:bg-hover/30',
+          props.compact ? 'min-h-8 gap-1 px-1' : 'min-h-10 gap-1.5 px-2'
         )}
       >
         <Show when={showActor()}>
-          <span class="shrink-0 font-medium">
+          <span class="shrink-0 font-medium text-ink">
             <ActorName name={actorName()} />
           </span>
         </Show>
@@ -104,7 +128,7 @@ export function ActivityTimelineRow(props: {
         >
           {(display) => (
             <>
-              <span class="min-w-0 text-ink-muted">
+              <span class="min-w-0 truncate text-ink-muted">
                 <Show
                   when={propertyChange()}
                   fallback={
@@ -125,7 +149,12 @@ export function ActivityTimelineRow(props: {
                   <span class="shrink-0 text-ink-muted">{connector()}</span>
                 )}
               </Show>
-              <span class="min-w-0 truncate">
+              {/* A zero basis grown up to its own content sizes the mention
+                  to whatever room is left, so a long name gives way before
+                  the verb loses a pixel. Proportional shrinking nicks the
+                  verb by a subpixel and ellipsizes it ("edit…"). The full
+                  name stays in the mention's hover preview. */}
+              <span class="min-w-0 max-w-max flex-1 truncate">
                 <EntityMention entityId={head().entityId} display={display()} />
               </span>
             </>
@@ -141,15 +170,15 @@ export function ActivityTimelineRow(props: {
             </>
           )}
         </Show>
-        <Separator />
-        <time
-          class="shrink-0 text-ink-extra-muted"
-          dateTime={head().occurredAt}
-        >
-          {formatRelativeTimestamp(new Date(head().occurredAt), {
-            condensed: true,
-          })}
-        </time>
+        <span class="flex shrink-0 items-center gap-1 text-ink-extra-muted">
+          <Separator />
+          <time
+            dateTime={head().occurredAt}
+            title={formatDateAndTime(head().occurredAt)}
+          >
+            {formatCompactRelativeTimestamp(head().occurredAt)}
+          </time>
+        </span>
       </div>
     </div>
   );

--- a/apps/web/src/features/activity/components/activity-timeline-row.tsx
+++ b/apps/web/src/features/activity/components/activity-timeline-row.tsx
@@ -114,52 +114,62 @@ export function ActivityTimelineRow(props: {
             <ActorName name={actorName()} />
           </span>
         </Show>
-        <Show
-          when={props.display}
-          fallback={
-            <span class="min-w-0 truncate text-ink-muted">
-              <ActionPhrase
-                action={action()}
-                propertyDefinition={props.propertyDefinition}
-                capitalize={!showActor()}
-              />
-            </span>
-          }
-        >
-          {(display) => (
-            <>
-              <Show
-                when={propertyChange()}
-                fallback={
-                  <span class="shrink-0 text-ink-muted">
-                    {showActor() ? parts().verb : capitalize(parts().verb)}
-                  </span>
-                }
-              >
-                {(change) => (
-                  <span class="min-w-0 truncate text-ink-muted">
-                    <PropertyChangeText
-                      action={change()}
-                      definition={props.propertyDefinition}
-                      capitalize={!showActor()}
-                    />
-                  </span>
-                )}
-              </Show>
-              <Show when={parts().connector}>
-                {(connector) => (
-                  <span class="shrink-0 text-ink-muted">{connector()}</span>
-                )}
-              </Show>
-              {/* Zero basis grown to its own content: the mention takes only
-                  the room left, so a long name gives way before the verb, and
-                  the floor keeps an ellipsis visible in the tightest pane. */}
-              <span class="min-w-[5ch] max-w-max flex-1 truncate">
-                <EntityMention entityId={head().entityId} display={display()} />
-              </span>
-            </>
+        {/* The sentence gives way in order: the entity name truncates to its
+            icon, then the sentence clips at its right edge. The actor, the
+            count and the time outside this box always stay. */}
+        <span
+          class={cn(
+            'flex min-w-0 max-w-max flex-1 items-center overflow-hidden',
+            props.compact ? 'gap-1' : 'gap-1.5'
           )}
-        </Show>
+        >
+          <Show
+            when={props.display}
+            fallback={
+              <span class="min-w-0 truncate text-ink-muted">
+                <ActionPhrase
+                  action={action()}
+                  propertyDefinition={props.propertyDefinition}
+                  capitalize={!showActor()}
+                />
+              </span>
+            }
+          >
+            {(display) => (
+              <>
+                <span class="shrink-0 text-ink-muted">
+                  <Show
+                    when={propertyChange()}
+                    fallback={
+                      showActor() ? parts().verb : capitalize(parts().verb)
+                    }
+                  >
+                    {(change) => (
+                      <PropertyChangeText
+                        action={change()}
+                        definition={props.propertyDefinition}
+                        capitalize={!showActor()}
+                      />
+                    )}
+                  </Show>
+                </span>
+                <Show when={parts().connector}>
+                  {(connector) => (
+                    <span class="shrink-0 text-ink-muted">{connector()}</span>
+                  )}
+                </Show>
+                {/* Zero basis grown to its own content: the mention takes
+                    only the room left, so a long name gives way first. */}
+                <span class="min-w-[3ch] max-w-max flex-1 truncate">
+                  <EntityMention
+                    entityId={head().entityId}
+                    display={display()}
+                  />
+                </span>
+              </>
+            )}
+          </Show>
+        </span>
         <Show when={described().countLabel}>
           {(label) => (
             <>

--- a/apps/web/src/features/activity/components/activity-timeline-row.tsx
+++ b/apps/web/src/features/activity/components/activity-timeline-row.tsx
@@ -59,6 +59,11 @@ export function ActivityTimelineRow(props: {
     const current = action();
     return current.kind === 'property-changed' ? current : undefined;
   };
+  // Rows with a named entity, and property runs anywhere, take the count as
+  // a suffix ("… 5 times", "… 3 changes"); a plain phrase without an entity
+  // folds it in instead ("made 5 edits").
+  const countSuffix = () =>
+    props.display || propertyChange() ? described().countLabel : undefined;
 
   return (
     <div
@@ -129,6 +134,7 @@ export function ActivityTimelineRow(props: {
               <span class="min-w-0 truncate text-ink-muted">
                 <ActionPhrase
                   action={action()}
+                  count={entrySize(props.entry)}
                   propertyDefinition={props.propertyDefinition}
                   capitalize={!showActor()}
                 />
@@ -170,7 +176,7 @@ export function ActivityTimelineRow(props: {
             )}
           </Show>
         </span>
-        <Show when={described().countLabel}>
+        <Show when={countSuffix()}>
           {(label) => (
             <>
               <Show when={propertyChange()}>

--- a/apps/web/src/features/activity/components/activity-timeline-row.tsx
+++ b/apps/web/src/features/activity/components/activity-timeline-row.tsx
@@ -128,33 +128,33 @@ export function ActivityTimelineRow(props: {
         >
           {(display) => (
             <>
-              <span class="min-w-0 truncate text-ink-muted">
-                <Show
-                  when={propertyChange()}
-                  fallback={
-                    showActor() ? parts().verb : capitalize(parts().verb)
-                  }
-                >
-                  {(change) => (
+              <Show
+                when={propertyChange()}
+                fallback={
+                  <span class="shrink-0 text-ink-muted">
+                    {showActor() ? parts().verb : capitalize(parts().verb)}
+                  </span>
+                }
+              >
+                {(change) => (
+                  <span class="min-w-0 truncate text-ink-muted">
                     <PropertyChangeText
                       action={change()}
                       definition={props.propertyDefinition}
                       capitalize={!showActor()}
                     />
-                  )}
-                </Show>
-              </span>
+                  </span>
+                )}
+              </Show>
               <Show when={parts().connector}>
                 {(connector) => (
                   <span class="shrink-0 text-ink-muted">{connector()}</span>
                 )}
               </Show>
-              {/* A zero basis grown up to its own content sizes the mention
-                  to whatever room is left, so a long name gives way before
-                  the verb loses a pixel. Proportional shrinking nicks the
-                  verb by a subpixel and ellipsizes it ("edit…"). The full
-                  name stays in the mention's hover preview. */}
-              <span class="min-w-0 max-w-max flex-1 truncate">
+              {/* Zero basis grown to its own content: the mention takes only
+                  the room left, so a long name gives way before the verb, and
+                  the floor keeps an ellipsis visible in the tightest pane. */}
+              <span class="min-w-[5ch] max-w-max flex-1 truncate">
                 <EntityMention entityId={head().entityId} display={display()} />
               </span>
             </>

--- a/apps/web/src/features/activity/components/property-change.tsx
+++ b/apps/web/src/features/activity/components/property-change.tsx
@@ -20,7 +20,7 @@ type PropertyChangedAction = Extract<
  * colors); scalars render as text. Falls back word by word: unknown
  * definition → "a property", unlabelable values → plain "changed"/"cleared"
  * wording. `from` is rendered only when the source event carried it (most
- * producers don't yet).
+ * producers don't yet). Stays on one line: values truncate, never wrap.
  */
 export function PropertyChangeText(props: {
   action: PropertyChangedAction;
@@ -38,7 +38,7 @@ export function PropertyChangeText(props: {
     propertyValueLabel(props.action.to, definition()) !== undefined;
 
   return (
-    <span class="inline-flex min-w-0 flex-wrap items-center gap-x-1 gap-y-0.5">
+    <span class="inline-flex min-w-0 max-w-full items-center gap-1">
       <span class="shrink-0">
         {cleared()
           ? props.capitalize
@@ -84,7 +84,7 @@ function PropertyValueDisplay(props: {
       }
     >
       {(entries) => (
-        <span class="inline-flex min-w-0 flex-wrap items-center gap-1">
+        <span class="inline-flex min-w-0 items-center gap-1">
           <For each={entries()}>
             {(entry) => (
               <span class="inline-flex min-w-0 max-w-[20ch] items-center gap-1 rounded-full px-1.5 py-0.5 text-ink text-xs leading-tight ring ring-edge-muted/50 ring-inset">

--- a/apps/web/src/features/activity/core/collapse-runs.test.ts
+++ b/apps/web/src/features/activity/core/collapse-runs.test.ts
@@ -127,13 +127,18 @@ describe('collapseRuns', () => {
     const events = Array.from({ length: 1000 }, (_, index) =>
       event(`evt-${index}`, { entityId: `doc-${Math.floor(index / 5)}` })
     );
-    collapseRuns(events);
+    expect(collapseRuns(events)).toHaveLength(200);
 
-    const started = performance.now();
-    const entries = collapseRuns(events);
-    const elapsed = performance.now() - started;
+    // Shared CI runners inject GC pauses and scheduler hiccups into any single
+    // sample, so the budget applies to the best of several runs: that still
+    // fails on an algorithmic regression without failing on a noisy neighbour.
+    let fastest = Number.POSITIVE_INFINITY;
+    for (let sample = 0; sample < 20; sample++) {
+      const started = performance.now();
+      collapseRuns(events);
+      fastest = Math.min(fastest, performance.now() - started);
+    }
 
-    expect(entries).toHaveLength(200);
-    expect(elapsed).toBeLessThan(2);
+    expect(fastest).toBeLessThan(2);
   });
 });

--- a/apps/web/src/features/activity/core/collapse-runs.test.ts
+++ b/apps/web/src/features/activity/core/collapse-runs.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collapseRuns,
+  entryAction,
+  entryHead,
+  entryKey,
+  entrySize,
+} from './collapse-runs';
+import type { ActivityAction, ActivityEvent } from './event';
+
+let clock = 0;
+
+function event(
+  id: string,
+  overrides: Partial<Omit<ActivityEvent, 'action'>> & {
+    action?: ActivityAction;
+  } = {}
+): ActivityEvent {
+  clock += 1;
+  return {
+    id,
+    actorId: 'macro|sarah@example.com',
+    entityId: 'doc-1',
+    entityType: 'document',
+    occurredAt: new Date(
+      Date.UTC(2026, 7, 21, 12, 0, 0) - clock * 60_000
+    ).toISOString(),
+    action: { kind: 'edited' },
+    ...overrides,
+  };
+}
+
+function property(
+  id: string,
+  from: unknown,
+  to: unknown,
+  propertyId = 'status'
+): ActivityEvent {
+  return event(id, {
+    action: { kind: 'property-changed', property: propertyId, from, to },
+  });
+}
+
+describe('collapseRuns', () => {
+  it('returns nothing for no events', () => {
+    expect(collapseRuns([])).toEqual([]);
+  });
+
+  it('keeps a lone event as a single', () => {
+    const only = event('a');
+    expect(collapseRuns([only])).toEqual([{ kind: 'single', event: only }]);
+  });
+
+  it('folds consecutive same-actor same-entity same-action events into one run, newest first', () => {
+    const events = [event('a'), event('b'), event('c')];
+    const entries = collapseRuns(events);
+
+    expect(entries).toHaveLength(1);
+    const run = entries[0];
+    if (run.kind !== 'run') throw new Error(run.kind);
+    expect(run.events.map((item) => item.id)).toEqual(['a', 'b', 'c']);
+    expect(run.first.id).toBe('a');
+    expect(run.last.id).toBe('c');
+    expect(entrySize(run)).toBe(3);
+    expect(entryHead(run).id).toBe('a');
+    expect(entryKey(run)).toBe('a..c');
+  });
+
+  it('breaks a run on a different actor, entity, or action kind', () => {
+    const entries = collapseRuns([
+      event('a'),
+      event('b', { actorId: 'macro|joe@example.com' }),
+      event('c', { actorId: 'macro|joe@example.com' }),
+      event('d', { actorId: 'macro|joe@example.com', entityId: 'doc-2' }),
+      event('e', {
+        actorId: 'macro|joe@example.com',
+        entityId: 'doc-2',
+        action: { kind: 'opened' },
+      }),
+    ]);
+
+    expect(entries.map((entry) => [entry.kind, entrySize(entry)])).toEqual([
+      ['single', 1],
+      ['run', 2],
+      ['single', 1],
+      ['single', 1],
+    ]);
+  });
+
+  it('does not fold non-consecutive events on the same entity', () => {
+    const entries = collapseRuns([
+      event('a'),
+      event('b', { entityId: 'doc-2' }),
+      event('c'),
+    ]);
+    expect(entries.map((entry) => entryHead(entry).id)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+    expect(entries.every((entry) => entry.kind === 'single')).toBe(true);
+  });
+
+  it('folds property changes only when they touch the same property and reads the net change', () => {
+    const entries = collapseRuns([
+      property('c', 'In progress', 'Done'),
+      property('b', 'Todo', 'In progress'),
+      property('a', null, 'Todo'),
+      property('p', 'Low', 'High', 'priority'),
+    ]);
+
+    expect(entries).toHaveLength(2);
+    expect(entrySize(entries[0])).toBe(3);
+    expect(entryAction(entries[0])).toEqual({
+      kind: 'property-changed',
+      property: 'status',
+      from: null,
+      to: 'Done',
+    });
+    expect(entries[1]).toEqual({
+      kind: 'single',
+      event: expect.objectContaining({ id: 'p' }),
+    });
+  });
+
+  it('collapses 1,000 events in under 2ms', () => {
+    const events = Array.from({ length: 1000 }, (_, index) =>
+      event(`evt-${index}`, { entityId: `doc-${Math.floor(index / 5)}` })
+    );
+    collapseRuns(events);
+
+    const started = performance.now();
+    const entries = collapseRuns(events);
+    const elapsed = performance.now() - started;
+
+    expect(entries).toHaveLength(200);
+    expect(elapsed).toBeLessThan(2);
+  });
+});

--- a/apps/web/src/features/activity/core/collapse-runs.ts
+++ b/apps/web/src/features/activity/core/collapse-runs.ts
@@ -1,0 +1,85 @@
+import type { ActivityAction, ActivityEvent } from './event';
+
+/**
+ * One feed line. A `run` is two or more consecutive events by the same
+ * actor, on the same entity, of the same action kind (and, for property
+ * changes, the same property), read as one line. Events keep the feed's
+ * newest-first order: `first` is the newest, `last` the oldest.
+ */
+export type FeedEntry =
+  | { kind: 'single'; event: ActivityEvent }
+  | {
+      kind: 'run';
+      events: ActivityEvent[];
+      first: ActivityEvent;
+      last: ActivityEvent;
+    };
+
+function runKey(event: ActivityEvent): string {
+  const property =
+    event.action.kind === 'property-changed' ? event.action.property : '';
+  return `${event.actorId}\u0000${event.entityId}\u0000${event.action.kind}\u0000${property}`;
+}
+
+/** Fold consecutive same-actor, same-entity, same-action events into runs. */
+export function collapseRuns(events: ActivityEvent[]): FeedEntry[] {
+  const entries: FeedEntry[] = [];
+  let open: ActivityEvent[] = [];
+  let openKey: string | undefined;
+
+  const flush = () => {
+    const first = open[0];
+    if (!first) return;
+    const last = open[open.length - 1] ?? first;
+    entries.push(
+      open.length === 1
+        ? { kind: 'single', event: first }
+        : { kind: 'run', events: open, first, last }
+    );
+    open = [];
+    openKey = undefined;
+  };
+
+  for (const event of events) {
+    const key = runKey(event);
+    if (key !== openKey) flush();
+    open.push(event);
+    openKey = key;
+  }
+  flush();
+  return entries;
+}
+
+/** The newest event of an entry, whose actor, entity, and time the line shows. */
+export function entryHead(entry: FeedEntry): ActivityEvent {
+  return entry.kind === 'single' ? entry.event : entry.first;
+}
+
+/** How many events an entry stands for. */
+export function entrySize(entry: FeedEntry): number {
+  return entry.kind === 'single' ? 1 : entry.events.length;
+}
+
+/**
+ * The one action an entry reads as. A property run reads as the net change,
+ * from the oldest event's `from` to the newest event's `to`.
+ */
+export function entryAction(entry: FeedEntry): ActivityAction {
+  if (entry.kind === 'single') return entry.event.action;
+  const newest = entry.first.action;
+  const oldest = entry.last.action;
+  if (
+    newest.kind === 'property-changed' &&
+    oldest.kind === 'property-changed'
+  ) {
+    return { ...newest, from: oldest.from };
+  }
+  return newest;
+}
+
+/** Stable identity for keying a rendered entry. */
+export function entryKey(entry: FeedEntry): string {
+  return entry.kind === 'single'
+    ? entry.event.id
+    : `${entry.first.id}..${entry.last.id}`;
+}

--- a/apps/web/src/features/activity/core/describe-action.test.ts
+++ b/apps/web/src/features/activity/core/describe-action.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { describeAction, describeActionForEntity } from './describe-action';
-import type { ActivityAction } from './event';
+import {
+  describeAction,
+  describeActionForEntity,
+  describeRun,
+} from './describe-action';
+import type { ActivityAction, ActivityEvent } from './event';
 
 const DESCRIBE_CASES: Array<[ActivityAction, string]> = [
   [{ kind: 'created' }, 'created this'],
@@ -58,5 +62,67 @@ describe('describeAction', () => {
         tag: 'transmogrified_thoroughly',
       })
     ).toBe('transmogrified thoroughly');
+  });
+});
+
+describe('describeRun', () => {
+  const event = (id: string, action: ActivityAction): ActivityEvent => ({
+    id,
+    actorId: 'macro|sarah@example.com',
+    entityId: 'doc-1',
+    entityType: 'document',
+    occurredAt: '2026-08-21T12:00:00.000Z',
+    action,
+  });
+
+  it('carries no count for a single', () => {
+    expect(
+      describeRun({ kind: 'single', event: event('a', { kind: 'edited' }) })
+    ).toEqual({ action: { kind: 'edited' }, countLabel: undefined });
+  });
+
+  it('counts a run in times', () => {
+    const events = ['a', 'b', 'c', 'd', 'e'].map((id) =>
+      event(id, { kind: 'edited' })
+    );
+    expect(
+      describeRun({
+        kind: 'run',
+        events,
+        first: events[0],
+        last: events[events.length - 1],
+      })
+    ).toEqual({ action: { kind: 'edited' }, countLabel: '5 times' });
+  });
+
+  it('counts a property run in changes and reads the net change', () => {
+    const newest = event('b', {
+      kind: 'property-changed',
+      property: 'status',
+      from: 'B',
+      to: 'C',
+    });
+    const oldest = event('a', {
+      kind: 'property-changed',
+      property: 'status',
+      from: 'A',
+      to: 'B',
+    });
+    expect(
+      describeRun({
+        kind: 'run',
+        events: [newest, oldest],
+        first: newest,
+        last: oldest,
+      })
+    ).toEqual({
+      action: {
+        kind: 'property-changed',
+        property: 'status',
+        from: 'A',
+        to: 'C',
+      },
+      countLabel: '2 changes',
+    });
   });
 });

--- a/apps/web/src/features/activity/core/describe-action.test.ts
+++ b/apps/web/src/features/activity/core/describe-action.test.ts
@@ -75,8 +75,14 @@ describe('describeAction', () => {
       { kind: 'property-changed', property: 'prop-1', from: null, to: 'Done' },
       'made 5 property changes',
     ],
-    [{ kind: 'participant-added' }, 'added 5 participants'],
-    [{ kind: 'participant-removed' }, 'removed 5 participants'],
+    [
+      { kind: 'participant-added', participant: 'macro|sarah@example.com' },
+      'added 5 participants',
+    ],
+    [
+      { kind: 'participant-removed', participant: 'macro|sarah@example.com' },
+      'removed 5 participants',
+    ],
     [{ kind: 'call-started' }, 'started 5 calls'],
     [{ kind: 'unknown', tag: 'transmogrified' }, 'transmogrified 5 times'],
   ];

--- a/apps/web/src/features/activity/core/describe-action.test.ts
+++ b/apps/web/src/features/activity/core/describe-action.test.ts
@@ -63,6 +63,31 @@ describe('describeAction', () => {
       })
     ).toBe('transmogrified thoroughly');
   });
+
+  const COUNTED_CASES: Array<[ActivityAction, string]> = [
+    [{ kind: 'created' }, 'created this 5 times'],
+    [{ kind: 'edited' }, 'made 5 edits'],
+    [{ kind: 'opened' }, 'opened this 5 times'],
+    [{ kind: 'deleted' }, 'deleted this 5 times'],
+    [{ kind: 'messaged' }, 'sent 5 messages'],
+    [{ kind: 'email-sent' }, 'sent 5 emails'],
+    [
+      { kind: 'property-changed', property: 'prop-1', from: null, to: 'Done' },
+      'made 5 property changes',
+    ],
+    [{ kind: 'participant-added' }, 'added 5 participants'],
+    [{ kind: 'participant-removed' }, 'removed 5 participants'],
+    [{ kind: 'call-started' }, 'started 5 calls'],
+    [{ kind: 'unknown', tag: 'transmogrified' }, 'transmogrified 5 times'],
+  ];
+
+  it.each(COUNTED_CASES)('folds a run count into %j', (action, expected) => {
+    expect(describeAction(action, 5)).toBe(expected);
+  });
+
+  it('reads a count of one as the plain phrase', () => {
+    expect(describeAction({ kind: 'edited' }, 1)).toBe('made an edit');
+  });
 });
 
 describe('describeRun', () => {

--- a/apps/web/src/features/activity/core/describe-action.ts
+++ b/apps/web/src/features/activity/core/describe-action.ts
@@ -1,5 +1,25 @@
 import { match } from 'ts-pattern';
+import { entryAction, entrySize, type FeedEntry } from './collapse-runs';
 import type { ActivityAction } from './event';
+
+/**
+ * How a feed entry reads: the action its line carries (a property run
+ * collapses to its net change) and, for runs, the count suffix that follows
+ * the entity ("5 times", "3 changes"). Singles carry no suffix.
+ */
+export function describeRun(entry: FeedEntry): {
+  action: ActivityAction;
+  countLabel: string | undefined;
+} {
+  const action = entryAction(entry);
+  const size = entrySize(entry);
+  if (size < 2) return { action, countLabel: undefined };
+  return {
+    action,
+    countLabel:
+      action.kind === 'property-changed' ? `${size} changes` : `${size} times`,
+  };
+}
 
 /**
  * Short verb phrase for one activity action, phrased to follow an actor

--- a/apps/web/src/features/activity/core/describe-action.ts
+++ b/apps/web/src/features/activity/core/describe-action.ts
@@ -23,23 +23,46 @@ export function describeRun(entry: FeedEntry): {
 
 /**
  * Short verb phrase for one activity action, phrased to follow an actor
- * name: "Sarah <created this>". Unknown actions (rows written by a newer
- * deployment) fall back to their humanized raw tag rather than hiding the
- * row.
+ * name: "Sarah <created this>". With a `count` of two or more the count is
+ * folded into the phrase ("made 5 edits", "opened this 5 times") so a run
+ * without a named entity never reads as "made an edit 5 times". Unknown
+ * actions (rows written by a newer deployment) fall back to their humanized
+ * raw tag rather than hiding the row.
  */
-export function describeAction(action: ActivityAction): string {
+export function describeAction(action: ActivityAction, count = 1): string {
+  if (count < 2) {
+    return match(action)
+      .with({ kind: 'created' }, () => 'created this')
+      .with({ kind: 'edited' }, () => 'made an edit')
+      .with({ kind: 'opened' }, () => 'opened this')
+      .with({ kind: 'deleted' }, () => 'deleted this')
+      .with({ kind: 'messaged' }, () => 'sent a message')
+      .with({ kind: 'email-sent' }, () => 'sent an email')
+      .with({ kind: 'property-changed' }, () => 'changed a property')
+      .with({ kind: 'participant-added' }, () => 'added a participant')
+      .with({ kind: 'participant-removed' }, () => 'removed a participant')
+      .with({ kind: 'call-started' }, () => 'started a call')
+      .with({ kind: 'unknown' }, (unknown) => unknown.tag.replaceAll('_', ' '))
+      .exhaustive();
+  }
   return match(action)
-    .with({ kind: 'created' }, () => 'created this')
-    .with({ kind: 'edited' }, () => 'made an edit')
-    .with({ kind: 'opened' }, () => 'opened this')
-    .with({ kind: 'deleted' }, () => 'deleted this')
-    .with({ kind: 'messaged' }, () => 'sent a message')
-    .with({ kind: 'email-sent' }, () => 'sent an email')
-    .with({ kind: 'property-changed' }, () => 'changed a property')
-    .with({ kind: 'participant-added' }, () => 'added a participant')
-    .with({ kind: 'participant-removed' }, () => 'removed a participant')
-    .with({ kind: 'call-started' }, () => 'started a call')
-    .with({ kind: 'unknown' }, (unknown) => unknown.tag.replaceAll('_', ' '))
+    .with({ kind: 'created' }, () => `created this ${count} times`)
+    .with({ kind: 'edited' }, () => `made ${count} edits`)
+    .with({ kind: 'opened' }, () => `opened this ${count} times`)
+    .with({ kind: 'deleted' }, () => `deleted this ${count} times`)
+    .with({ kind: 'messaged' }, () => `sent ${count} messages`)
+    .with({ kind: 'email-sent' }, () => `sent ${count} emails`)
+    .with({ kind: 'property-changed' }, () => `made ${count} property changes`)
+    .with({ kind: 'participant-added' }, () => `added ${count} participants`)
+    .with(
+      { kind: 'participant-removed' },
+      () => `removed ${count} participants`
+    )
+    .with({ kind: 'call-started' }, () => `started ${count} calls`)
+    .with(
+      { kind: 'unknown' },
+      (unknown) => `${unknown.tag.replaceAll('_', ' ')} ${count} times`
+    )
     .exhaustive();
 }
 

--- a/apps/web/src/features/activity/core/feed-rows.test.ts
+++ b/apps/web/src/features/activity/core/feed-rows.test.ts
@@ -1,50 +1,57 @@
 import { describe, expect, it } from 'vitest';
 import { decodeActivityEvent } from '../queries/decode';
 import { createdEvent, editedEvent } from '../queries/fixtures';
+import type { FeedEntry } from './collapse-runs';
 import { flattenFeed, reuseRows, shouldFetchMore } from './feed-rows';
 
-const created = decodeActivityEvent(createdEvent);
-const edited = decodeActivityEvent(editedEvent);
+const created: FeedEntry = {
+  kind: 'single',
+  event: decodeActivityEvent(createdEvent),
+};
+const edited: FeedEntry = {
+  kind: 'single',
+  event: decodeActivityEvent(editedEvent),
+};
 
 describe('flattenFeed', () => {
   it('interleaves day headers and events in order and ends with a tail when more pages exist', () => {
     const rows = flattenFeed(
       [
-        { key: 'today', label: 'Today', events: [created] },
-        { key: 'yesterday', label: 'Yesterday', events: [edited] },
+        { key: 'today', label: 'Today', entries: [created] },
+        { key: 'yesterday', label: 'Yesterday', entries: [edited] },
       ],
       { hasMore: true }
     );
     expect(rows.map((row) => row.kind)).toEqual([
       'day',
-      'event',
+      'entry',
       'day',
-      'event',
+      'entry',
       'tail',
     ]);
     expect(rows[0]).toEqual({ kind: 'day', key: 'today', label: 'Today' });
-    expect(rows[1]).toEqual({ kind: 'event', event: created });
+    expect(rows[1]).toEqual({ kind: 'entry', entry: created });
   });
 
   it('omits the tail on the last page', () => {
     const rows = flattenFeed(
-      [{ key: 'today', label: 'Today', events: [created] }],
+      [{ key: 'today', label: 'Today', entries: [created] }],
       { hasMore: false }
     );
-    expect(rows.map((row) => row.kind)).toEqual(['day', 'event']);
+    expect(rows.map((row) => row.kind)).toEqual(['day', 'entry']);
   });
 });
 
 describe('reuseRows', () => {
   it('keeps previous row objects for matching keys and adds the rest', () => {
     const previous = flattenFeed(
-      [{ key: 'today', label: 'Today', events: [created] }],
+      [{ key: 'today', label: 'Today', entries: [created] }],
       { hasMore: true }
     );
     const next = flattenFeed(
       [
-        { key: 'today', label: 'Today', events: [{ ...created }] },
-        { key: 'yesterday', label: 'Yesterday', events: [edited] },
+        { key: 'today', label: 'Today', entries: [{ ...created }] },
+        { key: 'yesterday', label: 'Yesterday', entries: [edited] },
       ],
       { hasMore: false }
     );
@@ -55,9 +62,9 @@ describe('reuseRows', () => {
     expect(reused[3]).toBe(next[3]);
     expect(reused.map((row) => row.kind)).toEqual([
       'day',
-      'event',
+      'entry',
       'day',
-      'event',
+      'entry',
     ]);
   });
 });

--- a/apps/web/src/features/activity/core/feed-rows.test.ts
+++ b/apps/web/src/features/activity/core/feed-rows.test.ts
@@ -12,6 +12,13 @@ const edited: FeedEntry = {
   kind: 'single',
   event: decodeActivityEvent(editedEvent),
 };
+const withId = (entry: FeedEntry, id: string): FeedEntry =>
+  entry.kind === 'single'
+    ? { kind: 'single', event: { ...entry.event, id } }
+    : entry;
+
+const rails = (rows: ReturnType<typeof flattenFeed>) =>
+  rows.flatMap((row) => (row.kind === 'entry' ? [row.rail] : []));
 
 describe('flattenFeed', () => {
   it('interleaves day headers and events in order and ends with a tail when more pages exist', () => {
@@ -30,7 +37,11 @@ describe('flattenFeed', () => {
       'tail',
     ]);
     expect(rows[0]).toEqual({ kind: 'day', key: 'today', label: 'Today' });
-    expect(rows[1]).toEqual({ kind: 'entry', entry: created });
+    expect(rows[1]).toEqual({
+      kind: 'entry',
+      entry: created,
+      rail: { above: false, below: false },
+    });
   });
 
   it('omits the tail on the last page', () => {
@@ -39,6 +50,38 @@ describe('flattenFeed', () => {
       { hasMore: false }
     );
     expect(rows.map((row) => row.kind)).toEqual(['day', 'entry']);
+  });
+
+  it('draws no rail around a single-entry day', () => {
+    const rows = flattenFeed(
+      [{ key: 'today', label: 'Today', entries: [created] }],
+      { hasMore: false }
+    );
+    expect(rails(rows)).toEqual([{ above: false, below: false }]);
+  });
+
+  it('joins the entries of a day and stops the rail at the day header', () => {
+    const rows = flattenFeed(
+      [
+        {
+          key: 'today',
+          label: 'Today',
+          entries: [
+            withId(created, 'e3'),
+            withId(edited, 'e2'),
+            withId(created, 'e1'),
+          ],
+        },
+        { key: 'yesterday', label: 'Yesterday', entries: [edited] },
+      ],
+      { hasMore: false }
+    );
+    expect(rails(rows)).toEqual([
+      { above: false, below: true },
+      { above: true, below: true },
+      { above: true, below: false },
+      { above: false, below: false },
+    ]);
   });
 });
 
@@ -66,6 +109,40 @@ describe('reuseRows', () => {
       'day',
       'entry',
     ]);
+  });
+
+  it('replaces the last entry of a day when the next page extends its rail below', () => {
+    const previous = flattenFeed(
+      [
+        {
+          key: 'today',
+          label: 'Today',
+          entries: [withId(created, 'e2'), withId(edited, 'e1')],
+        },
+      ],
+      { hasMore: true }
+    );
+    const next = flattenFeed(
+      [
+        {
+          key: 'today',
+          label: 'Today',
+          entries: [
+            withId(created, 'e2'),
+            withId(edited, 'e1'),
+            withId(created, 'e0'),
+          ],
+        },
+      ],
+      { hasMore: false }
+    );
+    const reused = reuseRows(previous, next);
+    expect(reused[1]).toBe(previous[1]);
+    expect(reused[2]).toBe(next[2]);
+    expect(reused[2]).toEqual(
+      expect.objectContaining({ rail: { above: true, below: true } })
+    );
+    expect(reused[3]).toBe(next[3]);
   });
 });
 

--- a/apps/web/src/features/activity/core/feed-rows.ts
+++ b/apps/web/src/features/activity/core/feed-rows.ts
@@ -1,4 +1,4 @@
-import type { ActivityEvent } from './event';
+import { entryKey, type FeedEntry } from './collapse-runs';
 import type { FeedGroup } from './group-events';
 
 /**
@@ -8,11 +8,11 @@ import type { FeedGroup } from './group-events';
 export type FeedRow =
   | { kind: 'overview' }
   | { kind: 'day'; key: string; label: string }
-  | { kind: 'event'; event: ActivityEvent }
+  | { kind: 'entry'; entry: FeedEntry }
   | { kind: 'status'; status: 'loading' | 'error' | 'empty' }
   | { kind: 'tail' };
 
-/** Day headers and their events in order, plus a tail row while more pages exist. */
+/** Day headers and their entries in order, plus a tail row while more pages exist. */
 export function flattenFeed(
   groups: FeedGroup[],
   options: { hasMore: boolean }
@@ -20,7 +20,7 @@ export function flattenFeed(
   const rows: FeedRow[] = [];
   for (const group of groups) {
     rows.push({ kind: 'day', key: group.key, label: group.label });
-    for (const event of group.events) rows.push({ kind: 'event', event });
+    for (const entry of group.entries) rows.push({ kind: 'entry', entry });
   }
   if (options.hasMore) rows.push({ kind: 'tail' });
   return rows;
@@ -33,8 +33,8 @@ function rowKey(row: FeedRow): string {
       return row.kind;
     case 'day':
       return `day:${row.key}`;
-    case 'event':
-      return `event:${row.event.id}`;
+    case 'entry':
+      return `entry:${entryKey(row.entry)}`;
     case 'status':
       return `status:${row.status}`;
   }
@@ -44,7 +44,8 @@ function rowKey(row: FeedRow): string {
  * Carry previous row objects forward where the key matches, so the list
  * keys rows by reference and a refetch or a paging flag flip does not
  * remount every mounted row. Events are immutable once recorded, so a
- * matching id is a matching row.
+ * matching id is a matching row; a run is keyed by its first and last event,
+ * so a run that grows with the next page reads as a new row.
  */
 export function reuseRows(previous: FeedRow[], next: FeedRow[]): FeedRow[] {
   if (previous.length === 0) return next;

--- a/apps/web/src/features/activity/core/feed-rows.ts
+++ b/apps/web/src/features/activity/core/feed-rows.ts
@@ -1,6 +1,9 @@
 import { entryKey, type FeedEntry } from './collapse-runs';
 import type { FeedGroup } from './group-events';
 
+/** Which connector segments a glyph-rail row draws toward its neighbours. */
+export type RailEnds = { above: boolean; below: boolean };
+
 /**
  * One virtualized row of the Activity screen. The overview card is row zero
  * so it scrolls with the feed and the virtualizer needs no start margin.
@@ -8,11 +11,14 @@ import type { FeedGroup } from './group-events';
 export type FeedRow =
   | { kind: 'overview' }
   | { kind: 'day'; key: string; label: string }
-  | { kind: 'entry'; entry: FeedEntry }
+  | { kind: 'entry'; entry: FeedEntry; rail: RailEnds }
   | { kind: 'status'; status: 'loading' | 'error' | 'empty' }
   | { kind: 'tail' };
 
-/** Day headers and their entries in order, plus a tail row while more pages exist. */
+/**
+ * Day headers and their entries in order, plus a tail row while more pages
+ * exist. The rail joins entries within a day and never crosses a header.
+ */
 export function flattenFeed(
   groups: FeedGroup[],
   options: { hasMore: boolean }
@@ -20,7 +26,14 @@ export function flattenFeed(
   const rows: FeedRow[] = [];
   for (const group of groups) {
     rows.push({ kind: 'day', key: group.key, label: group.label });
-    for (const entry of group.entries) rows.push({ kind: 'entry', entry });
+    const last = group.entries.length - 1;
+    for (const [index, entry] of group.entries.entries()) {
+      rows.push({
+        kind: 'entry',
+        entry,
+        rail: { above: index > 0, below: index < last },
+      });
+    }
   }
   if (options.hasMore) rows.push({ kind: 'tail' });
   return rows;
@@ -40,17 +53,30 @@ function rowKey(row: FeedRow): string {
   }
 }
 
+function sameRail(previous: FeedRow, next: FeedRow): boolean {
+  if (previous.kind !== 'entry' || next.kind !== 'entry') return true;
+  return (
+    previous.rail.above === next.rail.above &&
+    previous.rail.below === next.rail.below
+  );
+}
+
 /**
  * Carry previous row objects forward where the key matches, so the list
  * keys rows by reference and a refetch or a paging flag flip does not
  * remount every mounted row. Events are immutable once recorded, so a
  * matching id is a matching row; a run is keyed by its first and last event,
- * so a run that grows with the next page reads as a new row.
+ * so a run that grows with the next page reads as a new row. The last entry
+ * of a day gains a rail below when the next page adds to that day, so a
+ * changed rail also reads as a new row.
  */
 export function reuseRows(previous: FeedRow[], next: FeedRow[]): FeedRow[] {
   if (previous.length === 0) return next;
   const byKey = new Map(previous.map((row) => [rowKey(row), row]));
-  return next.map((row) => byKey.get(rowKey(row)) ?? row);
+  return next.map((row) => {
+    const reused = byKey.get(rowKey(row));
+    return reused && sameRail(reused, row) ? reused : row;
+  });
 }
 
 /** Floor for the near-bottom threshold so tiny viewports still page. */

--- a/apps/web/src/features/activity/core/fold-panel.test.ts
+++ b/apps/web/src/features/activity/core/fold-panel.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { FeedEntry } from './collapse-runs';
+import type { ActivityEvent } from './event';
+import { foldPanel } from './fold-panel';
+
+function single(id: string): FeedEntry {
+  const event: ActivityEvent = {
+    id,
+    actorId: 'macro|sarah@example.com',
+    entityId: 'doc-1',
+    entityType: 'document',
+    occurredAt: '2026-08-21T12:00:00.000Z',
+    action: { kind: 'edited' },
+  };
+  return { kind: 'single', event };
+}
+
+const entries = (count: number) =>
+  Array.from({ length: count }, (_, index) => single(`evt-${index}`));
+
+describe('foldPanel', () => {
+  it('shows everything when the entries fit within the limit', () => {
+    const list = entries(3);
+    expect(foldPanel(list, 3)).toEqual({
+      head: list,
+      hidden: 0,
+      tail: undefined,
+    });
+  });
+
+  it('does not fold one extra entry, since the tail would show it anyway', () => {
+    const list = entries(4);
+    expect(foldPanel(list, 3)).toEqual({
+      head: list,
+      hidden: 0,
+      tail: undefined,
+    });
+  });
+
+  it('keeps the newest entries, counts the fold, and pins the oldest last', () => {
+    const list = entries(20);
+    const fold = foldPanel(list, 3);
+
+    expect(fold.head).toEqual(list.slice(0, 3));
+    expect(fold.hidden).toBe(16);
+    expect(fold.tail).toBe(list[19]);
+  });
+
+  it('folds exactly one entry when the list is two past the limit', () => {
+    const list = entries(5);
+    const fold = foldPanel(list, 3);
+    expect(fold.head.length + fold.hidden + 1).toBe(list.length);
+    expect(fold.hidden).toBe(1);
+  });
+
+  it('returns nothing for no entries', () => {
+    expect(foldPanel([], 3)).toEqual({ head: [], hidden: 0, tail: undefined });
+  });
+});

--- a/apps/web/src/features/activity/core/fold-panel.ts
+++ b/apps/web/src/features/activity/core/fold-panel.ts
@@ -1,0 +1,27 @@
+import type { FeedEntry } from './collapse-runs';
+
+/**
+ * The side panel's collapsed shape: the newest `head` entries, how many are
+ * folded away behind the toggle, and the oldest fetched entry pinned last
+ * so the line that started the entity's history stays in view.
+ */
+export type PanelFold = {
+  head: FeedEntry[];
+  hidden: number;
+  tail: FeedEntry | undefined;
+};
+
+/**
+ * Fold `entries` (newest first) to `limit` visible lines plus a pinned tail.
+ * Nothing folds when every entry already fits, tail included.
+ */
+export function foldPanel(entries: FeedEntry[], limit: number): PanelFold {
+  if (entries.length <= limit + 1) {
+    return { head: entries, hidden: 0, tail: undefined };
+  }
+  return {
+    head: entries.slice(0, limit),
+    hidden: entries.length - limit - 1,
+    tail: entries[entries.length - 1],
+  };
+}

--- a/apps/web/src/features/activity/core/group-events.test.ts
+++ b/apps/web/src/features/activity/core/group-events.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
+import { entryHead } from './collapse-runs';
 import type { ActivityEvent } from './event';
 import { groupEventsByDay } from './group-events';
 
-function event(id: string, occurredAt: string): ActivityEvent {
+function event(
+  id: string,
+  occurredAt: string,
+  overrides: Partial<ActivityEvent> = {}
+): ActivityEvent {
   return {
     id,
     actorId: 'macro|e2e@macro.local',
@@ -10,8 +15,12 @@ function event(id: string, occurredAt: string): ActivityEvent {
     entityType: 'document',
     occurredAt,
     action: { kind: 'created' },
+    ...overrides,
   };
 }
+
+const ids = (entries: ReturnType<typeof groupEventsByDay>[number]['entries']) =>
+  entries.map((entry) => entryHead(entry).id);
 
 describe('groupEventsByDay', () => {
   it('returns an empty list for no events', () => {
@@ -20,13 +29,12 @@ describe('groupEventsByDay', () => {
 
   it('keeps consecutive events that share a date bucket in one group', () => {
     const groups = groupEventsByDay([
-      event('a', '2026-08-21T10:00:00.000Z'),
+      event('a', '2026-08-21T10:00:00.000Z', { action: { kind: 'edited' } }),
       event('b', '2026-08-21T11:00:00.000Z'),
     ]);
 
     expect(groups).toHaveLength(1);
-    expect(groups[0].events.map((item) => item.id)).toEqual(['a', 'b']);
-    expect(groups[0].key).toBe(groups[0].key);
+    expect(ids(groups[0].entries)).toEqual(['a', 'b']);
   });
 
   it('starts a new group when the date bucket changes', () => {
@@ -36,8 +44,23 @@ describe('groupEventsByDay', () => {
     ]);
 
     expect(groups).toHaveLength(2);
-    expect(groups[0].events.map((item) => item.id)).toEqual(['today']);
-    expect(groups[1].events.map((item) => item.id)).toEqual(['older']);
+    expect(ids(groups[0].entries)).toEqual(['today']);
+    expect(ids(groups[1].entries)).toEqual(['older']);
     expect(groups[0].key).not.toBe(groups[1].key);
+  });
+
+  it('collapses same-entity runs inside a day but never across a day header', () => {
+    const groups = groupEventsByDay([
+      event('a', '2026-08-21T12:00:00.000Z', { action: { kind: 'edited' } }),
+      event('b', '2026-08-21T11:00:00.000Z', { action: { kind: 'edited' } }),
+      event('c', '2020-01-01T10:00:00.000Z', { action: { kind: 'edited' } }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].entries).toHaveLength(1);
+    expect(groups[0].entries[0].kind).toBe('run');
+    expect(groups[1].entries).toEqual([
+      { kind: 'single', event: expect.objectContaining({ id: 'c' }) },
+    ]);
   });
 });

--- a/apps/web/src/features/activity/core/group-events.ts
+++ b/apps/web/src/features/activity/core/group-events.ts
@@ -1,22 +1,36 @@
 import { dateBucket } from '@app/features/soup/collection/date-buckets';
+import { collapseRuns, type FeedEntry } from './collapse-runs';
 import type { ActivityEvent } from './event';
 
 export type FeedGroup = {
   key: string;
   label: string;
-  events: ActivityEvent[];
+  entries: FeedEntry[];
 };
 
+/**
+ * Bucket newest-first events by day, then fold each day's consecutive
+ * same-entity events into runs. Bucketing first keeps a run inside one day
+ * header.
+ */
 export function groupEventsByDay(events: ActivityEvent[]): FeedGroup[] {
-  const out: FeedGroup[] = [];
+  const buckets: Array<{
+    key: string;
+    label: string;
+    events: ActivityEvent[];
+  }> = [];
   for (const event of events) {
     const bucket = dateBucket(event.occurredAt);
-    const last = out[out.length - 1];
+    const last = buckets[buckets.length - 1];
     if (last?.key === bucket.key) {
       last.events.push(event);
     } else {
-      out.push({ ...bucket, events: [event] });
+      buckets.push({ ...bucket, events: [event] });
     }
   }
-  return out;
+  return buckets.map(({ key, label, events }) => ({
+    key,
+    label,
+    entries: collapseRuns(events),
+  }));
 }

--- a/apps/web/src/features/activity/primitives/my-activity.test.ts
+++ b/apps/web/src/features/activity/primitives/my-activity.test.ts
@@ -99,7 +99,13 @@ describe('createMyActivityState', () => {
       'entry',
       'entry',
     ]);
-    expect(state.rows()[2]).toBe(ready[2]);
+    // The same day grew, so the first entry now draws a rail below it and
+    // is a new row; the header keeps its identity.
+    expect(state.rows()[1]).toBe(ready[1]);
+    expect(state.rows()[2]).not.toBe(ready[2]);
+    expect(state.rows()[2]).toEqual(
+      expect.objectContaining({ rail: { above: false, below: true } })
+    );
   });
 
   it('ignores loadMore while a page is in flight or none remain', () => {

--- a/apps/web/src/features/activity/primitives/my-activity.test.ts
+++ b/apps/web/src/features/activity/primitives/my-activity.test.ts
@@ -160,7 +160,7 @@ describe('createMyActivityState', () => {
     if (after.t !== 'ready') throw new Error('feed should stay ready');
     expect(after.moreFailed).toBe(false);
     expect(after.hasMore).toBe(false);
-    expect(after.groups.flatMap((g) => g.events)).toHaveLength(2);
+    expect(after.groups.flatMap((g) => g.entries)).toHaveLength(2);
   });
 
   it('is empty when the first page has no rows', () => {

--- a/apps/web/src/features/activity/primitives/my-activity.test.ts
+++ b/apps/web/src/features/activity/primitives/my-activity.test.ts
@@ -1,5 +1,6 @@
 import { createRoot } from 'solid-js';
 import { afterEach, describe, expect, it } from 'vitest';
+import { entryHead } from '../core/collapse-runs';
 import { createdEvent, editedEvent } from '../queries/fixtures';
 import { createMockActivityContext } from '../tests/mock-context';
 import { feedPage, overviewPage } from '../tests/wire';
@@ -51,9 +52,9 @@ describe('createMyActivityState', () => {
     if (feed.t !== 'ready') return;
     expect(feed.hasMore).toBe(true);
     expect(feed.loadingMore).toBe(false);
-    expect(feed.groups.flatMap((g) => g.events.map((e) => e.id))).toEqual([
-      'evt-1',
-    ]);
+    expect(
+      feed.groups.flatMap((g) => g.entries.map((e) => entryHead(e).id))
+    ).toEqual(['evt-1']);
   });
 
   it('appends the next page on loadMore', () => {
@@ -67,10 +68,9 @@ describe('createMyActivityState', () => {
 
     const feed = state.feed();
     if (feed.t !== 'ready') throw new Error(feed.t);
-    expect(feed.groups.flatMap((g) => g.events.map((e) => e.id))).toEqual([
-      'evt-1',
-      'evt-2',
-    ]);
+    expect(
+      feed.groups.flatMap((g) => g.entries.map((e) => entryHead(e).id))
+    ).toEqual(['evt-1', 'evt-2']);
     expect(feed.hasMore).toBe(false);
   });
 
@@ -83,7 +83,7 @@ describe('createMyActivityState', () => {
     expect(ready.map((row) => row.kind)).toEqual([
       'overview',
       'day',
-      'event',
+      'entry',
       'tail',
     ]);
 
@@ -96,8 +96,8 @@ describe('createMyActivityState', () => {
     expect(state.rows().map((row) => row.kind)).toEqual([
       'overview',
       'day',
-      'event',
-      'event',
+      'entry',
+      'entry',
     ]);
     expect(state.rows()[2]).toBe(ready[2]);
   });

--- a/apps/web/src/features/activity/views/activity-timeline-row.tsx
+++ b/apps/web/src/features/activity/views/activity-timeline-row.tsx
@@ -3,7 +3,7 @@ import {
   type OpenEntityTarget,
   useActivityContext,
 } from '../context/activity-context';
-import type { ActivityEvent } from '../core/event';
+import { entryAction, entryHead, type FeedEntry } from '../core/collapse-runs';
 import { createEntityOpener } from '../primitives/entity-opener';
 
 /**
@@ -11,26 +11,27 @@ import { createEntityOpener } from '../primitives/entity-opener';
  * `onOpen` to make the row click-to-open; leave it out for inert rows.
  */
 export function ActivityTimelineRow(props: {
-  event: ActivityEvent;
+  entry: FeedEntry;
   actorName?: string;
   showActor?: boolean;
   onOpen?: (target: OpenEntityTarget) => void;
 }) {
   const context = useActivityContext();
+  const head = () => entryHead(props.entry);
   const opener = createEntityOpener(
     context,
-    () => props.event.entityId,
-    () => props.event.entityType,
+    () => head().entityId,
+    () => head().entityType,
     props.onOpen
   );
   const definition = context.propertyDefinition(() => {
-    const action = props.event.action;
+    const action = entryAction(props.entry);
     return action.kind === 'property-changed' ? action.property : undefined;
   });
 
   return (
     <ActivityTimelineRowView
-      event={props.event}
+      entry={props.entry}
       actorName={props.actorName}
       showActor={props.showActor}
       display={opener()?.display}

--- a/apps/web/src/features/activity/views/activity-timeline-row.tsx
+++ b/apps/web/src/features/activity/views/activity-timeline-row.tsx
@@ -4,6 +4,7 @@ import {
   useActivityContext,
 } from '../context/activity-context';
 import { entryAction, entryHead, type FeedEntry } from '../core/collapse-runs';
+import type { RailEnds } from '../core/feed-rows';
 import { createEntityOpener } from '../primitives/entity-opener';
 
 /**
@@ -14,6 +15,7 @@ export function ActivityTimelineRow(props: {
   entry: FeedEntry;
   actorName?: string;
   showActor?: boolean;
+  rail?: RailEnds;
   onOpen?: (target: OpenEntityTarget) => void;
 }) {
   const context = useActivityContext();
@@ -34,6 +36,7 @@ export function ActivityTimelineRow(props: {
       entry={props.entry}
       actorName={props.actorName}
       showActor={props.showActor}
+      rail={props.rail}
       display={opener()?.display}
       rowProps={opener()?.handlers}
       propertyDefinition={definition()}

--- a/apps/web/src/features/activity/views/entity-activity-section.test.tsx
+++ b/apps/web/src/features/activity/views/entity-activity-section.test.tsx
@@ -1,0 +1,152 @@
+import type { ActivityEventFieldsFragment } from '@service-storage/graphql/generated/graphql';
+import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library';
+import type { JSX } from 'solid-js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ActivityContextProvider } from '../context/activity-context';
+import {
+  createdEvent,
+  editedEvent,
+  openedEvent,
+  propertyChangedEvent,
+} from '../queries/fixtures';
+import { createMockActivityContext } from '../tests/mock-context';
+import { soupPage } from '../tests/wire';
+import { EntityActivitySection } from './entity-activity-section';
+
+// The section registers with the side panel accordion, which needs the
+// panel layout; here only the section body is under test.
+vi.mock('@components/app/side-panel/SidePanel', () => ({
+  SidePanel: {
+    Section: (props: { children: JSX.Element }) => props.children,
+    Loading: () => <div data-loading />,
+    EmptyPill: (props: { label: string }) => <span>{props.label}</span>,
+  },
+}));
+
+vi.mock(
+  '@core/component/LexicalMarkdown/component/core/StaticMarkdown',
+  () => ({
+    StaticMarkdownContext: (props: { children: unknown }) => props.children,
+    StaticMarkdown: () => null,
+  })
+);
+
+vi.mock('@service-connection/websocket', () => ({
+  ws: { send() {}, addEventListener() {}, removeEventListener() {} },
+  state: () => 'closed',
+  createConnectionBlockWebsocketEffect() {},
+  createConnectionWebsocketEffect() {},
+  parseWebsocketPayload: () => undefined,
+}));
+
+vi.mock('@service-storage/websocket', () => ({
+  storageWS: { send() {}, addEventListener() {}, removeEventListener() {} },
+  createWebSocketJob: () => Promise.reject(new Error('no websocket in tests')),
+}));
+
+afterEach(cleanup);
+
+function renderSection() {
+  const context = createMockActivityContext();
+  const result = render(() => (
+    <ActivityContextProvider value={context}>
+      <EntityActivitySection entityId="doc-1" entityType="DOCUMENT" />
+    </ActivityContextProvider>
+  ));
+  return { ...result, graphql: context.graphqlMock };
+}
+
+function resolve(
+  graphql: ReturnType<typeof renderSection>['graphql'],
+  activity: ActivityEventFieldsFragment[]
+) {
+  graphql
+    .latest('EntityActivity')
+    .resolve(
+      soupPage([{ __typename: 'GraphqlSoupDocument', id: 'doc-1', activity }])
+    );
+}
+
+const rows = () => document.querySelectorAll('[data-activity-row]');
+const at = (id: string, event: ActivityEventFieldsFragment) => ({
+  ...event,
+  id,
+});
+
+// Newest first: three edits fold into one run, then four singles, with the
+// creation row oldest. Six entries for eight events.
+const HISTORY: ActivityEventFieldsFragment[] = [
+  at('e8', editedEvent),
+  at('e7', editedEvent),
+  at('e6', editedEvent),
+  at('e5', openedEvent),
+  at('e4', editedEvent),
+  at('e3', propertyChangedEvent),
+  at('e2', openedEvent),
+  at('e1', createdEvent),
+];
+
+describe('EntityActivitySection', () => {
+  it('shows every entry unfolded when the history is short', () => {
+    const { container, graphql } = renderSection();
+    resolve(graphql, HISTORY.slice(4));
+
+    expect(rows()).toHaveLength(4);
+    expect(container.querySelector('[data-activity-fold-toggle]')).toBeNull();
+  });
+
+  it('folds to three newest entries, a toggle, and the pinned creation row', () => {
+    const { container, graphql } = renderSection();
+    resolve(graphql, HISTORY);
+
+    const visible = rows();
+    expect(visible).toHaveLength(4);
+    expect(visible[0]?.getAttribute('data-activity-run-size')).toBe('3');
+    expect(visible[0]?.textContent).toContain('3 times');
+    expect(visible[1]?.getAttribute('data-activity-action')).toBe('opened');
+    expect(visible[2]?.getAttribute('data-activity-action')).toBe('edited');
+    expect(visible[3]?.getAttribute('data-activity-action')).toBe('created');
+
+    const toggle = screen.getByRole('button', { name: 'View all activities' });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(container.textContent).not.toContain('Show all');
+
+    fireEvent.click(toggle);
+    expect(rows()).toHaveLength(6);
+    expect(
+      screen
+        .getByRole('button', { name: 'Show less' })
+        .getAttribute('aria-expanded')
+    ).toBe('true');
+    expect(rows()[5]?.getAttribute('data-activity-action')).toBe('created');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show less' }));
+    expect(rows()).toHaveLength(4);
+    expect(
+      screen.getByRole('button', { name: 'View all activities' })
+    ).toBeTruthy();
+  });
+
+  it('reads compact rows with the actor, the phrase, and an inline time', () => {
+    const { graphql } = renderSection();
+    resolve(graphql, [at('e1', createdEvent)]);
+
+    const row = rows()[0];
+    if (!row) throw new Error('row not rendered');
+    expect(row.textContent).toContain('sarah');
+    expect(row.textContent).toContain('created this');
+    expect(row.querySelector('time')).not.toBeNull();
+    expect(row.textContent).toContain('·');
+  });
+
+  it('shows the empty and error states', () => {
+    const empty = renderSection();
+    resolve(empty.graphql, []);
+    expect(empty.container.textContent).toContain('No activity yet');
+    cleanup();
+
+    const failed = renderSection();
+    failed.graphql.latest('EntityActivity').fail('boom');
+    expect(failed.container.textContent).toContain('Activity is unavailable');
+  });
+});

--- a/apps/web/src/features/activity/views/entity-activity-section.test.tsx
+++ b/apps/web/src/features/activity/views/entity-activity-section.test.tsx
@@ -111,7 +111,9 @@ describe('EntityActivitySection', () => {
     const visible = rows();
     expect(visible).toHaveLength(4);
     expect(visible[0]?.getAttribute('data-activity-run-size')).toBe('3');
-    expect(visible[0]?.textContent).toContain('3 times');
+    // No entity on the panel's own rows, so the count folds into the verb.
+    expect(visible[0]?.textContent).toContain('made 3 edits');
+    expect(visible[0]?.textContent).not.toContain('times');
     expect(visible[1]?.getAttribute('data-activity-action')).toBe('opened');
     expect(visible[2]?.getAttribute('data-activity-action')).toBe('edited');
     expect(visible[3]?.getAttribute('data-activity-action')).toBe('created');

--- a/apps/web/src/features/activity/views/entity-activity-section.test.tsx
+++ b/apps/web/src/features/activity/views/entity-activity-section.test.tsx
@@ -68,6 +68,8 @@ function resolve(
 }
 
 const rows = () => document.querySelectorAll('[data-activity-row]');
+const RAIL_ABOVE = '[data-activity-rail="above"]';
+const RAIL_BELOW = '[data-activity-rail="below"]';
 const at = (id: string, event: ActivityEventFieldsFragment) => ({
   ...event,
   id,
@@ -91,8 +93,15 @@ describe('EntityActivitySection', () => {
     const { container, graphql } = renderSection();
     resolve(graphql, HISTORY.slice(4));
 
-    expect(rows()).toHaveLength(4);
+    const visible = rows();
+    expect(visible).toHaveLength(4);
     expect(container.querySelector('[data-activity-fold-toggle]')).toBeNull();
+    expect(visible[0]?.querySelector(RAIL_ABOVE)?.classList).toContain(
+      'invisible'
+    );
+    expect(visible[3]?.querySelector(RAIL_BELOW)?.classList).toContain(
+      'invisible'
+    );
   });
 
   it('folds to three newest entries, a toggle, and the pinned creation row', () => {
@@ -111,14 +120,39 @@ describe('EntityActivitySection', () => {
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
     expect(container.textContent).not.toContain('Show all');
 
+    // The rail starts at the first glyph, runs through the toggle, and ends
+    // at the pinned row's glyph.
+    expect(visible[0]?.querySelector(RAIL_ABOVE)?.classList).toContain(
+      'invisible'
+    );
+    expect(visible[0]?.querySelector(RAIL_BELOW)?.classList).not.toContain(
+      'invisible'
+    );
+    expect(visible[2]?.querySelector(RAIL_BELOW)?.classList).not.toContain(
+      'invisible'
+    );
+    expect(toggle.querySelector(RAIL_BELOW)?.classList).not.toContain(
+      'invisible'
+    );
+    expect(visible[3]?.querySelector(RAIL_ABOVE)?.classList).not.toContain(
+      'invisible'
+    );
+    expect(visible[3]?.querySelector(RAIL_BELOW)?.classList).toContain(
+      'invisible'
+    );
+    expect(container.querySelector('.ring')).toBeNull();
+
     fireEvent.click(toggle);
     expect(rows()).toHaveLength(6);
-    expect(
-      screen
-        .getByRole('button', { name: 'Show less' })
-        .getAttribute('aria-expanded')
-    ).toBe('true');
+    const showLess = screen.getByRole('button', { name: 'Show less' });
+    expect(showLess.getAttribute('aria-expanded')).toBe('true');
     expect(rows()[5]?.getAttribute('data-activity-action')).toBe('created');
+    expect(rows()[5]?.querySelector(RAIL_BELOW)?.classList).not.toContain(
+      'invisible'
+    );
+    expect(showLess.querySelector(RAIL_BELOW)?.classList).toContain(
+      'invisible'
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Show less' }));
     expect(rows()).toHaveLength(4);
@@ -127,7 +161,7 @@ describe('EntityActivitySection', () => {
     ).toBeTruthy();
   });
 
-  it('reads compact rows with the actor, the phrase, and an inline time', () => {
+  it('reads compact rows with the actor, the phrase, and a compact inline time', () => {
     const { graphql } = renderSection();
     resolve(graphql, [at('e1', createdEvent)]);
 
@@ -135,8 +169,12 @@ describe('EntityActivitySection', () => {
     if (!row) throw new Error('row not rendered');
     expect(row.textContent).toContain('sarah');
     expect(row.textContent).toContain('created this');
-    expect(row.querySelector('time')).not.toBeNull();
+    const time = row.querySelector('time');
+    expect(time?.getAttribute('dateTime')).toBe(createdEvent.occurredAt);
+    expect(time?.textContent).toMatch(/^(now|\d+(m|h|d|w|mo|y))$/);
+    expect(time?.getAttribute('title')).toBeTruthy();
     expect(row.textContent).toContain('·');
+    expect(row.textContent).not.toContain('ago');
   });
 
   it('shows the empty and error states', () => {

--- a/apps/web/src/features/activity/views/entity-activity-section.tsx
+++ b/apps/web/src/features/activity/views/entity-activity-section.tsx
@@ -1,19 +1,31 @@
 import { SidePanel } from '@components/app/side-panel/SidePanel';
-import { formatRelativeTimestamp } from '@entity/utils/timestamp';
-import CaretRightIcon from '@phosphor/caret-right.svg';
+import CaretUpDownIcon from '@phosphor/caret-up-down.svg';
 import type { EntityType } from '@service-properties/generated/schemas/entityType';
-import { cn } from '@ui';
-import { createSignal, For, Match, Show, Suspense, Switch } from 'solid-js';
-import { ActionPhrase } from '../components/action-phrase';
-import { ActorName } from '../components/actor-name';
+import {
+  createMemo,
+  createSignal,
+  For,
+  Match,
+  Show,
+  Suspense,
+  Switch,
+} from 'solid-js';
+import { ActivityTimelineRow } from '../components/activity-timeline-row';
 import { useActivityContext } from '../context/activity-context';
+import {
+  collapseRuns,
+  entryAction,
+  entryHead,
+  type FeedEntry,
+} from '../core/collapse-runs';
 import type { ActivityEvent } from '../core/event';
+import { foldPanel } from '../core/fold-panel';
 import { createActorName } from '../primitives/actor-name';
 import { createEntityActivityState } from '../primitives/entity-activity';
 import { useEntityActivityFlag } from '../use-entity-activity-flag';
 
-/** Rows shown before the section collapses behind a "Show all" toggle. */
-const COLLAPSED_ROW_LIMIT = 10;
+/** Newest entries shown before the section folds behind its toggle. */
+const PANEL_HEAD_LIMIT = 3;
 
 export interface EntityActivitySectionProps {
   entityId: string;
@@ -72,67 +84,76 @@ export function EntityActivitySection(props: EntityActivitySectionProps) {
   );
 }
 
+/**
+ * Newest entries first, folded to `PANEL_HEAD_LIMIT` lines plus the oldest
+ * fetched entry pinned last so the line that started the history stays in
+ * view. The rail is trimmed to the glyph centers at both ends.
+ */
 function ReadyActivityList(props: { events: ActivityEvent[] }) {
   const [expanded, setExpanded] = createSignal(false);
-  const visibleEvents = () =>
-    expanded() ? props.events : props.events.slice(0, COLLAPSED_ROW_LIMIT);
-  const hasOverflow = () => props.events.length > COLLAPSED_ROW_LIMIT;
+  const entries = createMemo(() => collapseRuns(props.events));
+  const fold = createMemo(() => foldPanel(entries(), PANEL_HEAD_LIMIT));
+  const folded = () => fold().tail !== undefined;
+  const visible = () => (expanded() ? entries() : fold().head);
 
   return (
-    <div class="text-xs">
-      <SidePanel.Card>
-        <For each={visibleEvents()}>
-          {(event) => <ActivityRow event={event} />}
-        </For>
-      </SidePanel.Card>
-      <Show when={hasOverflow()}>
-        <button
-          type="button"
-          aria-expanded={expanded()}
-          class="mt-1 flex w-full items-center gap-1.5 rounded-md px-1 py-1 text-ink-muted text-xs hover:bg-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-          onClick={() => setExpanded((current) => !current)}
-        >
-          <CaretRightIcon
-            class={cn(
-              'size-3 shrink-0 transition-transform duration-90',
-              expanded() && 'rotate-90'
-            )}
-          />
-          <span>
-            {expanded() ? 'Show less' : `Show all (${props.events.length})`}
-          </span>
-        </button>
+    <div
+      class="flex flex-col [&>:first-child_[data-activity-rail]]:top-1/2 [&>:last-child_[data-activity-rail]]:bottom-1/2"
+      data-activity-panel
+    >
+      <For each={visible()}>{(entry) => <PanelRow entry={entry} />}</For>
+      <Show when={folded()}>
+        <FoldToggle
+          expanded={expanded()}
+          onToggle={() => setExpanded((current) => !current)}
+        />
+        <Show when={!expanded() ? fold().tail : undefined}>
+          {(tail) => <PanelRow entry={tail()} />}
+        </Show>
       </Show>
     </div>
   );
 }
 
-function ActivityRow(props: { event: ActivityEvent }) {
+function PanelRow(props: { entry: FeedEntry }) {
   const context = useActivityContext();
-  const name = createActorName(context, () => props.event.actorId);
+  const name = createActorName(context, () => entryHead(props.entry).actorId);
   const definition = context.propertyDefinition(() => {
-    const action = props.event.action;
+    const action = entryAction(props.entry);
     return action.kind === 'property-changed' ? action.property : undefined;
   });
   return (
-    <div
-      class="flex min-h-7 min-w-0 items-center gap-2 px-2 py-1"
-      data-activity-row
-      data-activity-action={props.event.action.kind}
+    <ActivityTimelineRow
+      entry={props.entry}
+      actorName={name()}
+      propertyDefinition={definition()}
+      compact
+    />
+  );
+}
+
+/** The fold row sits in the rail with a dotted connector in place of the line. */
+function FoldToggle(props: { expanded: boolean; onToggle: () => void }) {
+  return (
+    <button
+      type="button"
+      aria-expanded={props.expanded}
+      class="flex w-full items-stretch gap-1 text-left text-ink-muted text-xs hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+      data-activity-fold-toggle
+      onClick={() => props.onToggle()}
     >
-      <span class="flex min-w-0 flex-1 flex-wrap items-center gap-x-1 gap-y-0.5">
-        <span class="font-medium text-ink">
-          <ActorName name={name()} />
-        </span>
-        <span class="min-w-0 text-ink-muted">
-          <ActionPhrase event={props.event} propertyDefinition={definition()} />
+      <span class="relative flex w-5 shrink-0 items-center justify-center">
+        <span
+          class="absolute inset-y-0 border-edge-muted border-l border-dotted"
+          data-activity-rail
+        />
+        <span class="relative flex size-4 items-center justify-center rounded-full bg-surface ring ring-edge-muted">
+          <CaretUpDownIcon class="size-2.5" />
         </span>
       </span>
-      <span class="ml-auto shrink-0 text-ink-extra-muted">
-        {formatRelativeTimestamp(new Date(props.event.occurredAt), {
-          condensed: true,
-        })}
+      <span class="flex min-h-7 min-w-0 flex-1 items-center rounded-lg px-1.5 py-0.5 hover:bg-hover/30">
+        {props.expanded ? 'Show less' : 'View all activities'}
       </span>
-    </div>
+    </button>
   );
 }

--- a/apps/web/src/features/activity/views/entity-activity-section.tsx
+++ b/apps/web/src/features/activity/views/entity-activity-section.tsx
@@ -1,6 +1,7 @@
 import { SidePanel } from '@components/app/side-panel/SidePanel';
 import CaretUpDownIcon from '@phosphor/caret-up-down.svg';
 import type { EntityType } from '@service-properties/generated/schemas/entityType';
+import { cn } from '@ui';
 import {
   createMemo,
   createSignal,
@@ -19,6 +20,7 @@ import {
   type FeedEntry,
 } from '../core/collapse-runs';
 import type { ActivityEvent } from '../core/event';
+import type { RailEnds } from '../core/feed-rows';
 import { foldPanel } from '../core/fold-panel';
 import { createActorName } from '../primitives/actor-name';
 import { createEntityActivityState } from '../primitives/entity-activity';
@@ -87,7 +89,7 @@ export function EntityActivitySection(props: EntityActivitySectionProps) {
 /**
  * Newest entries first, folded to `PANEL_HEAD_LIMIT` lines plus the oldest
  * fetched entry pinned last so the line that started the history stays in
- * view. The rail is trimmed to the glyph centers at both ends.
+ * view. The rail runs from the first glyph to the last, through the toggle.
  */
 function ReadyActivityList(props: { events: ActivityEvent[] }) {
   const [expanded, setExpanded] = createSignal(false);
@@ -97,25 +99,34 @@ function ReadyActivityList(props: { events: ActivityEvent[] }) {
   const visible = () => (expanded() ? entries() : fold().head);
 
   return (
-    <div
-      class="flex flex-col [&>:first-child_[data-activity-rail]]:top-1/2 [&>:last-child_[data-activity-rail]]:bottom-1/2"
-      data-activity-panel
-    >
-      <For each={visible()}>{(entry) => <PanelRow entry={entry} />}</For>
+    <div class="flex flex-col" data-activity-panel>
+      <For each={visible()}>
+        {(entry, index) => (
+          <PanelRow
+            entry={entry}
+            rail={{
+              above: index() > 0,
+              below: index() < visible().length - 1 || folded(),
+            }}
+          />
+        )}
+      </For>
       <Show when={folded()}>
         <FoldToggle
           expanded={expanded()}
           onToggle={() => setExpanded((current) => !current)}
         />
         <Show when={!expanded() ? fold().tail : undefined}>
-          {(tail) => <PanelRow entry={tail()} />}
+          {(tail) => (
+            <PanelRow entry={tail()} rail={{ above: true, below: false }} />
+          )}
         </Show>
       </Show>
     </div>
   );
 }
 
-function PanelRow(props: { entry: FeedEntry }) {
+function PanelRow(props: { entry: FeedEntry; rail: RailEnds }) {
   const context = useActivityContext();
   const name = createActorName(context, () => entryHead(props.entry).actorId);
   const definition = context.propertyDefinition(() => {
@@ -127,31 +138,42 @@ function PanelRow(props: { entry: FeedEntry }) {
       entry={props.entry}
       actorName={name()}
       propertyDefinition={definition()}
+      rail={props.rail}
       compact
     />
   );
 }
 
-/** The fold row sits in the rail with a dotted connector in place of the line. */
+/**
+ * The fold row sits in the rail like a compact entry, with dotted connectors
+ * in place of the line. Expanded, it is the last row, so nothing runs below.
+ */
 function FoldToggle(props: { expanded: boolean; onToggle: () => void }) {
   return (
     <button
       type="button"
       aria-expanded={props.expanded}
-      class="flex w-full items-stretch gap-1 text-left text-ink-muted text-xs hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+      class="flex w-full items-stretch gap-1.5 text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
       data-activity-fold-toggle
       onClick={() => props.onToggle()}
     >
-      <span class="relative flex w-5 shrink-0 items-center justify-center">
+      <span class="flex w-3.5 shrink-0 flex-col items-center">
         <span
-          class="absolute inset-y-0 border-edge-muted border-l border-dotted"
-          data-activity-rail
+          aria-hidden
+          class="mb-[3px] flex-1 border-edge-muted border-l border-dotted"
+          data-activity-rail="above"
         />
-        <span class="relative flex size-4 items-center justify-center rounded-full bg-surface ring ring-edge-muted">
-          <CaretUpDownIcon class="size-2.5" />
-        </span>
+        <CaretUpDownIcon class="size-3.5 shrink-0 text-ink-muted" />
+        <span
+          aria-hidden
+          class={cn(
+            'mt-[3px] flex-1 border-edge-muted border-l border-dotted',
+            props.expanded && 'invisible'
+          )}
+          data-activity-rail="below"
+        />
       </span>
-      <span class="flex min-h-7 min-w-0 flex-1 items-center rounded-lg px-1.5 py-0.5 hover:bg-hover/30">
+      <span class="flex min-h-8 min-w-0 flex-1 items-center rounded-lg px-1 text-ink hover:bg-hover/30">
         {props.expanded ? 'Show less' : 'View all activities'}
       </span>
     </button>

--- a/apps/web/src/features/activity/views/my-activity-view.test.tsx
+++ b/apps/web/src/features/activity/views/my-activity-view.test.tsx
@@ -3,7 +3,12 @@ import type { JSX } from 'solid-js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ActivityContextProvider } from '../context/activity-context';
 import { placeholderOverview } from '../core/placeholder-overview';
-import { createdEvent, messagedEvent } from '../queries/fixtures';
+import {
+  createdEvent,
+  editedEvent,
+  messagedEvent,
+  propertyChangedEvent,
+} from '../queries/fixtures';
 import { createMockActivityContext } from '../tests/mock-context';
 import { feedPage, overviewPage } from '../tests/wire';
 import { MyActivityView } from './my-activity-view';
@@ -190,6 +195,47 @@ describe('MyActivityView', () => {
       .resolve(feedPage([{ ...createdEvent, id: 'evt-99' }], null));
     expect(rows()).toHaveLength(3);
     expect(container.querySelector('[data-activity-feed-tail]')).toBeNull();
+  });
+
+  it('collapses consecutive same-entity edits into one row with a count and inline time', () => {
+    const { graphql } = renderView();
+    const edits = ['e5', 'e4', 'e3', 'e2', 'e1'].map((id) => ({
+      ...editedEvent,
+      id,
+    }));
+    const text = (value: string) => ({ type: 'String', value });
+    const statusChange = (id: string, from: string, to: string) => ({
+      ...propertyChangedEvent,
+      id,
+      action: {
+        ...propertyChangedEvent.action,
+        from: text(from),
+        to: text(to),
+      },
+    });
+    graphql
+      .latest('MyActivity')
+      .resolve(
+        feedPage([
+          ...edits,
+          statusChange('p2', 'Todo', 'Done'),
+          statusChange('p1', 'Backlog', 'Todo'),
+          { ...createdEvent, id: 'c1' },
+        ])
+      );
+
+    const visible = rows();
+    expect(visible).toHaveLength(3);
+    expect(visible[0]?.getAttribute('data-activity-run-size')).toBe('5');
+    expect(visible[0]?.textContent).toContain('5 times');
+    expect(visible[0]?.querySelector('time')).not.toBeNull();
+    expect(visible[1]?.getAttribute('data-activity-run-size')).toBe('2');
+    expect(visible[1]?.textContent).toContain('2 changes');
+    expect(visible[1]?.textContent).toContain('Backlog');
+    expect(visible[1]?.textContent).toContain('Done');
+    expect(visible[1]?.textContent).not.toContain('Todo');
+    expect(visible[2]?.getAttribute('data-activity-run-size')).toBe('1');
+    expect(visible[2]?.textContent).not.toContain('times');
   });
 
   it('asks the host to open the row entity', () => {

--- a/apps/web/src/features/activity/views/my-activity-view.test.tsx
+++ b/apps/web/src/features/activity/views/my-activity-view.test.tsx
@@ -126,6 +126,13 @@ describe('MyActivityView', () => {
     expect(rows()[0]?.getAttribute('data-activity-action')).toBe('created');
     expect(rows()[1]?.getAttribute('data-activity-action')).toBe('messaged');
     expect(screen.getAllByText('sarah')).toHaveLength(2);
+    // Same day: one rail segment joins the two glyphs, nothing runs past them.
+    const rail = (row: Element | undefined, end: string) =>
+      row?.querySelector(`[data-activity-rail="${end}"]`)?.classList;
+    expect(rail(rows()[0], 'above')).toContain('invisible');
+    expect(rail(rows()[0], 'below')).not.toContain('invisible');
+    expect(rail(rows()[1], 'above')).not.toContain('invisible');
+    expect(rail(rows()[1], 'below')).toContain('invisible');
     expect(screen.queryByRole('button', { name: 'Show more' })).toBeNull();
     expect(container.querySelector('[data-activity-feed-tail]')).not.toBeNull();
 
@@ -228,7 +235,9 @@ describe('MyActivityView', () => {
     expect(visible).toHaveLength(3);
     expect(visible[0]?.getAttribute('data-activity-run-size')).toBe('5');
     expect(visible[0]?.textContent).toContain('5 times');
-    expect(visible[0]?.querySelector('time')).not.toBeNull();
+    expect(visible[0]?.querySelector('time')?.textContent).toMatch(
+      /^(now|\d+(m|h|d|w|mo|y))$/
+    );
     expect(visible[1]?.getAttribute('data-activity-run-size')).toBe('2');
     expect(visible[1]?.textContent).toContain('2 changes');
     expect(visible[1]?.textContent).toContain('Backlog');

--- a/apps/web/src/features/activity/views/my-activity-view.tsx
+++ b/apps/web/src/features/activity/views/my-activity-view.tsx
@@ -22,7 +22,11 @@ import {
 } from '../context/activity-context';
 import { entryHead, type FeedEntry } from '../core/collapse-runs';
 import type { ActivityTopEntity } from '../core/event';
-import { type FeedRow, shouldFetchMore } from '../core/feed-rows';
+import {
+  type FeedRow,
+  type RailEnds,
+  shouldFetchMore,
+} from '../core/feed-rows';
 import { placeholderOverview } from '../core/placeholder-overview';
 import { createActorName } from '../primitives/actor-name';
 import { createEntityOpener } from '../primitives/entity-opener';
@@ -129,7 +133,11 @@ function FeedRowView(props: {
       <SoupSectionHeader>{row.label}</SoupSectionHeader>
     ))
     .with({ kind: 'entry' }, (row) => (
-      <NamedActivityRow entry={row.entry} onOpen={props.onOpen} />
+      <NamedActivityRow
+        entry={row.entry}
+        rail={row.rail}
+        onOpen={props.onOpen}
+      />
     ))
     .with({ kind: 'status', status: 'loading' }, () => (
       <FeedStatus>Loading…</FeedStatus>
@@ -228,6 +236,7 @@ function OverviewRow(props: {
 // position to the top.
 function NamedActivityRow(props: {
   entry: FeedEntry;
+  rail: RailEnds;
   onOpen: (target: OpenEntityTarget) => void;
 }) {
   const context = useActivityContext();
@@ -235,12 +244,17 @@ function NamedActivityRow(props: {
   return (
     <Suspense
       fallback={
-        <ActivityTimelineRowView entry={props.entry} actorName={name()} />
+        <ActivityTimelineRowView
+          entry={props.entry}
+          actorName={name()}
+          rail={props.rail}
+        />
       }
     >
       <ActivityTimelineRow
         entry={props.entry}
         actorName={name()}
+        rail={props.rail}
         onOpen={props.onOpen}
       />
     </Suspense>

--- a/apps/web/src/features/activity/views/my-activity-view.tsx
+++ b/apps/web/src/features/activity/views/my-activity-view.tsx
@@ -20,7 +20,8 @@ import {
   type OpenEntityTarget,
   useActivityContext,
 } from '../context/activity-context';
-import type { ActivityEvent, ActivityTopEntity } from '../core/event';
+import { entryHead, type FeedEntry } from '../core/collapse-runs';
+import type { ActivityTopEntity } from '../core/event';
 import { type FeedRow, shouldFetchMore } from '../core/feed-rows';
 import { placeholderOverview } from '../core/placeholder-overview';
 import { createActorName } from '../primitives/actor-name';
@@ -127,8 +128,8 @@ function FeedRowView(props: {
     .with({ kind: 'day' }, (row) => (
       <SoupSectionHeader>{row.label}</SoupSectionHeader>
     ))
-    .with({ kind: 'event' }, (row) => (
-      <NamedActivityRow event={row.event} onOpen={props.onOpen} />
+    .with({ kind: 'entry' }, (row) => (
+      <NamedActivityRow entry={row.entry} onOpen={props.onOpen} />
     ))
     .with({ kind: 'status', status: 'loading' }, () => (
       <FeedStatus>Loading…</FeedStatus>
@@ -226,19 +227,19 @@ function OverviewRow(props: {
 // pane boundary never re-inserts the scroller, which would reset its scroll
 // position to the top.
 function NamedActivityRow(props: {
-  event: ActivityEvent;
+  entry: FeedEntry;
   onOpen: (target: OpenEntityTarget) => void;
 }) {
   const context = useActivityContext();
-  const name = createActorName(context, () => props.event.actorId);
+  const name = createActorName(context, () => entryHead(props.entry).actorId);
   return (
     <Suspense
       fallback={
-        <ActivityTimelineRowView event={props.event} actorName={name()} />
+        <ActivityTimelineRowView entry={props.entry} actorName={name()} />
       }
     >
       <ActivityTimelineRow
-        event={props.event}
+        entry={props.entry}
         actorName={name()}
         onOpen={props.onOpen}
       />

--- a/apps/web/src/features/entity/utils/timestamp.test.ts
+++ b/apps/web/src/features/entity/utils/timestamp.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { formatCompactRelativeTimestamp } from './timestamp';
+
+const NOW = new Date('2026-09-07T12:00:00.000Z');
+
+describe('formatCompactRelativeTimestamp', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ['2026-09-07T11:59:30.000Z', 'now'],
+    ['2026-09-07T12:00:30.000Z', 'now'],
+    ['2026-09-07T11:55:00.000Z', '5m'],
+    ['2026-09-07T11:00:01.000Z', '59m'],
+    ['2026-09-06T19:00:00.000Z', '17h'],
+    ['2026-09-06T12:00:00.000Z', '1d'],
+    ['2026-09-01T12:00:00.000Z', '6d'],
+    ['2026-08-30T12:00:00.000Z', '1w'],
+    ['2026-08-17T12:00:00.000Z', '3w'],
+    ['2026-08-01T12:00:00.000Z', '1mo'],
+    ['2025-10-07T12:00:00.000Z', '11mo'],
+    ['2024-09-07T12:00:00.000Z', '2y'],
+  ])('%s -> %s', (value, expected) => {
+    expect(formatCompactRelativeTimestamp(value)).toBe(expected);
+  });
+
+  it('returns an unparseable value unchanged', () => {
+    expect(formatCompactRelativeTimestamp('not a date')).toBe('not a date');
+  });
+});

--- a/apps/web/src/features/entity/utils/timestamp.ts
+++ b/apps/web/src/features/entity/utils/timestamp.ts
@@ -1,7 +1,12 @@
 import type { DateValue } from '@core/util/date';
 import {
+  differenceInDays,
   differenceInHours,
+  differenceInMilliseconds,
   differenceInMinutes,
+  differenceInMonths,
+  differenceInWeeks,
+  differenceInYears,
   format,
   isSameYear,
   isToday,
@@ -67,6 +72,37 @@ export function formatRelativeTimestamp(
   }
 
   return format(date, 'M/d/yy');
+}
+
+/**
+ * The shortest relative age for dense rows: `now`, `5m`, `17h`, `8d`, `3w`,
+ * `1mo`, `2y`. An unparseable value is returned as is.
+ */
+export function formatCompactRelativeTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  const now = new Date();
+  const ageMs = Math.max(0, differenceInMilliseconds(now, date));
+  const seconds = Math.floor(ageMs / 1000);
+  if (seconds < 60) return 'now';
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+
+  const days = differenceInDays(now, date);
+  if (days < 7) return `${Math.max(1, days)}d`;
+
+  const weeks = differenceInWeeks(now, date);
+  if (weeks < 5) return `${Math.max(1, weeks)}w`;
+
+  const months = differenceInMonths(now, date);
+  if (months < 12) return `${Math.max(1, months)}mo`;
+
+  return `${Math.max(1, differenceInYears(now, date))}y`;
 }
 
 /**

--- a/apps/web/src/features/next-soup/soup-view/views/inbox/inbox-card-layouts.tsx
+++ b/apps/web/src/features/next-soup/soup-view/views/inbox/inbox-card-layouts.tsx
@@ -26,6 +26,7 @@ import {
   unreadFilterFn,
   type WithNotification,
 } from '@entity';
+import { formatCompactRelativeTimestamp } from '@entity/utils/timestamp';
 import MacroLogo from '@icon/macro-logo.svg';
 import GithubIcon from '@icon/mcp-github.svg';
 import { formatCalendarReminderTime } from '@notifications';
@@ -57,7 +58,6 @@ import { Dynamic } from 'solid-js/web';
 import { match, P } from 'ts-pattern';
 import { InboxCard } from './InboxCard';
 import {
-  formatCompactRelativeTimestamp,
   getGithubTitle,
   getInboxTaskProperties,
   getNotificationTag,

--- a/apps/web/src/features/next-soup/soup-view/views/inbox/utils.ts
+++ b/apps/web/src/features/next-soup/soup-view/views/inbox/utils.ts
@@ -4,13 +4,6 @@ import {
   soupPropertyToProperty,
 } from '@entity/extractors-property/property-helpers';
 import type { SoupProperty } from '@service-storage/generated/schemas/soupProperty';
-import {
-  differenceInDays,
-  differenceInMilliseconds,
-  differenceInMonths,
-  differenceInWeeks,
-  differenceInYears,
-} from 'date-fns';
 import { match } from 'ts-pattern';
 
 /**
@@ -172,33 +165,6 @@ export function getInboxTaskProperties(entity: EntityData) {
     )
   );
   return keyProperties.length ? keyProperties : undefined;
-}
-
-export function formatCompactRelativeTimestamp(value: string) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-
-  const now = new Date();
-  const ageMs = Math.max(0, differenceInMilliseconds(now, date));
-  const seconds = Math.floor(ageMs / 1000);
-  if (seconds < 60) return 'now';
-
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m`;
-
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h`;
-
-  const days = differenceInDays(now, date);
-  if (days < 7) return `${Math.max(1, days)}d`;
-
-  const weeks = differenceInWeeks(now, date);
-  if (weeks < 5) return `${Math.max(1, weeks)}w`;
-
-  const months = differenceInMonths(now, date);
-  if (months < 12) return `${Math.max(1, months)}mo`;
-
-  return `${Math.max(1, differenceInYears(now, date))}y`;
 }
 
 export function getFirstName(value: string) {

--- a/apps/web/src/lib/core/component/AI/component/tool/ReadActivity.tsx
+++ b/apps/web/src/lib/core/component/AI/component/tool/ReadActivity.tsx
@@ -1,3 +1,4 @@
+import type { FeedEntry } from '@app/features/activity/core/collapse-runs';
 import type {
   ActivityAction,
   ActivityEntityType,
@@ -99,7 +100,12 @@ const handler = createToolRenderer({
       ctx.renderContext.grouped !== true
     );
     const activities = () => ctx.response?.data.activities ?? [];
-    const events = createMemo(() => activities().map(activityEvent));
+    const entries = createMemo<FeedEntry[]>(() =>
+      activities().map((activity, index) => ({
+        kind: 'single',
+        event: activityEvent(activity, index),
+      }))
+    );
     const hasResults = () => activities().length > 0;
     const statusText = () => {
       if (!ctx.response) return undefined;
@@ -119,10 +125,10 @@ const handler = createToolRenderer({
           hasResults() && isExpanded() ? (
             <StaticMarkdownContext>
               <div class="max-h-120 overflow-y-auto rounded-md border border-edge-muted/60 py-1">
-                <For each={events()}>
-                  {(event) => (
+                <For each={entries()}>
+                  {(entry) => (
                     <ActivityTimelineRow
-                      event={event}
+                      entry={entry}
                       showActor={false}
                       onOpen={openEntityInSplit}
                     />

--- a/apps/web/src/lib/core/component/AI/component/tool/ReadActivity.tsx
+++ b/apps/web/src/lib/core/component/AI/component/tool/ReadActivity.tsx
@@ -126,10 +126,14 @@ const handler = createToolRenderer({
             <StaticMarkdownContext>
               <div class="max-h-120 overflow-y-auto rounded-md border border-edge-muted/60 py-1">
                 <For each={entries()}>
-                  {(entry) => (
+                  {(entry, index) => (
                     <ActivityTimelineRow
                       entry={entry}
                       showActor={false}
+                      rail={{
+                        above: index() > 0,
+                        below: index() < entries().length - 1,
+                      }}
                       onOpen={openEntityInSplit}
                     />
                   )}

--- a/docs/AGENT_GUIDE/documents.md
+++ b/docs/AGENT_GUIDE/documents.md
@@ -55,7 +55,7 @@ Right side of a doc (toggle with `Hide/Show Side Panel`):
 - Collapsed sections: `Stats`, `History` (version time-travel), `Activity`.
 - `Activity` lists the same glyph-rail lines as `/app/component/activity` (plain glyphs on a
   thin connector, one line each with long names truncated, compact `17h` / `8d` / `1mo`
-  times; consecutive edits fold into one `3 times` line). Past four entries it shows the
+  times; consecutive edits fold into one `made 3 edits` line). Past four entries it shows the
   three newest, a `View all activities` toggle row (dotted connector, caret glyph), and the
   oldest fetched entry (usually `created this`) pinned last; the toggle flips to `Show less`
   once expanded.

--- a/docs/AGENT_GUIDE/documents.md
+++ b/docs/AGENT_GUIDE/documents.md
@@ -53,6 +53,10 @@ Right side of a doc (toggle with `Hide/Show Side Panel`):
 - `Details` → Owner, Created, Last updated.
 - `Tags` → `Add tags` (dialog). `Properties` → `Add property`.
 - Collapsed sections: `Stats`, `History` (version time-travel), `Activity`.
+- `Activity` lists the same glyph-rail lines as `/app/component/activity` (consecutive edits
+  fold into one `3 times` line). Past four entries it shows the three newest, a
+  `View all activities` toggle row, and the oldest fetched entry (usually `created this`)
+  pinned last; the toggle flips to `Show less` once expanded.
 - Header: `Share`, `Copy Share Link`, overflow menu — use `Share` to inspect or change the
   doc's visibility/permissions.
 

--- a/docs/AGENT_GUIDE/documents.md
+++ b/docs/AGENT_GUIDE/documents.md
@@ -53,10 +53,12 @@ Right side of a doc (toggle with `Hide/Show Side Panel`):
 - `Details` → Owner, Created, Last updated.
 - `Tags` → `Add tags` (dialog). `Properties` → `Add property`.
 - Collapsed sections: `Stats`, `History` (version time-travel), `Activity`.
-- `Activity` lists the same glyph-rail lines as `/app/component/activity` (consecutive edits
-  fold into one `3 times` line). Past four entries it shows the three newest, a
-  `View all activities` toggle row, and the oldest fetched entry (usually `created this`)
-  pinned last; the toggle flips to `Show less` once expanded.
+- `Activity` lists the same glyph-rail lines as `/app/component/activity` (plain glyphs on a
+  thin connector, one line each with long names truncated, compact `17h` / `8d` / `1mo`
+  times; consecutive edits fold into one `3 times` line). Past four entries it shows the
+  three newest, a `View all activities` toggle row (dotted connector, caret glyph), and the
+  oldest fetched entry (usually `created this`) pinned last; the toggle flips to `Show less`
+  once expanded.
 - Header: `Share`, `Copy Share Link`, overflow menu — use `Share` to inspect or change the
   doc's visibility/permissions.
 

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -119,11 +119,19 @@ GitHub-style actions heatmap (one a11y node per day — makes snapshots huge; pr
 snapshot to a file), then a `Most active` section header (styled like the feed's day headers)
 over a wrapping row of pill chips (entity icon, name, action count; click opens the entity,
 shift-click opens a new split; the section is absent when there are no entities), then a feed
-of "You edited/created X" entries grouped under day headers. The whole page is one virtualized
-list: only rows near the viewport are in the DOM, and scrolling near the bottom fetches the
-next page automatically (a `Loading…` tail appears while it lands). If a page fails, the tail
-reads `Couldn't load more.` with a `Retry` button and automatic paging stops until it is
-pressed. There is no `Show more` button.
+of "You edited/created X · 17h" entries grouped under day headers, with the compact relative
+time (`17h`, `8d`, `1mo`) inline after a middot rather than right-aligned; hovering the time
+shows the full date. Each row is a plain action glyph joined to its neighbours by a thin
+connector line (the line stops at day headers) and never wraps: a long entity name truncates
+with an ellipsis, and the full name is in the mention's hover preview. Consecutive same-actor,
+same-entity, same-action events within a day read as one line with a count (`You edited Doc X
+5 times · 2h`; property changes read the net change, `changed Status from A to C on Doc X · 3
+changes · 2h`), so the row count is lower than the event count (`[data-activity-run-size]`
+carries the fold size). The whole page is one virtualized list: only rows near the viewport
+are in the DOM, and scrolling near the bottom fetches the next page automatically (a
+`Loading…` tail appears while it lands). If a page fails, the tail reads `Couldn't load more.`
+with a `Retry` button and automatic paging stops until it is pressed. There is no `Show more`
+button.
 
 ## Home — `/app/component/home`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fourth PR of the activity feed polish program (depends on A3, `synoet/activity-feed-virtualized-6fe8`; this branch includes A3's commits until it merges).

- `core/collapse-runs.ts`: `FeedEntry = single | run`. Consecutive same-actor, same-entity, same-action events (and, for property changes, same property) fold into one run. A property run reads the net change (`from` of the oldest → `to` of the newest). Runs never cross a day header (`groupEventsByDay` buckets first, then collapses).
- `core/fold-panel.ts`: `foldPanel(entries, 3)` → three newest, hidden count, oldest fetched entry pinned last. Nothing folds when everything fits.
- `core/feed-rows.ts`: entry rows carry `rail: { above, below }` so the connector joins entries within a day and stops at day headers; `reuseRows` treats a changed rail as a new row.
- `components/activity-timeline-row.tsx`, restyled after the reference picture: a plain action glyph (no disc or ring) on a thin connector that leaves a gap around each glyph; one line per row, never wraps; the entity name truncates first (to its icon in the tightest pane), then the sentence clips, and the actor, count and time always stay; compact relative time (`17h`, `8d`, `1mo`) after a middot, full date on hover; `compact` density for the panel; `data-activity-run-size`.
- Side panel `Activity` renders the shared row; the bespoke `ActivityRow`, `COLLAPSED_ROW_LIMIT`, and `Show all (n)` are deleted. Folded state: three rows, a `View all activities` row in the rail (dotted connector, caret glyph), and the creation row; expanded shows all with `Show less`.
- `formatCompactRelativeTimestamp` moves from the inbox utils to `@entity/utils/timestamp` and is shared.
- `ReadActivity` tool wraps each event as a `single` entry (no collapsing in the tool).
- Agent guides updated (`surfaces.md`, `documents.md`).

## Demo

Before (`main`) then after (this PR). One document seeded with a create, five renames, two `Launch phase` changes, a rename, another `Launch phase` change, and two more renames (12 events). `main` lists them as separate rows; this branch shows six rows (`5 times`, `2 changes`, `2 times`) in the reference style, and the side panel folds to three rows plus the pinned creation row behind `View all activities`; the toggle is clicked to expand (`Show less`) and clicked again to fold.

[a4_run_collapsing_before_after_v2.mp4](https://cursor.com/agents/bc-be408f63-be6f-4984-9d7e-8488650b6fe8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fa4_run_collapsing_before_after_v2.mp4)

Reference picture (left) next to the side panel on this branch (right):

[Reference picture next to the side panel on this branch](https://cursor.com/agents/bc-be408f63-be6f-4984-9d7e-8488650b6fe8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fa4_panel_reference_vs_pr.png)

## Verification

- `bunx tsc --noEmit` on `apps/web`, biome, `bunx vitest run src/features/activity src/features/entity/utils/timestamp.test.ts` — all green (129 tests). Includes the `collapseRuns` on 1,000 events < 2ms perf rule, measured as the fastest of 20 samples so a noisy CI runner cannot fail it.
- Live stack (`bash .cursor/stack.sh`), Playwright against the running app: side panel folded/expanded, feed at 1280 and 720 (rows stay 40px, the long `Quarterly Infrastructure Reliability Review…` name truncates with the time still in view), as in the demo above.

Note: the `Automation` rows come from the seed scenario's system actions; A5 (`synoet/activity-actor-attribution-6fe8`) renames those and is independent of this branch.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be408f63-be6f-4984-9d7e-8488650b6fe8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be408f63-be6f-4984-9d7e-8488650b6fe8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

