### PR TITLE
chore(calendar): gate team out of office behind a feature flag

### DIFF
--- a/apps/web/src/features/block-calendar/components/SidePanelSections.tsx
+++ b/apps/web/src/features/block-calendar/components/SidePanelSections.tsx
@@ -7,7 +7,9 @@ import {
   useHasTeammates,
   useUpcomingTeamOoo,
 } from '@app/features/calendar/hooks/use-team-ooo';
+import { ShowFeatureFlag } from '@app/lib/analytics/posthog';
 import { SidePanel, useSidePanel } from '@components/app/side-panel/SidePanel';
+import { enableCalendarTeamOoo } from '@core/constant/featureFlags';
 import { Calendar as MiniCalendar, ToggleSwitch } from '@ui';
 import { format } from 'date-fns';
 import {
@@ -219,7 +221,9 @@ export function SidePanelSections() {
     <Show when={!sidePanel?.isNarrow()}>
       <CalendarMiniCalendarSidePanelSection />
       <CalendarSourcesSidePanelSection />
-      <CalendarTeamOooSidePanelSection />
+      <ShowFeatureFlag flag={enableCalendarTeamOoo}>
+        <CalendarTeamOooSidePanelSection />
+      </ShowFeatureFlag>
     </Show>
   );
 }

--- a/apps/web/src/features/calendar/hooks/use-calendar-ui-flag.ts
+++ b/apps/web/src/features/calendar/hooks/use-calendar-ui-flag.ts
@@ -3,6 +3,7 @@ import {
   enableCalendarPromptMobile,
   enableCalendarPromptWeb,
   enableCalendarSearchUi,
+  enableCalendarTeamOoo,
   enableCalendarUi,
 } from '@core/constant/featureFlags';
 import { isMobile } from '@core/mobile/isMobile';
@@ -36,4 +37,13 @@ export function useCalendarPromptAllowed(): Accessor<boolean> {
   const mobileFlag = useFeatureFlag(enableCalendarPromptMobile);
   const webFlag = useFeatureFlag(enableCalendarPromptWeb);
   return () => (isMobile() ? mobileFlag() : webFlag()).enabled;
+}
+
+/**
+ * Whether the team out-of-office surfaces (the side panel section and the
+ * teammate absence overlay on the grid) are enabled.
+ */
+export function useCalendarTeamOooFlag(): Accessor<boolean> {
+  const flag = useFeatureFlag(enableCalendarTeamOoo);
+  return () => flag().enabled;
 }

--- a/apps/web/src/features/calendar/hooks/use-team-ooo.ts
+++ b/apps/web/src/features/calendar/hooks/use-team-ooo.ts
@@ -12,6 +12,7 @@ import { parseISO } from 'date-fns';
 import { type Accessor, createMemo } from 'solid-js';
 import type { CalendarEvent } from '../types';
 import { isCalendarRangeSupported } from '../utils/calendar-supported-range';
+import { useCalendarTeamOooFlag } from './use-calendar-ui-flag';
 
 /** Visibility-source id gating the whole team out-of-office overlay. */
 export const TEAM_OOO_SOURCE_ID = 'team-ooo';
