### PR TITLE
feat(infra): remove some legacy albs

### DIFF
--- a/infra/stacks/agent-schedule-service/index.ts
+++ b/infra/stacks/agent-schedule-service/index.ts
@@ -54,7 +54,6 @@ const service = new AgentScheduleService(`agent-schedule-service-${stack}`, {
   platform: { family: 'linux', architecture: 'amd64' },
   serviceContainerPort: 8080,
   healthCheckPath: '/health',
-  isPrivate: false,
   ecsClusterArn: cloudStorageClusterArn,
   cloudStorageClusterName,
   secretKeyArns: [

--- a/infra/stacks/agent-schedule-service/legacy-alb.test.ts
+++ b/infra/stacks/agent-schedule-service/legacy-alb.test.ts
@@ -1,0 +1,310 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+
+// Parse source only: importing the stack would perform cloud lookups and builds.
+function parse(file: string): ts.SourceFile {
+  return ts.createSourceFile(
+    file,
+    readFileSync(new URL(file, import.meta.url), 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+}
+
+const service = parse('./service.ts');
+const index = parse('./index.ts');
+
+function nodes<T extends ts.Node>(
+  root: ts.Node,
+  predicate: (node: ts.Node) => node is T
+): T[] {
+  const result: T[] = [];
+  function visit(node: ts.Node): void {
+    if (predicate(node)) result.push(node);
+    ts.forEachChild(node, visit);
+  }
+  visit(root);
+  return result;
+}
+
+function text(node: ts.Node): string {
+  return node.getText().replace(/\s+/g, '');
+}
+
+function constructors(
+  type: string,
+  root: ts.Node = service
+): ts.NewExpression[] {
+  return nodes(root, ts.isNewExpression).filter(
+    (node) => text(node.expression) === type
+  );
+}
+
+function resource(type: string, root: ts.Node = service): ts.NewExpression {
+  const matches = constructors(type, root);
+  expect(matches).toHaveLength(1);
+  return matches[0];
+}
+
+function property(node: ts.Node, key: string): ts.Expression {
+  if (!ts.isObjectLiteralExpression(node)) throw new Error('Expected object');
+  const member = node.properties.find((entry) => entry.name?.getText() === key);
+  if (member && ts.isPropertyAssignment(member)) return member.initializer;
+  if (member && ts.isShorthandPropertyAssignment(member)) return member.name;
+  throw new Error(`Missing property ${key}`);
+}
+
+function shape(node: ts.Node): Record<string, string> {
+  if (!ts.isObjectLiteralExpression(node)) throw new Error('Expected object');
+  return Object.fromEntries(
+    node.properties.map((entry) => {
+      const key = entry.name?.getText();
+      if (!key) throw new Error('Expected named property');
+      return [key, text(property(node, key))];
+    })
+  );
+}
+
+function elements(node: ts.Node): ts.Expression[] {
+  if (!ts.isArrayLiteralExpression(node)) throw new Error('Expected array');
+  return [...node.elements];
+}
+
+function variable(file: ts.SourceFile, name: string): ts.Expression {
+  const matches = nodes(file, ts.isVariableDeclaration).filter(
+    (node) => text(node.name) === name
+  );
+  expect(matches).toHaveLength(1);
+  if (!matches[0].initializer) throw new Error(`Missing initializer: ${name}`);
+  return matches[0].initializer;
+}
+
+const ecs = resource('awsx.ecs.FargateService');
+const ecsArgs = ecs.arguments![1];
+const caller = resource('AgentScheduleService', index);
+const container = property(
+  property(property(ecsArgs, 'taskDefinitionArgs'), 'containers'),
+  'service'
+);
+
+test('removes dedicated ALB, DNS, listeners, and legacy security-group surface', () => {
+  for (const file of [service, index]) {
+    const identifiers = nodes(file, ts.isIdentifier).map((node) => node.text);
+    for (const removed of [
+      'serviceLoadBalancer',
+      'SERVICE_DOMAIN_NAME',
+      'serviceAlbSg',
+      'isPrivate',
+      'publicSubnetIds',
+    ]) {
+      expect(identifiers).not.toContain(removed);
+    }
+    for (const type of [
+      'aws.lb.LoadBalancer',
+      'aws.lb.Listener',
+      'aws.lb.ListenerRule',
+      'aws.lb.TargetGroup',
+      'aws.route53.Record',
+      'aws.vpc.SecurityGroupIngressRule',
+    ]) {
+      expect(constructors(type, file)).toHaveLength(0);
+    }
+  }
+  const fields = nodes(service, ts.isPropertyDeclaration).map((node) =>
+    text(node.name)
+  );
+  for (const field of ['lb', 'listener', 'targetGroup']) {
+    expect(fields).not.toContain(field);
+  }
+});
+
+test('retains scheduled-action gateway identity, paired routes, health and port', () => {
+  expect(text(variable(service, 'BASE_NAME'))).toBe('pulumi.getProject()');
+  expect(text(variable(service, 'GATEWAY_PATH_PREFIX'))).toBe(
+    "'/scheduled-action'"
+  );
+  const component = nodes(service, ts.isCallExpression).find(
+    (node) => node.expression.kind === ts.SyntaxKind.SuperKeyword
+  );
+  expect(component!.arguments.map(text)).toEqual([
+    "'my:components:AgentScheduleService'",
+    'name',
+    '{}',
+    'opts',
+  ]);
+  expect(text(caller.arguments![0])).toBe('`agent-schedule-service-${stack}`');
+  expect(text(ecs.arguments![0])).toBe('`${BASE_NAME}`');
+  const gateway = resource('ServiceTargetGroup');
+  expect(text(gateway.arguments![0])).toBe('`${stack}-${BASE_NAME}`');
+  expect(shape(gateway.arguments![1])).toEqual({
+    tags: 'this.tags',
+    listenerArn: 'gatewayLoadBalancer.httpsListenerArn',
+    vpcId: 'vpc.vpcId',
+    containerPort: 'serviceContainerPort',
+    service: 'GatewayService.AGENT_SCHEDULE_SERVICE',
+    healthCheckPath: 'healthCheckPath',
+    pathPatterns: '[GATEWAY_PATH_PREFIX,`${GATEWAY_PATH_PREFIX}/*`]',
+    serviceSecurityGroupId: 'this.serviceSg.id',
+    albSecurityGroupId: 'gatewayLoadBalancer.albSecurityGroupId',
+  });
+  expect(shape(gateway.arguments![2])).toEqual({ parent: 'this' });
+  expect(text(property(caller.arguments![1], 'serviceContainerPort'))).toBe(
+    '8080'
+  );
+  expect(text(property(caller.arguments![1], 'healthCheckPath'))).toBe(
+    "'/health'"
+  );
+});
+
+test('registers ECS only with the gateway and retains listener dependency', () => {
+  expect(elements(property(ecsArgs, 'loadBalancers')).map(shape)).toEqual([
+    {
+      targetGroupArn: 'gatewayTargetGroup.target_group.arn',
+      containerName: "'service'",
+      containerPort: 'serviceContainerPort',
+    },
+  ]);
+  expect(elements(property(container, 'portMappings')).map(shape)).toEqual([
+    {
+      appProtocol: "'http'",
+      name: '`${BASE_NAME}-tcp-${stack}`',
+      hostPort: 'serviceContainerPort',
+      containerPort: 'serviceContainerPort',
+      targetGroup: 'gatewayTargetGroup.target_group',
+    },
+  ]);
+  expect(shape(ecs.arguments![2])).toEqual({
+    parent: 'this',
+    dependsOn: '[gatewayTargetGroup.listener_rule]',
+  });
+  expect(shape(property(ecsArgs, 'networkConfiguration'))).toEqual({
+    subnets: 'vpc.privateSubnetIds',
+    securityGroups: '[this.serviceSg.id]',
+  });
+});
+
+test('preserves the service security group and unrestricted outbound rule', () => {
+  const sg = resource('aws.ec2.SecurityGroup');
+  expect(text(sg.arguments![0])).toBe('`${BASE_NAME}-sg-${stack}`');
+  expect(shape(sg.arguments![1])).toEqual({
+    name: '`${BASE_NAME}-sg-${stack}`',
+    vpcId: 'vpcId',
+    description: '`${BASE_NAME}servicesecuritygroup`',
+    tags: 'this.tags',
+  });
+  expect(shape(sg.arguments![2])).toEqual({ parent: 'this' });
+  const egress = resource('aws.vpc.SecurityGroupEgressRule');
+  expect(text(egress.arguments![0])).toBe('`${BASE_NAME}-service-out`');
+  expect(shape(egress.arguments![1])).toEqual({
+    securityGroupId: 'serviceSg.id',
+    description: "'Allowalloutboundtraffic'",
+    cidrIpv4: "'0.0.0.0/0'",
+    ipProtocol: "'-1'",
+    tags: 'this.tags',
+  });
+  expect(shape(egress.arguments![2])).toEqual({ parent: 'this' });
+});
+
+test('preserves BASE_URL and Output-shaped dev/prod scheduled-action URL', () => {
+  expect(text(variable(service, 'GATEWAY_DOMAIN_NAME'))).toBe(
+    "`${stack==='prod'?'gateway':'dev-gateway'}.${BASE_DOMAIN}`"
+  );
+  const assignments = nodes(service, ts.isBinaryExpression).filter(
+    (node) => text(node.left) === 'this.domain'
+  );
+  expect(assignments).toHaveLength(1);
+  expect(text(assignments[0].right)).toBe(
+    '`https://${GATEWAY_DOMAIN_NAME}${GATEWAY_PATH_PREFIX}`'
+  );
+  const baseUrl = elements(property(container, 'environment')).find((node) =>
+    ts.isObjectLiteralExpression(node)
+  );
+  expect(shape(baseUrl!)).toEqual({ name: "'BASE_URL'", value: 'this.domain' });
+  expect(text(variable(index, 'agentScheduleServiceUrl'))).toBe(
+    'pulumi.interpolate`${service.domain}`'
+  );
+  expect(text(variable(index, 'agentScheduleServiceRoleArn'))).toBe(
+    'service.role.arn'
+  );
+});
+
+test('preserves CPU-only scaling and capacity/deployment settings', () => {
+  const target = resource('aws.appautoscaling.Target');
+  expect(text(target.arguments![0])).toBe(
+    '`${BASE_NAME}-service-scalable-target-${stack}`'
+  );
+  expect(shape(target.arguments![1])).toEqual({
+    maxCapacity: "stack==='prod'?3:2",
+    minCapacity: '1',
+    resourceId:
+      'pulumi.interpolate`service/${this.cloudStorageClusterName}/${this.service.service.name}`',
+    scalableDimension: "'ecs:service:DesiredCount'",
+    serviceNamespace: "'ecs'",
+    tags: 'this.tags',
+  });
+  expect(shape(target.arguments![2])).toEqual({ parent: 'this' });
+  const policy = resource('aws.appautoscaling.Policy');
+  expect(text(policy.arguments![0])).toBe(
+    '`${BASE_NAME}-scaling-policy-cpu-${stack}`'
+  );
+  expect(shape(policy.arguments![1])).toEqual({
+    policyType: "'TargetTrackingScaling'",
+    resourceId: 'target.resourceId',
+    scalableDimension: 'target.scalableDimension',
+    serviceNamespace: 'target.serviceNamespace',
+    targetTrackingScalingPolicyConfiguration:
+      "{targetValue:60,predefinedMetricSpecification:{predefinedMetricType:'ECSServiceAverageCPUUtilization',},scaleInCooldown:60,scaleOutCooldown:120,}",
+  });
+  expect(shape(policy.arguments![2])).toEqual({ parent: 'this' });
+  expect(shape(container)).toMatchObject({
+    cpu: '256',
+    memory: '512',
+    stopTimeout: '10',
+  });
+  expect(text(property(ecsArgs, 'desiredCount'))).toBe('1');
+  expect(text(property(ecsArgs, 'continueBeforeSteadyState'))).toBe(
+    'DEFAULT_CONTINUE_BEFORE_STEADY_STATE'
+  );
+  expect(shape(property(ecsArgs, 'deploymentCircuitBreaker'))).toEqual({
+    enable: 'true',
+    rollback: 'true',
+  });
+  expect(
+    shape(property(resource('EcrImage').arguments![1], 'buildArgs'))
+  ).toEqual({
+    SERVICE_NAME: "'service'",
+  });
+});
+
+test('retains exactly the existing CPU and deployment alarms', () => {
+  const alarm = resource('aws.cloudwatch.MetricAlarm');
+  expect(text(alarm.arguments![0])).toBe('`${BASE_NAME}-service-cpu-alarm`');
+  expect(shape(alarm.arguments![1])).toEqual({
+    name: '`${BASE_NAME}-service-cpu-${stack}`',
+    alarmDescription: '`Alarmwhen${BASE_NAME}CPUstayselevated`',
+    namespace: "'AWS/ECS'",
+    metricName: "'CPUUtilization'",
+    statistic: "'Average'",
+    period: '300',
+    evaluationPeriods: '2',
+    threshold: '90',
+    comparisonOperator: "'GreaterThanOrEqualToThreshold'",
+    dimensions:
+      '{ClusterName:pulumi.interpolate`${this.cloudStorageClusterName}`,ServiceName:this.service.service.name,}',
+    alarmActions: '[CLOUD_TRAIL_SNS_TOPIC_ARN]',
+    tags: 'this.tags',
+  });
+  expect(shape(alarm.arguments![2])).toEqual({ parent: 'this' });
+  const deployment = resource('EcsDeploymentFailureAlarm');
+  expect(text(deployment.arguments![0])).toBe(
+    '`${BASE_NAME}-deployment-failure-alarm`'
+  );
+  expect(shape(deployment.arguments![1])).toEqual({
+    serviceName: 'BASE_NAME',
+    serviceArn: 'this.service.service.arn',
+    tags: 'this.tags',
+  });
+  expect(shape(deployment.arguments![2])).toEqual({ parent: 'this' });
+});

--- a/infra/stacks/agent-schedule-service/service.ts
+++ b/infra/stacks/agent-schedule-service/service.ts
@@ -7,7 +7,6 @@ import {
   EcsDeploymentFailureAlarm,
   datadogAgentContainer,
   fargateLogRouterSidecarContainer,
-  serviceLoadBalancer,
   ServiceTargetGroup,
 } from '../../packages/resources';
 import { EcrImage } from '../../packages/service';
@@ -27,14 +26,9 @@ const REPO_ROOT = '../../..';
 const GATEWAY_PATH_PREFIX = '/scheduled-action';
 const GATEWAY_DOMAIN_NAME = `${stack === 'prod' ? 'gateway' : 'dev-gateway'}.${BASE_DOMAIN}`;
 
-export const SERVICE_DOMAIN_NAME = `agent-schedule${
-  stack === 'prod' ? '' : `-${stack}`
-}.${BASE_DOMAIN}`;
-
 type Args = {
   vpc: {
     vpcId: pulumi.Output<string> | string;
-    publicSubnetIds: pulumi.Output<string[]> | string[];
     privateSubnetIds: pulumi.Output<string[]> | string[];
   };
   tags: { [key: string]: string };
@@ -42,7 +36,6 @@ type Args = {
   platform: { family: string; architecture: 'amd64' | 'arm64' };
   serviceContainerPort: number;
   healthCheckPath: string;
-  isPrivate?: boolean;
   ecsClusterArn: pulumi.Output<string> | string;
   cloudStorageClusterName: pulumi.Output<string> | string;
   secretKeyArns: (pulumi.Output<string> | string)[];
@@ -55,12 +48,8 @@ type Args = {
 export class AgentScheduleService extends pulumi.ComponentResource {
   public role: aws.iam.Role;
   public ecr: awsx.ecr.Repository;
-  public serviceAlbSg: aws.ec2.SecurityGroup;
   public serviceSg: aws.ec2.SecurityGroup;
   public domain: string;
-  public targetGroup: aws.lb.TargetGroup;
-  public lb: aws.lb.LoadBalancer;
-  public listener: aws.lb.Listener;
   public service: awsx.ecs.FargateService;
   public cloudStorageClusterName: pulumi.Output<string> | string;
   public tags: { [key: string]: string };
@@ -77,7 +66,6 @@ export class AgentScheduleService extends pulumi.ComponentResource {
       platform,
       serviceContainerPort,
       healthCheckPath,
-      isPrivate,
       ecsClusterArn,
       containerEnvVars,
       cloudStorageClusterName,
@@ -204,12 +192,7 @@ export class AgentScheduleService extends pulumi.ComponentResource {
     );
     this.ecr = image.ecr;
 
-    const { serviceAlbSg, serviceSg } = this.initializeSecurityGroups({
-      vpcId: vpc.vpcId,
-      serviceContainerPort,
-    });
-    this.serviceAlbSg = serviceAlbSg;
-    this.serviceSg = serviceSg;
+    this.serviceSg = this.initializeSecurityGroups({ vpcId: vpc.vpcId });
 
     const gatewayTargetGroup = new ServiceTargetGroup(
       `${stack}-${BASE_NAME}`,
@@ -227,19 +210,6 @@ export class AgentScheduleService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    const { targetGroup, lb, listener } = serviceLoadBalancer(this, {
-      serviceName: BASE_NAME,
-      serviceContainerPort,
-      healthCheckPath,
-      vpc,
-      albSecurityGroupId: serviceAlbSg.id,
-      isPrivate,
-      tags,
-    });
-    this.targetGroup = targetGroup;
-    this.lb = lb;
-    this.listener = listener;
-
     const dopplerEcsEnvironment = new DopplerEcsEnvironment(
       BASE_NAME,
       { tags: this.tags },
@@ -253,7 +223,7 @@ export class AgentScheduleService extends pulumi.ComponentResource {
         cluster: ecsClusterArn,
         networkConfiguration: {
           subnets: vpc.privateSubnetIds,
-          securityGroups: [serviceSg.id],
+          securityGroups: [this.serviceSg.id],
         },
         continueBeforeSteadyState: DEFAULT_CONTINUE_BEFORE_STEADY_STATE,
         deploymentCircuitBreaker: {
@@ -261,11 +231,6 @@ export class AgentScheduleService extends pulumi.ComponentResource {
           rollback: true,
         },
         loadBalancers: [
-          {
-            targetGroupArn: targetGroup.arn,
-            containerName: 'service',
-            containerPort: serviceContainerPort,
-          },
           {
             targetGroupArn: gatewayTargetGroup.target_group.arn,
             containerName: 'service',
@@ -314,7 +279,7 @@ export class AgentScheduleService extends pulumi.ComponentResource {
                   name: `${BASE_NAME}-tcp-${stack}`,
                   hostPort: serviceContainerPort,
                   containerPort: serviceContainerPort,
-                  targetGroup,
+                  targetGroup: gatewayTargetGroup.target_group,
                 },
               ],
             },
@@ -337,64 +302,19 @@ export class AgentScheduleService extends pulumi.ComponentResource {
 
     this.setupAutoScaling();
     this.setupServiceAlarms();
-
-    const zone = aws.route53.getZoneOutput({ name: BASE_DOMAIN });
-    new aws.route53.Record(
-      `${BASE_NAME}-domain-record`,
-      {
-        name: SERVICE_DOMAIN_NAME,
-        type: 'A',
-        zoneId: zone.zoneId,
-        aliases: [
-          {
-            evaluateTargetHealth: false,
-            name: this.lb.dnsName,
-            zoneId: this.lb.zoneId,
-          },
-        ],
-      },
-      { parent: this }
-    );
   }
 
   private initializeSecurityGroups({
     vpcId,
-    serviceContainerPort,
   }: {
     vpcId: pulumi.Output<string> | string;
-    serviceContainerPort: number;
   }) {
-    const serviceAlbSg = new aws.ec2.SecurityGroup(
-      `${BASE_NAME}-alb-sg-${stack}`,
-      {
-        name: `${BASE_NAME}-alb-sg-${stack}`,
-        description: `${BASE_NAME} application load balancer security group`,
-        vpcId,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
     const serviceSg = new aws.ec2.SecurityGroup(
       `${BASE_NAME}-sg-${stack}`,
       {
         name: `${BASE_NAME}-sg-${stack}`,
         vpcId,
         description: `${BASE_NAME} service security group`,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-alb-in`,
-      {
-        securityGroupId: serviceSg.id,
-        description: 'Allow inbound traffic from the service ALB',
-        referencedSecurityGroupId: serviceAlbSg.id,
-        fromPort: serviceContainerPort,
-        toPort: serviceContainerPort,
-        ipProtocol: 'tcp',
         tags: this.tags,
       },
       { parent: this }
@@ -412,49 +332,7 @@ export class AgentScheduleService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-http`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTP traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 80,
-        toPort: 80,
-        ipProtocol: 'tcp',
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-https`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTPS traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 443,
-        toPort: 443,
-        ipProtocol: 'tcp',
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupEgressRule(
-      `${BASE_NAME}-alb-out`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow traffic to the service security group',
-        referencedSecurityGroupId: serviceSg.id,
-        fromPort: serviceContainerPort,
-        toPort: serviceContainerPort,
-        ipProtocol: 'tcp',
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    return { serviceAlbSg, serviceSg };
+    return serviceSg;
   }
 
   private setupAutoScaling() {

--- a/infra/stacks/connection-gateway/connection_gateway.ts
+++ b/infra/stacks/connection-gateway/connection_gateway.ts
@@ -8,16 +8,16 @@ import {
   EcsDeploymentFailureAlarm,
   datadogAgentContainer,
   fargateLogRouterSidecarContainer,
-  serviceLoadBalancer,
   ServiceTargetGroup,
 } from '../../packages/resources';
 import { EcrImage } from '../../packages/service';
 import {
-  BASE_DOMAIN,
   CLOUD_TRAIL_SNS_TOPIC_ARN,
   DopplerEcsEnvironment,
   getGatewayAlb,
   GatewayService,
+  getServiceUrl,
+  ServiceUrl,
   stack,
 } from '../../packages/shared';
 
@@ -26,21 +26,15 @@ const gatewayLoadBalancer = getGatewayAlb();
 const BASE_NAME = pulumi.getProject();
 const REPO_ROOT = '../../..';
 
-export const SERVICE_DOMAIN_NAME = `connection-gateway${
-  stack === 'prod' ? '' : `-${stack}`
-}.${BASE_DOMAIN}`;
-
 type CreateConnectionGatewayArgs = {
   cloudStorageClusterName: pulumi.Output<string> | string;
   ecsClusterArn: pulumi.Output<string> | string;
   vpc: {
     vpcId: pulumi.Output<string> | string;
-    publicSubnetIds: pulumi.Output<string[]> | string[];
     privateSubnetIds: pulumi.Output<string[]> | string[];
   };
   platform: { family: string; architecture: 'amd64' | 'arm64' };
   serviceContainerPort: number;
-  isPrivate?: boolean;
   containerEnvVars?: { name: string; value: pulumi.Output<string> | string }[];
   healthCheckPath: string;
   tags: { [key: string]: string };
@@ -50,11 +44,8 @@ type CreateConnectionGatewayArgs = {
 
 export class ConnectionGateway extends pulumi.ComponentResource {
   public ecr: awsx.ecr.Repository;
-  public serviceAlbSg: aws.ec2.SecurityGroup;
   public serviceSg: aws.ec2.SecurityGroup;
   public targetGroup: aws.lb.TargetGroup;
-  public lb: aws.lb.LoadBalancer;
-  public listener: aws.lb.Listener;
   public service: awsx.ecs.FargateService;
   public domain: string;
   public cloudStorageClusterName: pulumi.Output<string> | string;
@@ -69,7 +60,6 @@ export class ConnectionGateway extends pulumi.ComponentResource {
       platform,
       serviceContainerPort,
       healthCheckPath,
-      isPrivate,
       containerEnvVars,
       cloudStorageClusterName,
       secretKeyArns,
@@ -103,12 +93,7 @@ export class ConnectionGateway extends pulumi.ComponentResource {
     this.ecr = image.ecr;
 
     // sg
-    const sg = this.initializeSecurityGroups({
-      vpcId: vpc.vpcId,
-      serviceContainerPort,
-    });
-    this.serviceAlbSg = sg.serviceAlbSg;
-    this.serviceSg = sg.serviceSg;
+    this.serviceSg = this.initializeSecurityGroups({ vpcId: vpc.vpcId });
 
     const gatewayTargetGroup = new ServiceTargetGroup(
       `${stack}-${BASE_NAME}`,
@@ -127,21 +112,7 @@ export class ConnectionGateway extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // lb
-    const { targetGroup, lb, listener } = serviceLoadBalancer(this, {
-      serviceName: BASE_NAME, // service name
-      serviceContainerPort,
-      healthCheckPath,
-      vpc,
-      albSecurityGroupId: this.serviceAlbSg.id,
-      isPrivate,
-      tags,
-      idleTimeout: 3600,
-      deregistrationDelay: 30,
-    });
-    this.targetGroup = targetGroup;
-    this.lb = lb;
-    this.listener = listener;
+    this.targetGroup = gatewayTargetGroup.target_group;
 
     const secretsManagerPolicy = new aws.iam.Policy(
       `${BASE_NAME}-secrets-manager-policy`,
@@ -221,11 +192,6 @@ export class ConnectionGateway extends pulumi.ComponentResource {
         },
         loadBalancers: [
           {
-            targetGroupArn: targetGroup.arn,
-            containerName: 'service',
-            containerPort: serviceContainerPort,
-          },
-          {
             targetGroupArn: gatewayTargetGroup.target_group.arn,
             containerName: 'service',
             containerPort: serviceContainerPort,
@@ -267,7 +233,7 @@ export class ConnectionGateway extends pulumi.ComponentResource {
                   name: `${BASE_NAME}-tcp-${stack}`,
                   hostPort: serviceContainerPort,
                   containerPort: serviceContainerPort,
-                  targetGroup,
+                  targetGroup: this.targetGroup,
                 },
               ],
             },
@@ -298,67 +264,20 @@ export class ConnectionGateway extends pulumi.ComponentResource {
 
     this.setupServiceAlarms();
 
-    // domain record
-    const zone = aws.route53.getZoneOutput({ name: BASE_DOMAIN });
-
-    new aws.route53.Record(
-      `${BASE_NAME}-domain-record`,
-      {
-        name: `${SERVICE_DOMAIN_NAME}`,
-        type: 'A',
-        zoneId: zone.zoneId,
-        aliases: [
-          {
-            evaluateTargetHealth: false,
-            name: this.lb.dnsName,
-            zoneId: this.lb.zoneId,
-          },
-        ],
-      },
-      { parent: this }
-    );
-
-    this.domain = `https://${SERVICE_DOMAIN_NAME}`;
+    this.domain = getServiceUrl(ServiceUrl.CONNECTION_GATEWAY_URL);
   }
 
   initializeSecurityGroups({
     vpcId,
-    serviceContainerPort,
   }: {
     vpcId: pulumi.Output<string> | string;
-    serviceContainerPort: number;
   }) {
-    const serviceAlbSg = new aws.ec2.SecurityGroup(
-      `${BASE_NAME}-alb-sg-${stack}`,
-      {
-        name: `${BASE_NAME}-alb-sg-${stack}`,
-        description: `${BASE_NAME} application load balancer security group`,
-        vpcId,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
     const serviceSg = new aws.ec2.SecurityGroup(
       `${BASE_NAME}-sg-${stack}`,
       {
         name: `${BASE_NAME}-sg-${stack}`,
         vpcId,
         description: `${BASE_NAME} security group that is attached directly to the service`,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-alb-in`,
-      {
-        securityGroupId: serviceSg.id,
-        description: 'Allow inbound traffic from the services ALB',
-        referencedSecurityGroupId: serviceAlbSg.id,
-        fromPort: serviceContainerPort,
-        toPort: serviceContainerPort,
-        ipProtocol: 'tcp',
         tags: this.tags,
       },
       { parent: this }
@@ -376,50 +295,7 @@ export class ConnectionGateway extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // ALB SG rules
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-http`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTP traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 80,
-        ipProtocol: 'tcp',
-        toPort: 80,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-https`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTPS traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 443,
-        ipProtocol: 'tcp',
-        toPort: 443,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupEgressRule(
-      `${BASE_NAME}-out-service`,
-      {
-        description: 'Allow traffic to the service security group',
-        securityGroupId: serviceAlbSg.id,
-        referencedSecurityGroupId: serviceSg.id,
-        fromPort: serviceContainerPort,
-        ipProtocol: 'tcp',
-        toPort: serviceContainerPort,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    return { serviceAlbSg, serviceSg };
+    return serviceSg;
   }
 
   setupAutoScaling() {
@@ -437,19 +313,7 @@ export class ConnectionGateway extends pulumi.ComponentResource {
       },
       { parent: this }
     );
-    const lbPortion: pulumi.Output<string> = this.lb.arn.apply((arn) => {
-      const parts = arn.split(':loadbalancer/');
-      return parts[1];
-    });
-
-    const tgPortion: pulumi.Output<string> = this.targetGroup.arn.apply(
-      (arn) => {
-        const parts = arn.split(':');
-        return parts[parts.length - 1];
-      }
-    );
-
-    const resourceLabel = pulumi.interpolate`${lbPortion}/${tgPortion}`;
+    const resourceLabel = pulumi.interpolate`${gatewayLoadBalancer.albArnSuffix}/${this.targetGroup.arnSuffix}`;
 
     // Create an Auto Scaling policy for request count.
     new aws.appautoscaling.Policy(
@@ -573,7 +437,7 @@ export class ConnectionGateway extends pulumi.ComponentResource {
       `${BASE_NAME}-http-5xx-alarm`,
       {
         name: `${BASE_NAME}-http-5xx-${stack}`,
-        metricName: 'HTTPCode_ELB_5XX_Count',
+        metricName: 'HTTPCode_Target_5XX_Count',
         namespace: 'AWS/ApplicationELB',
         statistic: 'Sum',
         period: 180,
@@ -581,9 +445,10 @@ export class ConnectionGateway extends pulumi.ComponentResource {
         threshold: 25,
         comparisonOperator: 'GreaterThanOrEqualToThreshold',
         dimensions: {
-          LoadBalancer: this.lb.arn,
+          LoadBalancer: gatewayLoadBalancer.albArnSuffix,
+          TargetGroup: this.targetGroup.arnSuffix,
         },
-        alarmDescription: `High HTTP 5XX count alarm for ${BASE_NAME} Load Balancer.`,
+        alarmDescription: `High HTTP 5XX count alarm for ${BASE_NAME} gateway target group.`,
         actionsEnabled: true,
         alarmActions: [CLOUD_TRAIL_SNS_TOPIC_ARN],
         tags: this.tags,

--- a/infra/stacks/connection-gateway/index.ts
+++ b/infra/stacks/connection-gateway/index.ts
@@ -84,12 +84,10 @@ const connectionGateway = new ConnectionGateway(`connection-gateway-${stack}`, {
       value: stack,
     },
   ],
-  isPrivate: false,
   tags,
 });
 
 export const connectionGatewaySgId = connectionGateway.serviceSg.id;
-export const connectionGatewayAlbSgId = connectionGateway.serviceAlbSg.id;
 export const connectionGatewayUrl = pulumi.interpolate`${connectionGateway.domain}`;
 export const connectionGatewayRedisUrl = pulumi.interpolate`${connectionGatewayRedis.endpoint}`;
 export const connectionGatewayTableName = connectionGatewayTable.table.name;

--- a/infra/stacks/connection-gateway/legacy-alb.test.ts
+++ b/infra/stacks/connection-gateway/legacy-alb.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+
+// Parse source only: importing a stack would run Pulumi lookups and image builds.
+function parse(relativePath: string): ts.SourceFile {
+  return ts.createSourceFile(
+    relativePath,
+    readFileSync(new URL(relativePath, import.meta.url), 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+}
+
+const service = parse('./connection_gateway.ts');
+const index = parse('./index.ts');
+
+function nodes<T extends ts.Node>(
+  root: ts.Node,
+  guard: (node: ts.Node) => node is T
+): T[] {
+  const matches: T[] = [];
+  function visit(node: ts.Node): void {
+    if (guard(node)) matches.push(node);
+    ts.forEachChild(node, visit);
+  }
+  visit(root);
+  return matches;
+}
+
+function resource(
+  source: ts.SourceFile,
+  constructorName: string,
+  name?: string
+): ts.NewExpression {
+  const matches = nodes(source, ts.isNewExpression).filter(
+    (node) =>
+      node.expression.getText() === constructorName &&
+      (name === undefined || node.arguments?.[0].getText() === name)
+  );
+  expect(matches).toHaveLength(1);
+  return matches[0];
+}
+
+function variable(source: ts.SourceFile, name: string): ts.Expression {
+  const matches = nodes(source, ts.isVariableDeclaration).filter(
+    (node) => node.name.getText() === name
+  );
+  expect(matches).toHaveLength(1);
+  const initializer = matches[0].initializer;
+  if (!initializer) throw new Error(`Missing initializer for ${name}`);
+  return initializer;
+}
+
+function property(node: ts.Node, ...path: string[]): ts.Node {
+  let current = node;
+  for (const key of path) {
+    if (!ts.isObjectLiteralExpression(current)) {
+      throw new Error(`Expected object for ${key}`);
+    }
+    const member = current.properties.find(
+      (entry) => entry.name?.getText() === key
+    );
+    if (!member) throw new Error(`Missing property ${key}`);
+    if (ts.isPropertyAssignment(member)) current = member.initializer;
+    else if (ts.isShorthandPropertyAssignment(member)) current = member.name;
+    else throw new Error(`Unsupported property ${key}`);
+  }
+  return current;
+}
+
+type Shape = string | Shape[] | { [key: string]: Shape };
+
+function shape(node: ts.Node): Shape {
+  if (ts.isObjectLiteralExpression(node)) {
+    return Object.fromEntries(
+      node.properties.map((member) => {
+        const key = member.name?.getText();
+        if (!key) throw new Error('Expected named property');
+        return [key, shape(property(node, key))];
+      })
+    );
+  }
+  if (ts.isArrayLiteralExpression(node)) return node.elements.map(shape);
+  return node.getText();
+}
+
+describe('connection-gateway shared gateway migration', () => {
+  test('removes dedicated load balancing, DNS, and obsolete API fields', () => {
+    const identifiers = [service, index].flatMap((source) =>
+      nodes(source, ts.isIdentifier).map((node) => node.text)
+    );
+    for (const removed of [
+      'serviceLoadBalancer',
+      'SERVICE_DOMAIN_NAME',
+      'BASE_DOMAIN',
+      'serviceAlbSg',
+      'connectionGatewayAlbSgId',
+      'isPrivate',
+      'publicSubnetIds',
+      'listener',
+      'lbPortion',
+      'tgPortion',
+    ]) {
+      expect(identifiers).not.toContain(removed);
+    }
+    expect(
+      nodes(service, ts.isPropertyDeclaration).map((node) =>
+        node.name.getText()
+      )
+    ).not.toContain('lb');
+    const constructors = nodes(service, ts.isNewExpression).map((node) =>
+      node.expression.getText()
+    );
+    expect(constructors).not.toContain('MacroApplicationLoadBalancer');
+    expect(
+      constructors.some((name) => /^aws\.(lb|alb|route53)\./.test(name))
+    ).toBe(false);
+  });
+
+  test('preserves websocket routes, gateway identity, health check, and 30-second drain', () => {
+    const gateway = resource(service, 'ServiceTargetGroup');
+    expect(gateway.arguments![0].getText()).toBe('`${stack}-${BASE_NAME}`');
+    expect(shape(gateway.arguments![1])).toEqual({
+      tags: 'this.tags',
+      listenerArn: 'gatewayLoadBalancer.httpsListenerArn',
+      vpcId: 'vpc.vpcId',
+      containerPort: 'serviceContainerPort',
+      service: 'GatewayService.CONNECTION_GATEWAY',
+      healthCheckPath: 'healthCheckPath',
+      pathPatterns: ["'/connection-gateway'", "'/connection-gateway/*'"],
+      serviceSecurityGroupId: 'this.serviceSg.id',
+      albSecurityGroupId: 'gatewayLoadBalancer.albSecurityGroupId',
+      deregistrationDelay: '30',
+    });
+    expect(shape(gateway.arguments![2])).toEqual({ parent: 'this' });
+    const caller = resource(index, 'ConnectionGateway');
+    expect(caller.arguments![0].getText()).toBe(
+      '`connection-gateway-${stack}`'
+    );
+    expect(
+      property(caller.arguments![1], 'serviceContainerPort').getText()
+    ).toBe('8080');
+    expect(property(caller.arguments![1], 'healthCheckPath').getText()).toBe(
+      "'/health'"
+    );
+    const assignments = nodes(service, ts.isBinaryExpression).filter(
+      (node) => node.left.getText() === 'this.targetGroup'
+    );
+    expect(assignments).toHaveLength(1);
+    expect(assignments[0].right.getText()).toBe(
+      'gatewayTargetGroup.target_group'
+    );
+  });
+
+  test('registers ECS only with the gateway and retains its listener dependency and capacity', () => {
+    const ecs = resource(service, 'awsx.ecs.FargateService');
+    expect(ecs.arguments![0].getText()).toBe('`${BASE_NAME}`');
+    expect(shape(property(ecs.arguments![1], 'loadBalancers'))).toEqual([
+      {
+        targetGroupArn: 'gatewayTargetGroup.target_group.arn',
+        containerName: "'service'",
+        containerPort: 'serviceContainerPort',
+      },
+    ]);
+    const container = property(
+      ecs.arguments![1],
+      'taskDefinitionArgs',
+      'containers',
+      'service'
+    );
+    expect(shape(property(container, 'portMappings'))).toEqual([
+      {
+        appProtocol: "'http'",
+        name: '`${BASE_NAME}-tcp-${stack}`',
+        hostPort: 'serviceContainerPort',
+        containerPort: 'serviceContainerPort',
+        targetGroup: 'this.targetGroup',
+      },
+    ]);
+    for (const [key, value] of [
+      ['stopTimeout', '10'],
+      ['cpu', '4096'],
+      ['memory', '8192'],
+    ]) {
+      expect(property(container, key).getText()).toBe(value);
+    }
+    expect(property(ecs.arguments![1], 'desiredCount').getText()).toBe(
+      "stack === 'prod' ? 3 : 1"
+    );
+    expect(shape(ecs.arguments![2])).toEqual({
+      parent: 'this',
+      dependsOn: ['gatewayTargetGroup.listener_rule'],
+    });
+    expect(shape(property(ecs.arguments![1], 'networkConfiguration'))).toEqual({
+      subnets: 'vpc.privateSubnetIds',
+      securityGroups: ['this.serviceSg.id'],
+    });
+  });
+
+  test('retains only the service security group and unrestricted outbound rule', () => {
+    const sg = resource(service, 'aws.ec2.SecurityGroup');
+    expect(sg.arguments![0].getText()).toBe('`${BASE_NAME}-sg-${stack}`');
+    expect(shape(sg.arguments![1])).toEqual({
+      name: '`${BASE_NAME}-sg-${stack}`',
+      vpcId: 'vpcId',
+      description:
+        '`${BASE_NAME} security group that is attached directly to the service`',
+      tags: 'this.tags',
+    });
+    expect(shape(sg.arguments![2])).toEqual({ parent: 'this' });
+    const egress = resource(service, 'aws.vpc.SecurityGroupEgressRule');
+    expect(egress.arguments![0].getText()).toBe('`${BASE_NAME}-all-out`');
+    expect(shape(egress.arguments![1])).toEqual({
+      securityGroupId: 'serviceSg.id',
+      description: "'Allow all outbound'",
+      cidrIpv4: "'0.0.0.0/0'",
+      ipProtocol: "'-1'",
+      tags: 'this.tags',
+    });
+    expect(shape(egress.arguments![2])).toEqual({ parent: 'this' });
+    expect(
+      nodes(service, ts.isNewExpression).filter(
+        (node) =>
+          node.expression.getText() === 'aws.vpc.SecurityGroupIngressRule'
+      )
+    ).toHaveLength(0);
+  });
+
+  test('exports the prefixed HTTPS API URL as an Output in dev and prod', () => {
+    const assignments = nodes(service, ts.isBinaryExpression).filter(
+      (node) => node.left.getText() === 'this.domain'
+    );
+    expect(assignments).toHaveLength(1);
+    expect(assignments[0].right.getText()).toBe(
+      'getServiceUrl(ServiceUrl.CONNECTION_GATEWAY_URL)'
+    );
+    expect(variable(index, 'connectionGatewayUrl').getText()).toBe(
+      'pulumi.interpolate`${connectionGateway.domain}`'
+    );
+    expect(variable(index, 'connectionGatewaySgId').getText()).toBe(
+      'connectionGateway.serviceSg.id'
+    );
+    const urls = parse('../../packages/shared/src/service_urls.ts');
+    for (const [map, url] of [
+      ['DEV_SERVICE_URLS', 'https://dev-gateway.macro.com/connection-gateway'],
+      ['PROD_SERVICE_URLS', 'https://gateway.macro.com/connection-gateway'],
+    ]) {
+      expect(
+        property(
+          variable(urls, map),
+          '[ServiceUrl.CONNECTION_GATEWAY_URL]'
+        ).getText()
+      ).toBe(`'${url}'`);
+    }
+  });
+
+  test('uses gateway ARN suffixes for HTTP request scaling without retuning policies', () => {
+    // Request counts measure HTTP requests, not websocket messages or disconnects.
+    expect(variable(service, 'resourceLabel').getText()).toBe(
+      'pulumi.interpolate`${gatewayLoadBalancer.albArnSuffix}/${this.targetGroup.arnSuffix}`'
+    );
+    const target = resource(service, 'aws.appautoscaling.Target');
+    expect(target.arguments![0].getText()).toBe(
+      '`${BASE_NAME}-service-scalable-target-${stack}`'
+    );
+    expect(shape(target.arguments![1])).toEqual({
+      maxCapacity: "stack === 'prod' ? 15 : 3",
+      minCapacity: "stack === 'prod' ? 3 : 3",
+      resourceId:
+        'pulumi.interpolate`service/${this.cloudStorageClusterName}/${this.service.service.name}`',
+      scalableDimension: "'ecs:service:DesiredCount'",
+      serviceNamespace: "'ecs'",
+      tags: 'this.tags',
+    });
+    for (const [suffix, metric, value, scaleIn, scaleOut] of [
+      ['request-count', 'ALBRequestCountPerTarget', '1000', '60', '120'],
+      ['cpu', 'ECSServiceAverageCPUUtilization', '70.0', '100', '300'],
+      ['memory', 'ECSServiceAverageMemoryUtilization', '70.0', '100', '300'],
+    ]) {
+      const policy = resource(
+        service,
+        'aws.appautoscaling.Policy',
+        `\`\${BASE_NAME}-scaling-policy-${suffix}-\${stack}\``
+      );
+      expect(shape(policy.arguments![1])).toEqual({
+        policyType: "'TargetTrackingScaling'",
+        resourceId: 'serviceScalableTarget.resourceId',
+        scalableDimension: 'serviceScalableTarget.scalableDimension',
+        serviceNamespace: 'serviceScalableTarget.serviceNamespace',
+        targetTrackingScalingPolicyConfiguration: {
+          targetValue: value,
+          predefinedMetricSpecification: {
+            predefinedMetricType: `'${metric}'`,
+            ...(suffix === 'request-count'
+              ? { resourceLabel: 'resourceLabel' }
+              : {}),
+          },
+          scaleInCooldown: scaleIn,
+          scaleOutCooldown: scaleOut,
+        },
+      });
+      expect(shape(policy.arguments![2])).toEqual({ parent: 'this' });
+    }
+  });
+
+  test('scopes the existing 5xx alarm to target HTTP failures without policy changes', () => {
+    // Target 5xx is not websocket disconnection monitoring; ALB failures remain centralized.
+    const alarm = resource(
+      service,
+      'aws.cloudwatch.MetricAlarm',
+      '`${BASE_NAME}-http-5xx-alarm`'
+    );
+    expect(shape(alarm.arguments![1])).toEqual({
+      name: '`${BASE_NAME}-http-5xx-${stack}`',
+      metricName: "'HTTPCode_Target_5XX_Count'",
+      namespace: "'AWS/ApplicationELB'",
+      statistic: "'Sum'",
+      period: '180',
+      evaluationPeriods: '1',
+      threshold: '25',
+      comparisonOperator: "'GreaterThanOrEqualToThreshold'",
+      dimensions: {
+        LoadBalancer: 'gatewayLoadBalancer.albArnSuffix',
+        TargetGroup: 'this.targetGroup.arnSuffix',
+      },
+      alarmDescription:
+        '`High HTTP 5XX count alarm for ${BASE_NAME} gateway target group.`',
+      actionsEnabled: 'true',
+      alarmActions: ['CLOUD_TRAIL_SNS_TOPIC_ARN'],
+      tags: 'this.tags',
+    });
+    expect(shape(alarm.arguments![2])).toEqual({ parent: 'this' });
+  });
+
+  test('relies on the existing shared gateway 3600-second idle timeout', () => {
+    const gateway = resource(
+      parse('../gateway/index.ts'),
+      'MacroApplicationLoadBalancer'
+    );
+    expect(property(gateway.arguments![1], 'idleTimeout').getText()).toBe(
+      '3600'
+    );
+  });
+});

--- a/infra/stacks/contacts-service/index.ts
+++ b/infra/stacks/contacts-service/index.ts
@@ -74,7 +74,6 @@ new ContactsService('contacts-service', {
   platform: { family: 'linux', architecture: 'amd64' },
   serviceContainerPort: 8080,
   healthCheckPath: '/health',
-  isPrivate: false,
   ecsClusterArn: cloudStorageClusterArn,
   cloudStorageClusterName,
   secretKeyArns,

--- a/infra/stacks/contacts-service/legacy-alb.test.ts
+++ b/infra/stacks/contacts-service/legacy-alb.test.ts
@@ -1,0 +1,308 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import ts from 'typescript';
+
+function source(file: string): ts.SourceFile {
+  return ts.createSourceFile(
+    file,
+    readFileSync(new URL(file, import.meta.url), 'utf8'),
+    ts.ScriptTarget.Latest,
+    true
+  );
+}
+
+const service = source('service.ts');
+const index = source('index.ts');
+const printer = ts.createPrinter({ removeComments: true });
+
+function text(node: ts.Node): string {
+  return printer.printNode(ts.EmitHint.Unspecified, node, node.getSourceFile());
+}
+
+function nodes<T extends ts.Node>(
+  root: ts.Node,
+  predicate: (node: ts.Node) => node is T
+): T[] {
+  const result: T[] = [];
+  function visit(node: ts.Node): void {
+    if (predicate(node)) result.push(node);
+    ts.forEachChild(node, visit);
+  }
+  visit(root);
+  return result;
+}
+
+function only<T>(items: T[]): T {
+  expect(items).toHaveLength(1);
+  return items[0];
+}
+
+function construction(
+  root: ts.Node,
+  type: string,
+  name?: string
+): ts.NewExpression {
+  return only(
+    nodes(root, ts.isNewExpression).filter(
+      (node) =>
+        text(node.expression) === type &&
+        (name === undefined || text(node.arguments![0]) === name)
+    )
+  );
+}
+
+function property(node: ts.Node, name: string): ts.Expression {
+  if (!ts.isObjectLiteralExpression(node)) {
+    throw new Error(`Expected object: ${text(node)}`);
+  }
+  const member = only(
+    node.properties.filter((entry) => entry.name?.getText() === name)
+  );
+  if (ts.isPropertyAssignment(member)) return member.initializer;
+  if (ts.isShorthandPropertyAssignment(member)) return member.name;
+  throw new Error(`Expected property: ${name}`);
+}
+
+function elements(node: ts.Node): ts.NodeArray<ts.Expression> {
+  if (!ts.isArrayLiteralExpression(node)) {
+    throw new Error(`Expected array: ${text(node)}`);
+  }
+  return node.elements;
+}
+
+function properties(node: ts.Node, expected: Record<string, string>): void {
+  for (const [name, value] of Object.entries(expected)) {
+    expect(text(property(node, name))).toBe(value);
+  }
+}
+
+function variable(root: ts.Node, name: string): ts.Expression {
+  return only(
+    nodes(root, ts.isVariableDeclaration).filter(
+      (node) => text(node.name) === name
+    )
+  ).initializer!;
+}
+
+const ecs = construction(service, 'awsx.ecs.FargateService');
+const ecsArgs = ecs.arguments![1];
+const container = property(
+  property(property(ecsArgs, 'taskDefinitionArgs'), 'containers'),
+  'service'
+);
+
+test('removes dedicated ALB, DNS, security group, and obsolete arguments', () => {
+  for (const file of [service, index]) {
+    const identifiers = nodes(file, ts.isIdentifier).map((node) => node.text);
+    for (const removed of [
+      'serviceLoadBalancer',
+      'SERVICE_DOMAIN_NAME',
+      'serviceAlbSg',
+      'isPrivate',
+      'publicSubnetIds',
+    ]) {
+      expect(identifiers).not.toContain(removed);
+    }
+    const constructors = nodes(file, ts.isNewExpression).map((node) =>
+      text(node.expression)
+    );
+    for (const removed of [
+      'aws.lb.LoadBalancer',
+      'aws.lb.Listener',
+      'aws.lb.ListenerRule',
+      'aws.lb.TargetGroup',
+      'aws.route53.Record',
+      'aws.vpc.SecurityGroupIngressRule',
+    ]) {
+      expect(constructors).not.toContain(removed);
+    }
+    expect(file.text).not.toContain('aws.route53');
+  }
+  const fields = nodes(service, ts.isPropertyDeclaration).map((node) =>
+    text(node.name)
+  );
+  expect(fields).not.toContain('lb');
+  expect(fields).not.toContain('listener');
+});
+
+test('preserves gateway identity, routing, health checks, and service security', () => {
+  const gateway = construction(service, 'ServiceTargetGroup');
+  expect(text(gateway.arguments![0])).toBe('`${stack}-${BASE_NAME}`');
+  properties(gateway.arguments![1], {
+    listenerArn: 'gatewayLoadBalancer.httpsListenerArn',
+    vpcId: 'vpc.vpcId',
+    containerPort: 'serviceContainerPort',
+    service: 'GatewayService.CONTACTS_SERVICE',
+    healthCheckPath: 'healthCheckPath',
+    pathPatterns: "['/contacts', '/contacts/*']",
+    serviceSecurityGroupId: 'this.serviceSg.id',
+    albSecurityGroupId: 'gatewayLoadBalancer.albSecurityGroupId',
+    tags: 'this.tags',
+  });
+  expect(text(gateway.arguments![1])).not.toContain('priority:');
+  properties(gateway.arguments![2], { parent: 'this' });
+  const caller = construction(index, 'ContactsService');
+  expect(text(caller.arguments![0])).toBe("'contacts-service'");
+  properties(caller.arguments![1], {
+    serviceContainerPort: '8080',
+    healthCheckPath: "'/health'",
+    contactsQueueArn: 'contactsQueueArn',
+  });
+  const superCall = only(
+    nodes(service, ts.isCallExpression).filter(
+      (node) => node.expression.kind === ts.SyntaxKind.SuperKeyword
+    )
+  );
+  expect(text(superCall.arguments[0])).toBe(
+    "'my:components:CloudStorageService'"
+  );
+  const sg = construction(service, 'aws.ec2.SecurityGroup');
+  expect(text(sg.arguments![0])).toBe('`${BASE_NAME}-sg-${stack}`');
+  properties(sg.arguments![1], {
+    name: '`${BASE_NAME}-sg-${stack}`',
+    vpcId: 'vpcId',
+    tags: 'this.tags',
+  });
+  properties(sg.arguments![2], { parent: 'this' });
+  const outbound = construction(service, 'aws.vpc.SecurityGroupEgressRule');
+  expect(text(outbound.arguments![0])).toBe('`${BASE_NAME}-all-out`');
+  properties(outbound.arguments![1], {
+    securityGroupId: 'serviceSg.id',
+    cidrIpv4: "'0.0.0.0/0'",
+    ipProtocol: "'-1'",
+    tags: 'this.tags',
+  });
+  properties(outbound.arguments![2], { parent: 'this' });
+  properties(property(ecsArgs, 'networkConfiguration'), {
+    securityGroups: '[this.serviceSg.id]',
+    subnets: 'vpc.privateSubnetIds',
+  });
+});
+
+test('registers ECS only with the gateway and retains listener dependency', () => {
+  const assignment = only(
+    nodes(service, ts.isBinaryExpression).filter(
+      (node) => text(node.left) === 'this.targetGroup'
+    )
+  );
+  expect(text(assignment.right)).toBe('gatewayTargetGroup.target_group');
+  expect(text(ecs.arguments![0])).toBe('`${BASE_NAME}`');
+  properties(only([...elements(property(ecsArgs, 'loadBalancers'))]), {
+    targetGroupArn: 'gatewayTargetGroup.target_group.arn',
+    containerName: "'service'",
+    containerPort: 'serviceContainerPort',
+  });
+  properties(only([...elements(property(container, 'portMappings'))]), {
+    appProtocol: "'http'",
+    name: '`${BASE_NAME}-tcp-${stack}`',
+    hostPort: 'serviceContainerPort',
+    containerPort: 'serviceContainerPort',
+    targetGroup: 'this.targetGroup',
+  });
+  properties(ecs.arguments![2], {
+    parent: 'this',
+    dependsOn: '[gatewayTargetGroup.listener_rule]',
+  });
+});
+
+test('BASE_URL and exported URL agree for prod and non-prod; queues stay stable', () => {
+  const domain = only(
+    nodes(service, ts.isBinaryExpression).filter(
+      (node) => text(node.left) === 'this.domain'
+    )
+  ).right;
+  const exportedUrl = variable(index, 'contactsServiceUrl');
+  for (const stack of ['prod', 'dev', 'staging']) {
+    const context = { stack, BASE_DOMAIN: 'macro.com' };
+    const expected = `https://${stack === 'prod' ? '' : `${stack}-`}gateway.macro.com/contacts`;
+    // Evaluate only the isolated URL expressions, never the Pulumi modules.
+    expect(runInNewContext(text(domain), context)).toBe(expected);
+    expect(runInNewContext(text(exportedUrl), context)).toBe(expected);
+  }
+  const baseUrl = only(
+    elements(property(container, 'environment')).filter(
+      (node) =>
+        ts.isObjectLiteralExpression(node) &&
+        text(property(node, 'name')) === "'BASE_URL'"
+    )
+  );
+  properties(baseUrl, { value: 'this.domain' });
+  expect(text(construction(index, 'Queue').arguments![0])).toBe("'contacts'");
+  expect(text(variable(index, 'contactsQueueArn'))).toBe(
+    'contactsQueue.queue.arn'
+  );
+  expect(text(variable(index, 'contactsQueueName'))).toBe(
+    'contactsQueue.queue.name'
+  );
+});
+
+test('preserves gateway request scaling and CPU/memory policy settings', () => {
+  expect(text(variable(service, 'resourceLabel'))).toBe(
+    'pulumi.interpolate `${gatewayAlbArnSuffix}/${gatewayTargetGroup.arnSuffix}`'
+  );
+  const setup = only(
+    nodes(service, ts.isCallExpression).filter(
+      (node) => text(node.expression) === 'this.setupAutoScaling'
+    )
+  );
+  properties(setup.arguments[0], {
+    gatewayAlbArnSuffix: 'gatewayLoadBalancer.albArnSuffix',
+    gatewayTargetGroup: 'gatewayTargetGroup.target_group',
+  });
+  for (const [suffix, metric, target, scaleIn, scaleOut] of [
+    ['request-count', 'ALBRequestCountPerTarget', '1000', '60', '120'],
+    ['cpu', 'ECSServiceAverageCPUUtilization', '70.0', '100', '300'],
+    ['memory', 'ECSServiceAverageMemoryUtilization', '70.0', '100', '300'],
+  ]) {
+    const policy = construction(
+      service,
+      'aws.appautoscaling.Policy',
+      `\`\${BASE_NAME}-scaling-policy-${suffix}-\${stack}\``
+    );
+    const tracking = property(
+      policy.arguments![1],
+      'targetTrackingScalingPolicyConfiguration'
+    );
+    properties(tracking, {
+      targetValue: target,
+      scaleInCooldown: scaleIn,
+      scaleOutCooldown: scaleOut,
+    });
+    properties(property(tracking, 'predefinedMetricSpecification'), {
+      predefinedMetricType: `'${metric}'`,
+      ...(suffix === 'request-count' ? { resourceLabel: 'resourceLabel' } : {}),
+    });
+  }
+});
+
+test('scopes the existing 5xx alarm to gateway target errors without policy changes', () => {
+  const alarm = construction(
+    service,
+    'aws.cloudwatch.MetricAlarm',
+    '`${BASE_NAME}-http-5xx-alarm`'
+  );
+  properties(alarm.arguments![1], {
+    name: '`${BASE_NAME}-http-5xx-${stack}`',
+    metricName: "'HTTPCode_Target_5XX_Count'",
+    namespace: "'AWS/ApplicationELB'",
+    statistic: "'Sum'",
+    period: '180',
+    evaluationPeriods: '1',
+    threshold: '25',
+    comparisonOperator: "'GreaterThanOrEqualToThreshold'",
+    actionsEnabled: 'true',
+    alarmActions: '[CLOUD_TRAIL_SNS_TOPIC_ARN]',
+    tags: 'this.tags',
+    alarmDescription:
+      '`High HTTP 5XX count alarm for ${BASE_NAME} gateway target group.`',
+  });
+  const dimensions = property(alarm.arguments![1], 'dimensions');
+  properties(dimensions, {
+    LoadBalancer: 'gatewayLoadBalancer.albArnSuffix',
+    TargetGroup: 'this.targetGroup.arnSuffix',
+  });
+  expect((dimensions as ts.ObjectLiteralExpression).properties).toHaveLength(2);
+  expect(text(alarm.arguments![1])).not.toContain('treatMissingData');
+  properties(alarm.arguments![2], { parent: 'this' });
+});

--- a/infra/stacks/contacts-service/service.ts
+++ b/infra/stacks/contacts-service/service.ts
@@ -7,7 +7,6 @@ import {
   EcsDeploymentFailureAlarm,
   datadogAgentContainer,
   fargateLogRouterSidecarContainer,
-  serviceLoadBalancer,
   ServiceTargetGroup,
 } from '../../packages/resources';
 import { EcrImage } from '../../packages/service';
@@ -24,15 +23,11 @@ const gatewayLoadBalancer = getGatewayAlb();
 
 const BASE_NAME = pulumi.getProject();
 const REPO_ROOT = '../../..';
-export const SERVICE_DOMAIN_NAME = `contacts${
-  stack === 'prod' ? '' : `-${stack}`
-}.${BASE_DOMAIN}`;
 
 type CreateContactsServiceArgs = {
   contactsQueueArn: pulumi.Output<string> | string;
   vpc: {
     vpcId: pulumi.Output<string> | string;
-    publicSubnetIds: pulumi.Output<string[]> | string[];
     privateSubnetIds: pulumi.Output<string[]> | string[];
   };
   tags: { [key: string]: string };
@@ -40,7 +35,6 @@ type CreateContactsServiceArgs = {
   platform: { family: string; architecture: 'amd64' | 'arm64' };
   serviceContainerPort: number;
   healthCheckPath: string;
-  isPrivate?: boolean;
   ecsClusterArn: pulumi.Output<string> | string;
   cloudStorageClusterName: pulumi.Output<string> | string;
   secretKeyArns: (pulumi.Output<string> | string)[];
@@ -49,13 +43,10 @@ type CreateContactsServiceArgs = {
 export class ContactsService extends pulumi.ComponentResource {
   public role: aws.iam.Role;
   public ecr: awsx.ecr.Repository;
-  public serviceAlbSg: aws.ec2.SecurityGroup;
   public serviceSg: aws.ec2.SecurityGroup;
   public domain: string;
   public tags: { [key: string]: string };
   public targetGroup: aws.lb.TargetGroup;
-  public lb: aws.lb.LoadBalancer;
-  public listener: aws.lb.Listener;
   public service: awsx.ecs.FargateService;
   public cloudStorageClusterName: pulumi.Output<string> | string;
 
@@ -68,7 +59,6 @@ export class ContactsService extends pulumi.ComponentResource {
       platform,
       serviceContainerPort,
       healthCheckPath,
-      isPrivate,
       ecsClusterArn,
       containerEnvVars,
       cloudStorageClusterName,
@@ -77,7 +67,9 @@ export class ContactsService extends pulumi.ComponentResource {
     opts?: pulumi.ComponentResourceOptions
   ) {
     super('my:components:CloudStorageService', name, {}, opts);
-    this.domain = `https://${SERVICE_DOMAIN_NAME}`;
+    this.domain = `https://${
+      stack === 'prod' ? '' : `${stack}-`
+    }gateway.${BASE_DOMAIN}/contacts`;
     this.tags = tags;
     this.cloudStorageClusterName = cloudStorageClusterName;
 
@@ -166,12 +158,7 @@ export class ContactsService extends pulumi.ComponentResource {
     this.ecr = image.ecr;
 
     // Security groups
-    const sg = this.initializeSecurityGroups({
-      vpcId: vpc.vpcId,
-      serviceContainerPort,
-    });
-    this.serviceAlbSg = sg.serviceAlbSg;
-    this.serviceSg = sg.serviceSg;
+    this.serviceSg = this.initializeSecurityGroups({ vpcId: vpc.vpcId });
 
     const gatewayTargetGroup = new ServiceTargetGroup(
       `${stack}-${BASE_NAME}`,
@@ -189,19 +176,7 @@ export class ContactsService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // Load balancer
-    const { targetGroup, lb, listener } = serviceLoadBalancer(this, {
-      serviceName: BASE_NAME, // service name
-      serviceContainerPort,
-      healthCheckPath,
-      vpc,
-      albSecurityGroupId: this.serviceAlbSg.id,
-      isPrivate,
-      tags,
-    });
-    this.targetGroup = targetGroup;
-    this.lb = lb;
-    this.listener = listener;
+    this.targetGroup = gatewayTargetGroup.target_group;
 
     const dopplerEcsEnvironment = new DopplerEcsEnvironment(
       BASE_NAME,
@@ -224,17 +199,8 @@ export class ContactsService extends pulumi.ComponentResource {
           enable: true,
           rollback: true,
         },
-        // Register tasks in both the legacy ALB's target group and the gateway
-        // target group while we migrate to the gateway. An explicit
-        // `loadBalancers` replaces the list awsx derives from
-        // `portMappings.targetGroup`, so the legacy entry must be listed here
-        // too.
+        // Register tasks only with the shared gateway.
         loadBalancers: [
-          {
-            targetGroupArn: targetGroup.arn,
-            containerName: 'service',
-            containerPort: serviceContainerPort,
-          },
           {
             targetGroupArn: gatewayTargetGroup.target_group.arn,
             containerName: 'service',
@@ -287,7 +253,7 @@ export class ContactsService extends pulumi.ComponentResource {
                   name: `${BASE_NAME}-tcp-${stack}`,
                   hostPort: serviceContainerPort,
                   containerPort: serviceContainerPort,
-                  targetGroup,
+                  targetGroup: this.targetGroup,
                 },
               ],
             },
@@ -319,66 +285,19 @@ export class ContactsService extends pulumi.ComponentResource {
       gatewayTargetGroup: gatewayTargetGroup.target_group,
     });
     this.setupServiceAlarms();
-
-    // DNS
-    const zone = aws.route53.getZoneOutput({ name: BASE_DOMAIN });
-
-    new aws.route53.Record(
-      `${BASE_NAME}-domain-record`,
-      {
-        name: SERVICE_DOMAIN_NAME,
-        type: 'A',
-        zoneId: zone.zoneId,
-        aliases: [
-          {
-            evaluateTargetHealth: false,
-            name: this.lb.dnsName,
-            zoneId: this.lb.zoneId,
-          },
-        ],
-      },
-      { parent: this }
-    );
   }
 
   initializeSecurityGroups({
     vpcId,
-    serviceContainerPort,
   }: {
     vpcId: pulumi.Output<string> | string;
-    serviceContainerPort: number;
   }) {
-    const serviceAlbSg = new aws.ec2.SecurityGroup(
-      `${BASE_NAME}-alb-sg-${stack}`,
-      {
-        name: `${BASE_NAME}-alb-sg-${stack}`,
-        description: `${BASE_NAME} application load balancer security group`,
-        vpcId,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
     const serviceSg = new aws.ec2.SecurityGroup(
       `${BASE_NAME}-sg-${stack}`,
       {
         name: `${BASE_NAME}-sg-${stack}`,
         vpcId,
         description: `${BASE_NAME} security group that is attached directly to the service`,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-alb-in`,
-      {
-        securityGroupId: serviceSg.id,
-        description: 'Allow inbound traffic from the services ALB',
-        referencedSecurityGroupId: serviceAlbSg.id,
-        fromPort: serviceContainerPort,
-        toPort: serviceContainerPort,
-        ipProtocol: 'tcp',
         tags: this.tags,
       },
       { parent: this }
@@ -396,50 +315,7 @@ export class ContactsService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // ALB SG rules
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-http`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTP traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 80,
-        ipProtocol: 'tcp',
-        toPort: 80,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-https`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTPS traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 443,
-        ipProtocol: 'tcp',
-        toPort: 443,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupEgressRule(
-      `${BASE_NAME}-out-service`,
-      {
-        description: 'Allow traffic to the service security group',
-        securityGroupId: serviceAlbSg.id,
-        referencedSecurityGroupId: serviceSg.id,
-        fromPort: serviceContainerPort,
-        ipProtocol: 'tcp',
-        toPort: serviceContainerPort,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    return { serviceAlbSg, serviceSg };
+    return serviceSg;
   }
 
   setupAutoScaling({
@@ -588,7 +464,7 @@ export class ContactsService extends pulumi.ComponentResource {
       `${BASE_NAME}-http-5xx-alarm`,
       {
         name: `${BASE_NAME}-http-5xx-${stack}`,
-        metricName: 'HTTPCode_ELB_5XX_Count',
+        metricName: 'HTTPCode_Target_5XX_Count',
         namespace: 'AWS/ApplicationELB',
         statistic: 'Sum',
         period: 180,
@@ -596,9 +472,10 @@ export class ContactsService extends pulumi.ComponentResource {
         threshold: 25,
         comparisonOperator: 'GreaterThanOrEqualToThreshold',
         dimensions: {
-          LoadBalancer: this.lb.arn,
+          LoadBalancer: gatewayLoadBalancer.albArnSuffix,
+          TargetGroup: this.targetGroup.arnSuffix,
         },
-        alarmDescription: `High HTTP 5XX count alarm for ${BASE_NAME} Load Balancer.`,
+        alarmDescription: `High HTTP 5XX count alarm for ${BASE_NAME} gateway target group.`,
         actionsEnabled: true,
         alarmActions: [CLOUD_TRAIL_SNS_TOPIC_ARN],
         tags: this.tags,

--- a/infra/stacks/convert-service/index.ts
+++ b/infra/stacks/convert-service/index.ts
@@ -77,7 +77,6 @@ const convertService = new ConvertService('convert-service', {
   platform: { family: 'linux', architecture: 'amd64' },
   serviceContainerPort: 8080,
   healthCheckPath: '/health',
-  isPrivate: false,
   ecsClusterArn: cloudStorageClusterArn,
   cloudStorageClusterName,
 });

--- a/infra/stacks/convert-service/legacy-alb.test.ts
+++ b/infra/stacks/convert-service/legacy-alb.test.ts
@@ -1,0 +1,382 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import ts from 'typescript';
+
+function source(file: string): ts.SourceFile {
+  return ts.createSourceFile(
+    file,
+    readFileSync(new URL(file, import.meta.url), 'utf8'),
+    ts.ScriptTarget.Latest,
+    true
+  );
+}
+
+const service = source('service.ts');
+const index = source('index.ts');
+const printer = ts.createPrinter({ removeComments: true });
+
+function text(node: ts.Node): string {
+  return printer.printNode(ts.EmitHint.Unspecified, node, node.getSourceFile());
+}
+
+function nodes<T extends ts.Node>(
+  root: ts.Node,
+  predicate: (node: ts.Node) => node is T
+): T[] {
+  const result: T[] = [];
+  function visit(node: ts.Node): void {
+    if (predicate(node)) result.push(node);
+    ts.forEachChild(node, visit);
+  }
+  visit(root);
+  return result;
+}
+
+function only<T>(items: readonly T[]): T {
+  expect(items).toHaveLength(1);
+  return items[0];
+}
+
+function construction(
+  root: ts.Node,
+  type: string,
+  name?: string
+): ts.NewExpression {
+  return only(
+    nodes(root, ts.isNewExpression).filter(
+      (node) =>
+        text(node.expression) === type &&
+        (name === undefined || text(node.arguments![0]) === name)
+    )
+  );
+}
+
+function property(node: ts.Node, name: string): ts.Expression {
+  if (!ts.isObjectLiteralExpression(node)) {
+    throw new Error(`Expected object: ${text(node)}`);
+  }
+  const member = only(
+    node.properties.filter((entry) => entry.name?.getText() === name)
+  );
+  if (ts.isPropertyAssignment(member)) return member.initializer;
+  if (ts.isShorthandPropertyAssignment(member)) return member.name;
+  throw new Error(`Expected property: ${name}`);
+}
+
+function elements(node: ts.Node): ts.NodeArray<ts.Expression> {
+  if (!ts.isArrayLiteralExpression(node))
+    throw new Error(`Expected array: ${text(node)}`);
+  return node.elements;
+}
+
+function properties(node: ts.Node, expected: Record<string, string>): void {
+  for (const [name, value] of Object.entries(expected)) {
+    expect(text(property(node, name))).toBe(value);
+  }
+}
+
+function variable(root: ts.Node, name: string): ts.Expression {
+  return only(
+    nodes(root, ts.isVariableDeclaration).filter(
+      (node) => text(node.name) === name
+    )
+  ).initializer!;
+}
+
+function assignment(name: string): ts.Expression {
+  return only(
+    nodes(service, ts.isBinaryExpression).filter(
+      (node) => text(node.left) === name
+    )
+  ).right;
+}
+
+const ecs = construction(service, 'awsx.ecs.FargateService');
+const ecsArgs = ecs.arguments![1];
+const container = property(
+  property(property(ecsArgs, 'taskDefinitionArgs'), 'containers'),
+  'service'
+);
+
+test('removes dedicated ALB, DNS, security group, and obsolete arguments', () => {
+  for (const file of [service, index]) {
+    const identifiers = nodes(file, ts.isIdentifier).map((node) => node.text);
+    for (const removed of [
+      'serviceLoadBalancer',
+      'SERVICE_DOMAIN_NAME',
+      'serviceAlbSg',
+      'isPrivate',
+      'publicSubnetIds',
+    ]) {
+      expect(identifiers).not.toContain(removed);
+    }
+    const constructors = nodes(file, ts.isNewExpression).map((node) =>
+      text(node.expression)
+    );
+    for (const removed of [
+      'aws.lb.LoadBalancer',
+      'aws.lb.Listener',
+      'aws.lb.ListenerRule',
+      'aws.lb.TargetGroup',
+      'aws.route53.Record',
+      'aws.vpc.SecurityGroupIngressRule',
+    ]) {
+      expect(constructors).not.toContain(removed);
+    }
+    expect(file.text).not.toContain('aws.route53');
+  }
+  const fields = nodes(service, ts.isPropertyDeclaration).map((node) =>
+    text(node.name)
+  );
+  expect(fields).not.toContain('lb');
+  expect(fields).not.toContain('listener');
+});
+
+test('preserves gateway identity, paired paths, health checks, and service security', () => {
+  const gateway = construction(service, 'ServiceTargetGroup');
+  expect(text(gateway.arguments![0])).toBe('`${stack}-${BASE_NAME}`');
+  properties(gateway.arguments![1], {
+    listenerArn: 'gatewayLoadBalancer.httpsListenerArn',
+    vpcId: 'vpc.vpcId',
+    containerPort: 'serviceContainerPort',
+    service: 'GatewayService.CONVERT_SERVICE',
+    healthCheckPath: 'healthCheckPath',
+    pathPatterns: "['/convert', '/convert/*']",
+    serviceSecurityGroupId: 'this.serviceSg.id',
+    albSecurityGroupId: 'gatewayLoadBalancer.albSecurityGroupId',
+    tags: 'this.tags',
+  });
+  expect(text(gateway.arguments![1])).not.toContain('priority:');
+  properties(gateway.arguments![2], { parent: 'this' });
+  const registry = variable(
+    source('../../packages/shared/src/gateway_priorities.ts'),
+    'GATEWAY_PRIORITIES'
+  );
+  properties(registry, { '[GatewayService.CONVERT_SERVICE]': '3000' });
+  const caller = construction(index, 'ConvertService');
+  expect(text(caller.arguments![0])).toBe("'convert-service'");
+  properties(caller.arguments![1], {
+    serviceContainerPort: '8080',
+    healthCheckPath: "'/health'",
+    convertQueueArn: 'convertQueueArn',
+    jobUpdateHandlerLambdaArn: 'jobUpdateHandlerLambdaArn',
+  });
+  const superCall = only(
+    nodes(service, ts.isCallExpression).filter(
+      (node) => node.expression.kind === ts.SyntaxKind.SuperKeyword
+    )
+  );
+  expect(text(superCall.arguments[0])).toBe(
+    "'my:components:CloudStorageService'"
+  );
+  const sg = construction(service, 'aws.ec2.SecurityGroup');
+  expect(text(sg.arguments![0])).toBe('`${BASE_NAME}-sg-${stack}`');
+  properties(sg.arguments![1], {
+    name: '`${BASE_NAME}-sg-${stack}`',
+    vpcId: 'vpcId',
+    tags: 'this.tags',
+  });
+  properties(sg.arguments![2], { parent: 'this' });
+  const outbound = construction(service, 'aws.vpc.SecurityGroupEgressRule');
+  expect(text(outbound.arguments![0])).toBe('`${BASE_NAME}-all-out`');
+  properties(outbound.arguments![1], {
+    securityGroupId: 'serviceSg.id',
+    cidrIpv4: "'0.0.0.0/0'",
+    ipProtocol: "'-1'",
+    tags: 'this.tags',
+  });
+  properties(outbound.arguments![2], { parent: 'this' });
+  properties(property(ecsArgs, 'networkConfiguration'), {
+    securityGroups: '[this.serviceSg.id]',
+    subnets: 'vpc.privateSubnetIds',
+  });
+});
+
+test('registers ECS only with the gateway and retains listener dependency', () => {
+  expect(text(assignment('this.targetGroup'))).toBe(
+    'gatewayTargetGroup.target_group'
+  );
+  expect(text(ecs.arguments![0])).toBe('`${BASE_NAME}`');
+  properties(only(elements(property(ecsArgs, 'loadBalancers'))), {
+    targetGroupArn: 'gatewayTargetGroup.target_group.arn',
+    containerName: "'service'",
+    containerPort: 'serviceContainerPort',
+  });
+  properties(only(elements(property(container, 'portMappings'))), {
+    appProtocol: "'http'",
+    name: '`${BASE_NAME}-tcp-${stack}`',
+    hostPort: 'serviceContainerPort',
+    containerPort: 'serviceContainerPort',
+    targetGroup: 'this.targetGroup',
+  });
+  properties(ecs.arguments![2], {
+    parent: 'this',
+    dependsOn: '[gatewayTargetGroup.listener_rule]',
+  });
+});
+
+test('BASE_URL and exported URL agree for prod and non-prod', () => {
+  for (const stack of ['prod', 'dev', 'staging']) {
+    const context = { stack, BASE_DOMAIN: 'macro.com' };
+    const expected = `https://${stack === 'prod' ? '' : `${stack}-`}gateway.macro.com/convert`;
+    // Evaluate isolated URL expressions without executing Pulumi modules.
+    expect(runInNewContext(text(assignment('this.domain')), context)).toBe(
+      expected
+    );
+    expect(
+      runInNewContext(text(variable(index, 'convertServiceUrl')), context)
+    ).toBe(expected);
+  }
+  const baseUrl = only(
+    elements(property(container, 'environment')).filter(
+      (node) =>
+        ts.isObjectLiteralExpression(node) &&
+        text(property(node, 'name')) === "'BASE_URL'"
+    )
+  );
+  properties(baseUrl, { value: 'this.domain' });
+});
+
+test('preserves asynchronous queue, Lambda permissions, role, and specialized image', () => {
+  const queue = construction(index, 'Queue');
+  expect(text(queue.arguments![0])).toBe("'convert-service'");
+  properties(queue.arguments![1], { tags: 'tags', maxReceiveCount: '2' });
+  expect(text(variable(index, 'convertQueueArn'))).toBe(
+    'convertQueue.queue.arn'
+  );
+  expect(text(variable(index, 'convertQueueName'))).toBe(
+    'convertQueue.queue.name'
+  );
+  const websocket = construction(
+    index,
+    'pulumi.StackReference',
+    "'websocket-connection-stack'"
+  );
+  properties(websocket.arguments![1], {
+    name: '`macro-inc/websocket-connection/${stack}`',
+  });
+  expect(
+    text(variable(index, 'jobUpdateHandlerLambdaArn')).replace(/\s+/g, '')
+  ).toBe(
+    "websocketConnectionStack.getOutput('jobUpdateHandlerLambda').apply((jobUpdateHandlerLambda)=>jobUpdateHandlerLambda.arnasstring)"
+  );
+  expect(
+    text(variable(index, 'jobUpdateHandlerLambdaName')).replace(/\s+/g, '')
+  ).toBe(
+    "jobUpdateHandlerLambdaArn.apply((arn)=>{constjobUpdateHandlerLambdaArnSplit=arn.split(':');returnjobUpdateHandlerLambdaArnSplit[jobUpdateHandlerLambdaArnSplit.length-1];})"
+  );
+  for (const [name, action, resource] of [
+    [
+      '`${BASE_NAME}-sqs-policy`',
+      "['sqs:*']",
+      '[pulumi.interpolate `${convertQueueArn}`]',
+    ],
+    [
+      '`${BASE_NAME}-lambda-invoke-policy-${stack}`',
+      "['lambda:InvokeFunction']",
+      '[jobUpdateHandlerLambdaArn]',
+    ],
+  ]) {
+    const policy = construction(service, 'aws.iam.Policy', name);
+    properties(
+      only(
+        elements(
+          property(property(policy.arguments![1], 'policy'), 'Statement')
+        )
+      ),
+      { Action: action, Resource: resource, Effect: "'Allow'" }
+    );
+    properties(policy.arguments![2], { parent: 'this' });
+  }
+  properties(construction(service, 'aws.iam.Role').arguments![1], {
+    managedPolicyArns: '[queuePolicy.arn, lambdaInvokePolicy.arn]',
+  });
+  expect(text(variable(index, 'convertServiceRoleArn'))).toBe(
+    'pulumi.interpolate `${convertService.role.arn}`'
+  );
+  const image = construction(service, 'EcrImage');
+  properties(image.arguments![1], {
+    dockerfile: "'docker/Dockerfile.convert_service'",
+    imagePath: 'REPO_ROOT',
+    platform: 'platform',
+  });
+  properties(property(image.arguments![1], 'buildArgs'), {
+    SERVICE_NAME: "'convert_service'",
+  });
+  properties(container, { cpu: '4096', memory: '8192', stopTimeout: '10' });
+});
+
+test('preserves gateway request scaling and CPU/memory policy settings', () => {
+  expect(text(variable(service, 'resourceLabel'))).toBe(
+    'pulumi.interpolate `${gatewayAlbArnSuffix}/${gatewayTargetGroup.arnSuffix}`'
+  );
+  const setup = only(
+    nodes(service, ts.isCallExpression).filter(
+      (node) => text(node.expression) === 'this.setupAutoScaling'
+    )
+  );
+  properties(setup.arguments[0], {
+    gatewayAlbArnSuffix: 'gatewayLoadBalancer.albArnSuffix',
+    gatewayTargetGroup: 'gatewayTargetGroup.target_group',
+  });
+  properties(construction(service, 'aws.appautoscaling.Target').arguments![1], {
+    maxCapacity: "stack === 'prod' ? 10 : 3",
+    minCapacity: '1',
+  });
+  for (const [suffix, metric, target, scaleIn, scaleOut] of [
+    ['request-count', 'ALBRequestCountPerTarget', '1000', '60', '120'],
+    ['cpu', 'ECSServiceAverageCPUUtilization', '70.0', '100', '300'],
+    ['memory', 'ECSServiceAverageMemoryUtilization', '70.0', '100', '300'],
+  ]) {
+    const policy = construction(
+      service,
+      'aws.appautoscaling.Policy',
+      `\`\${BASE_NAME}-scaling-policy-${suffix}-\${stack}\``
+    );
+    const tracking = property(
+      policy.arguments![1],
+      'targetTrackingScalingPolicyConfiguration'
+    );
+    properties(tracking, {
+      targetValue: target,
+      scaleInCooldown: scaleIn,
+      scaleOutCooldown: scaleOut,
+    });
+    properties(property(tracking, 'predefinedMetricSpecification'), {
+      predefinedMetricType: `'${metric}'`,
+      ...(suffix === 'request-count' ? { resourceLabel: 'resourceLabel' } : {}),
+    });
+  }
+});
+
+test('scopes the existing 5xx alarm to gateway targets without policy changes', () => {
+  const alarm = construction(
+    service,
+    'aws.cloudwatch.MetricAlarm',
+    '`${BASE_NAME}-http-5xx-alarm`'
+  );
+  properties(alarm.arguments![1], {
+    name: '`${BASE_NAME}-http-5xx-${stack}`',
+    metricName: "'HTTPCode_Target_5XX_Count'",
+    namespace: "'AWS/ApplicationELB'",
+    statistic: "'Sum'",
+    period: '180',
+    evaluationPeriods: '1',
+    threshold: '25',
+    comparisonOperator: "'GreaterThanOrEqualToThreshold'",
+    actionsEnabled: 'true',
+    alarmActions: '[CLOUD_TRAIL_SNS_TOPIC_ARN]',
+    tags: 'this.tags',
+    alarmDescription:
+      '`High HTTP 5XX count alarm for ${BASE_NAME} gateway target group.`',
+  });
+  const dimensions = property(alarm.arguments![1], 'dimensions');
+  properties(dimensions, {
+    LoadBalancer: 'gatewayLoadBalancer.albArnSuffix',
+    TargetGroup: 'this.targetGroup.arnSuffix',
+  });
+  expect((dimensions as ts.ObjectLiteralExpression).properties).toHaveLength(2);
+  expect(text(alarm.arguments![1])).not.toContain('treatMissingData');
+  properties(alarm.arguments![2], { parent: 'this' });
+});

--- a/infra/stacks/convert-service/service.ts
+++ b/infra/stacks/convert-service/service.ts
@@ -7,7 +7,6 @@ import {
   EcsDeploymentFailureAlarm,
   datadogAgentContainer,
   fargateLogRouterSidecarContainer,
-  serviceLoadBalancer,
   ServiceTargetGroup,
 } from '../../packages/resources';
 import { EcrImage } from '../../packages/service';
@@ -24,15 +23,11 @@ const gatewayLoadBalancer = getGatewayAlb();
 
 const BASE_NAME = pulumi.getProject();
 const REPO_ROOT = '../../..';
-export const SERVICE_DOMAIN_NAME = `convert-service${
-  stack === 'prod' ? '' : `-${stack}`
-}.${BASE_DOMAIN}`;
 
 type CreateConvertServiceArgs = {
   convertQueueArn: pulumi.Output<string> | string;
   vpc: {
     vpcId: pulumi.Output<string> | string;
-    publicSubnetIds: pulumi.Output<string[]> | string[];
     privateSubnetIds: pulumi.Output<string[]> | string[];
   };
   tags: { [key: string]: string };
@@ -40,7 +35,6 @@ type CreateConvertServiceArgs = {
   platform: { family: string; architecture: 'amd64' | 'arm64' };
   serviceContainerPort: number;
   healthCheckPath: string;
-  isPrivate?: boolean;
   ecsClusterArn: pulumi.Output<string> | string;
   cloudStorageClusterName: pulumi.Output<string> | string;
   jobUpdateHandlerLambdaArn: pulumi.Output<string> | string;
@@ -49,13 +43,10 @@ type CreateConvertServiceArgs = {
 export class ConvertService extends pulumi.ComponentResource {
   public role: aws.iam.Role;
   public ecr: awsx.ecr.Repository;
-  public serviceAlbSg: aws.ec2.SecurityGroup;
   public serviceSg: aws.ec2.SecurityGroup;
   public domain: string;
   public tags: { [key: string]: string };
   public targetGroup: aws.lb.TargetGroup;
-  public lb: aws.lb.LoadBalancer;
-  public listener: aws.lb.Listener;
   public service: awsx.ecs.FargateService;
   public cloudStorageClusterName: pulumi.Output<string> | string;
 
@@ -68,7 +59,6 @@ export class ConvertService extends pulumi.ComponentResource {
       platform,
       serviceContainerPort,
       healthCheckPath,
-      isPrivate,
       ecsClusterArn,
       containerEnvVars,
       cloudStorageClusterName,
@@ -77,7 +67,9 @@ export class ConvertService extends pulumi.ComponentResource {
     opts?: pulumi.ComponentResourceOptions
   ) {
     super('my:components:CloudStorageService', name, {}, opts);
-    this.domain = `https://${SERVICE_DOMAIN_NAME}`;
+    this.domain = `https://${
+      stack === 'prod' ? '' : `${stack}-`
+    }gateway.${BASE_DOMAIN}/convert`;
     this.tags = tags;
     this.cloudStorageClusterName = cloudStorageClusterName;
 
@@ -162,12 +154,7 @@ export class ConvertService extends pulumi.ComponentResource {
     this.ecr = image.ecr;
 
     // Security groups
-    const sg = this.initializeSecurityGroups({
-      vpcId: vpc.vpcId,
-      serviceContainerPort,
-    });
-    this.serviceAlbSg = sg.serviceAlbSg;
-    this.serviceSg = sg.serviceSg;
+    this.serviceSg = this.initializeSecurityGroups({ vpcId: vpc.vpcId });
 
     const gatewayTargetGroup = new ServiceTargetGroup(
       `${stack}-${BASE_NAME}`,
@@ -185,19 +172,7 @@ export class ConvertService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // Load balancer
-    const { targetGroup, lb, listener } = serviceLoadBalancer(this, {
-      serviceName: BASE_NAME, // service name
-      serviceContainerPort,
-      healthCheckPath,
-      vpc,
-      albSecurityGroupId: this.serviceAlbSg.id,
-      isPrivate,
-      tags,
-    });
-    this.targetGroup = targetGroup;
-    this.lb = lb;
-    this.listener = listener;
+    this.targetGroup = gatewayTargetGroup.target_group;
 
     const dopplerEcsEnvironment = new DopplerEcsEnvironment(
       BASE_NAME,
@@ -220,17 +195,8 @@ export class ConvertService extends pulumi.ComponentResource {
           enable: true,
           rollback: true,
         },
-        // Register tasks in both the legacy ALB's target group and the gateway
-        // target group while we migrate to the gateway. An explicit
-        // `loadBalancers` replaces the list awsx derives from
-        // `portMappings.targetGroup`, so the legacy entry must be listed here
-        // too.
+        // Register tasks only with the shared gateway.
         loadBalancers: [
-          {
-            targetGroupArn: targetGroup.arn,
-            containerName: 'service',
-            containerPort: serviceContainerPort,
-          },
           {
             targetGroupArn: gatewayTargetGroup.target_group.arn,
             containerName: 'service',
@@ -279,7 +245,7 @@ export class ConvertService extends pulumi.ComponentResource {
                   name: `${BASE_NAME}-tcp-${stack}`,
                   hostPort: serviceContainerPort,
                   containerPort: serviceContainerPort,
-                  targetGroup,
+                  targetGroup: this.targetGroup,
                 },
               ],
             },
@@ -311,66 +277,19 @@ export class ConvertService extends pulumi.ComponentResource {
       gatewayTargetGroup: gatewayTargetGroup.target_group,
     });
     this.setupServiceAlarms();
-
-    // DNS
-    const zone = aws.route53.getZoneOutput({ name: BASE_DOMAIN });
-
-    new aws.route53.Record(
-      `${BASE_NAME}-domain-record`,
-      {
-        name: SERVICE_DOMAIN_NAME,
-        type: 'A',
-        zoneId: zone.zoneId,
-        aliases: [
-          {
-            evaluateTargetHealth: false,
-            name: this.lb.dnsName,
-            zoneId: this.lb.zoneId,
-          },
-        ],
-      },
-      { parent: this }
-    );
   }
 
   initializeSecurityGroups({
     vpcId,
-    serviceContainerPort,
   }: {
     vpcId: pulumi.Output<string> | string;
-    serviceContainerPort: number;
   }) {
-    const serviceAlbSg = new aws.ec2.SecurityGroup(
-      `${BASE_NAME}-alb-sg-${stack}`,
-      {
-        name: `${BASE_NAME}-alb-sg-${stack}`,
-        description: `${BASE_NAME} application load balancer security group`,
-        vpcId,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
     const serviceSg = new aws.ec2.SecurityGroup(
       `${BASE_NAME}-sg-${stack}`,
       {
         name: `${BASE_NAME}-sg-${stack}`,
         vpcId,
         description: `${BASE_NAME} security group that is attached directly to the service`,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-alb-in`,
-      {
-        securityGroupId: serviceSg.id,
-        description: 'Allow inbound traffic from the services ALB',
-        referencedSecurityGroupId: serviceAlbSg.id,
-        fromPort: serviceContainerPort,
-        toPort: serviceContainerPort,
-        ipProtocol: 'tcp',
         tags: this.tags,
       },
       { parent: this }
@@ -388,50 +307,7 @@ export class ConvertService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // ALB SG rules
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-http`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTP traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 80,
-        ipProtocol: 'tcp',
-        toPort: 80,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-https`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTPS traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 443,
-        ipProtocol: 'tcp',
-        toPort: 443,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupEgressRule(
-      `${BASE_NAME}-out-service`,
-      {
-        description: 'Allow traffic to the service security group',
-        securityGroupId: serviceAlbSg.id,
-        referencedSecurityGroupId: serviceSg.id,
-        fromPort: serviceContainerPort,
-        ipProtocol: 'tcp',
-        toPort: serviceContainerPort,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    return { serviceAlbSg, serviceSg };
+    return serviceSg;
   }
 
   setupAutoScaling({
@@ -579,7 +455,7 @@ export class ConvertService extends pulumi.ComponentResource {
       `${BASE_NAME}-http-5xx-alarm`,
       {
         name: `${BASE_NAME}-http-5xx-${stack}`,
-        metricName: 'HTTPCode_ELB_5XX_Count',
+        metricName: 'HTTPCode_Target_5XX_Count',
         namespace: 'AWS/ApplicationELB',
         statistic: 'Sum',
         period: 180,
@@ -587,9 +463,10 @@ export class ConvertService extends pulumi.ComponentResource {
         threshold: 25,
         comparisonOperator: 'GreaterThanOrEqualToThreshold',
         dimensions: {
-          LoadBalancer: this.lb.arn,
+          LoadBalancer: gatewayLoadBalancer.albArnSuffix,
+          TargetGroup: this.targetGroup.arnSuffix,
         },
-        alarmDescription: `High HTTP 5XX count alarm for ${BASE_NAME} Load Balancer.`,
+        alarmDescription: `High HTTP 5XX count alarm for ${BASE_NAME} gateway target group.`,
         actionsEnabled: true,
         alarmActions: [CLOUD_TRAIL_SNS_TOPIC_ARN],
         tags: this.tags,

--- a/infra/stacks/email-service/index.ts
+++ b/infra/stacks/email-service/index.ts
@@ -413,7 +413,6 @@ const emailService = new EmailService('email-service', {
   clusterName: cloudStorageClusterName,
   role: emailServiceRole,
   serviceContainerPort: 8080,
-  isPrivate: false,
   healthCheckPath: '/health',
   platform: { family: 'linux', architecture: 'amd64' },
   containerEnvVars,

--- a/infra/stacks/email-service/legacy-alb.test.ts
+++ b/infra/stacks/email-service/legacy-alb.test.ts
@@ -1,0 +1,302 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+
+// Parse source only: importing a stack would run cloud lookups and image builds.
+function readSource(path: string): ts.SourceFile {
+  return ts.createSourceFile(
+    path,
+    readFileSync(new URL(path, import.meta.url), 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+}
+
+const service = readSource('./service.ts');
+const index = readSource('./index.ts');
+const urls = readSource('../../packages/shared/src/service_urls.ts');
+
+function nodes<T extends ts.Node>(
+  root: ts.Node,
+  predicate: (node: ts.Node) => node is T
+): T[] {
+  const matches: T[] = [];
+  function visit(node: ts.Node): void {
+    if (predicate(node)) matches.push(node);
+    ts.forEachChild(node, visit);
+  }
+  visit(root);
+  return matches;
+}
+
+function only<T>(matches: T[]): T {
+  expect(matches).toHaveLength(1);
+  return matches[0];
+}
+
+function resource(
+  root: ts.Node,
+  constructorName: string,
+  name?: string
+): ts.NewExpression {
+  return only(
+    nodes(root, ts.isNewExpression).filter(
+      (node) =>
+        node.expression.getText() === constructorName &&
+        (name === undefined || node.arguments?.[0].getText() === name)
+    )
+  );
+}
+
+function property(root: ts.Node, name: string): ts.Expression {
+  if (!ts.isObjectLiteralExpression(root)) {
+    throw new Error(`Expected object for ${name}: ${root.getText()}`);
+  }
+  const member = only(
+    root.properties.filter((node) => node.name?.getText() === name)
+  );
+  if (ts.isPropertyAssignment(member)) return member.initializer;
+  if (ts.isShorthandPropertyAssignment(member)) return member.name;
+  throw new Error(`Expected property assignment: ${member.getText()}`);
+}
+
+function variable(root: ts.Node, name: string): ts.Expression {
+  const declaration = only(
+    nodes(root, ts.isVariableDeclaration).filter(
+      (node) => node.name.getText() === name
+    )
+  );
+  if (!declaration.initializer) throw new Error(`Missing initializer: ${name}`);
+  return declaration.initializer;
+}
+
+function assignment(name: string): string {
+  return only(
+    nodes(service, ts.isBinaryExpression).filter(
+      (node) =>
+        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        node.left.getText() === name
+    )
+  ).right.getText();
+}
+
+type Shape = string | Shape[] | { [key: string]: Shape };
+
+function shape(node: ts.Node): Shape {
+  if (ts.isObjectLiteralExpression(node)) {
+    return Object.fromEntries(
+      node.properties.map((member) => {
+        if (!member.name) throw new Error('Unexpected spread');
+        return [
+          member.name.getText(),
+          shape(property(node, member.name.getText())),
+        ];
+      })
+    );
+  }
+  if (ts.isArrayLiteralExpression(node)) return node.elements.map(shape);
+  return node.getText();
+}
+
+const ecs = resource(service, 'awsx.ecs.FargateService');
+const gateway = resource(service, 'ServiceTargetGroup');
+
+test('removes dedicated ALB, DNS, security groups and obsolete arguments', () => {
+  const identifiers = nodes(service, ts.isIdentifier).map((node) => node.text);
+  for (const removed of [
+    'serviceLoadBalancer',
+    'SERVICE_DOMAIN_NAME',
+    'BASE_DOMAIN',
+    'serviceAlbSg',
+    'listener',
+    'isPrivate',
+    'publicSubnetIds',
+    'route53',
+  ]) {
+    expect(identifiers).not.toContain(removed);
+  }
+  expect(
+    nodes(service, ts.isPropertyDeclaration).map((node) => node.name.getText())
+  ).not.toContain('lb');
+  expect(
+    nodes(service, ts.isPropertyAccessExpression).map((node) => node.getText())
+  ).not.toContain('this.lb');
+  const constructors = nodes(service, ts.isNewExpression).map((node) =>
+    node.expression.getText()
+  );
+  for (const removed of [
+    'aws.lb.LoadBalancer',
+    'aws.lb.Listener',
+    'aws.lb.ListenerRule',
+    'aws.lb.TargetGroup',
+    'aws.route53.Record',
+    'aws.vpc.SecurityGroupIngressRule',
+  ]) {
+    expect(constructors).not.toContain(removed);
+  }
+  expect(nodes(index, ts.isIdentifier).map((node) => node.text)).not.toContain(
+    'isPrivate'
+  );
+  expect(index.text).not.toContain('serviceAlbSg');
+});
+
+test('preserves gateway identity, routing, health checks and security wiring', () => {
+  expect(variable(service, 'BASE_NAME').getText()).toBe("'email-service'");
+  expect(variable(service, 'gatewayLoadBalancer').getText()).toBe(
+    'getGatewayAlb()'
+  );
+  expect(gateway.arguments?.[0].getText()).toBe('`${stack}-${BASE_NAME}`');
+  expect(shape(gateway.arguments![1])).toEqual({
+    tags: 'this.tags',
+    listenerArn: 'gatewayLoadBalancer.httpsListenerArn',
+    vpcId: 'vpc.vpcId',
+    containerPort: 'serviceContainerPort',
+    service: 'GatewayService.EMAIL_SERVICE',
+    healthCheckPath: 'healthCheckPath',
+    pathPatterns: ["'/email'", "'/email/*'"],
+    serviceSecurityGroupId: 'this.serviceSg.id',
+    albSecurityGroupId: 'gatewayLoadBalancer.albSecurityGroupId',
+  });
+  expect(shape(gateway.arguments![2])).toEqual({ parent: 'this' });
+  const api = resource(index, 'EmailService');
+  expect(api.arguments?.[0].getText()).toBe("'email-service'");
+  expect(property(api.arguments![1], 'serviceContainerPort').getText()).toBe(
+    '8080'
+  );
+  expect(property(api.arguments![1], 'healthCheckPath').getText()).toBe(
+    "'/health'"
+  );
+
+  const sg = resource(service, 'aws.ec2.SecurityGroup');
+  expect(sg.arguments?.[0].getText()).toBe('`${BASE_NAME}-sg-${stack}`');
+  expect(shape(sg.arguments![1])).toEqual({
+    name: '`${BASE_NAME}-sg-${stack}`',
+    vpcId: 'vpcId',
+    description:
+      '`${BASE_NAME} security group that is attached directly to the service`',
+    tags: 'this.tags',
+  });
+  expect(shape(sg.arguments![2])).toEqual({ parent: 'this' });
+  const egress = resource(service, 'aws.vpc.SecurityGroupEgressRule');
+  expect(egress.arguments?.[0].getText()).toBe('`${BASE_NAME}-all-out`');
+  expect(shape(egress.arguments![1])).toEqual({
+    securityGroupId: 'serviceSg.id',
+    description: "'Allow all outbound'",
+    cidrIpv4: "'0.0.0.0/0'",
+    ipProtocol: "'-1'",
+    tags: 'this.tags',
+  });
+  expect(shape(egress.arguments![2])).toEqual({ parent: 'this' });
+  expect(shape(property(ecs.arguments![1], 'networkConfiguration'))).toEqual({
+    subnets: 'vpc.privateSubnetIds',
+    securityGroups: ['this.serviceSg.id'],
+  });
+});
+
+test('registers ECS and its port mapping only with the existing gateway target', () => {
+  expect(assignment('this.targetGroup')).toBe(
+    'gatewayTargetGroup.target_group'
+  );
+  expect(ecs.arguments?.[0].getText()).toBe('`${BASE_NAME}`');
+  expect(shape(property(ecs.arguments![1], 'loadBalancers'))).toEqual([
+    {
+      targetGroupArn: 'gatewayTargetGroup.target_group.arn',
+      containerName: "'service'",
+      containerPort: 'serviceContainerPort',
+    },
+  ]);
+  const task = property(ecs.arguments![1], 'taskDefinitionArgs');
+  const container = property(property(task, 'containers'), 'service');
+  expect(shape(property(container, 'portMappings'))).toEqual([
+    {
+      appProtocol: "'http'",
+      name: '`${BASE_NAME}-tcp-${stack}`',
+      hostPort: 'serviceContainerPort',
+      containerPort: 'serviceContainerPort',
+      targetGroup: 'this.targetGroup',
+    },
+  ]);
+  expect(shape(ecs.arguments![2])).toEqual({
+    parent: 'this',
+    dependsOn: ['gatewayTargetGroup.listener_rule'],
+  });
+});
+
+test('exports the gateway email URL as a Pulumi Output in dev and prod', () => {
+  expect(assignment('this.domain')).toBe(
+    'getServiceUrl(ServiceUrl.EMAIL_SERVICE_URL)'
+  );
+  expect(variable(index, 'emailServiceUrl').getText()).toBe(
+    'pulumi.interpolate`${emailService.domain}`'
+  );
+  for (const [map, url] of [
+    ['DEV_SERVICE_URLS', 'https://dev-gateway.macro.com/email'],
+    ['PROD_SERVICE_URLS', 'https://gateway.macro.com/email'],
+  ]) {
+    expect(
+      property(variable(urls, map), '[ServiceUrl.EMAIL_SERVICE_URL]').getText()
+    ).toBe(`'${url}'`);
+  }
+});
+
+test('preserves gateway request autoscaling', () => {
+  expect(variable(service, 'resourceLabel').getText()).toBe(
+    'pulumi.interpolate`${gatewayAlbArnSuffix}/${gatewayTargetGroup.arnSuffix}`'
+  );
+  const setup = only(
+    nodes(service, ts.isCallExpression).filter(
+      (node) => node.expression.getText() === 'this.setupAutoScaling'
+    )
+  );
+  expect(shape(setup.arguments[0])).toEqual({
+    gatewayAlbArnSuffix: 'gatewayLoadBalancer.albArnSuffix',
+    gatewayTargetGroup: 'gatewayTargetGroup.target_group',
+  });
+  const policy = resource(
+    service,
+    'aws.appautoscaling.Policy',
+    '`${BASE_NAME}-scaling-policy-request-count-${stack}`'
+  );
+  expect(
+    shape(
+      property(policy.arguments![1], 'targetTrackingScalingPolicyConfiguration')
+    )
+  ).toEqual({
+    targetValue: '1000',
+    predefinedMetricSpecification: {
+      predefinedMetricType: "'ALBRequestCountPerTarget'",
+      resourceLabel: 'resourceLabel',
+    },
+    scaleInCooldown: '60',
+    scaleOutCooldown: '120',
+  });
+});
+
+test('scopes the existing 5xx alarm to email targets without changing alarm policy', () => {
+  const alarm = resource(
+    service,
+    'aws.cloudwatch.MetricAlarm',
+    '`${BASE_NAME}-http-5xx-alarm`'
+  );
+  expect(shape(alarm.arguments![1])).toEqual({
+    name: '`${BASE_NAME}-http-5xx-${stack}`',
+    metricName: "'HTTPCode_Target_5XX_Count'",
+    namespace: "'AWS/ApplicationELB'",
+    statistic: "'Sum'",
+    period: '180',
+    evaluationPeriods: '1',
+    threshold: '25',
+    comparisonOperator: "'GreaterThanOrEqualToThreshold'",
+    dimensions: {
+      LoadBalancer: 'gatewayLoadBalancer.albArnSuffix',
+      TargetGroup: 'this.targetGroup.arnSuffix',
+    },
+    alarmDescription:
+      '`High HTTP 5XX count alarm for ${BASE_NAME} gateway target group.`',
+    actionsEnabled: 'true',
+    alarmActions: ['CLOUD_TRAIL_SNS_TOPIC_ARN'],
+    tags: 'this.tags',
+  });
+  expect(shape(alarm.arguments![2])).toEqual({ parent: 'this' });
+});

--- a/infra/stacks/email-service/service.ts
+++ b/infra/stacks/email-service/service.ts
@@ -7,16 +7,16 @@ import {
   EcsDeploymentFailureAlarm,
   datadogAgentContainer,
   fargateLogRouterSidecarContainer,
-  serviceLoadBalancer,
   ServiceTargetGroup,
 } from '../../packages/resources';
 import { EcrImage } from '../../packages/service';
 import {
-  BASE_DOMAIN,
   CLOUD_TRAIL_SNS_TOPIC_ARN,
   type DopplerEcsEnvironment,
   getGatewayAlb,
+  getServiceUrl,
   GatewayService,
+  ServiceUrl,
   stack,
 } from '../../packages/shared';
 
@@ -25,22 +25,16 @@ const gatewayLoadBalancer = getGatewayAlb();
 const BASE_NAME = 'email-service';
 const REPO_ROOT = '../../..';
 
-export const SERVICE_DOMAIN_NAME = `email-service${
-  stack === 'prod' ? '' : `-${stack}`
-}.${BASE_DOMAIN}`;
-
 type Args = {
   role: aws.iam.Role;
   clusterName: pulumi.Output<string> | string;
   ecsClusterArn: pulumi.Output<string> | string;
   vpc: {
     vpcId: pulumi.Output<string> | string;
-    publicSubnetIds: pulumi.Output<string[]> | string[];
     privateSubnetIds: pulumi.Output<string[]> | string[];
   };
   platform: { family: string; architecture: 'amd64' | 'arm64' };
   serviceContainerPort: number;
-  isPrivate?: boolean;
   containerEnvVars: { name: string; value: pulumi.Output<string> | string }[];
   healthCheckPath: string;
   tags: { [key: string]: string };
@@ -50,11 +44,8 @@ type Args = {
 export class EmailService extends pulumi.ComponentResource {
   public role: aws.iam.Role;
   public ecr: awsx.ecr.Repository;
-  public serviceAlbSg: aws.ec2.SecurityGroup;
   public serviceSg: aws.ec2.SecurityGroup;
   public targetGroup: aws.lb.TargetGroup;
-  public lb: aws.lb.LoadBalancer;
-  public listener: aws.lb.Listener;
   public service: awsx.ecs.FargateService;
   public domain: string;
   public clusterName: pulumi.Output<string> | string;
@@ -69,7 +60,6 @@ export class EmailService extends pulumi.ComponentResource {
       platform,
       serviceContainerPort,
       healthCheckPath,
-      isPrivate,
       containerEnvVars,
       clusterName,
       dopplerEcsEnvironment,
@@ -103,12 +93,7 @@ export class EmailService extends pulumi.ComponentResource {
     this.ecr = image.ecr;
 
     // sg
-    const sg = this.initializeSecurityGroups({
-      vpcId: vpc.vpcId,
-      serviceContainerPort,
-    });
-    this.serviceAlbSg = sg.serviceAlbSg;
-    this.serviceSg = sg.serviceSg;
+    this.serviceSg = this.initializeSecurityGroups({ vpcId: vpc.vpcId });
 
     const gatewayTargetGroup = new ServiceTargetGroup(
       `${stack}-${BASE_NAME}`,
@@ -126,19 +111,7 @@ export class EmailService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // lb
-    const { targetGroup, lb, listener } = serviceLoadBalancer(this, {
-      serviceName: BASE_NAME, // service name
-      serviceContainerPort,
-      healthCheckPath,
-      vpc,
-      albSecurityGroupId: this.serviceAlbSg.id,
-      isPrivate,
-      tags,
-    });
-    this.targetGroup = targetGroup;
-    this.lb = lb;
-    this.listener = listener;
+    this.targetGroup = gatewayTargetGroup.target_group;
 
     // service
     const service = new awsx.ecs.FargateService(
@@ -155,15 +128,8 @@ export class EmailService extends pulumi.ComponentResource {
           enable: true,
           rollback: true,
         },
-        // An explicit `loadBalancers` replaces the list awsx derives from
-        // `portMappings.targetGroup`, so the legacy entry must be listed here
-        // too.
+        // Register tasks only with the shared gateway.
         loadBalancers: [
-          {
-            targetGroupArn: targetGroup.arn,
-            containerName: 'service',
-            containerPort: serviceContainerPort,
-          },
           {
             targetGroupArn: gatewayTargetGroup.target_group.arn,
             containerName: 'service',
@@ -206,7 +172,7 @@ export class EmailService extends pulumi.ComponentResource {
                   name: `${BASE_NAME}-tcp-${stack}`,
                   hostPort: serviceContainerPort,
                   containerPort: serviceContainerPort,
-                  targetGroup,
+                  targetGroup: this.targetGroup,
                 },
               ],
             },
@@ -240,67 +206,20 @@ export class EmailService extends pulumi.ComponentResource {
 
     this.setupServiceAlarms();
 
-    // domain record
-    const zone = aws.route53.getZoneOutput({ name: BASE_DOMAIN });
-
-    new aws.route53.Record(
-      `${BASE_NAME}-domain-record`,
-      {
-        name: SERVICE_DOMAIN_NAME,
-        type: 'A',
-        zoneId: zone.zoneId,
-        aliases: [
-          {
-            evaluateTargetHealth: false,
-            name: this.lb.dnsName,
-            zoneId: this.lb.zoneId,
-          },
-        ],
-      },
-      { parent: this }
-    );
-
-    this.domain = `https://${SERVICE_DOMAIN_NAME}`;
+    this.domain = getServiceUrl(ServiceUrl.EMAIL_SERVICE_URL);
   }
 
   initializeSecurityGroups({
     vpcId,
-    serviceContainerPort,
   }: {
     vpcId: pulumi.Output<string> | string;
-    serviceContainerPort: number;
-  }) {
-    const serviceAlbSg = new aws.ec2.SecurityGroup(
-      `${BASE_NAME}-alb-sg-${stack}`,
-      {
-        name: `${BASE_NAME}-alb-sg-${stack}`,
-        description: `${BASE_NAME} application load balancer security group`,
-        vpcId,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
+  }): aws.ec2.SecurityGroup {
     const serviceSg = new aws.ec2.SecurityGroup(
       `${BASE_NAME}-sg-${stack}`,
       {
         name: `${BASE_NAME}-sg-${stack}`,
         vpcId,
         description: `${BASE_NAME} security group that is attached directly to the service`,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-alb-in`,
-      {
-        securityGroupId: serviceSg.id,
-        description: 'Allow inbound traffic from the services ALB',
-        referencedSecurityGroupId: serviceAlbSg.id,
-        fromPort: serviceContainerPort,
-        toPort: serviceContainerPort,
-        ipProtocol: 'tcp',
         tags: this.tags,
       },
       { parent: this }
@@ -318,50 +237,7 @@ export class EmailService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // ALB SG rules
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-http`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTP traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 80,
-        ipProtocol: 'tcp',
-        toPort: 80,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-https`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTPS traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 443,
-        ipProtocol: 'tcp',
-        toPort: 443,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupEgressRule(
-      `${BASE_NAME}-out-service`,
-      {
-        description: 'Allow traffic to the service security group',
-        securityGroupId: serviceAlbSg.id,
-        referencedSecurityGroupId: serviceSg.id,
-        fromPort: serviceContainerPort,
-        ipProtocol: 'tcp',
-        toPort: serviceContainerPort,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    return { serviceAlbSg, serviceSg };
+    return serviceSg;
   }
 
   setupAutoScaling({
@@ -510,7 +386,7 @@ export class EmailService extends pulumi.ComponentResource {
       `${BASE_NAME}-http-5xx-alarm`,
       {
         name: `${BASE_NAME}-http-5xx-${stack}`,
-        metricName: 'HTTPCode_ELB_5XX_Count',
+        metricName: 'HTTPCode_Target_5XX_Count',
         namespace: 'AWS/ApplicationELB',
         statistic: 'Sum',
         period: 180,
@@ -518,9 +394,10 @@ export class EmailService extends pulumi.ComponentResource {
         threshold: 25,
         comparisonOperator: 'GreaterThanOrEqualToThreshold',
         dimensions: {
-          LoadBalancer: this.lb.arn,
+          LoadBalancer: gatewayLoadBalancer.albArnSuffix,
+          TargetGroup: this.targetGroup.arnSuffix,
         },
-        alarmDescription: `High HTTP 5XX count alarm for ${BASE_NAME} Load Balancer.`,
+        alarmDescription: `High HTTP 5XX count alarm for ${BASE_NAME} gateway target group.`,
         actionsEnabled: true,
         alarmActions: [CLOUD_TRAIL_SNS_TOPIC_ARN],
         tags: this.tags,

--- a/infra/stacks/image-proxy-service/image-proxy-service.ts
+++ b/infra/stacks/image-proxy-service/image-proxy-service.ts
@@ -7,12 +7,10 @@ import {
   EcsDeploymentFailureAlarm,
   datadogAgentContainer,
   fargateLogRouterSidecarContainer,
-  serviceLoadBalancer,
   ServiceTargetGroup,
 } from '../../packages/resources';
 import { EcrImage } from '../../packages/service';
 import {
-  BASE_DOMAIN,
   CLOUD_TRAIL_SNS_TOPIC_ARN,
   DopplerEcsEnvironment,
   getGatewayAlb,
@@ -25,21 +23,15 @@ const gatewayLoadBalancer = getGatewayAlb();
 const BASE_NAME = pulumi.getProject();
 const REPO_ROOT = '../../..';
 
-export const SERVICE_DOMAIN_NAME = `image-proxy${
-  stack === 'prod' ? '' : `-${stack}`
-}.${BASE_DOMAIN}`;
-
 type CreateImageProxyServiceArgs = {
   cloudStorageClusterName: pulumi.Output<string> | string;
   ecsClusterArn: pulumi.Output<string> | string;
   vpc: {
     vpcId: pulumi.Output<string> | string;
-    publicSubnetIds: pulumi.Output<string[]> | string[];
     privateSubnetIds: pulumi.Output<string[]> | string[];
   };
   platform: { family: string; architecture: 'amd64' | 'arm64' };
   serviceContainerPort: number;
-  isPrivate?: boolean;
   containerEnvVars?: { name: string; value: pulumi.Output<string> | string }[];
   healthCheckPath: string;
   secretKeyArns: (pulumi.Output<string> | string)[];
@@ -48,13 +40,9 @@ type CreateImageProxyServiceArgs = {
 
 export class ImageProxyService extends pulumi.ComponentResource {
   public ecr: awsx.ecr.Repository;
-  public serviceAlbSg: aws.ec2.SecurityGroup;
   public serviceSg: aws.ec2.SecurityGroup;
   public targetGroup: aws.lb.TargetGroup;
-  public lb: aws.lb.LoadBalancer;
-  public listener: aws.lb.Listener;
   public service: awsx.ecs.FargateService;
-  public domain: string;
   public cloudStorageClusterName: pulumi.Output<string> | string;
   public tags: { [key: string]: string };
   public role: aws.iam.Role;
@@ -67,7 +55,6 @@ export class ImageProxyService extends pulumi.ComponentResource {
       platform,
       serviceContainerPort,
       healthCheckPath,
-      isPrivate,
       containerEnvVars,
       cloudStorageClusterName,
       secretKeyArns,
@@ -100,12 +87,7 @@ export class ImageProxyService extends pulumi.ComponentResource {
     this.ecr = image.ecr;
 
     // sg
-    const sg = this.initializeSecurityGroups({
-      vpcId: vpc.vpcId,
-      serviceContainerPort,
-    });
-    this.serviceAlbSg = sg.serviceAlbSg;
-    this.serviceSg = sg.serviceSg;
+    this.serviceSg = this.initializeSecurityGroups({ vpcId: vpc.vpcId });
 
     const gatewayTargetGroup = new ServiceTargetGroup(
       `${stack}-${BASE_NAME}`,
@@ -123,21 +105,7 @@ export class ImageProxyService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // lb
-    const { targetGroup, lb, listener } = serviceLoadBalancer(this, {
-      serviceName: BASE_NAME,
-      serviceContainerPort,
-      healthCheckPath,
-      vpc,
-      albSecurityGroupId: this.serviceAlbSg.id,
-      isPrivate,
-      tags,
-      idleTimeout: 3600,
-      deregistrationDelay: 30,
-    });
-    this.targetGroup = targetGroup;
-    this.lb = lb;
-    this.listener = listener;
+    this.targetGroup = gatewayTargetGroup.target_group;
 
     this.role = new aws.iam.Role(
       `${BASE_NAME}-role`,
@@ -211,15 +179,8 @@ export class ImageProxyService extends pulumi.ComponentResource {
           enable: true,
           rollback: true,
         },
-        // An explicit `loadBalancers` replaces the list awsx derives from
-        // `portMappings.targetGroup`, so the legacy entry must be listed here
-        // too.
+        // Register tasks only with the shared gateway.
         loadBalancers: [
-          {
-            targetGroupArn: targetGroup.arn,
-            containerName: 'service',
-            containerPort: serviceContainerPort,
-          },
           {
             targetGroupArn: gatewayTargetGroup.target_group.arn,
             containerName: 'service',
@@ -262,7 +223,7 @@ export class ImageProxyService extends pulumi.ComponentResource {
                   name: `${BASE_NAME}-tcp-${stack}`,
                   hostPort: serviceContainerPort,
                   containerPort: serviceContainerPort,
-                  targetGroup,
+                  targetGroup: this.targetGroup,
                 },
               ],
             },
@@ -295,68 +256,19 @@ export class ImageProxyService extends pulumi.ComponentResource {
     });
 
     this.setupServiceAlarms();
-
-    // domain record
-    const zone = aws.route53.getZoneOutput({ name: BASE_DOMAIN });
-
-    new aws.route53.Record(
-      `${BASE_NAME}-domain-record`,
-      {
-        name: `${SERVICE_DOMAIN_NAME}`,
-        type: 'A',
-        zoneId: zone.zoneId,
-        aliases: [
-          {
-            evaluateTargetHealth: false,
-            name: this.lb.dnsName,
-            zoneId: this.lb.zoneId,
-          },
-        ],
-      },
-      { parent: this }
-    );
-
-    this.domain = `https://${SERVICE_DOMAIN_NAME}`;
   }
 
   initializeSecurityGroups({
     vpcId,
-    serviceContainerPort,
   }: {
     vpcId: pulumi.Output<string> | string;
-    serviceContainerPort: number;
-  }) {
-    const serviceAlbSg = new aws.ec2.SecurityGroup(
-      `${BASE_NAME}-alb-sg-${stack}`,
-      {
-        name: `${BASE_NAME}-alb-sg-${stack}`,
-        description: `${BASE_NAME} application load balancer security group`,
-        vpcId,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
+  }): aws.ec2.SecurityGroup {
     const serviceSg = new aws.ec2.SecurityGroup(
       `${BASE_NAME}-sg-${stack}`,
       {
         name: `${BASE_NAME}-sg-${stack}`,
         vpcId,
         description: `${BASE_NAME} security group that is attached directly to the service`,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-alb-in`,
-      {
-        securityGroupId: serviceSg.id,
-        description: 'Allow inbound traffic from the services ALB',
-        referencedSecurityGroupId: serviceAlbSg.id,
-        fromPort: serviceContainerPort,
-        toPort: serviceContainerPort,
-        ipProtocol: 'tcp',
         tags: this.tags,
       },
       { parent: this }
@@ -374,50 +286,7 @@ export class ImageProxyService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // ALB SG rules
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-http`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTP traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 80,
-        ipProtocol: 'tcp',
-        toPort: 80,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-https`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTPS traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 443,
-        ipProtocol: 'tcp',
-        toPort: 443,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupEgressRule(
-      `${BASE_NAME}-out-service`,
-      {
-        description: 'Allow traffic to the service security group',
-        securityGroupId: serviceAlbSg.id,
-        referencedSecurityGroupId: serviceSg.id,
-        fromPort: serviceContainerPort,
-        ipProtocol: 'tcp',
-        toPort: serviceContainerPort,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    return { serviceAlbSg, serviceSg };
+    return serviceSg;
   }
 
   setupAutoScaling({
@@ -564,7 +433,7 @@ export class ImageProxyService extends pulumi.ComponentResource {
       `${BASE_NAME}-http-5xx-alarm`,
       {
         name: `${BASE_NAME}-http-5xx-${stack}`,
-        metricName: 'HTTPCode_ELB_5XX_Count',
+        metricName: 'HTTPCode_Target_5XX_Count',
         namespace: 'AWS/ApplicationELB',
         statistic: 'Sum',
         period: 180,
@@ -572,9 +441,10 @@ export class ImageProxyService extends pulumi.ComponentResource {
         threshold: 25,
         comparisonOperator: 'GreaterThanOrEqualToThreshold',
         dimensions: {
-          LoadBalancer: this.lb.arn,
+          LoadBalancer: gatewayLoadBalancer.albArnSuffix,
+          TargetGroup: this.targetGroup.arnSuffix,
         },
-        alarmDescription: `High HTTP 5XX count alarm for ${BASE_NAME} Load Balancer.`,
+        alarmDescription: `High HTTP 5XX count alarm for ${BASE_NAME} gateway target group.`,
         actionsEnabled: true,
         alarmActions: [CLOUD_TRAIL_SNS_TOPIC_ARN],
         tags: this.tags,

--- a/infra/stacks/image-proxy-service/index.ts
+++ b/infra/stacks/image-proxy-service/index.ts
@@ -70,13 +70,11 @@ const imageProxyService = new ImageProxyService(
         value: stack,
       },
     ],
-    isPrivate: false,
     tags,
   }
 );
 
 export const imageProxyServiceSgId = imageProxyService.serviceSg.id;
-export const imageProxyServiceAlbSgId = imageProxyService.serviceAlbSg.id;
 export const imageProxyServiceUrl = `https://${
   stack === 'prod' ? '' : `${stack}-`
 }gateway.${BASE_DOMAIN}/image-proxy`;

--- a/infra/stacks/image-proxy-service/legacy-alb.test.ts
+++ b/infra/stacks/image-proxy-service/legacy-alb.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+
+// Parse source only: importing a stack would run Pulumi lookups and image builds.
+function parse(relativePath: string): ts.SourceFile {
+  return ts.createSourceFile(
+    relativePath,
+    readFileSync(new URL(relativePath, import.meta.url), 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+}
+
+const service = parse('./image-proxy-service.ts');
+const index = parse('./index.ts');
+
+function nodes<T extends ts.Node>(
+  root: ts.Node,
+  guard: (node: ts.Node) => node is T
+): T[] {
+  const matches: T[] = [];
+  function visit(node: ts.Node): void {
+    if (guard(node)) matches.push(node);
+    ts.forEachChild(node, visit);
+  }
+  visit(root);
+  return matches;
+}
+
+function resource(
+  source: ts.SourceFile,
+  constructorName: string,
+  name?: string
+): ts.NewExpression {
+  const matches = nodes(source, ts.isNewExpression).filter(
+    (node) =>
+      node.expression.getText() === constructorName &&
+      (name === undefined || node.arguments?.[0].getText() === name)
+  );
+  expect(matches).toHaveLength(1);
+  return matches[0];
+}
+
+function variable(source: ts.SourceFile, name: string): ts.Expression {
+  const matches = nodes(source, ts.isVariableDeclaration).filter(
+    (node) => node.name.getText() === name
+  );
+  expect(matches).toHaveLength(1);
+  const initializer = matches[0].initializer;
+  if (!initializer) throw new Error(`Missing initializer for ${name}`);
+  return initializer;
+}
+
+function property(node: ts.Node, ...path: string[]): ts.Node {
+  let current = node;
+  for (const key of path) {
+    if (!ts.isObjectLiteralExpression(current)) {
+      throw new Error(`Expected object for ${key}`);
+    }
+    const member = current.properties.find(
+      (entry) => entry.name?.getText() === key
+    );
+    if (!member) throw new Error(`Missing property ${key}`);
+    if (ts.isPropertyAssignment(member)) current = member.initializer;
+    else if (ts.isShorthandPropertyAssignment(member)) current = member.name;
+    else throw new Error(`Unsupported property ${key}`);
+  }
+  return current;
+}
+
+type Shape = string | Shape[] | { [key: string]: Shape };
+
+function shape(node: ts.Node): Shape {
+  if (ts.isObjectLiteralExpression(node)) {
+    return Object.fromEntries(
+      node.properties.map((member) => {
+        const key = member.name?.getText();
+        if (!key) throw new Error('Expected named property');
+        return [key, shape(property(node, key))];
+      })
+    );
+  }
+  if (ts.isArrayLiteralExpression(node)) return node.elements.map(shape);
+  return node.getText();
+}
+
+describe('image proxy shared gateway migration', () => {
+  test('removes dedicated load balancing, DNS, and obsolete API fields', () => {
+    const identifiers = [service, index].flatMap((source) =>
+      nodes(source, ts.isIdentifier).map((node) => node.text)
+    );
+    for (const removed of [
+      'serviceLoadBalancer',
+      'SERVICE_DOMAIN_NAME',
+      'serviceAlbSg',
+      'imageProxyServiceAlbSgId',
+      'isPrivate',
+      'publicSubnetIds',
+      'domain',
+      'listener',
+    ]) {
+      expect(identifiers).not.toContain(removed);
+    }
+    expect(
+      nodes(service, ts.isPropertyDeclaration).map((node) =>
+        node.name.getText()
+      )
+    ).not.toContain('lb');
+    expect(
+      nodes(service, ts.isIdentifier).map((node) => node.text)
+    ).not.toContain('BASE_DOMAIN');
+    const constructors = nodes(service, ts.isNewExpression).map((node) =>
+      node.expression.getText()
+    );
+    expect(constructors).not.toContain('MacroApplicationLoadBalancer');
+    expect(
+      constructors.some((name) => /^aws\.(lb|alb|route53)\./.test(name))
+    ).toBe(false);
+  });
+
+  test('preserves gateway identity, routes, health check, and security pairing', () => {
+    const gateway = resource(service, 'ServiceTargetGroup');
+    expect(gateway.arguments?.[0].getText()).toBe('`${stack}-${BASE_NAME}`');
+    expect(shape(gateway.arguments![1])).toEqual({
+      tags: 'this.tags',
+      listenerArn: 'gatewayLoadBalancer.httpsListenerArn',
+      vpcId: 'vpc.vpcId',
+      containerPort: 'serviceContainerPort',
+      service: 'GatewayService.IMAGE_PROXY_SERVICE',
+      healthCheckPath: 'healthCheckPath',
+      pathPatterns: ["'/image-proxy'", "'/image-proxy/*'"],
+      serviceSecurityGroupId: 'this.serviceSg.id',
+      albSecurityGroupId: 'gatewayLoadBalancer.albSecurityGroupId',
+    });
+    expect(shape(gateway.arguments![2])).toEqual({ parent: 'this' });
+    const caller = resource(index, 'ImageProxyService');
+    expect(
+      property(caller.arguments![1], 'serviceContainerPort').getText()
+    ).toBe('8080');
+    expect(property(caller.arguments![1], 'healthCheckPath').getText()).toBe(
+      "'/health'"
+    );
+    const assignments = nodes(service, ts.isBinaryExpression).filter(
+      (node) => node.left.getText() === 'this.targetGroup'
+    );
+    expect(assignments).toHaveLength(1);
+    expect(assignments[0].right.getText()).toBe(
+      'gatewayTargetGroup.target_group'
+    );
+  });
+
+  test('registers ECS only with the gateway and retains its listener dependency', () => {
+    const ecs = resource(service, 'awsx.ecs.FargateService');
+    expect(ecs.arguments![0].getText()).toBe('`${BASE_NAME}`');
+    expect(shape(property(ecs.arguments![1], 'loadBalancers'))).toEqual([
+      {
+        targetGroupArn: 'gatewayTargetGroup.target_group.arn',
+        containerName: "'service'",
+        containerPort: 'serviceContainerPort',
+      },
+    ]);
+    const container = property(
+      ecs.arguments![1],
+      'taskDefinitionArgs',
+      'containers',
+      'service'
+    );
+    expect(shape(property(container, 'portMappings'))).toEqual([
+      {
+        appProtocol: "'http'",
+        name: '`${BASE_NAME}-tcp-${stack}`',
+        hostPort: 'serviceContainerPort',
+        containerPort: 'serviceContainerPort',
+        targetGroup: 'this.targetGroup',
+      },
+    ]);
+    for (const [key, value] of [
+      ['cpu', '512'],
+      ['memory', '1024'],
+      ['stopTimeout', '10'],
+    ]) {
+      expect(property(container, key).getText()).toBe(value);
+    }
+    expect(property(ecs.arguments![1], 'desiredCount').getText()).toBe('1');
+    expect(shape(ecs.arguments![2])).toEqual({
+      parent: 'this',
+      dependsOn: ['gatewayTargetGroup.listener_rule'],
+    });
+    expect(shape(property(ecs.arguments![1], 'networkConfiguration'))).toEqual({
+      subnets: 'vpc.privateSubnetIds',
+      securityGroups: ['this.serviceSg.id'],
+    });
+  });
+
+  test('retains only the service security group and unrestricted outbound rule', () => {
+    const sg = resource(service, 'aws.ec2.SecurityGroup');
+    expect(sg.arguments![0].getText()).toBe('`${BASE_NAME}-sg-${stack}`');
+    expect(shape(sg.arguments![1])).toEqual({
+      name: '`${BASE_NAME}-sg-${stack}`',
+      vpcId: 'vpcId',
+      description:
+        '`${BASE_NAME} security group that is attached directly to the service`',
+      tags: 'this.tags',
+    });
+    expect(shape(sg.arguments![2])).toEqual({ parent: 'this' });
+    const egress = resource(service, 'aws.vpc.SecurityGroupEgressRule');
+    expect(egress.arguments![0].getText()).toBe('`${BASE_NAME}-all-out`');
+    expect(shape(egress.arguments![1])).toEqual({
+      securityGroupId: 'serviceSg.id',
+      description: "'Allow all outbound'",
+      cidrIpv4: "'0.0.0.0/0'",
+      ipProtocol: "'-1'",
+      tags: 'this.tags',
+    });
+    expect(shape(egress.arguments![2])).toEqual({ parent: 'this' });
+    expect(
+      nodes(service, ts.isNewExpression).filter(
+        (node) =>
+          node.expression.getText() === 'aws.vpc.SecurityGroupIngressRule'
+      )
+    ).toHaveLength(0);
+  });
+
+  test('retains the dev/prod gateway URL expression and service SG export', () => {
+    expect(variable(index, 'imageProxyServiceSgId').getText()).toBe(
+      'imageProxyService.serviceSg.id'
+    );
+    expect(variable(index, 'imageProxyServiceUrl').getText()).toBe(
+      "`https://${\n  stack === 'prod' ? '' : `${stack}-`\n}gateway.${BASE_DOMAIN}/image-proxy`"
+    );
+  });
+
+  test('uses gateway ARN suffixes for request scaling without retuning policies', () => {
+    const calls = nodes(service, ts.isCallExpression).filter(
+      (node) => node.expression.getText() === 'this.setupAutoScaling'
+    );
+    expect(calls).toHaveLength(1);
+    expect(shape(calls[0].arguments[0])).toEqual({
+      gatewayAlbArnSuffix: 'gatewayLoadBalancer.albArnSuffix',
+      gatewayTargetGroup: 'gatewayTargetGroup.target_group',
+    });
+    expect(variable(service, 'resourceLabel').getText()).toBe(
+      'pulumi.interpolate`${gatewayAlbArnSuffix}/${gatewayTargetGroup.arnSuffix}`'
+    );
+    const target = resource(service, 'aws.appautoscaling.Target');
+    expect(target.arguments![0].getText()).toBe(
+      '`${BASE_NAME}-service-scalable-target-${stack}`'
+    );
+    expect(shape(target.arguments![1])).toEqual({
+      maxCapacity: "stack === 'prod' ? 15 : 3",
+      minCapacity: '1',
+      resourceId:
+        'pulumi.interpolate`service/${this.cloudStorageClusterName}/${this.service.service.name}`',
+      scalableDimension: "'ecs:service:DesiredCount'",
+      serviceNamespace: "'ecs'",
+      tags: 'this.tags',
+    });
+    for (const [suffix, metric, value, scaleIn, scaleOut] of [
+      ['request-count', 'ALBRequestCountPerTarget', '1000', '60', '120'],
+      ['cpu', 'ECSServiceAverageCPUUtilization', '70.0', '100', '300'],
+      ['memory', 'ECSServiceAverageMemoryUtilization', '70.0', '100', '300'],
+    ]) {
+      const policy = resource(
+        service,
+        'aws.appautoscaling.Policy',
+        `\`\${BASE_NAME}-scaling-policy-${suffix}-\${stack}\``
+      );
+      expect(shape(policy.arguments![1])).toEqual({
+        policyType: "'TargetTrackingScaling'",
+        resourceId: 'serviceScalableTarget.resourceId',
+        scalableDimension: 'serviceScalableTarget.scalableDimension',
+        serviceNamespace: 'serviceScalableTarget.serviceNamespace',
+        targetTrackingScalingPolicyConfiguration: {
+          targetValue: value,
+          predefinedMetricSpecification: {
+            predefinedMetricType: `'${metric}'`,
+            ...(suffix === 'request-count'
+              ? { resourceLabel: 'resourceLabel' }
+              : {}),
+          },
+          scaleInCooldown: scaleIn,
+          scaleOutCooldown: scaleOut,
+        },
+      });
+      expect(shape(policy.arguments![2])).toEqual({ parent: 'this' });
+    }
+  });
+
+  test('scopes the existing 5xx alarm to image proxy targets without policy changes', () => {
+    const alarm = resource(
+      service,
+      'aws.cloudwatch.MetricAlarm',
+      '`${BASE_NAME}-http-5xx-alarm`'
+    );
+    expect(shape(alarm.arguments![1])).toEqual({
+      name: '`${BASE_NAME}-http-5xx-${stack}`',
+      metricName: "'HTTPCode_Target_5XX_Count'",
+      namespace: "'AWS/ApplicationELB'",
+      statistic: "'Sum'",
+      period: '180',
+      evaluationPeriods: '1',
+      threshold: '25',
+      comparisonOperator: "'GreaterThanOrEqualToThreshold'",
+      dimensions: {
+        LoadBalancer: 'gatewayLoadBalancer.albArnSuffix',
+        TargetGroup: 'this.targetGroup.arnSuffix',
+      },
+      alarmDescription:
+        '`High HTTP 5XX count alarm for ${BASE_NAME} gateway target group.`',
+      actionsEnabled: 'true',
+      alarmActions: ['CLOUD_TRAIL_SNS_TOPIC_ARN'],
+      tags: 'this.tags',
+    });
+    expect(shape(alarm.arguments![2])).toEqual({ parent: 'this' });
+  });
+
+  test('retains JWT secret permissions and their role attachment', () => {
+    const policy = resource(
+      service,
+      'aws.iam.Policy',
+      '`${BASE_NAME}-secrets-policy`'
+    );
+    expect(shape(policy.arguments![1])).toEqual({
+      policy: {
+        Version: "'2012-10-17'",
+        Statement: [
+          {
+            Action: ["'secretsmanager:GetSecretValue'"],
+            Resource: ['...secretKeyArns'],
+            Effect: "'Allow'",
+          },
+        ],
+      },
+      tags: 'this.tags',
+    });
+    const attachment = resource(service, 'aws.iam.RolePolicyAttachment');
+    expect(attachment.arguments![0].getText()).toBe(
+      '`${BASE_NAME}-secrets-policy-attachment`'
+    );
+    expect(shape(attachment.arguments![1])).toEqual({
+      role: 'this.role.name',
+      policyArn: 'secretsPolicy.arn',
+    });
+    expect(shape(variable(index, 'secretKeyArns'))).toEqual([
+      'pulumi.interpolate`${jwtSecretKeyArn}`',
+      'pulumi.interpolate`${MACRO_API_TOKENS.macroApiTokenPublicKeyArn}`',
+    ]);
+  });
+
+  test('keeps the implicit 15-second gateway drain and 3600-second idle timeout', () => {
+    const gatewayTarget = resource(service, 'ServiceTargetGroup');
+    expect(shape(gatewayTarget.arguments![1])).not.toHaveProperty(
+      'deregistrationDelay'
+    );
+    const sharedTarget = resource(
+      parse('../../packages/resources/src/resources/service_target_group.ts'),
+      'aws.lb.TargetGroup'
+    );
+    expect(
+      property(sharedTarget.arguments![1], 'deregistrationDelay').getText()
+    ).toBe('args.deregistrationDelay ?? DEFAULT_DEREGISTRATION_DELAY_SECONDS');
+    expect(
+      variable(
+        parse(
+          '../../packages/resources/src/resources/ecs_deployment_defaults.ts'
+        ),
+        'DEFAULT_DEREGISTRATION_DELAY_SECONDS'
+      ).getText()
+    ).toBe('15');
+    const gateway = resource(
+      parse('../gateway/index.ts'),
+      'MacroApplicationLoadBalancer'
+    );
+    expect(property(gateway.arguments![1], 'idleTimeout').getText()).toBe(
+      '3600'
+    );
+  });
+});

--- a/infra/stacks/search-processing-service/index.ts
+++ b/infra/stacks/search-processing-service/index.ts
@@ -59,7 +59,6 @@ const searchProcessingService = new SearchProcessingService(
     vpc,
     platform: { family: 'linux', architecture: 'amd64' },
     serviceContainerPort: 8080,
-    isPrivate: false,
     healthCheckPath: '/health',
     containerEnvVars: [
       { name: 'ENVIRONMENT', value: stack },

--- a/infra/stacks/search-processing-service/legacy-alb.test.ts
+++ b/infra/stacks/search-processing-service/legacy-alb.test.ts
@@ -1,0 +1,313 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+
+// Parse source only: importing the stack would perform cloud lookups and builds.
+function parse(file: string): ts.SourceFile {
+  return ts.createSourceFile(
+    file,
+    readFileSync(new URL(file, import.meta.url), 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+}
+
+const service = parse('./service.ts');
+const index = parse('./index.ts');
+
+function nodes<T extends ts.Node>(
+  root: ts.Node,
+  predicate: (node: ts.Node) => node is T
+): T[] {
+  const result: T[] = [];
+  function visit(node: ts.Node): void {
+    if (predicate(node)) result.push(node);
+    ts.forEachChild(node, visit);
+  }
+  visit(root);
+  return result;
+}
+
+function text(node: ts.Node): string {
+  return node.getText().replace(/\s+/g, '');
+}
+
+function constructors(
+  type: string,
+  root: ts.Node = service
+): ts.NewExpression[] {
+  return nodes(root, ts.isNewExpression).filter(
+    (node) => text(node.expression) === type
+  );
+}
+
+function resource(type: string, root: ts.Node = service): ts.NewExpression {
+  const matches = constructors(type, root);
+  expect(matches).toHaveLength(1);
+  return matches[0];
+}
+
+function property(node: ts.Node, key: string): ts.Expression {
+  if (!ts.isObjectLiteralExpression(node)) {
+    throw new Error(`Expected object, got ${node.getText()}`);
+  }
+  const member = node.properties.find((entry) => entry.name?.getText() === key);
+  if (member && ts.isPropertyAssignment(member)) return member.initializer;
+  if (member && ts.isShorthandPropertyAssignment(member)) return member.name;
+  throw new Error(`Missing property ${key}`);
+}
+
+function shape(node: ts.Node): Record<string, string> {
+  if (!ts.isObjectLiteralExpression(node)) throw new Error('Expected object');
+  return Object.fromEntries(
+    node.properties.map((entry) => {
+      const key = entry.name?.getText();
+      if (!key) throw new Error('Expected named property');
+      return [key, text(property(node, key))];
+    })
+  );
+}
+
+function elements(node: ts.Node): ts.Expression[] {
+  if (!ts.isArrayLiteralExpression(node)) throw new Error('Expected array');
+  return [...node.elements];
+}
+
+function variable(file: ts.SourceFile, name: string): ts.Expression {
+  const matches = nodes(file, ts.isVariableDeclaration).filter(
+    (node) => text(node.name) === name
+  );
+  expect(matches).toHaveLength(1);
+  if (!matches[0].initializer) throw new Error(`Missing initializer: ${name}`);
+  return matches[0].initializer;
+}
+
+const ecs = resource('awsx.ecs.FargateService');
+const ecsArgs = ecs.arguments![1];
+const caller = resource('SearchProcessingService', index);
+const container = property(
+  property(property(ecsArgs, 'taskDefinitionArgs'), 'containers'),
+  'service'
+);
+
+test('removes dedicated ALB, DNS, listeners, and legacy security-group surface', () => {
+  for (const file of [service, index]) {
+    const identifiers = nodes(file, ts.isIdentifier).map((node) => node.text);
+    for (const removed of [
+      'serviceLoadBalancer',
+      'SERVICE_DOMAIN_NAME',
+      'serviceAlbSg',
+      'isPrivate',
+      'publicSubnetIds',
+    ]) {
+      expect(identifiers).not.toContain(removed);
+    }
+    for (const type of [
+      'aws.lb.LoadBalancer',
+      'aws.lb.Listener',
+      'aws.lb.ListenerRule',
+      'aws.lb.TargetGroup',
+      'aws.route53.Record',
+      'aws.vpc.SecurityGroupIngressRule',
+    ]) {
+      expect(constructors(type, file)).toHaveLength(0);
+    }
+  }
+  const fields = nodes(service, ts.isPropertyDeclaration).map((node) =>
+    text(node.name)
+  );
+  expect(fields).not.toContain('lb');
+  expect(fields).not.toContain('listener');
+});
+
+test('retains gateway identity, paired routes, direct health check and port', () => {
+  expect(text(variable(service, 'BASE_NAME'))).toBe("'search-processing'");
+  expect(text(variable(index, 'BASE_NAME'))).toBe(
+    "'search-processing-service'"
+  );
+  const component = nodes(service, ts.isCallExpression).find(
+    (node) => node.expression.kind === ts.SyntaxKind.SuperKeyword
+  );
+  expect(component!.arguments.map(text)).toEqual([
+    "'my:components:Service'",
+    'name',
+    '{}',
+    'opts',
+  ]);
+  expect(text(caller.arguments![0])).toBe('`${BASE_NAME}-${stack}`');
+  expect(text(ecs.arguments![0])).toBe('`${BASE_NAME}`');
+  const gateway = resource('ServiceTargetGroup');
+  expect(text(gateway.arguments![0])).toBe('`${stack}-${BASE_NAME}`');
+  expect(shape(gateway.arguments![1])).toEqual({
+    tags: 'this.tags',
+    listenerArn: 'gatewayLoadBalancer.httpsListenerArn',
+    vpcId: 'vpc.vpcId',
+    containerPort: 'serviceContainerPort',
+    service: 'GatewayService.SEARCH_PROCESSING_SERVICE',
+    healthCheckPath: 'healthCheckPath',
+    pathPatterns: "['/search-processing','/search-processing/*']",
+    serviceSecurityGroupId: 'this.serviceSg.id',
+    albSecurityGroupId: 'gatewayLoadBalancer.albSecurityGroupId',
+  });
+  expect(shape(gateway.arguments![2])).toEqual({ parent: 'this' });
+  expect(text(property(caller.arguments![1], 'serviceContainerPort'))).toBe(
+    '8080'
+  );
+  expect(text(property(caller.arguments![1], 'healthCheckPath'))).toBe(
+    "'/health'"
+  );
+});
+
+test('registers ECS only with the gateway and retains listener dependency', () => {
+  expect(nodes(service, ts.isBinaryExpression).map(text)).toContain(
+    'this.targetGroup=gatewayTargetGroup.target_group'
+  );
+  expect(elements(property(ecsArgs, 'loadBalancers')).map(shape)).toEqual([
+    {
+      targetGroupArn: 'gatewayTargetGroup.target_group.arn',
+      containerName: "'service'",
+      containerPort: 'serviceContainerPort',
+    },
+  ]);
+  expect(elements(property(container, 'portMappings')).map(shape)).toEqual([
+    {
+      appProtocol: "'http'",
+      name: '`${BASE_NAME}-tcp-${stack}`',
+      hostPort: 'serviceContainerPort',
+      containerPort: 'serviceContainerPort',
+      targetGroup: 'this.targetGroup',
+    },
+  ]);
+  expect(shape(ecs.arguments![2])).toEqual({
+    parent: 'this',
+    dependsOn: '[gatewayTargetGroup.listener_rule]',
+  });
+  expect(shape(property(ecsArgs, 'networkConfiguration'))).toEqual({
+    subnets: 'vpc.privateSubnetIds',
+    securityGroups: '[this.serviceSg.id]',
+  });
+});
+
+test('preserves the service security group and unrestricted outbound rule', () => {
+  const sg = resource('aws.ec2.SecurityGroup');
+  expect(text(sg.arguments![0])).toBe('`${BASE_NAME}-sg-${stack}`');
+  expect(text(property(sg.arguments![1], 'name'))).toBe(
+    '`${BASE_NAME}-sg-${stack}`'
+  );
+  expect(text(property(sg.arguments![1], 'vpcId'))).toBe('vpcId');
+  expect(shape(sg.arguments![2])).toEqual({ parent: 'this' });
+  const egress = resource('aws.vpc.SecurityGroupEgressRule');
+  expect(text(egress.arguments![0])).toBe('`${BASE_NAME}-all-out`');
+  expect(shape(egress.arguments![1])).toEqual({
+    securityGroupId: 'serviceSg.id',
+    description: "'Allowalloutbound'",
+    cidrIpv4: "'0.0.0.0/0'",
+    ipProtocol: "'-1'",
+    tags: 'this.tags',
+  });
+  expect(shape(egress.arguments![2])).toEqual({ parent: 'this' });
+});
+
+test('BASE_URL matches the exported dev/prod prefixed gateway URL', () => {
+  const assignments = nodes(service, ts.isBinaryExpression).filter(
+    (node) => text(node.left) === 'this.domain'
+  );
+  expect(assignments).toHaveLength(1);
+  const url = variable(index, 'searchProcessingServiceUrl');
+  expect(text(assignments[0].right)).toBe(text(url));
+  expect(text(url)).toBe(
+    "`https://${stack==='prod'?'':`${stack}-`}gateway.${BASE_DOMAIN}/search-processing`"
+  );
+  const baseUrl = elements(property(container, 'environment')).find((node) =>
+    ts.isObjectLiteralExpression(node)
+  );
+  expect(shape(baseUrl!)).toEqual({ name: "'BASE_URL'", value: 'this.domain' });
+  expect(text(variable(index, 'searchProcessingServiceRoleArn'))).toBe(
+    'searchProcessingService.role.arn'
+  );
+});
+
+test('retains gateway request scaling and 60 percent CPU/memory targets', () => {
+  const call = nodes(service, ts.isCallExpression).filter(
+    (node) => text(node.expression) === 'this.setupAutoScaling'
+  );
+  expect(call).toHaveLength(1);
+  expect(shape(call[0].arguments[0])).toEqual({
+    gatewayAlbArnSuffix: 'gatewayLoadBalancer.albArnSuffix',
+    gatewayTargetGroup: 'gatewayTargetGroup.target_group',
+  });
+  expect(text(variable(service, 'resourceLabel'))).toBe(
+    'pulumi.interpolate`${gatewayAlbArnSuffix}/${gatewayTargetGroup.arnSuffix}`'
+  );
+  const policies = constructors('aws.appautoscaling.Policy');
+  expect(policies).toHaveLength(3);
+  for (const [i, kind, metric] of [
+    [0, 'request-count', 'ALBRequestCountPerTarget'],
+    [1, 'cpu', 'ECSServiceAverageCPUUtilization'],
+    [2, 'memory', 'ECSServiceAverageMemoryUtilization'],
+  ] as const) {
+    const policy = policies[i];
+    expect(text(policy.arguments![0])).toBe(
+      `\`\${BASE_NAME}-scaling-policy-${kind}-\${stack}\``
+    );
+    const config = property(
+      policy.arguments![1],
+      'targetTrackingScalingPolicyConfiguration'
+    );
+    expect(shape(config)).toMatchObject({
+      targetValue: i === 0 ? '1000' : '60.0',
+      scaleInCooldown: i === 0 ? '60' : '100',
+      scaleOutCooldown: i === 0 ? '120' : '300',
+    });
+    expect(shape(property(config, 'predefinedMetricSpecification'))).toEqual(
+      i === 0
+        ? {
+            predefinedMetricType: `'${metric}'`,
+            resourceLabel: 'resourceLabel',
+          }
+        : { predefinedMetricType: `'${metric}'` }
+    );
+  }
+});
+
+test('retains exactly the ECS CPU, memory, and deployment alarms', () => {
+  const alarms = constructors('aws.cloudwatch.MetricAlarm');
+  expect(alarms).toHaveLength(2);
+  for (const [i, kind, metric, description] of [
+    [0, 'cpu', 'CPUUtilization', 'CPU'],
+    [1, 'mem', 'MemoryUtilization', 'Memory'],
+  ] as const) {
+    const alarm = alarms[i];
+    expect(text(alarm.arguments![0])).toBe(
+      `\`\${BASE_NAME}-high-${kind}-alarm\``
+    );
+    expect(shape(alarm.arguments![1])).toEqual({
+      name: `\`\${BASE_NAME}-high-${kind}-alarm-\${stack}\``,
+      metricName: `'${metric}'`,
+      namespace: "'AWS/ECS'",
+      statistic: "'Average'",
+      period: '180',
+      evaluationPeriods: '1',
+      threshold: '80',
+      comparisonOperator: "'GreaterThanThreshold'",
+      dimensions:
+        '{ClusterName:this.clusterName,ServiceName:this.service.service.name,}',
+      alarmDescription: `\`High${description}usagealarmfor\${BASE_NAME}service.\``,
+      actionsEnabled: 'true',
+      alarmActions: '[CLOUD_TRAIL_SNS_TOPIC_ARN]',
+      tags: 'this.tags',
+    });
+    expect(shape(alarm.arguments![2])).toEqual({ parent: 'this' });
+  }
+  const deployment = resource('EcsDeploymentFailureAlarm');
+  expect(text(deployment.arguments![0])).toBe(
+    '`${BASE_NAME}-deployment-failure-alarm`'
+  );
+  expect(shape(deployment.arguments![1])).toEqual({
+    serviceName: 'BASE_NAME',
+    serviceArn: 'this.service.service.arn',
+    tags: 'this.tags',
+  });
+  expect(shape(deployment.arguments![2])).toEqual({ parent: 'this' });
+});

--- a/infra/stacks/search-processing-service/service.ts
+++ b/infra/stacks/search-processing-service/service.ts
@@ -7,7 +7,6 @@ import {
   EcsDeploymentFailureAlarm,
   datadogAgentContainer,
   fargateLogRouterSidecarContainer,
-  serviceLoadBalancer,
   ServiceTargetGroup,
 } from '../../packages/resources';
 import { EcrImage } from '../../packages/service';
@@ -26,22 +25,16 @@ const gatewayLoadBalancer = getGatewayAlb();
 const BASE_NAME = 'search-processing';
 const REPO_ROOT = '../../..';
 
-export const SERVICE_DOMAIN_NAME = `search-processing${
-  stack === 'prod' ? '' : `-${stack}`
-}.${BASE_DOMAIN}`;
-
 type Args = {
   clusterName: pulumi.Output<string> | string;
   ecsClusterArn: pulumi.Output<string> | string;
   documentStorageBucketArn: pulumi.Output<string> | string;
   vpc: {
     vpcId: pulumi.Output<string> | string;
-    publicSubnetIds: pulumi.Output<string[]> | string[];
     privateSubnetIds: pulumi.Output<string[]> | string[];
   };
   platform: { family: string; architecture: 'amd64' | 'arm64' };
   serviceContainerPort: number;
-  isPrivate?: boolean;
   containerEnvVars?: { name: string; value: pulumi.Output<string> | string }[];
   healthCheckPath: string;
   searchEventQueueArn: pulumi.Output<string> | string;
@@ -54,11 +47,8 @@ type Args = {
 export class SearchProcessingService extends pulumi.ComponentResource {
   public role: aws.iam.Role;
   public ecr: awsx.ecr.Repository;
-  public serviceAlbSg: aws.ec2.SecurityGroup;
   public serviceSg: aws.ec2.SecurityGroup;
   public targetGroup: aws.lb.TargetGroup;
-  public lb: aws.lb.LoadBalancer;
-  public listener: aws.lb.Listener;
   public service: awsx.ecs.FargateService;
   public domain: string;
   public clusterName: pulumi.Output<string> | string;
@@ -73,7 +63,6 @@ export class SearchProcessingService extends pulumi.ComponentResource {
       platform,
       serviceContainerPort,
       healthCheckPath,
-      isPrivate,
       containerEnvVars,
       clusterName,
       tags,
@@ -87,7 +76,9 @@ export class SearchProcessingService extends pulumi.ComponentResource {
 
     this.clusterName = clusterName;
 
-    this.domain = `https://${SERVICE_DOMAIN_NAME}`;
+    this.domain = `https://${
+      stack === 'prod' ? '' : `${stack}-`
+    }gateway.${BASE_DOMAIN}/search-processing`;
 
     // role
     const docStorageBucketPolicy = new aws.iam.Policy(
@@ -177,12 +168,7 @@ export class SearchProcessingService extends pulumi.ComponentResource {
     this.ecr = image.ecr;
 
     // sg
-    const sg = this.initializeSecurityGroups({
-      vpcId: vpc.vpcId,
-      serviceContainerPort,
-    });
-    this.serviceAlbSg = sg.serviceAlbSg;
-    this.serviceSg = sg.serviceSg;
+    this.serviceSg = this.initializeSecurityGroups({ vpcId: vpc.vpcId });
 
     const gatewayTargetGroup = new ServiceTargetGroup(
       `${stack}-${BASE_NAME}`,
@@ -200,19 +186,7 @@ export class SearchProcessingService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // lb
-    const { targetGroup, lb, listener } = serviceLoadBalancer(this, {
-      serviceName: BASE_NAME, // service name
-      serviceContainerPort,
-      healthCheckPath,
-      vpc,
-      albSecurityGroupId: this.serviceAlbSg.id,
-      isPrivate,
-      tags,
-    });
-    this.targetGroup = targetGroup;
-    this.lb = lb;
-    this.listener = listener;
+    this.targetGroup = gatewayTargetGroup.target_group;
 
     const dopplerEcsEnvironment = new DopplerEcsEnvironment(
       pulumi.getProject(),
@@ -235,17 +209,8 @@ export class SearchProcessingService extends pulumi.ComponentResource {
           enable: true,
           rollback: true,
         },
-        // Register tasks in both the legacy ALB's target group and the gateway
-        // target group while we migrate to the gateway. An explicit
-        // `loadBalancers` replaces the list awsx derives from
-        // `portMappings.targetGroup`, so the legacy entry must be listed here
-        // too.
+        // Register tasks only with the shared gateway.
         loadBalancers: [
-          {
-            targetGroupArn: targetGroup.arn,
-            containerName: 'service',
-            containerPort: serviceContainerPort,
-          },
           {
             targetGroupArn: gatewayTargetGroup.target_group.arn,
             containerName: 'service',
@@ -291,7 +256,7 @@ export class SearchProcessingService extends pulumi.ComponentResource {
                   name: `${BASE_NAME}-tcp-${stack}`,
                   hostPort: serviceContainerPort,
                   containerPort: serviceContainerPort,
-                  targetGroup,
+                  targetGroup: this.targetGroup,
                 },
               ],
             },
@@ -324,66 +289,19 @@ export class SearchProcessingService extends pulumi.ComponentResource {
     });
 
     this.setupServiceAlarms();
-
-    // domain record
-    const zone = aws.route53.getZoneOutput({ name: BASE_DOMAIN });
-
-    new aws.route53.Record(
-      `${BASE_NAME}-domain-record`,
-      {
-        name: SERVICE_DOMAIN_NAME,
-        type: 'A',
-        zoneId: zone.zoneId,
-        aliases: [
-          {
-            evaluateTargetHealth: false,
-            name: this.lb.dnsName,
-            zoneId: this.lb.zoneId,
-          },
-        ],
-      },
-      { parent: this }
-    );
   }
 
   initializeSecurityGroups({
     vpcId,
-    serviceContainerPort,
   }: {
     vpcId: pulumi.Output<string> | string;
-    serviceContainerPort: number;
   }) {
-    const serviceAlbSg = new aws.ec2.SecurityGroup(
-      `${BASE_NAME}-alb-sg-${stack}`,
-      {
-        name: `${BASE_NAME}-alb-sg-${stack}`,
-        description: `${BASE_NAME} application load balancer security group`,
-        vpcId,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
     const serviceSg = new aws.ec2.SecurityGroup(
       `${BASE_NAME}-sg-${stack}`,
       {
         name: `${BASE_NAME}-sg-${stack}`,
         vpcId,
         description: `${BASE_NAME} security group that is attached directly to the service`,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-alb-in`,
-      {
-        securityGroupId: serviceSg.id,
-        description: 'Allow inbound traffic from the services ALB',
-        referencedSecurityGroupId: serviceAlbSg.id,
-        fromPort: serviceContainerPort,
-        toPort: serviceContainerPort,
-        ipProtocol: 'tcp',
         tags: this.tags,
       },
       { parent: this }
@@ -401,50 +319,7 @@ export class SearchProcessingService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // ALB SG rules
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-http`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTP traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 80,
-        ipProtocol: 'tcp',
-        toPort: 80,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-https`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTPS traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 443,
-        ipProtocol: 'tcp',
-        toPort: 443,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupEgressRule(
-      `${BASE_NAME}-out-service`,
-      {
-        description: 'Allow traffic to the service security group',
-        securityGroupId: serviceAlbSg.id,
-        referencedSecurityGroupId: serviceSg.id,
-        fromPort: serviceContainerPort,
-        ipProtocol: 'tcp',
-        toPort: serviceContainerPort,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    return { serviceAlbSg, serviceSg };
+    return serviceSg;
   }
 
   setupAutoScaling({

--- a/infra/stacks/unfurl-service/index.ts
+++ b/infra/stacks/unfurl-service/index.ts
@@ -48,10 +48,8 @@ const unfurlService = new UnfurlService(`unfurl-service-${stack}`, {
       value: stack,
     },
   ],
-  isPrivate: false,
   tags,
 });
 
 export const unfurlServiceSgId = unfurlService.serviceSg.id;
-export const unfurlServiceAlbSgId = unfurlService.serviceAlbSg.id;
 export const unfurlServiceUrl = getServiceUrl(ServiceUrl.UNFURL_SERVICE_URL);

--- a/infra/stacks/unfurl-service/legacy-alb.test.ts
+++ b/infra/stacks/unfurl-service/legacy-alb.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+
+// Parse source only: importing a stack would run Pulumi lookups and image builds.
+function parse(relativePath: string): ts.SourceFile {
+  return ts.createSourceFile(
+    relativePath,
+    readFileSync(new URL(relativePath, import.meta.url), 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+}
+
+const service = parse('./unfurl-service.ts');
+const index = parse('./index.ts');
+
+function nodes<T extends ts.Node>(
+  root: ts.Node,
+  guard: (node: ts.Node) => node is T
+): T[] {
+  const matches: T[] = [];
+  function visit(node: ts.Node): void {
+    if (guard(node)) matches.push(node);
+    ts.forEachChild(node, visit);
+  }
+  visit(root);
+  return matches;
+}
+
+function resource(
+  source: ts.SourceFile,
+  constructorName: string,
+  name?: string
+): ts.NewExpression {
+  const matches = nodes(source, ts.isNewExpression).filter(
+    (node) =>
+      node.expression.getText() === constructorName &&
+      (name === undefined || node.arguments?.[0].getText() === name)
+  );
+  expect(matches).toHaveLength(1);
+  return matches[0];
+}
+
+function variable(source: ts.SourceFile, name: string): ts.Expression {
+  const matches = nodes(source, ts.isVariableDeclaration).filter(
+    (node) => node.name.getText() === name
+  );
+  expect(matches).toHaveLength(1);
+  const initializer = matches[0].initializer;
+  if (!initializer) throw new Error(`Missing initializer for ${name}`);
+  return initializer;
+}
+
+function property(node: ts.Node, ...path: string[]): ts.Node {
+  let current = node;
+  for (const key of path) {
+    if (!ts.isObjectLiteralExpression(current)) {
+      throw new Error(`Expected object for ${key}`);
+    }
+    const member = current.properties.find(
+      (entry) => entry.name?.getText() === key
+    );
+    if (!member) throw new Error(`Missing property ${key}`);
+    if (ts.isPropertyAssignment(member)) current = member.initializer;
+    else if (ts.isShorthandPropertyAssignment(member)) current = member.name;
+    else throw new Error(`Unsupported property ${key}`);
+  }
+  return current;
+}
+
+type Shape = string | Shape[] | { [key: string]: Shape };
+
+function shape(node: ts.Node): Shape {
+  if (ts.isObjectLiteralExpression(node)) {
+    return Object.fromEntries(
+      node.properties.map((member) => {
+        const key = member.name?.getText();
+        if (!key) throw new Error('Expected named property');
+        return [key, shape(property(node, key))];
+      })
+    );
+  }
+  if (ts.isArrayLiteralExpression(node)) return node.elements.map(shape);
+  return node.getText();
+}
+
+describe('unfurl shared gateway migration', () => {
+  test('removes dedicated load balancing, DNS, and obsolete API fields', () => {
+    const identifiers = [service, index].flatMap((source) =>
+      nodes(source, ts.isIdentifier).map((node) => node.text)
+    );
+    for (const removed of [
+      'serviceLoadBalancer',
+      'SERVICE_DOMAIN_NAME',
+      'BASE_DOMAIN',
+      'serviceAlbSg',
+      'unfurlServiceAlbSgId',
+      'isPrivate',
+      'publicSubnetIds',
+      'domain',
+      'listener',
+    ]) {
+      expect(identifiers).not.toContain(removed);
+    }
+    expect(
+      nodes(service, ts.isPropertyDeclaration).map((node) =>
+        node.name.getText()
+      )
+    ).not.toContain('lb');
+    const constructors = nodes(service, ts.isNewExpression).map((node) =>
+      node.expression.getText()
+    );
+    expect(constructors).not.toContain('MacroApplicationLoadBalancer');
+    expect(
+      constructors.some((name) => /^aws\.(lb|alb|route53)\./.test(name))
+    ).toBe(false);
+  });
+
+  test('preserves gateway identity, routes, health check, and security pairing', () => {
+    const gateway = resource(service, 'ServiceTargetGroup');
+    expect(gateway.arguments?.[0].getText()).toBe('`${stack}-${BASE_NAME}`');
+    expect(shape(gateway.arguments![1])).toEqual({
+      tags: 'this.tags',
+      listenerArn: 'gatewayLoadBalancer.httpsListenerArn',
+      vpcId: 'vpc.vpcId',
+      containerPort: 'serviceContainerPort',
+      service: 'GatewayService.UNFURL_SERVICE',
+      healthCheckPath: 'healthCheckPath',
+      pathPatterns: ["'/unfurl'", "'/unfurl/*'"],
+      serviceSecurityGroupId: 'this.serviceSg.id',
+      albSecurityGroupId: 'gatewayLoadBalancer.albSecurityGroupId',
+    });
+    expect(shape(gateway.arguments![2])).toEqual({ parent: 'this' });
+    const caller = resource(index, 'UnfurlService');
+    expect(
+      property(caller.arguments![1], 'serviceContainerPort').getText()
+    ).toBe('8080');
+    expect(property(caller.arguments![1], 'healthCheckPath').getText()).toBe(
+      "'/health'"
+    );
+    const assignments = nodes(service, ts.isBinaryExpression).filter(
+      (node) => node.left.getText() === 'this.targetGroup'
+    );
+    expect(assignments).toHaveLength(1);
+    expect(assignments[0].right.getText()).toBe(
+      'gatewayTargetGroup.target_group'
+    );
+  });
+
+  test('registers ECS only with the gateway and retains its listener dependency', () => {
+    const ecs = resource(service, 'awsx.ecs.FargateService');
+    expect(ecs.arguments![0].getText()).toBe('`${BASE_NAME}`');
+    expect(shape(property(ecs.arguments![1], 'loadBalancers'))).toEqual([
+      {
+        targetGroupArn: 'gatewayTargetGroup.target_group.arn',
+        containerName: "'service'",
+        containerPort: 'serviceContainerPort',
+      },
+    ]);
+    expect(
+      shape(
+        property(
+          ecs.arguments![1],
+          'taskDefinitionArgs',
+          'containers',
+          'service',
+          'portMappings'
+        )
+      )
+    ).toEqual([
+      {
+        appProtocol: "'http'",
+        name: '`${BASE_NAME}-tcp-${stack}`',
+        hostPort: 'serviceContainerPort',
+        containerPort: 'serviceContainerPort',
+        targetGroup: 'this.targetGroup',
+      },
+    ]);
+    expect(shape(ecs.arguments![2])).toEqual({
+      parent: 'this',
+      dependsOn: ['gatewayTargetGroup.listener_rule'],
+    });
+    expect(shape(property(ecs.arguments![1], 'networkConfiguration'))).toEqual({
+      subnets: 'vpc.privateSubnetIds',
+      securityGroups: ['this.serviceSg.id'],
+    });
+  });
+
+  test('retains only the service security group and unrestricted outbound rule', () => {
+    const sg = resource(service, 'aws.ec2.SecurityGroup');
+    expect(sg.arguments![0].getText()).toBe('`${BASE_NAME}-sg-${stack}`');
+    expect(shape(sg.arguments![1])).toEqual({
+      name: '`${BASE_NAME}-sg-${stack}`',
+      vpcId: 'vpcId',
+      description:
+        '`${BASE_NAME} security group that is attached directly to the service`',
+      tags: 'this.tags',
+    });
+    expect(shape(sg.arguments![2])).toEqual({ parent: 'this' });
+    const egress = resource(service, 'aws.vpc.SecurityGroupEgressRule');
+    expect(egress.arguments![0].getText()).toBe('`${BASE_NAME}-all-out`');
+    expect(shape(egress.arguments![1])).toEqual({
+      securityGroupId: 'serviceSg.id',
+      description: "'Allow all outbound'",
+      cidrIpv4: "'0.0.0.0/0'",
+      ipProtocol: "'-1'",
+      tags: 'this.tags',
+    });
+    expect(shape(egress.arguments![2])).toEqual({ parent: 'this' });
+    expect(
+      nodes(service, ts.isNewExpression).filter(
+        (node) =>
+          node.expression.getText() === 'aws.vpc.SecurityGroupIngressRule'
+      )
+    ).toHaveLength(0);
+  });
+
+  test('retains gateway URL and service SG exports for dev and prod', () => {
+    expect(variable(index, 'unfurlServiceSgId').getText()).toBe(
+      'unfurlService.serviceSg.id'
+    );
+    expect(variable(index, 'unfurlServiceUrl').getText()).toBe(
+      'getServiceUrl(ServiceUrl.UNFURL_SERVICE_URL)'
+    );
+    const urls = parse('../../packages/shared/src/service_urls.ts');
+    for (const [map, url] of [
+      ['DEV_SERVICE_URLS', 'https://dev-gateway.macro.com/unfurl'],
+      ['PROD_SERVICE_URLS', 'https://gateway.macro.com/unfurl'],
+    ]) {
+      expect(
+        property(
+          variable(urls, map),
+          '[ServiceUrl.UNFURL_SERVICE_URL]'
+        ).getText()
+      ).toBe(`'${url}'`);
+    }
+  });
+
+  test('uses gateway ARN suffixes for request scaling without retuning policies', () => {
+    expect(variable(service, 'resourceLabel').getText()).toBe(
+      'pulumi.interpolate`${gatewayLoadBalancer.albArnSuffix}/${this.targetGroup.arnSuffix}`'
+    );
+    const target = resource(service, 'aws.appautoscaling.Target');
+    expect(target.arguments![0].getText()).toBe(
+      '`${BASE_NAME}-service-scalable-target-${stack}`'
+    );
+    expect(shape(target.arguments![1])).toEqual({
+      maxCapacity: "stack === 'prod' ? 15 : 3",
+      minCapacity: '1',
+      resourceId:
+        'pulumi.interpolate`service/${this.cloudStorageClusterName}/${this.service.service.name}`',
+      scalableDimension: "'ecs:service:DesiredCount'",
+      serviceNamespace: "'ecs'",
+      tags: 'this.tags',
+    });
+    for (const [suffix, metric, value, scaleIn, scaleOut] of [
+      ['request-count', 'ALBRequestCountPerTarget', '1000', '60', '120'],
+      ['cpu', 'ECSServiceAverageCPUUtilization', '70.0', '100', '300'],
+      ['memory', 'ECSServiceAverageMemoryUtilization', '70.0', '100', '300'],
+    ]) {
+      const policy = resource(
+        service,
+        'aws.appautoscaling.Policy',
+        `\`\${BASE_NAME}-scaling-policy-${suffix}-\${stack}\``
+      );
+      expect(shape(policy.arguments![1])).toEqual({
+        policyType: "'TargetTrackingScaling'",
+        resourceId: 'serviceScalableTarget.resourceId',
+        scalableDimension: 'serviceScalableTarget.scalableDimension',
+        serviceNamespace: 'serviceScalableTarget.serviceNamespace',
+        targetTrackingScalingPolicyConfiguration: {
+          targetValue: value,
+          predefinedMetricSpecification: {
+            predefinedMetricType: `'${metric}'`,
+            ...(suffix === 'request-count'
+              ? { resourceLabel: 'resourceLabel' }
+              : {}),
+          },
+          scaleInCooldown: scaleIn,
+          scaleOutCooldown: scaleOut,
+        },
+      });
+      expect(shape(policy.arguments![2])).toEqual({ parent: 'this' });
+    }
+  });
+
+  test('scopes the existing 5xx alarm to unfurl targets without policy changes', () => {
+    const alarm = resource(
+      service,
+      'aws.cloudwatch.MetricAlarm',
+      '`${BASE_NAME}-http-5xx-alarm`'
+    );
+    expect(shape(alarm.arguments![1])).toEqual({
+      name: '`${BASE_NAME}-http-5xx-${stack}`',
+      metricName: "'HTTPCode_Target_5XX_Count'",
+      namespace: "'AWS/ApplicationELB'",
+      statistic: "'Sum'",
+      period: '180',
+      evaluationPeriods: '1',
+      threshold: '25',
+      comparisonOperator: "'GreaterThanOrEqualToThreshold'",
+      dimensions: {
+        LoadBalancer: 'gatewayLoadBalancer.albArnSuffix',
+        TargetGroup: 'this.targetGroup.arnSuffix',
+      },
+      alarmDescription:
+        '`High HTTP 5XX count alarm for ${BASE_NAME} gateway target group.`',
+      actionsEnabled: 'true',
+      alarmActions: ['CLOUD_TRAIL_SNS_TOPIC_ARN'],
+      tags: 'this.tags',
+    });
+    expect(shape(alarm.arguments![2])).toEqual({ parent: 'this' });
+  });
+
+  test('relies on the existing shared gateway 3600-second idle timeout', () => {
+    const gateway = resource(
+      parse('../gateway/index.ts'),
+      'MacroApplicationLoadBalancer'
+    );
+    expect(property(gateway.arguments![1], 'idleTimeout').getText()).toBe(
+      '3600'
+    );
+  });
+});

--- a/infra/stacks/unfurl-service/unfurl-service.ts
+++ b/infra/stacks/unfurl-service/unfurl-service.ts
@@ -7,12 +7,10 @@ import {
   EcsDeploymentFailureAlarm,
   datadogAgentContainer,
   fargateLogRouterSidecarContainer,
-  serviceLoadBalancer,
   ServiceTargetGroup,
 } from '../../packages/resources';
 import { EcrImage } from '../../packages/service';
 import {
-  BASE_DOMAIN,
   CLOUD_TRAIL_SNS_TOPIC_ARN,
   DopplerEcsEnvironment,
   getGatewayAlb,
@@ -25,21 +23,15 @@ const gatewayLoadBalancer = getGatewayAlb();
 const BASE_NAME = pulumi.getProject();
 const REPO_ROOT = '../../..';
 
-export const SERVICE_DOMAIN_NAME = `unfurl-service${
-  stack === 'prod' ? '' : `-${stack}`
-}.${BASE_DOMAIN}`;
-
 type CreateUnfurlServiceArgs = {
   cloudStorageClusterName: pulumi.Output<string> | string;
   ecsClusterArn: pulumi.Output<string> | string;
   vpc: {
     vpcId: pulumi.Output<string> | string;
-    publicSubnetIds: pulumi.Output<string[]> | string[];
     privateSubnetIds: pulumi.Output<string[]> | string[];
   };
   platform: { family: string; architecture: 'amd64' | 'arm64' };
   serviceContainerPort: number;
-  isPrivate?: boolean;
   containerEnvVars?: { name: string; value: pulumi.Output<string> | string }[];
   healthCheckPath: string;
   tags: { [key: string]: string };
@@ -47,13 +39,9 @@ type CreateUnfurlServiceArgs = {
 
 export class UnfurlService extends pulumi.ComponentResource {
   public ecr: awsx.ecr.Repository;
-  public serviceAlbSg: aws.ec2.SecurityGroup;
   public serviceSg: aws.ec2.SecurityGroup;
   public targetGroup: aws.lb.TargetGroup;
-  public lb: aws.lb.LoadBalancer;
-  public listener: aws.lb.Listener;
   public service: awsx.ecs.FargateService;
-  public domain: string;
   public cloudStorageClusterName: pulumi.Output<string> | string;
   public tags: { [key: string]: string };
   public role: aws.iam.Role;
@@ -66,7 +54,6 @@ export class UnfurlService extends pulumi.ComponentResource {
       platform,
       serviceContainerPort,
       healthCheckPath,
-      isPrivate,
       containerEnvVars,
       cloudStorageClusterName,
       tags,
@@ -98,12 +85,7 @@ export class UnfurlService extends pulumi.ComponentResource {
     this.ecr = image.ecr;
 
     // sg
-    const sg = this.initializeSecurityGroups({
-      vpcId: vpc.vpcId,
-      serviceContainerPort,
-    });
-    this.serviceAlbSg = sg.serviceAlbSg;
-    this.serviceSg = sg.serviceSg;
+    this.serviceSg = this.initializeSecurityGroups({ vpcId: vpc.vpcId });
 
     const gatewayTargetGroup = new ServiceTargetGroup(
       `${stack}-${BASE_NAME}`,
@@ -121,20 +103,7 @@ export class UnfurlService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // lb
-    const { targetGroup, lb, listener } = serviceLoadBalancer(this, {
-      serviceName: BASE_NAME, // service name
-      serviceContainerPort,
-      healthCheckPath,
-      vpc,
-      albSecurityGroupId: this.serviceAlbSg.id,
-      isPrivate,
-      tags,
-      idleTimeout: 3600,
-    });
-    this.targetGroup = targetGroup;
-    this.lb = lb;
-    this.listener = listener;
+    this.targetGroup = gatewayTargetGroup.target_group;
 
     this.role = new aws.iam.Role(
       `${BASE_NAME}-role`,
@@ -182,11 +151,6 @@ export class UnfurlService extends pulumi.ComponentResource {
         },
         loadBalancers: [
           {
-            targetGroupArn: targetGroup.arn,
-            containerName: 'service',
-            containerPort: serviceContainerPort,
-          },
-          {
             targetGroupArn: gatewayTargetGroup.target_group.arn,
             containerName: 'service',
             containerPort: serviceContainerPort,
@@ -229,7 +193,7 @@ export class UnfurlService extends pulumi.ComponentResource {
                   name: `${BASE_NAME}-tcp-${stack}`,
                   hostPort: serviceContainerPort,
                   containerPort: serviceContainerPort,
-                  targetGroup,
+                  targetGroup: this.targetGroup,
                 },
               ],
             },
@@ -256,68 +220,19 @@ export class UnfurlService extends pulumi.ComponentResource {
     this.setupAutoScaling();
 
     this.setupServiceAlarms();
-
-    // domain record
-    const zone = aws.route53.getZoneOutput({ name: BASE_DOMAIN });
-
-    new aws.route53.Record(
-      `${BASE_NAME}-domain-record`,
-      {
-        name: `${SERVICE_DOMAIN_NAME}`,
-        type: 'A',
-        zoneId: zone.zoneId,
-        aliases: [
-          {
-            evaluateTargetHealth: false,
-            name: this.lb.dnsName,
-            zoneId: this.lb.zoneId,
-          },
-        ],
-      },
-      { parent: this }
-    );
-
-    this.domain = `https://${SERVICE_DOMAIN_NAME}`;
   }
 
   initializeSecurityGroups({
     vpcId,
-    serviceContainerPort,
   }: {
     vpcId: pulumi.Output<string> | string;
-    serviceContainerPort: number;
   }) {
-    const serviceAlbSg = new aws.ec2.SecurityGroup(
-      `${BASE_NAME}-alb-sg-${stack}`,
-      {
-        name: `${BASE_NAME}-alb-sg-${stack}`,
-        description: `${BASE_NAME} application load balancer security group`,
-        vpcId,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
     const serviceSg = new aws.ec2.SecurityGroup(
       `${BASE_NAME}-sg-${stack}`,
       {
         name: `${BASE_NAME}-sg-${stack}`,
         vpcId,
         description: `${BASE_NAME} security group that is attached directly to the service`,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-alb-in`,
-      {
-        securityGroupId: serviceSg.id,
-        description: 'Allow inbound traffic from the services ALB',
-        referencedSecurityGroupId: serviceAlbSg.id,
-        fromPort: serviceContainerPort,
-        toPort: serviceContainerPort,
-        ipProtocol: 'tcp',
         tags: this.tags,
       },
       { parent: this }
@@ -335,50 +250,7 @@ export class UnfurlService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // ALB SG rules
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-http`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTP traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 80,
-        ipProtocol: 'tcp',
-        toPort: 80,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-https`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTPS traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 443,
-        ipProtocol: 'tcp',
-        toPort: 443,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupEgressRule(
-      `${BASE_NAME}-out-service`,
-      {
-        description: 'Allow traffic to the service security group',
-        securityGroupId: serviceAlbSg.id,
-        referencedSecurityGroupId: serviceSg.id,
-        fromPort: serviceContainerPort,
-        ipProtocol: 'tcp',
-        toPort: serviceContainerPort,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    return { serviceAlbSg, serviceSg };
+    return serviceSg;
   }
 
   setupAutoScaling() {
@@ -397,19 +269,7 @@ export class UnfurlService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    const lbPortion: pulumi.Output<string> = this.lb.arn.apply((arn) => {
-      const parts = arn.split(':loadbalancer/');
-      return parts[1];
-    });
-
-    const tgPortion: pulumi.Output<string> = this.targetGroup.arn.apply(
-      (arn) => {
-        const parts = arn.split(':');
-        return parts[parts.length - 1];
-      }
-    );
-
-    const resourceLabel = pulumi.interpolate`${lbPortion}/${tgPortion}`;
+    const resourceLabel = pulumi.interpolate`${gatewayLoadBalancer.albArnSuffix}/${this.targetGroup.arnSuffix}`;
 
     // Create an Auto Scaling policy for request count.
     new aws.appautoscaling.Policy(
@@ -533,7 +393,7 @@ export class UnfurlService extends pulumi.ComponentResource {
       `${BASE_NAME}-http-5xx-alarm`,
       {
         name: `${BASE_NAME}-http-5xx-${stack}`,
-        metricName: 'HTTPCode_ELB_5XX_Count',
+        metricName: 'HTTPCode_Target_5XX_Count',
         namespace: 'AWS/ApplicationELB',
         statistic: 'Sum',
         period: 180,
@@ -541,9 +401,10 @@ export class UnfurlService extends pulumi.ComponentResource {
         threshold: 25,
         comparisonOperator: 'GreaterThanOrEqualToThreshold',
         dimensions: {
-          LoadBalancer: this.lb.arn,
+          LoadBalancer: gatewayLoadBalancer.albArnSuffix,
+          TargetGroup: this.targetGroup.arnSuffix,
         },
-        alarmDescription: `High HTTP 5XX count alarm for ${BASE_NAME} Load Balancer.`,
+        alarmDescription: `High HTTP 5XX count alarm for ${BASE_NAME} gateway target group.`,
         actionsEnabled: true,
         alarmActions: [CLOUD_TRAIL_SNS_TOPIC_ARN],
         tags: this.tags,


### PR DESCRIPTION
removes the following legacy albs
- sps
- email
- unfurl
- contacts
- agent-schedule
- convert
- connection-gateway
- image-proxy

agent harness, notification, dcs, mcp, and auth are left to remove. They require a little more tinkering to ensure safe removal so those will be done in separate prs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Production ingress moves off dedicated ALBs and DNS to the shared gateway; mis-deploy or lingering clients on old hostnames would cause outages or broken routing.
> 
> **Overview**
> Completes the **shared gateway-only** cutover for agent-schedule, connection-gateway, contacts, convert, email, image-proxy, search-processing, and unfurl by **removing per-service ALBs**, Route53 aliases, `serviceLoadBalancer`, dedicated ALB security groups, and dual target-group ECS registration.
> 
> Each stack now registers Fargate tasks **only** on the existing `ServiceTargetGroup` behind `getGatewayAlb()`, drops `isPrivate` / `publicSubnetIds` from callers, and points `BASE_URL` and stack exports at **gateway path URLs** (or `getServiceUrl` where centralized). **HTTP 5xx alarms** and **ALB request-count autoscaling** are retargeted to the gateway load balancer and per-service target group dimensions.
> 
> Adds **`legacy-alb.test.ts`** per stack (TypeScript AST checks, no Pulumi imports) to guard routing, security groups, scaling, and URL shape. Agent-harness, notification, DCS, MCP, and auth are **out of scope** here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2437b52e6a1a05641d326f22ea8bd9358bc8cbe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->