### PR TITLE
fix: new app views feature flag ready wait causing infinite loading

### DIFF
--- a/apps/web/src/components/app/split-layout/componentRegistry.tsx
+++ b/apps/web/src/components/app/split-layout/componentRegistry.tsx
@@ -68,7 +68,7 @@ function usePageViewTracking(pageTitle: string) {
   });
 }
 
-const NEW_APP_VIEWS_FLAG_WAIT_MS = 3_000;
+const NEW_APP_VIEWS_FLAG_WAIT_MS = 5_000;
 
 function useNewAppViews(options?: {
   enabledLayout?: () => 'legacy' | 'composable';

--- a/apps/web/src/components/app/split-layout/componentRegistry.tsx
+++ b/apps/web/src/components/app/split-layout/componentRegistry.tsx
@@ -49,8 +49,10 @@ import { EmptyStatePanel } from '@ui';
 import {
   type Component,
   createRenderEffect,
+  createSignal,
   type JSXElement,
   lazy,
+  onCleanup,
   onMount,
   Show,
 } from 'solid-js';
@@ -66,14 +68,21 @@ function usePageViewTracking(pageTitle: string) {
   });
 }
 
+const NEW_APP_VIEWS_FLAG_WAIT_MS = 3_000;
+
 function useNewAppViews(options?: {
   enabledLayout?: () => 'legacy' | 'composable';
 }) {
   const panel = useSplitPanelOrThrow();
-  const posthog = usePosthog();
   const flag = useFeatureFlag(enableNewAppViews);
-  const ready = () =>
-    enableNewAppViews.override !== undefined || posthog.flagsLoaded();
+  const [timedOut, setTimedOut] = createSignal(false);
+  const timer = setTimeout(() => setTimedOut(true), NEW_APP_VIEWS_FLAG_WAIT_MS);
+  onCleanup(() => clearTimeout(timer));
+
+  // PostHog can be blocked or fail before invoking its flag callback. Bound
+  // the loading state so these views fall back to their legacy equivalents
+  // instead of displaying a loading block forever.
+  const ready = () => !flag().loading || timedOut();
   const enabled = () => ready() && flag().enabled;
 
   createRenderEffect(() => {


### PR DESCRIPTION
Adds a timeout for the ready state and falls back to the legacy views

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX gating change in split-layout view registration; worst case is showing legacy views slightly early if the flag loads after 5s.
> 
> **Overview**
> **Fixes infinite loading** on inbox, tasks, and channels when the `enableNewAppViews` feature flag never finishes loading (e.g. PostHog blocked or failing before its callback).
> 
> `useNewAppViews` no longer waits on `posthog.flagsLoaded()` or flag overrides. **Ready** is now when `useFeatureFlag` reports not loading, or after a **5 second** timeout; on timeout or disabled flag, views **fall back to legacy** `SoupView` layouts as before. The timer is cleared on cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a33ba4214455a9590e299da58ab981616f9e1291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->