### PR TITLE
fix(agent): use shared channel message width

### DIFF
--- a/apps/web/src/features/block-agent/component/Block.tsx
+++ b/apps/web/src/features/block-agent/component/Block.tsx
@@ -66,7 +66,7 @@ function AgentBlockContent() {
                 {/* Home/chat: re-enable pointer events on the accessory
                     contribution — the float host is pointer-transparent. */}
                 <div class="flex w-full justify-center shrink-0 px-4 pb-4 pointer-events-auto touch:px-(--mobile-chrome-gutter) touch:pb-0">
-                  <div class="w-full md:w-1/2 mx-auto">
+                  <div class="macro-message-width mx-auto">
                     <AgentComposer />
                   </div>
                 </div>

--- a/apps/web/src/features/block-agent/component/Transcript.tsx
+++ b/apps/web/src/features/block-agent/component/Transcript.tsx
@@ -202,9 +202,7 @@ export function Transcript() {
               }}
             >
               {(message) => (
-                // Half the pane on desktop so expanding Context grows
-                // down, not out. A phone is full-bleed.
-                <div class="w-full md:w-1/2 mx-auto px-4 pb-4 min-w-0">
+                <div class="macro-message-width mx-auto px-4 pb-4 min-w-0">
                   <Message message={message} />
                 </div>
               )}

--- a/apps/web/src/features/block-agent/debug/replay/Replay.tsx
+++ b/apps/web/src/features/block-agent/debug/replay/Replay.tsx
@@ -260,7 +260,7 @@ export default function AgentReplay() {
               <div class="flex-1 min-h-0 flex flex-col">
                 <SessionChrome />
                 <Transcript />
-                <div class="shrink-0 w-full md:w-1/2 mx-auto px-4 pb-4">
+                <div class="macro-message-width shrink-0 mx-auto px-4 pb-4">
                   <AgentComposer />
                 </div>
               </div>


### PR DESCRIPTION
## What was wrong

The mobile agent-chat work gave the transcript and composer their own responsive width rule: `w-full md:w-1/2`. That preserved a full-width phone layout, but it bypassed the global `macro-message-width` utility used by channel messages and inputs. As a result, agent chat switched to 50% of its pane on desktop instead of following the shared 920px channel column, and future changes to the global message width would not apply to agent chat.

## What changed

- Replace the agent transcript row `w-full md:w-1/2` constraint with `macro-message-width`.
- Apply the same shared utility to the production agent composer.
- Keep the agent replay harness aligned with production by updating its composer wrapper too.

The shared utility remains 100% width below 640px, so the mobile full-width behavior from #6229 is preserved. At larger widths, the transcript and composer now use the same centered, 920px-capped column as channel messages.

## Verification

- `bun run check`
- `bunx vitest run "src/features/block-agent"` (86 tests passed)
- `git diff --check`
- Loaded the app through the local Vite server; an end-to-end agent transcript check was unavailable because the accessible session belonged to a different local backend.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout alignment in agent UI; no auth, data, or API changes.
> 
> **Overview**
> Agent chat transcript rows, the production composer, and the replay harness composer no longer use **`w-full md:w-1/2`**. They now use the shared **`macro-message-width`** utility so desktop layout matches the centered ~920px channel column instead of half the pane.
> 
> Mobile stays full width below the utility’s breakpoint; only the width rule changes—no behavior changes to scrolling or float regions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4856f8960bf85b7a2bee311343524a49dda531a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->