### PR TITLE
fix(channels): fix pin to bottom

### DIFF
--- a/apps/web/src/features/channel/Channel/ThreadList.tsx
+++ b/apps/web/src/features/channel/Channel/ThreadList.tsx
@@ -194,14 +194,16 @@ export function ThreadList(props: ThreadListProps) {
     // layout until ResizeObserver fires. Read mounted rows before first paint.
     measureElement: (element, entry, instance) =>
       entry ? measureElement(element, entry, instance) : element.offsetHeight,
-    // Measure outside ResizeObserver delivery: committing row/sizer geometry
-    // inside its callback can leave undelivered notifications in WebKit.
-    useAnimationFrameWithResizeObserver: true,
+    // Apply row and composer measurements before paint. Deferring them to the
+    // next frame exposes stale geometry and can lose the end anchor on send.
+    useAnimationFrameWithResizeObserver: false,
     useScrollendEvent: true,
     anchorTo: 'end',
     get followOnAppend() {
       return lifecycle.isReady() && (props.followOnAppend ?? true);
     },
+    // Use the same end tolerance for append, resize, navigation, and snapshots.
+    // A loose tolerance also mistakes optimistic row estimates for a pin.
     scrollEndThreshold: NEAR_BOTTOM_THRESHOLD,
     get paddingStart() {
       return insets().start;
@@ -474,7 +476,11 @@ export function ThreadList(props: ThreadListProps) {
                 on(
                   () => item().index,
                   () => {
-                    if (row) virtualizer.measureElement(row);
+                    // Markdown fills the row in child effects. Measuring the empty
+                    // shell can shrink the sizer and clamp scrollTop before paint.
+                    queueMicrotask(() => {
+                      if (row?.isConnected) virtualizer.measureElement(row);
+                    });
                   }
                 )
               );

--- a/apps/web/src/features/channel/Channel/constants.ts
+++ b/apps/web/src/features/channel/Channel/constants.ts
@@ -1,1 +1,1 @@
-export const NEAR_BOTTOM_THRESHOLD = 50;
+export const NEAR_BOTTOM_THRESHOLD = 1;

--- a/apps/web/src/features/channel/docs/sticky-scrolling.md
+++ b/apps/web/src/features/channel/docs/sticky-scrolling.md
@@ -6,6 +6,15 @@ and compensation when measured messages grow or shrink. `followOnAppend` is
 only enabled when the query includes the newest page. Reading older history
 must never be interrupted by incoming messages.
 
+Use the same 1px end tolerance for TanStack, composer/viewport resizing, and saved
+positions. Scrolling up beyond rounding tolerance stops following, even a few pixels
+from the bottom; returning to the end resumes it.
+Acknowledging a send replaces the optimistic message ID, temporarily replacing its
+measured height with an estimate. A loose end threshold treats that intermediate
+layout as pinned and applies the estimate-to-measurement delta as a backward scroll.
+ResizeObserver measurements also run in the current frame: delaying them with
+`useAnimationFrameWithResizeObserver` exposes stale row and composer geometry.
+
 The list exposes three navigation operations: `scrollToLatest`, `scrollToMessage`,
 and `scrollToElement`. Message navigation can include keyboard intent for pagination.
 `initialPosition` chooses latest, a mounted target, or a saved snapshot; these are mutually exclusive. `onReady` publishes the handle after the
@@ -46,7 +55,10 @@ accounted for those measurements. Actual touch/momentum deferral remains in the 
 Message IDs also key Solid's rendered components, preserving editors and expanded
 threads across pagination. `Key` owns each row's virtual-item accessor; a shared
 map lookup can disappear while a queued measurement effect is still running.
-Measurement effects track index changes only, leaving size changes to ResizeObserver.
+Measurement effects track index changes and register rows in a microtask after child
+effects fill their Markdown, still before paint. Measuring the empty shell can
+temporarily shrink the sizer and clamp the browser scroll position, especially
+with floating mobile insets. Later size changes belong to ResizeObserver.
 `targetId` keeps the pending thread mounted for precise navigation to nested replies;
 only the list translates that ID into a virtual index. Snapshot
 restoration pairs the offset with `takeSnapshot()`.

--- a/apps/web/tests/e2e/local-channel-send-scroll.spec.ts
+++ b/apps/web/tests/e2e/local-channel-send-scroll.spec.ts
@@ -1,0 +1,233 @@
+import { expect, type Page, test } from '@playwright/test';
+import { gotoApp, LOCAL_E2E, uniqueE2EText } from './helpers/local-app';
+import { observeBottomPresentation } from './helpers/scroll-presentation';
+
+const CHANNEL_SCROLL_SELECTOR = '[data-channel-scroll]';
+const BOTTOM_TOLERANCE_PX = 1;
+
+const composer = (page: Page, channelId: string) =>
+  page.locator(
+    `[data-input-id="channel-input-${channelId}"] [contenteditable="true"]`
+  );
+
+async function sendMessage(page: Page, channelId: string, text: string) {
+  const input = composer(page, channelId);
+  await input.fill(text);
+  const sent = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' &&
+      response.url().endsWith(`/channels/${channelId}/message`)
+  );
+  await page.getByRole('button', { name: 'Send message', exact: true }).click();
+  expect((await sent).ok()).toBe(true);
+  await expect(input).toHaveText('');
+}
+
+async function createOverflowingChannel(page: Page) {
+  await gotoApp(page, '/component/channels');
+  await page.getByRole('button', { name: 'Create', exact: true }).click();
+  await page.getByRole('menuitem', { name: /^Channel/ }).click();
+  await page.getByPlaceholder('Channel name').fill(uniqueE2EText('Scroll pin'));
+  await page
+    .getByRole('button', { name: 'Create Channel', exact: true })
+    .click();
+  await page.waitForURL(/\/channel\/[a-f0-9-]+$/);
+  const channelId = page.url().split('/').at(-1)!;
+  for (let index = 0; index < 32; index++) {
+    await sendMessage(page, channelId, `History message ${index}`);
+  }
+  return channelId;
+}
+
+async function positionFromBottom(page: Page, gap: number) {
+  const scroller = page.locator(CHANNEL_SCROLL_SELECTOR);
+  await scroller.evaluate((element, gap) => {
+    element.scrollTop = element.scrollHeight - element.clientHeight - gap;
+  }, gap);
+  await expect
+    .poll(async () => Math.abs((await scrollPosition(page)).gap - gap))
+    .toBeLessThanOrEqual(BOTTOM_TOLERANCE_PX);
+  // Let native scrollend and the physical-intent timeout settle.
+  await page.waitForTimeout(350);
+}
+
+function scrollPosition(page: Page) {
+  return page.locator(CHANNEL_SCROLL_SELECTOR).evaluate((element) => ({
+    top: element.scrollTop,
+    gap: element.scrollHeight - element.clientHeight - element.scrollTop,
+  }));
+}
+
+test.skip(!LOCAL_E2E, 'requires a local stack');
+
+test('stays pinned throughout consecutive sends and server acknowledgements', async ({
+  page,
+}) => {
+  test.setTimeout(90_000);
+  const presentation = await observeBottomPresentation(
+    page,
+    CHANNEL_SCROLL_SELECTOR,
+    BOTTOM_TOLERANCE_PX
+  );
+  const channelId = await createOverflowingChannel(page);
+  await positionFromBottom(page, 0);
+  await presentation.reset();
+
+  for (let index = 0; index < 6; index++) {
+    // Exercise Enter as well as the send button used by the shared helper.
+    const input = composer(page, channelId);
+    await input.fill(`Consecutive send ${index}`);
+    const sent = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().endsWith(`/channels/${channelId}/message`)
+    );
+    await input.press('Enter');
+    expect((await sent).ok()).toBe(true);
+    await page.waitForTimeout(250);
+  }
+  // Fast paste-and-send must include the composer resize, not wait it out.
+  await sendMessage(page, channelId, 'A wrapped message. '.repeat(50));
+  await page.waitForTimeout(250);
+  await sendMessage(
+    page,
+    channelId,
+    Array.from({ length: 22 }, (_, index) => `Tall message line ${index}`).join(
+      '\n'
+    )
+  );
+  await page.waitForTimeout(250);
+  await sendMessage(page, channelId, 'Short again 🙂');
+  await page.waitForTimeout(350);
+
+  const report = await presentation.read();
+  expect(report.first).toBeDefined();
+  expect(report.firstViolation).toBeUndefined();
+  expect(report.violationCount).toBe(0);
+});
+
+for (const viewport of [
+  { width: 390, height: 844 },
+  { width: 375, height: 667 },
+  { width: 844, height: 390 },
+]) {
+  test(`touch mobile ${viewport.width}×${viewport.height}: sends, small scrolls, and resizing`, async ({
+    page: setupPage,
+    browser,
+    context: setupContext,
+  }) => {
+    test.setTimeout(120_000);
+    const channelId = await createOverflowingChannel(setupPage);
+    const context = await browser.newContext({
+      storageState: await setupContext.storageState(),
+      viewport,
+      isMobile: true,
+      hasTouch: true,
+      deviceScaleFactor: 3,
+    });
+    try {
+      const page = await context.newPage();
+      const presentation = await observeBottomPresentation(
+        page,
+        CHANNEL_SCROLL_SELECTOR,
+        BOTTOM_TOLERANCE_PX
+      );
+      await page.goto(setupPage.url());
+      const input = composer(page, channelId);
+      const collapsedInput = page.getByRole('button', {
+        name: /Type @ to share/,
+      });
+      await expect(
+        input.or(collapsedInput).filter({ visible: true }).first()
+      ).toBeVisible();
+      if (await collapsedInput.isVisible()) await collapsedInput.tap();
+      await expect(input).toBeVisible();
+      await positionFromBottom(page, 0);
+      await presentation.reset();
+      for (const text of [
+        'Mobile send one',
+        'Mobile send two',
+        'Mobile send three',
+        'Wrapped mobile text. '.repeat(40),
+        'After wrapping',
+        Array.from({ length: 22 }, (_, index) => `Tall line ${index}`).join(
+          '\n'
+        ),
+        'After tall 🙂',
+      ]) {
+        await input.fill(text);
+        const sent = page.waitForResponse(
+          (response) =>
+            response.request().method() === 'POST' &&
+            response.url().endsWith(`/channels/${channelId}/message`)
+        );
+        await page
+          .getByRole('button', { name: 'Send message', exact: true })
+          .tap();
+        expect((await sent).ok()).toBe(true);
+        await page.waitForTimeout(350);
+      }
+      const report = await presentation.read();
+      expect(report.first).toBeDefined();
+      expect(report.firstViolation).toBeUndefined();
+      expect(report.violationCount).toBe(0);
+
+      // The same end tolerance must govern appends and floating composer growth.
+      for (const gap of [0, 1, 2, 10, 25, 49, 50, 51, 100, 420]) {
+        await test.step(`${gap}px from bottom`, async () => {
+          await positionFromBottom(page, gap);
+          const before = await scrollPosition(page);
+          await sendMessage(page, channelId, 'Small scroll check');
+          await page.waitForTimeout(350);
+          const after = await scrollPosition(page);
+          if (gap <= BOTTOM_TOLERANCE_PX) {
+            expect(after.gap).toBeLessThanOrEqual(BOTTOM_TOLERANCE_PX);
+          } else {
+            expect(Math.abs(after.top - before.top)).toBeLessThanOrEqual(
+              BOTTOM_TOLERANCE_PX
+            );
+          }
+        });
+      }
+      for (const gap of [0, 2, 10, 49, 51, 420]) {
+        await positionFromBottom(page, gap);
+        const before = await scrollPosition(page);
+        await input.fill('Growing composer. '.repeat(40));
+        await page.waitForTimeout(350);
+        const after = await scrollPosition(page);
+        if (gap === 0) {
+          expect(after.gap).toBeLessThanOrEqual(BOTTOM_TOLERANCE_PX);
+        } else {
+          expect(Math.abs(after.top - before.top)).toBeLessThanOrEqual(
+            BOTTOM_TOLERANCE_PX
+          );
+        }
+        await input.fill('');
+        await page.waitForTimeout(350);
+      }
+      // Model the viewport contraction of a keyboard; native OS keyboard
+      // events and momentum still require a physical-device check.
+      for (const gap of [0, 10, 51, 420]) {
+        await positionFromBottom(page, gap);
+        const before = await scrollPosition(page);
+        await page.setViewportSize({
+          ...viewport,
+          height: viewport.height - 150,
+        });
+        await page.waitForTimeout(350);
+        const after = await scrollPosition(page);
+        if (gap === 0) {
+          expect(after.gap).toBeLessThanOrEqual(BOTTOM_TOLERANCE_PX);
+        } else {
+          expect(Math.abs(after.top - before.top)).toBeLessThanOrEqual(
+            BOTTOM_TOLERANCE_PX
+          );
+        }
+        await page.setViewportSize(viewport);
+        await page.waitForTimeout(350);
+      }
+    } finally {
+      await context.close();
+    }
+  });
+}

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -61,8 +61,12 @@ thread past the chat's right edge.
 
 Channels open at the latest message, with short conversations aligned above the
 composer. Incoming messages and growing replies stay in view while the channel is
