### PR TITLE
fix(calendar): fold an event's calendar copies into one chip with a color bar per calendar

### DIFF
--- a/apps/web/src/components/app/app-sidebar/calendar-sidebar-preview.tsx
+++ b/apps/web/src/components/app/app-sidebar/calendar-sidebar-preview.tsx
@@ -165,9 +165,17 @@ function EventSummary(props: {
         <div class="flex min-w-0 items-start gap-2">
           <span
             aria-hidden="true"
-            class="mt-0.5 size-3 shrink-0 rounded-sm"
-            style={{ 'background-color': props.event.calendar.color }}
-          />
+            class="mt-0.5 flex size-3 shrink-0 gap-px overflow-hidden rounded-sm"
+          >
+            <For each={props.event.visibleCalendars}>
+              {(calendar) => (
+                <span
+                  class="min-w-0 flex-1"
+                  style={{ 'background-color': calendar.color }}
+                />
+              )}
+            </For>
+          </span>
           <div class="min-w-0">
             <h3 class="truncate text-sm font-semibold text-ink">
               {props.event.title}

--- a/apps/web/src/features/calendar/calendar.css
+++ b/apps/web/src/features/calendar/calendar.css
@@ -418,13 +418,18 @@
 	display: none;
 }
 
-.calendar-view .fc .calendar-event-color-bar {
+.calendar-view .fc .calendar-event-color-bars {
 	position: absolute;
 	top: 2px;
 	left: 2px;
 	z-index: 1;
-	width: 4px;
+	display: flex;
 	height: min(2rem, 70%);
+	gap: 1px;
+}
+
+.calendar-view .fc .calendar-event-color-bar {
+	width: 4px;
 	border-radius: 9999px;
 	background: var(--event-calendar-color, var(--color-calendar));
 }
@@ -433,7 +438,9 @@
 	.fc
 	.calendar-event-content-with-color-bar
 	.calendar-event-content-layout {
-	padding-left: 10px;
+	padding-left: calc(
+		5px + var(--calendar-event-color-bar-count, 1) * 5px
+	);
 }
 
 /* Single-day timed events use a compact dot treatment in the month grid. */
@@ -547,7 +554,7 @@
 
 /* A color bar and response dot carry no signal on a chip already filled
    with the calendar color. */
-.calendar-view .fc .calendar-event-out-of-office .calendar-event-color-bar,
+.calendar-view .fc .calendar-event-out-of-office .calendar-event-color-bars,
 .calendar-view .fc .calendar-event-out-of-office .calendar-event-response-dot {
 	display: none;
 }

--- a/apps/web/src/features/calendar/components/EventContent.tsx
+++ b/apps/web/src/features/calendar/components/EventContent.tsx
@@ -1,7 +1,7 @@
 import type { EventContentArg } from '@fullcalendar/core';
 import ExclamationIcon from '@phosphor/exclamation-mark.svg';
 import { cn } from '@ui';
-import { Show } from 'solid-js';
+import { For, Show } from 'solid-js';
 import type { CalendarEvent, CalendarTimeFormat } from '../types';
 import {
   formatCompactCalendarTime,
@@ -81,9 +81,23 @@ export function EventContent(props: EventContentProps) {
         props.isSelected && 'calendar-event-content-selected'
       )}
       data-response-status={selfResponseStatus()}
+      style={{
+        '--calendar-event-color-bar-count': String(
+          props.event.visibleCalendars.length
+        ),
+      }}
     >
       <Show when={showsColorBar()}>
-        <span class="calendar-event-color-bar" aria-hidden="true" />
+        <span class="calendar-event-color-bars" aria-hidden="true">
+          <For each={props.event.visibleCalendars}>
+            {(calendar) => (
+              <span
+                class="calendar-event-color-bar"
+                style={{ background: calendar.color }}
+              />
+            )}
+          </For>
+        </span>
       </Show>
       <div
         class={cn(

--- a/apps/web/src/features/calendar/components/EventDetails.tsx
+++ b/apps/web/src/features/calendar/components/EventDetails.tsx
@@ -539,10 +539,16 @@ export function EventDetails(props: {
         aria-hidden="true"
         class="mt-0.5 flex size-5 items-center justify-center sm:size-4"
       >
-        <span
-          class="size-4 rounded-sm sm:size-3"
-          style={{ 'background-color': props.event.calendar.color }}
-        />
+        <span class="flex size-4 gap-px overflow-hidden rounded-sm sm:size-3">
+          <For each={props.event.visibleCalendars}>
+            {(calendar) => (
+              <span
+                class="min-w-0 flex-1"
+                style={{ 'background-color': calendar.color }}
+              />
+            )}
+          </For>
+        </span>
       </span>
       <div class="flex min-w-0 flex-col gap-1">
         <div class="select-text text-lg font-semibold leading-snug text-ink sm:text-base">

--- a/apps/web/src/features/calendar/hooks/use-calendar-occurrence-data.ts
+++ b/apps/web/src/features/calendar/hooks/use-calendar-occurrence-data.ts
@@ -10,7 +10,7 @@ import {
   type CalendarEvent,
   type CalendarSource,
   isCalendarEventVisible,
-  mapCalendarOccurrenceChips,
+  mapCalendarOccurrence,
 } from '../types';
 import { isCalendarRangeSupported } from '../utils/calendar-supported-range';
 
@@ -53,8 +53,11 @@ export function useCalendarOccurrenceData(
   const events = createMemo(() => {
     if (!isRangeSupported()) return [];
     const sourceById = options.sourceById?.();
-    return (occurrencesQuery.data?.items ?? []).flatMap((item) =>
-      mapCalendarOccurrenceChips(item, { sourceById })
+    return (occurrencesQuery.data?.items ?? []).map((item) =>
+      mapCalendarOccurrence(item, {
+        sourceById,
+        isSourceVisible: options.isSourceVisible,
+      })
     );
   });
   const visibleEvents = createMemo(() =>

--- a/apps/web/src/features/calendar/hooks/use-team-ooo.ts
+++ b/apps/web/src/features/calendar/hooks/use-team-ooo.ts
@@ -47,6 +47,11 @@ function mapTeamOooItem(item: TeamOutOfOfficeItem): CalendarEvent {
       : { allDay: true, start: time.startDate, end: time.endDate };
   const name = getDisplayName(tryMacroId(item.ownerId));
   const title = item.title ?? TEAM_OOO_FALLBACK_TITLE;
+  const calendar = {
+    id: teamOooSourceId(item.ownerId),
+    name: name || TEAM_OOO_FALLBACK_TITLE,
+    color: TEAM_OOO_COLOR,
+  };
 
   return {
     ...range,
@@ -61,11 +66,8 @@ function mapTeamOooItem(item: TeamOutOfOfficeItem): CalendarEvent {
     eventType: EventType.out_of_office,
     timeZone: time.kind === 'timed' ? (time.timeZone ?? undefined) : undefined,
     title: name ? `${name}: ${title}` : title,
-    calendar: {
-      id: teamOooSourceId(item.ownerId),
-      name: name || TEAM_OOO_FALLBACK_TITLE,
-      color: TEAM_OOO_COLOR,
-    },
+    calendar,
+    visibleCalendars: [calendar],
   };
 }
 

--- a/apps/web/src/features/calendar/types.test.ts
+++ b/apps/web/src/features/calendar/types.test.ts
@@ -192,6 +192,27 @@ describe('mapCalendarOccurrence', () => {
     expect(event.visibleCalendars).toEqual([PRIMARY]);
   });
 
+  it('displays the first copy whose calendar is loaded so it leads the bars', () => {
+    const event = mapCalendarOccurrence(twoCopies(), {
+      sourceById: new Map([[SHARED.id, SHARED]]),
+    });
+
+    expect(event.calendar).toBe(SHARED);
+    expect(event.calendarId).toBe('shared');
+    expect(event.title).toBe('[teo] OOO');
+    expect(event.visibleCalendars).toEqual([SHARED]);
+  });
+
+  it('keeps choosing by visibility alone without a calendar map', () => {
+    const event = mapCalendarOccurrence(twoCopies(), {
+      isSourceVisible: hidden('primary'),
+    });
+
+    expect(event.calendarId).toBe('shared');
+    expect(event.title).toBe('[teo] OOO');
+    expect(event.visibleCalendars).toEqual([event.calendar]);
+  });
+
   it('renders a single-copy event with its one calendar', () => {
     const event = mapCalendarOccurrence(item([copy('primary')]), {
       sourceById,

--- a/apps/web/src/features/calendar/types.test.ts
+++ b/apps/web/src/features/calendar/types.test.ts
@@ -6,7 +6,7 @@ import {
   type CalendarSource,
   isCalendarEventVisible,
   mapCalendarEventToFullCalendar,
-  mapCalendarOccurrenceChips,
+  mapCalendarOccurrence,
 } from './types';
 
 const PRIMARY: CalendarSource = {
@@ -97,81 +97,119 @@ const hidden = (...ids: string[]) => {
   return (id: string) => !set.has(id);
 };
 
-describe('mapCalendarOccurrenceChips', () => {
-  it('renders one chip per calendar copy, each with its own content', () => {
-    const [primary, shared] = mapCalendarOccurrenceChips(
-      item([copy('primary'), sharedCopy]),
-      { sourceById }
-    );
+describe('mapCalendarOccurrence', () => {
+  const twoCopies = () => item([copy('primary'), sharedCopy]);
 
-    expect(primary.calendar).toBe(PRIMARY);
-    expect(primary.calendarId).toBe('primary');
-    expect(primary.title).toBe('OOO');
-    expect(primary.eventType).toBe('out_of_office');
-    expect(primary.isReadOnly).toBe(false);
-    expect(primary.creatorEmail).toBe('teo@example.com');
-    expect(primary.sourceCalendarIds).toEqual(['primary']);
-    expect(shared.calendar).toBe(SHARED);
-    expect(shared.calendarId).toBe('shared');
-    expect(shared.title).toBe('[teo] OOO');
-    expect(shared.eventType).toBe('default');
-    expect(shared.isReadOnly).toBe(true);
-    expect(shared.creatorEmail).toBe('script@example.com');
-    expect(shared.sourceCalendarIds).toEqual(['shared']);
+  it('folds every copy into one chip showing the primary copy', () => {
+    const event = mapCalendarOccurrence(twoCopies(), {
+      sourceById,
+      isSourceVisible: hidden(),
+    });
+
+    expect(event.id).toBe('["event","2026-09-10T13:00:00+00:00"]');
+    expect(event.calendar).toBe(PRIMARY);
+    expect(event.calendarId).toBe('primary');
+    expect(event.title).toBe('OOO');
+    expect(event.eventType).toBe('out_of_office');
+    expect(event.isReadOnly).toBe(false);
+    expect(event.creatorEmail).toBe('teo@example.com');
+    expect(event.sourceCalendarIds).toEqual(['primary', 'shared']);
   });
 
-  it('gives each copy its own identity on the shared occurrence', () => {
-    const [primary, shared] = mapCalendarOccurrenceChips(
-      item([copy('primary'), sharedCopy]),
-      { sourceById }
-    );
+  it('lists every shown calendar the event is on, displayed copy first', () => {
+    const event = mapCalendarOccurrence(twoCopies(), {
+      sourceById,
+      isSourceVisible: hidden(),
+    });
 
-    expect(JSON.parse(primary.id)).toEqual([
-      'event',
-      '2026-09-10T13:00:00+00:00',
-      'primary',
+    expect(event.visibleCalendars).toEqual([PRIMARY, SHARED]);
+  });
+
+  it('drops a hidden calendar from the bars and keeps the event on the other', () => {
+    const event = mapCalendarOccurrence(twoCopies(), {
+      sourceById,
+      isSourceVisible: hidden('shared'),
+    });
+
+    expect(event.visibleCalendars).toEqual([PRIMARY]);
+    expect(event.sourceCalendarIds).toEqual(['primary', 'shared']);
+    expect(isCalendarEventVisible(event, hidden('shared'))).toBe(true);
+  });
+
+  it('falls through to the shared copy once the primary calendar is hidden', () => {
+    const event = mapCalendarOccurrence(twoCopies(), {
+      sourceById,
+      isSourceVisible: hidden('primary'),
+    });
+
+    expect(event.calendar).toBe(SHARED);
+    expect(event.calendarId).toBe('shared');
+    expect(event.title).toBe('[teo] OOO');
+    expect(event.eventType).toBe('default');
+    expect(event.isReadOnly).toBe(true);
+    expect(event.creatorEmail).toBe('script@example.com');
+    expect(event.visibleCalendars).toEqual([SHARED]);
+  });
+
+  it('keeps the reminders that fire on the primary copy whichever copy shows', () => {
+    const event = mapCalendarOccurrence(twoCopies(), {
+      sourceById,
+      isSourceVisible: hidden('primary'),
+    });
+
+    expect(event.reminders?.overrides).toEqual([
+      { method: 'popup', minutes: 30 },
     ]);
-    expect(JSON.parse(shared.id)).toEqual([
-      'event',
-      '2026-09-10T13:00:00+00:00',
-      'shared',
-    ]);
-    expect(shared.eventId).toBe(primary.eventId);
-    expect(shared.occurrenceKey).toBe(primary.occurrenceKey);
+    expect(event.reminderCalendarId).toBe('primary');
+    expect(event.reminderEventType).toBe('out_of_office');
+    expect(event.eventType).toBe('default');
+    expect(event.calendarId).toBe('shared');
   });
 
-  it('keeps the reminders that fire on the primary copy on every chip', () => {
-    const chips = mapCalendarOccurrenceChips(
-      item([copy('primary'), sharedCopy]),
-      { sourceById }
-    );
+  it('keeps the canonical copy when every calendar is hidden', () => {
+    const event = mapCalendarOccurrence(twoCopies(), {
+      sourceById,
+      isSourceVisible: hidden('primary', 'shared'),
+    });
 
-    for (const chip of chips) {
-      expect(chip.reminders?.overrides).toEqual([
-        { method: 'popup', minutes: 30 },
-      ]);
-      expect(chip.reminderCalendarId).toBe('primary');
-      expect(chip.reminderEventType).toBe('out_of_office');
-    }
+    expect(event.calendarId).toBe('primary');
+    expect(event.title).toBe('OOO');
+    expect(event.visibleCalendars).toEqual([PRIMARY]);
   });
 
-  it('renders a single-copy event as one chip with the plain occurrence id', () => {
-    const chips = mapCalendarOccurrenceChips(item([copy('primary')]), {
+  it('shows every copy while no visibility predicate is given', () => {
+    const event = mapCalendarOccurrence(twoCopies(), { sourceById });
+
+    expect(event.calendar).toBe(PRIMARY);
+    expect(event.visibleCalendars).toEqual([PRIMARY, SHARED]);
+  });
+
+  it('skips a copy whose calendar is not loaded yet', () => {
+    const event = mapCalendarOccurrence(twoCopies(), {
+      sourceById: new Map([[PRIMARY.id, PRIMARY]]),
+    });
+
+    expect(event.visibleCalendars).toEqual([PRIMARY]);
+  });
+
+  it('renders a single-copy event with its one calendar', () => {
+    const event = mapCalendarOccurrence(item([copy('primary')]), {
       sourceById,
     });
 
-    expect(chips).toHaveLength(1);
-    expect(chips[0].id).toBe('["event","2026-09-10T13:00:00+00:00"]');
-    expect(chips[0].sourceCalendarIds).toEqual(['primary']);
+    expect(event.id).toBe('["event","2026-09-10T13:00:00+00:00"]');
+    expect(event.sourceCalendarIds).toEqual(['primary']);
+    expect(event.visibleCalendars).toEqual([PRIMARY]);
   });
 
   it('reads the entity when no copy data is present', () => {
-    const [event] = mapCalendarOccurrenceChips(item([]), { sourceById });
+    const event = mapCalendarOccurrence(item([]), { sourceById });
 
     expect(event.title).toBe('OOO');
     expect(event.calendarId).toBeUndefined();
     expect(event.reminderEventType).toBe('out_of_office');
     expect(event.sourceCalendarIds).toEqual([]);
+    expect(event.visibleCalendars).toEqual([event.calendar]);
   });
 });
 
@@ -200,16 +238,16 @@ describe('isCalendarEventVisible', () => {
 });
 
 describe('mapCalendarEventToFullCalendar', () => {
-  it('keeps each copy identity and title on the rendered event', () => {
-    const [primary, shared] = mapCalendarOccurrenceChips(
-      item([copy('primary'), sharedCopy]),
-      { sourceById }
-    ).map(mapCalendarEventToFullCalendar);
+  it('keeps the occurrence identity and displayed title on the rendered event', () => {
+    const rendered = mapCalendarEventToFullCalendar(
+      mapCalendarOccurrence(item([copy('primary'), sharedCopy]), {
+        sourceById,
+        isSourceVisible: hidden('primary'),
+      })
+    );
 
-    expect(primary.id).toBe('["event","2026-09-10T13:00:00+00:00","primary"]');
-    expect(shared.id).toBe('["event","2026-09-10T13:00:00+00:00","shared"]');
-    expect(shared.title).toBe('[teo] OOO');
-    expect(primary.extendedProps?.calendarEventId).toBe(primary.id);
-    expect(shared.extendedProps?.calendarEventId).toBe(shared.id);
+    expect(rendered.id).toBe('["event","2026-09-10T13:00:00+00:00"]');
+    expect(rendered.title).toBe('[teo] OOO');
+    expect(rendered.extendedProps?.calendarEventId).toBe(rendered.id);
   });
 });

--- a/apps/web/src/features/calendar/types.ts
+++ b/apps/web/src/features/calendar/types.ts
@@ -136,10 +136,32 @@ interface CalendarOccurrenceMappingOptions {
   isSourceVisible?: (sourceId: string) => boolean;
 }
 
+/** A copy of an event on a calendar the viewer is showing, with that calendar. */
+interface ShownEventCopy {
+  copy: CalendarEventSourceContent;
+  calendar: CalendarSource;
+}
+
 /**
- * The copy of an event to display: the first copy whose calendar is shown,
- * in the server's canonical-first order (primary calendar, then freshest),
- * falling back to the canonical copy when none of them is shown.
+ * The copies whose calendar is shown and loaded, in the server's
+ * canonical-first order (primary calendar, then freshest). The first one is
+ * the copy a chip displays.
+ */
+function shownEventCopies(
+  sources: CalendarEventSourceContent[],
+  options: CalendarOccurrenceMappingOptions
+): ShownEventCopy[] {
+  return sources.flatMap((copy) => {
+    if (options.isSourceVisible?.(copy.calendarId) === false) return [];
+    const calendar = options.sourceById?.get(copy.calendarId);
+    return calendar ? [{ copy, calendar }] : [];
+  });
+}
+
+/**
+ * The copy to display when no shown copy's calendar is loaded: the first
+ * copy whose calendar is shown, falling back to the canonical copy when none
+ * of them is.
  */
 function selectEventSource(
   sources: CalendarEventSourceContent[],
@@ -177,10 +199,10 @@ export function reminderCalendarIdOf(
 
 /**
  * Maps one backend occurrence projection into the single chip it renders as,
- * showing the copy that belongs to a calendar the viewer has on and listing
- * every shown calendar the event is synced to. The entity itself carries the
- * canonical copy's content, so an event with no copy data reads the same as
- * its first copy.
+ * showing the first copy whose calendar the viewer has on and loaded, and
+ * listing every such calendar the event is synced to. The entity itself
+ * carries the canonical copy's content, so an event with no copy data reads
+ * the same as its first copy.
  */
 export function mapCalendarOccurrence(
   item: CalendarOccurrenceItem,
@@ -193,18 +215,17 @@ export function mapCalendarOccurrence(
       ? { allDay: false, start: time.startsAt, end: time.endsAt }
       : { allDay: true, start: time.startDate, end: time.endDate };
   const sources = event.sources ?? [];
-  const copy = selectEventSource(sources, options.isSourceVisible);
+  const shown = shownEventCopies(sources, options);
+  const copy =
+    shown[0]?.copy ?? selectEventSource(sources, options.isSourceVisible);
   const content = copy ?? event;
   const canonical = sources[0] ?? event;
   const calendarId = copy?.calendarId ?? event.calendarId ?? undefined;
   const source =
+    shown[0]?.calendar ??
     (calendarId ? options.sourceById?.get(calendarId) : undefined) ??
     DEFAULT_CALENDAR_SOURCE;
-  const visibleCalendars = sources.flatMap((candidate) => {
-    if (options.isSourceVisible?.(candidate.calendarId) === false) return [];
-    const calendar = options.sourceById?.get(candidate.calendarId);
-    return calendar ? [calendar] : [];
-  });
+  const visibleCalendars = shown.map(({ calendar }) => calendar);
 
   return {
     ...range,

--- a/apps/web/src/features/calendar/types.ts
+++ b/apps/web/src/features/calendar/types.ts
@@ -88,9 +88,9 @@ export interface CalendarEvent {
   /** Calendar of the copy this chip shows. Mutations address that copy. */
   calendarId?: string;
   /**
-   * Calendars whose visibility governs this chip: the copy's own calendar,
-   * or the overlay id for a teammate's out-of-office event. Empty when the
-   * event has no copy data, in which case `calendar` decides.
+   * Calendars whose visibility governs this chip: every calendar the event
+   * is synced from, or the overlay id for a teammate's out-of-office event.
+   * Empty when the event has no copy data, in which case `calendar` decides.
    */
   sourceCalendarIds: string[];
   /** Raw recurrence rules attached to the canonical event. */
@@ -105,8 +105,14 @@ export interface CalendarEvent {
   end: string;
   /** Whether the canonical occurrence is all-day rather than timed. */
   allDay: boolean;
-  /** Calendar source that owns the event. */
+  /** Calendar of the copy this chip shows. */
   calendar: CalendarSource;
+  /**
+   * Every shown calendar the event is on, the displayed copy's first. A chip
+   * draws one color bar per entry, so an event synced to several calendars
+   * reads as one event that belongs to each of them.
+   */
+  visibleCalendars: CalendarSource[];
   /** Optional event location. */
   location?: string;
   /** Optional event description. */
@@ -124,9 +130,25 @@ function optionalText(value: string | null | undefined) {
   return value ?? undefined;
 }
 
-/** How an occurrence's chips resolve the calendars they belong to. */
+/** How an occurrence is attributed to the calendars the viewer is showing. */
 interface CalendarOccurrenceMappingOptions {
   sourceById?: ReadonlyMap<string, CalendarSource>;
+  isSourceVisible?: (sourceId: string) => boolean;
+}
+
+/**
+ * The copy of an event to display: the first copy whose calendar is shown,
+ * in the server's canonical-first order (primary calendar, then freshest),
+ * falling back to the canonical copy when none of them is shown.
+ */
+function selectEventSource(
+  sources: CalendarEventSourceContent[],
+  isSourceVisible?: (sourceId: string) => boolean
+): CalendarEventSourceContent | undefined {
+  return (
+    sources.find((source) => isSourceVisible?.(source.calendarId) !== false) ??
+    sources[0]
+  );
 }
 
 /**
@@ -154,30 +176,15 @@ export function reminderCalendarIdOf(
 }
 
 /**
- * Maps one backend occurrence projection into the chips it renders as: one
- * per calendar the event is synced from, each carrying that copy's content,
- * so an event on several calendars sits side by side the way the provider
- * shows it. The entity carries the canonical copy's content, so an event
- * with no copy data reads the same as its only copy.
+ * Maps one backend occurrence projection into the single chip it renders as,
+ * showing the copy that belongs to a calendar the viewer has on and listing
+ * every shown calendar the event is synced to. The entity itself carries the
+ * canonical copy's content, so an event with no copy data reads the same as
+ * its first copy.
  */
-export function mapCalendarOccurrenceChips(
+export function mapCalendarOccurrence(
   item: CalendarOccurrenceItem,
   options: CalendarOccurrenceMappingOptions = {}
-): CalendarEvent[] {
-  const sources = item.event.sources ?? [];
-  if (sources.length <= 1) {
-    return [buildCalendarEvent(item, options, sources[0], undefined)];
-  }
-  return sources.map((copy) =>
-    buildCalendarEvent(item, options, copy, copy.calendarId)
-  );
-}
-
-function buildCalendarEvent(
-  item: CalendarOccurrenceItem,
-  options: CalendarOccurrenceMappingOptions,
-  copy: CalendarEventSourceContent | undefined,
-  chipCalendarId: string | undefined
 ): CalendarEvent {
   const { event, occurrence } = item;
   const time = occurrence.time;
@@ -185,19 +192,23 @@ function buildCalendarEvent(
     time.kind === 'timed'
       ? { allDay: false, start: time.startsAt, end: time.endsAt }
       : { allDay: true, start: time.startDate, end: time.endDate };
+  const sources = event.sources ?? [];
+  const copy = selectEventSource(sources, options.isSourceVisible);
   const content = copy ?? event;
-  const canonical = event.sources?.[0] ?? event;
+  const canonical = sources[0] ?? event;
   const calendarId = copy?.calendarId ?? event.calendarId ?? undefined;
   const source =
     (calendarId ? options.sourceById?.get(calendarId) : undefined) ??
     DEFAULT_CALENDAR_SOURCE;
+  const visibleCalendars = sources.flatMap((candidate) => {
+    if (options.isSourceVisible?.(candidate.calendarId) === false) return [];
+    const calendar = options.sourceById?.get(candidate.calendarId);
+    return calendar ? [calendar] : [];
+  });
 
   return {
     ...range,
-    id:
-      chipCalendarId === undefined
-        ? JSON.stringify([event.id, occurrence.occurrenceKey])
-        : JSON.stringify([event.id, occurrence.occurrenceKey, chipCalendarId]),
+    id: JSON.stringify([event.id, occurrence.occurrenceKey]),
     eventId: event.id,
     occurrenceKey: occurrence.occurrenceKey,
     recurrenceId: occurrence.recurrenceId ?? undefined,
@@ -218,10 +229,11 @@ function buildCalendarEvent(
     reminderEventType: canonical.eventType ?? undefined,
     eventType: content.eventType ?? undefined,
     calendarId,
-    sourceCalendarIds: copy ? [copy.calendarId] : [],
+    sourceCalendarIds: sources.map((candidate) => candidate.calendarId),
     timeZone: time.kind === 'timed' ? (time.timeZone ?? undefined) : undefined,
     title: content.title,
     calendar: source,
+    visibleCalendars: visibleCalendars.length > 0 ? visibleCalendars : [source],
     location: content.location ?? undefined,
     description: content.description ?? undefined,
   };

--- a/apps/web/src/features/calendar/utils/event-attribution.test.ts
+++ b/apps/web/src/features/calendar/utils/event-attribution.test.ts
@@ -23,6 +23,7 @@ function event(overrides: Partial<CalendarEvent>): CalendarEvent {
       emailAddress: 'jackson@example.com',
       isPrimary: true,
     },
+    visibleCalendars: [],
     ...overrides,
   };
 }

--- a/apps/web/src/features/calendar/utils/event-guest-editing.test.ts
+++ b/apps/web/src/features/calendar/utils/event-guest-editing.test.ts
@@ -29,6 +29,7 @@ function event(overrides: Partial<CalendarEvent>): CalendarEvent {
     end: '2026-08-27T20:00:00.000Z',
     allDay: false,
     calendar: { id: 'cal', name: 'Calendar', color: 'orange' },
+    visibleCalendars: [{ id: 'cal', name: 'Calendar', color: 'orange' }],
     ...overrides,
   };
 }

--- a/apps/web/src/features/calendar/utils/working-location-events.test.ts
+++ b/apps/web/src/features/calendar/utils/working-location-events.test.ts
@@ -39,6 +39,7 @@ function event(
     end,
     allDay: overrides.allDay ?? true,
     calendar: overrides.calendar ?? OFFICE,
+    visibleCalendars: [overrides.calendar ?? OFFICE],
     eventType: overrides.eventType ?? EventType.working_location,
     location: overrides.location,
   };

--- a/apps/web/src/lib/core/component/AI/component/tool/calendar/event-preview-model.ts
+++ b/apps/web/src/lib/core/component/AI/component/tool/calendar/event-preview-model.ts
@@ -71,6 +71,7 @@ export function buildCalendarToolPreviewEvent(
     sourceCalendarIds: [],
     title: input.values.title.trim() || 'New event',
     calendar,
+    visibleCalendars: [calendar],
     location: input.values.location || undefined,
     description: input.values.description || undefined,
   };

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -57,14 +57,16 @@ provider does not report the stored ones. Out-of-office events render on the gri
 chips filled with their calendar color (like Google), unlike regular events' outlined chips,
 and their details card shows an `Out of office` line under the schedule.
 An event that Google carries on several of an account's calendars (a shared calendar's
-re-import of a member's own event, for example) renders once per calendar, side by side,
-the way Google Calendar shows it: each chip carries its own copy's title, color, and
-editability, and hiding a calendar hides its chip. Reminders, guests, and conferencing
-always show and follow the primary copy, since that is the copy Macro's alerts fire from
-and whose guest list and join link Macro records, and the editor only lets them be changed
-there. Answering an invitation likewise addresses the primary copy. The details popover and
-the editor act on the chip's copy, so editing or deleting it targets that calendar's event
-at Google.
+re-import of a member's own event, for example) renders as one chip, not one per calendar:
+the chip carries one thin color bar on its left edge per shown calendar the event is on
+(the details popover's color square splits the same way), and shows the title, color, and
+editability of the first shown copy in primary-first order — hiding the primary calendar
+switches the chip to the shared copy, hiding every one of its calendars hides the chip.
+Reminders, guests, and conferencing always show and follow the primary copy, since that is
+the copy Macro's alerts fire from and whose guest list and join link Macro records, and the
+editor only lets them be changed there. Answering an invitation likewise addresses the
+primary copy. The details popover and the editor act on the displayed copy, so editing or
+deleting it targets that calendar's event at Google.
 
 Teammates' Google Calendar out-of-office events overlay the grid as read-only chips titled
 `<name>: <event title>`. The side panel's `Team out of office` section (shown only when the


### PR DESCRIPTION
Since #6212 an event Google carries on several calendars rendered once per copy, so a subscribed calendar that re-carries your primary events doubled every standup. It now renders as one chip showing the first shown copy, with one thin color bar per shown calendar (the details popover's color square splits the same way), so duplicates collapse while each calendar's color still shows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core occurrence-to-UI mapping and event identity on the grid, which can affect selection, editing, and visibility when users toggle calendars; behavior is well covered by updated unit tests.
> 
> **Overview**
> Events synced to multiple Google calendars (e.g. primary plus a shared re-import) no longer render as duplicate chips. **`mapCalendarOccurrenceChips`** is replaced by **`mapCalendarOccurrence`**, which emits **one** `CalendarEvent` per occurrence with a stable id (no per-calendar suffix), **`sourceCalendarIds`** listing every copy, and **`visibleCalendars`** for shown/loaded calendars.
> 
> The grid chip, details popover, and sidebar preview draw **one color segment per** `visibleCalendars` entry; CSS adds a flex **`calendar-event-color-bars`** row and scales left padding via **`--calendar-event-color-bar-count`**. Title, editability, and **`calendarId`** follow the first visible copy (primary-first when loaded); hiding the primary falls through to another copy while reminders/guests still follow the canonical primary copy.
> 
> **`useCalendarOccurrenceData`** maps occurrences with **`isSourceVisible`** instead of flat-mapping to multiple chips. Tests and agent docs are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a3c910ae4f82d5315d216f839d38b8b98c6939b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->