### PR TITLE
feat(auth): add valentina and chaitanya to new-user support channels

### DIFF
--- a/services/authentication_service/src/api/webhooks/user/create_user_webhook.rs
+++ b/services/authentication_service/src/api/webhooks/user/create_user_webhook.rs
@@ -38,7 +38,13 @@ use model_entity::EntityType;
 use teams::domain::team_repo::TeamService;
 
 /// Macro support team members added to every new user's support channel.
-const MACRO_SUPPORT_EMAILS: [&str; 3] = ["jacob@macro.com", "julia@macro.com", "teo@macro.com"];
+const MACRO_SUPPORT_EMAILS: [&str; 5] = [
+    "jacob@macro.com",
+    "julia@macro.com",
+    "teo@macro.com",
+    "valentina@macro.com",
+    "chaitanya@macro.com",
+];
 
 fn support_channel_name<T: AsRef<str>>(email: &Email<T>) -> String {
     format!("Macro Support x {}", email.local_part())


### PR DESCRIPTION
Adds `valentina@macro.com` and `chaitanya@macro.com` to `MACRO_SUPPORT_EMAILS`, the participant set used when the user-created webhook spins up each new user's private "Macro Support x {name}" channel. Both are now added automatically on signup.

The welcome message in `support_channel_welcome.rs` is unchanged — it still names only Jacob (ceo), Teo (cto), and Julia, so the two new participants join silently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change on onboarding support-channel membership; no auth, billing, or data-model impact.
> 
> **Overview**
> Expands **`MACRO_SUPPORT_EMAILS`** from three to five addresses by adding `valentina@macro.com` and `chaitanya@macro.com`. On **`user.create`**, the webhook still builds the private “Macro Support x {user}” channel from that list, so both new addresses are included as participants automatically alongside the existing support team.
> 
> No other signup or channel logic changes; the welcome message in `support_channel_welcome.rs` is untouched, so the new members join without being named in the intro.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad48300a8f4e889dd04cac98d3f36df18ba002e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->