-at the bottom. Scrolling up leaves the viewport on the history being read; loading
-older messages preserves that message's position.
+at the bottom. Consecutive sends stay pinned through server acknowledgement and
+composer resizing, without bouncing upward between messages.
+Scrolling up more than 1px leaves the viewport on the history being read, even
+when only slightly above the bottom. Composer and viewport resizing respect the
+same boundary. Returning to the bottom resumes following; loading older messages
+preserves the reading position.
 
 Message and reply links reveal the target inside its thread. Keyboard message
 navigation scrolls only when the selected message is outside the usable viewport.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core virtualized scroll pinning and measurement timing for all channels; behavior shifts for users slightly above the bottom (1px vs 50px), though covered by new e2e tests.
> 
> **Overview**
> Fixes channel message list **bouncing away from the bottom** during sends, acks, and layout changes by tightening when the list is considered “pinned” and when row geometry is measured.
> 
> **`NEAR_BOTTOM_THRESHOLD` drops from 50px to 1px** so append-follow, composer/viewport resize, and saved snapshots share one strict end tolerance. A looser threshold could treat optimistic height estimates (e.g. after ID swap on ack) as still pinned and apply a backward scroll correction.
> 
> In **`ThreadList`**, **`useAnimationFrameWithResizeObserver` is disabled** so ResizeObserver-driven measurements apply in the current frame instead of the next, avoiding stale sizer/composer geometry that could drop the end anchor on send. Row **`measureElement` runs in a `queueMicrotask`** after child effects render Markdown, so the virtualizer does not measure an empty row shell and temporarily shrink the scroll extent.
> 
> Docs (`sticky-scrolling.md`, `channels.md`) describe the 1px boundary and measurement timing. **New Playwright e2e** (`local-channel-send-scroll.spec.ts`) asserts zero bottom presentation violations across consecutive sends, wrapped/tall messages, mobile touch viewports, sends at various gaps from bottom, composer growth, and simulated keyboard viewport shrink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d237f62af04af8442432c388c14ba8f6d093b100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->