@@ -86,12 +87,13 @@ export function useTeamOooEvents(
   options: TeamOooEventOptions
 ): TeamOooEventData {
   const userId = useUserId();
+  const teamOooEnabled = useCalendarTeamOooFlag();
   const isRangeSupported = createMemo(() => {
     const range = options.range();
     return range !== undefined && isCalendarRangeSupported(range);
   });
   const isOverlayVisible = () =>
-    options.isSourceVisible?.(TEAM_OOO_SOURCE_ID) !== false;
+    teamOooEnabled() && options.isSourceVisible?.(TEAM_OOO_SOURCE_ID) !== false;
   const query = useTeamOutOfOfficeQuery(
     () => ({ userId: userId(), range: options.range() }),
     () => ({
@@ -103,7 +105,9 @@ export function useTeamOooEvents(
     // Read data only on success: a failed overlay fetch degrades to no events
     // since the grid's own state is driven by the occurrences query, and gating
     // on success keeps this off the pending/errored resource read that suspends.
-    if (!isRangeSupported() || !query.isSuccess) return [];
+    if (!teamOooEnabled() || !isRangeSupported() || !query.isSuccess) {
+      return [];
+    }
     return query.data.map(mapTeamOooItem);
   });
   const visibleEvents = createMemo(() => (isOverlayVisible() ? events() : []));

--- a/apps/web/src/lib/core/constant/featureFlags.ts
+++ b/apps/web/src/lib/core/constant/featureFlags.ts
@@ -612,6 +612,18 @@ export const enableCalendarPromptWeb = defineFlag({
   env: 'ENABLE_CALENDAR_PROMPT_WEB',
 });
 
+// Team out of office: the calendar side panel's "Team out of office" section
+// and the read-only teammate absence chips on the grid. Purely additive: when
+// off, the section never mounts and no team out-of-office query is issued.
+// Lives inside the calendar block, so `enable-calendar-ui` already gates it.
+// PostHog-gated with a dev-mode default; override with
+// VITE_ENABLE_CALENDAR_TEAM_OOO.
+export const enableCalendarTeamOoo = defineFlag({
+  key: 'enable-calendar-team-ooo',
+  env: 'ENABLE_CALENDAR_TEAM_OOO',
+  default: onInDev,
+});
+
 // Sharing a personal tag with the team: the "Share with team" action on
 // personal tags in Settings › Tags, and the prompt that merges into an
 // existing team label when the names collide. The backend endpoints ship

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -66,12 +66,13 @@ there. Answering an invitation likewise addresses the primary copy. The details 
 the editor act on the chip's copy, so editing or deleting it targets that calendar's event
 at Google.
 
-Teammates' Google Calendar out-of-office events overlay the grid as read-only chips titled
-`<name>: <event title>`. The side panel's `Team out of office` section (shown only when the
-user belongs to a team with other members) has a checkbox in its header row toggling the
-whole overlay on or off — all teammates or none — and lists the next 90 days of teammate
-absences; clicking a row navigates the grid to that date. Coverage depends on each teammate
-having connected their own calendar and using Google's out-of-office event type.
+With the `enable-calendar-team-ooo` flag on, teammates' Google Calendar out-of-office events
+overlay the grid as read-only chips titled `<name>: <event title>`. The side panel's
+`Team out of office` section (shown only when the user belongs to a team with other members)
+has a checkbox in its header row toggling the whole overlay on or off — all teammates or
+none — and lists the next 90 days of teammate absences; clicking a row navigates the grid to
+that date. Coverage depends on each teammate having connected their own calendar and using
+Google's out-of-office event type.
 
 ## Calls — `/app/component/calls`
 


### PR DESCRIPTION
Gates the calendar's "Team out of office" side panel section and the teammate absence overlay behind a new `enable-calendar-team-ooo` flag (env override `VITE_ENABLE_CALENDAR_TEAM_OOO`, on by default in dev). When off, the section never mounts and the team out-of-office query is never issued. The PostHog flag exists and is targeted at @macro.com accounts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI gating with no backend changes; disabling the flag only hides surfaces and skips the team OOO query.
> 
> **Overview**
> Introduces **`enable-calendar-team-ooo`** (PostHog `enable-calendar-team-ooo`, local override `VITE_ENABLE_CALENDAR_TEAM_OOO`, default on in dev) so team OOO can be rolled out independently of the rest of calendar UI.
> 
> When the flag is off, the **Team out of office** side panel section does not mount (`ShowFeatureFlag`), and **`useTeamOooEvents`** treats the overlay as disabled: no team out-of-office fetch, no grid chips. A new **`useCalendarTeamOooFlag`** hook centralizes the check for overlay logic.
> 
> Agent guide docs now describe teammate OOO surfaces as conditional on this flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d47b985759dbecae750afd0a424e8fbd4faf042b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->