### PR TITLE
feat(channels-view): context menu, muted indicator, and fixed focus ring

### DIFF
--- a/apps/web/src/features/channels-view/components/ChannelsMobileView.tsx
+++ b/apps/web/src/features/channels-view/components/ChannelsMobileView.tsx
@@ -6,6 +6,7 @@ import { SplitHeaderLeft } from '@components/app/split-layout/components/SplitHe
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { useUserId } from '@core/context/user';
 import type { ChannelEntity } from '@entity';
+import { isMutedItem } from '@entity/utils/notification';
 import SpinnerIcon from '@phosphor/spinner.svg';
 import type { SoupAstItemsQuery } from '@queries/soup/items';
 import { createElementSize } from '@solid-primitives/resize-observer';
@@ -183,6 +184,10 @@ export function ChannelsMobileView(props: {
                       currentUserId()
                     )}
                     unread={channelActivity.unreadChannelIds().has(channel.id)}
+                    muted={isMutedItem(notificationSource.mutedEntities(), {
+                      item_id: channel.id,
+                      item_type: 'channel',
+                    })}
                     callStatus={channelActivity.callStatuses().get(channel.id)}
                     incomingCallId={channelActivity
                       .incomingCallIds()

--- a/apps/web/src/features/channels-view/components/rail/ChannelRailItems.tsx
+++ b/apps/web/src/features/channels-view/components/rail/ChannelRailItems.tsx
@@ -26,6 +26,7 @@ import { type ChannelEntity, Entity } from '@entity';
 import { ContextMenu } from '@kobalte/core/context-menu';
 import ReplyIcon from '@phosphor/arrow-bend-up-left.svg';
 import AtIcon from '@phosphor/at.svg';
+import BellSlashIcon from '@phosphor/bell-slash.svg';
 import XIcon from '@phosphor/x.svg';
 import PhoneCallIcon from '@phosphor-fill/phone-call-fill.svg';
 import PhoneIncomingIcon from '@phosphor-fill/phone-incoming-fill.svg';
@@ -41,6 +42,7 @@ export type ChannelRailItemProps = {
   id: string;
   channel: ChannelEntity;
   unread: boolean;
+  muted: boolean;
   callStatus?: ChannelCallStatus;
   incomingCallId?: string;
   selected: boolean;
@@ -126,6 +128,32 @@ export function ChannelCallIndicator(props: {
           </Switch>
         </span>
       )}
+    </Show>
+  );
+}
+
+export function ChannelMutedIndicator(props: {
+  muted: boolean;
+  class?: string;
+}) {
+  return (
+    <Show when={props.muted}>
+      <Tooltip
+        as="span"
+        label="Notifications are muted"
+        placement="right"
+        class={cn(
+          'size-4 shrink-0 justify-center text-ink-extra-muted',
+          props.class
+        )}
+      >
+        <span
+          aria-label="Notifications muted"
+          class="flex size-full items-center justify-center"
+        >
+          <BellSlashIcon class="size-full" />
+        </span>
+      </Tooltip>
     </Show>
   );
 }
@@ -290,6 +318,7 @@ export function ConversationCard(props: ConversationCardProps) {
             <span class="min-w-0 flex-1 truncate text-sm font-medium text-ink">
               {props.channel.name}
             </span>
+            <ChannelMutedIndicator muted={props.muted} />
             <ChannelCallIndicator
               status={props.incomingCallId ? undefined : props.callStatus}
             />

--- a/apps/web/src/features/channels-view/components/rail/ChannelRailItems.tsx
+++ b/apps/web/src/features/channels-view/components/rail/ChannelRailItems.tsx
@@ -287,7 +287,7 @@ export function ConversationCard(props: ConversationCardProps) {
       role="treeitem"
       tabIndex={-1}
       class={cn(
-        'relative w-full min-w-0 overflow-hidden px-2 py-3 text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent touch:focus-visible:ring-0',
+        'relative w-full min-w-0 overflow-hidden px-2 py-3 text-left outline-none transition-colors',
         props.selected && !isTouchDevice() && 'bg-active',
         !props.selected && !isTouchDevice() && props.focused && 'bg-hover',
         (!props.selected || isTouchDevice()) && 'bg-transparent',

--- a/apps/web/src/features/channels-view/components/rail/ChannelRailItems.tsx
+++ b/apps/web/src/features/channels-view/components/rail/ChannelRailItems.tsx
@@ -1,5 +1,21 @@
 import { dismissIncomingCallEverywhere } from '@app/features/block-call/sidebar/incoming-calls';
+import {
+  type EntityActionViewContext,
+  toEntityActionListState,
+} from '@app/features/next-soup/actions';
+import {
+  markChannelNotificationsSeenOnOpen,
+  openEntityInNewTab,
+} from '@app/features/next-soup/utils';
+import { SoupEntityActionsMenu } from '@app/features/soup/SoupEntityActionsMenu';
 import { joinChannelCall } from '@channel/Call/join-channel-call';
+import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
+import {
+  ContextMenuContent,
+  MenuGroup,
+  MenuItem,
+  MenuSeparator,
+} from '@core/component/ContextMenu';
 import { StaticMarkdown } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
 import { toast } from '@core/component/Toast/Toast';
 import { useUserId } from '@core/context/user';
@@ -7,6 +23,7 @@ import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { getDisplayName, tryMacroId } from '@core/user';
 import type { MacroId } from '@core/user/macroId';
 import { type ChannelEntity, Entity } from '@entity';
+import { ContextMenu } from '@kobalte/core/context-menu';
 import ReplyIcon from '@phosphor/arrow-bend-up-left.svg';
 import AtIcon from '@phosphor/at.svg';
 import XIcon from '@phosphor/x.svg';
@@ -14,8 +31,9 @@ import PhoneCallIcon from '@phosphor-fill/phone-call-fill.svg';
 import PhoneIncomingIcon from '@phosphor-fill/phone-incoming-fill.svg';
 import { getBotDisplayName } from '@queries/channel/message-sender';
 import { Button, cn, Tooltip } from '@ui';
-import { Match, Show, Switch } from 'solid-js';
+import { Match, type ParentProps, Show, Switch } from 'solid-js';
 import { formatDetailedTimestamp, isDirectMessage } from '../../utils';
+import { rowKeyForChannel, useChannelsRail } from './ChannelsRailContext';
 
 export type ChannelCallStatus = 'active' | 'incoming';
 
@@ -29,6 +47,60 @@ export type ChannelRailItemProps = {
   focused: boolean;
   onActivate: () => void;
 };
+
+const CHANNEL_RAIL_ACTION_VIEW_CONTEXT: EntityActionViewContext = {
+  supportsMarkDone: false,
+  senderBucket: undefined,
+};
+
+export function ChannelRailItemContextMenu(
+  props: ParentProps<{
+    channel: ChannelEntity;
+    class?: string;
+  }>
+) {
+  const rail = useChannelsRail();
+  const notificationSource = useGlobalNotificationSource();
+  const actionList = toEntityActionListState({
+    controller: rail.list,
+    getEntity: (row) => (row.kind === 'conversation' ? row.channel : undefined),
+  });
+
+  const openInNewTab = () => {
+    markChannelNotificationsSeenOnOpen(props.channel, notificationSource);
+    openEntityInNewTab({ entity: props.channel });
+  };
+
+  return (
+    <ContextMenu
+      onOpenChange={(open) => {
+        if (!open) return;
+
+        rail.list.focus.set(rowKeyForChannel(props.channel.id), {
+          reason: 'pointer',
+          force: true,
+        });
+      }}
+    >
+      <ContextMenu.Trigger class={props.class}>
+        {props.children}
+      </ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenuContent class="w-64 text-xs text-ink-muted">
+          <MenuGroup>
+            <MenuItem text="Open in new tab" onClick={openInNewTab} />
+          </MenuGroup>
+          <MenuSeparator />
+          <SoupEntityActionsMenu
+            entities={[props.channel]}
+            list={actionList}
+            viewContext={CHANNEL_RAIL_ACTION_VIEW_CONTEXT}
+          />
+        </ContextMenuContent>
+      </ContextMenu.Portal>
+    </ContextMenu>
+  );
+}
 
 export function ChannelCallIndicator(props: {
   status: ChannelCallStatus | undefined;

--- a/apps/web/src/features/channels-view/components/rail/ExpandedChannelsRail.tsx
+++ b/apps/web/src/features/channels-view/components/rail/ExpandedChannelsRail.tsx
@@ -15,6 +15,7 @@ import { ChannelsEmptyState } from '../ChannelsEmptyState';
 import {
   ChannelAvatar,
   ChannelCallIndicator,
+  ChannelRailItemContextMenu,
   ConversationCard,
   IncomingCallActions,
 } from './ChannelRailItems';
@@ -69,45 +70,47 @@ function ChannelOption(props: { channel: ChannelEntity }) {
   const item = useChannelRailItemState(() => props.channel.id);
 
   return (
-    <div
-      id={item().domId}
-      role="treeitem"
-      tabIndex={-1}
-      class={cn(
-        'relative flex w-full min-w-0 items-center gap-2 rounded-xl px-2 text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-accent touch:focus-visible:ring-0',
-        isDirectMessage(props.channel) ? 'min-h-10 py-2' : 'h-8',
-        item().selected && !isTouchDevice() && 'bg-active text-ink',
-        (!item().selected || isTouchDevice()) && 'text-ink-muted',
-        !item().selected &&
-          !isTouchDevice() &&
-          item().focused &&
-          'bg-hover text-ink',
-        !item().selected &&
-          !isTouchDevice() &&
-          !item().focused &&
-          'hover:bg-hover hover:text-ink'
-      )}
-      aria-current={item().selected ? 'page' : undefined}
-      onClick={() => rail.activateRow(rowKeyForChannel(props.channel.id))}
-    >
-      <ChannelAvatar channel={props.channel} />
-      <span class="min-w-0 flex-1 truncate text-sm font-medium">
-        {props.channel.name}
-      </span>
-      <ChannelCallIndicator
-        status={item().incomingCallId ? undefined : item().callStatus}
-      />
-      <IncomingCallActions
-        callId={item().incomingCallId}
-        channelId={props.channel.id}
-      />
-      <Show when={item().unread}>
-        <span
-          aria-label="Unread"
-          class="size-2 shrink-0 rounded-full bg-accent"
+    <ChannelRailItemContextMenu channel={props.channel} class="block w-full">
+      <div
+        id={item().domId}
+        role="treeitem"
+        tabIndex={-1}
+        class={cn(
+          'relative flex w-full min-w-0 items-center gap-2 rounded-xl px-2 text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-accent touch:focus-visible:ring-0',
+          isDirectMessage(props.channel) ? 'min-h-10 py-2' : 'h-8',
+          item().selected && !isTouchDevice() && 'bg-active text-ink',
+          (!item().selected || isTouchDevice()) && 'text-ink-muted',
+          !item().selected &&
+            !isTouchDevice() &&
+            item().focused &&
+            'bg-hover text-ink',
+          !item().selected &&
+            !isTouchDevice() &&
+            !item().focused &&
+            'hover:bg-hover hover:text-ink'
+        )}
+        aria-current={item().selected ? 'page' : undefined}
+        onClick={() => rail.activateRow(rowKeyForChannel(props.channel.id))}
+      >
+        <ChannelAvatar channel={props.channel} />
+        <span class="min-w-0 flex-1 truncate text-sm font-medium">
+          {props.channel.name}
+        </span>
+        <ChannelCallIndicator
+          status={item().incomingCallId ? undefined : item().callStatus}
         />
-      </Show>
-    </div>
+        <IncomingCallActions
+          callId={item().incomingCallId}
+          channelId={props.channel.id}
+        />
+        <Show when={item().unread}>
+          <span
+            aria-label="Unread"
+            class="size-2 shrink-0 rounded-full bg-accent"
+          />
+        </Show>
+      </div>
+    </ChannelRailItemContextMenu>
   );
 }
 
@@ -247,18 +250,23 @@ function RecentConversationCard(props: { channel: ChannelEntity }) {
   const item = useChannelRailItemState(() => props.channel.id);
 
   return (
-    <ConversationCard
-      id={item().domId}
-      channel={props.channel}
-      senderId={props.channel.latestRootMessage?.senderId}
-      mentionedCurrentUser={channelMentionsUser(props.channel, currentUserId())}
-      unread={item().unread}
-      callStatus={item().callStatus}
-      incomingCallId={item().incomingCallId}
-      selected={item().selected}
-      focused={item().focused}
-      onActivate={() => rail.activateRow(rowKeyForChannel(props.channel.id))}
-    />
+    <ChannelRailItemContextMenu channel={props.channel} class="block w-full">
+      <ConversationCard
+        id={item().domId}
+        channel={props.channel}
+        senderId={props.channel.latestRootMessage?.senderId}
+        mentionedCurrentUser={channelMentionsUser(
+          props.channel,
+          currentUserId()
+        )}
+        unread={item().unread}
+        callStatus={item().callStatus}
+        incomingCallId={item().incomingCallId}
+        selected={item().selected}
+        focused={item().focused}
+        onActivate={() => rail.activateRow(rowKeyForChannel(props.channel.id))}
+      />
+    </ChannelRailItemContextMenu>
   );
 }
 

--- a/apps/web/src/features/channels-view/components/rail/ExpandedChannelsRail.tsx
+++ b/apps/web/src/features/channels-view/components/rail/ExpandedChannelsRail.tsx
@@ -77,7 +77,7 @@ function ChannelOption(props: { channel: ChannelEntity }) {
         role="treeitem"
         tabIndex={-1}
         class={cn(
-          'relative flex w-full min-w-0 items-center gap-2 rounded-xl px-2 text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-accent touch:focus-visible:ring-0',
+          'relative flex w-full min-w-0 items-center gap-2 rounded-xl px-2 text-left outline-none transition-colors',
           isDirectMessage(props.channel) ? 'min-h-10 py-2' : 'h-8',
           item().selected && !isTouchDevice() && 'bg-active text-ink',
           (!item().selected || isTouchDevice()) && 'text-ink-muted',
@@ -173,7 +173,7 @@ function ExpandedGroupSection(props: { config: GroupConfig }) {
           type="button"
           role="treeitem"
           tabIndex={-1}
-          class="relative flex h-full min-w-0 flex-1 items-center gap-2 rounded-xl px-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          class="relative flex h-full min-w-0 flex-1 items-center gap-2 rounded-xl px-2 text-left outline-none"
           aria-expanded={section().open}
           onClick={() => rail.activateRow(rowKeyForSection(props.config.group))}
         >

--- a/apps/web/src/features/channels-view/components/rail/ExpandedChannelsRail.tsx
+++ b/apps/web/src/features/channels-view/components/rail/ExpandedChannelsRail.tsx
@@ -15,6 +15,7 @@ import { ChannelsEmptyState } from '../ChannelsEmptyState';
 import {
   ChannelAvatar,
   ChannelCallIndicator,
+  ChannelMutedIndicator,
   ChannelRailItemContextMenu,
   ConversationCard,
   IncomingCallActions,
@@ -96,6 +97,7 @@ function ChannelOption(props: { channel: ChannelEntity }) {
         <span class="min-w-0 flex-1 truncate text-sm font-medium">
           {props.channel.name}
         </span>
+        <ChannelMutedIndicator muted={item().muted} />
         <ChannelCallIndicator
           status={item().incomingCallId ? undefined : item().callStatus}
         />
@@ -260,6 +262,7 @@ function RecentConversationCard(props: { channel: ChannelEntity }) {
           currentUserId()
         )}
         unread={item().unread}
+        muted={item().muted}
         callStatus={item().callStatus}
         incomingCallId={item().incomingCallId}
         selected={item().selected}

--- a/apps/web/src/features/channels-view/components/rail/SlimChannelsRail.tsx
+++ b/apps/web/src/features/channels-view/components/rail/SlimChannelsRail.tsx
@@ -15,7 +15,10 @@ import { type Component, For, Match, Show, Switch } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
 import type { ChannelsGroup } from '../../types';
 import { channelInitials, isDirectMessage } from '../../utils';
-import { ChannelCallIndicator } from './ChannelRailItems';
+import {
+  ChannelCallIndicator,
+  ChannelRailItemContextMenu,
+} from './ChannelRailItems';
 import {
   domIdForRow,
   rowKeyForChannel,
@@ -96,47 +99,48 @@ function SlimChannelItem(props: { channel: ChannelEntity }) {
   const item = useChannelRailItemState(() => props.channel.id);
 
   return (
-    <Tooltip
-      label={props.channel.name}
-      placement="right"
-      class="size-10 self-center"
+    <ChannelRailItemContextMenu
+      channel={props.channel}
+      class="block size-10 self-center"
     >
-      <button
-        id={item().domId}
-        type="button"
-        role="treeitem"
-        tabIndex={-1}
-        class={cn(
-          'flex size-10 items-center justify-center rounded-full text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent touch:focus-visible:ring-0',
-          item().selected && !isTouchDevice() && 'bg-active text-ink',
-          (!item().selected || isTouchDevice()) && 'text-ink-muted',
-          !item().selected &&
-            !isTouchDevice() &&
-            item().focused &&
-            'bg-hover text-ink',
-          !item().selected &&
-            !isTouchDevice() &&
-            !item().focused &&
-            'hover:bg-hover hover:text-ink'
-        )}
-        aria-current={item().selected ? 'page' : undefined}
-        onClick={() => rail.activateRow(rowKeyForChannel(props.channel.id))}
-      >
-        <span class="relative">
-          <SlimChannelAvatar channel={props.channel} />
-          <ChannelCallIndicator
-            status={item().callStatus}
-            class="absolute -bottom-0.5 -right-0.5 rounded-full bg-inset p-0.5"
-          />
-          <Show when={item().unread}>
-            <span
-              aria-label="Unread"
-              class="absolute -right-0.5 -top-0.5 size-2.5 rounded-full bg-accent ring-2 ring-surface"
+      <Tooltip label={props.channel.name} placement="right" class="size-10">
+        <button
+          id={item().domId}
+          type="button"
+          role="treeitem"
+          tabIndex={-1}
+          class={cn(
+            'flex size-10 items-center justify-center rounded-full text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent touch:focus-visible:ring-0',
+            item().selected && !isTouchDevice() && 'bg-active text-ink',
+            (!item().selected || isTouchDevice()) && 'text-ink-muted',
+            !item().selected &&
+              !isTouchDevice() &&
+              item().focused &&
+              'bg-hover text-ink',
+            !item().selected &&
+              !isTouchDevice() &&
+              !item().focused &&
+              'hover:bg-hover hover:text-ink'
+          )}
+          aria-current={item().selected ? 'page' : undefined}
+          onClick={() => rail.activateRow(rowKeyForChannel(props.channel.id))}
+        >
+          <span class="relative">
+            <SlimChannelAvatar channel={props.channel} />
+            <ChannelCallIndicator
+              status={item().callStatus}
+              class="absolute -bottom-0.5 -right-0.5 rounded-full bg-inset p-0.5"
             />
-          </Show>
-        </span>
-      </button>
-    </Tooltip>
+            <Show when={item().unread}>
+              <span
+                aria-label="Unread"
+                class="absolute -right-0.5 -top-0.5 size-2.5 rounded-full bg-accent ring-2 ring-surface"
+              />
+            </Show>
+          </span>
+        </button>
+      </Tooltip>
+    </ChannelRailItemContextMenu>
   );
 }
 

--- a/apps/web/src/features/channels-view/components/rail/SlimChannelsRail.tsx
+++ b/apps/web/src/features/channels-view/components/rail/SlimChannelsRail.tsx
@@ -111,7 +111,7 @@ function SlimChannelItem(props: { channel: ChannelEntity }) {
           role="treeitem"
           tabIndex={-1}
           class={cn(
-            'flex size-10 items-center justify-center rounded-full text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent touch:focus-visible:ring-0',
+            'flex size-10 items-center justify-center rounded-full text-left outline-none transition-colors',
             item().selected && !isTouchDevice() && 'bg-active text-ink',
             (!item().selected || isTouchDevice()) && 'text-ink-muted',
             !item().selected &&
@@ -253,7 +253,7 @@ function SlimGroupSection(props: { config: GroupConfig }) {
           type="button"
           role="treeitem"
           tabIndex={-1}
-          class="relative flex size-10 min-w-10 flex-none items-center justify-center rounded-full outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          class="relative flex size-10 min-w-10 flex-none items-center justify-center rounded-full outline-none"
           aria-expanded={section().open}
           aria-label={props.config.label}
           onClick={() => rail.activateRow(rowKeyForSection(props.config.group))}

--- a/apps/web/src/features/channels-view/components/rail/SlimChannelsRail.tsx
+++ b/apps/web/src/features/channels-view/components/rail/SlimChannelsRail.tsx
@@ -17,6 +17,7 @@ import type { ChannelsGroup } from '../../types';
 import { channelInitials, isDirectMessage } from '../../utils';
 import {
   ChannelCallIndicator,
+  ChannelMutedIndicator,
   ChannelRailItemContextMenu,
 } from './ChannelRailItems';
 import {
@@ -127,10 +128,22 @@ function SlimChannelItem(props: { channel: ChannelEntity }) {
         >
           <span class="relative">
             <SlimChannelAvatar channel={props.channel} />
-            <ChannelCallIndicator
-              status={item().callStatus}
-              class="absolute -bottom-0.5 -right-0.5 rounded-full bg-inset p-0.5"
-            />
+            <Show
+              when={item().callStatus}
+              fallback={
+                <ChannelMutedIndicator
+                  muted={item().muted}
+                  class="absolute -bottom-0.5 -right-0.5 rounded-full bg-inset p-0.5"
+                />
+              }
+            >
+              {(callStatus) => (
+                <ChannelCallIndicator
+                  status={callStatus()}
+                  class="absolute -bottom-0.5 -right-0.5 rounded-full bg-inset p-0.5"
+                />
+              )}
+            </Show>
             <Show when={item().unread}>
               <span
                 aria-label="Unread"

--- a/apps/web/src/features/channels-view/components/rail/hooks/useChannelRailState.ts
+++ b/apps/web/src/features/channels-view/components/rail/hooks/useChannelRailState.ts
@@ -1,3 +1,5 @@
+import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
+import { isMutedItem } from '@entity/utils/notification';
 import { type Accessor, createMemo } from 'solid-js';
 import type { ChannelsGroup } from '../../../types';
 import {
@@ -9,6 +11,7 @@ import {
 
 export function useChannelRailItemState(channelId: Accessor<string>) {
   const rail = useChannelsRail();
+  const notificationSource = useGlobalNotificationSource();
 
   return createMemo(() => {
     const id = channelId();
@@ -18,6 +21,10 @@ export function useChannelRailItemState(channelId: Accessor<string>) {
       domId: domIdForRow(rail.railId, rowId),
       selected: rail.selectedChannelId() === id,
       focused: rail.list.focus.key() === rowId,
+      muted: isMutedItem(notificationSource.mutedEntities(), {
+        item_id: id,
+        item_type: 'channel',
+      }),
       unread: rail.channelActivity.unreadChannelIds().has(id),
       callStatus: rail.channelActivity.callStatuses().get(id),
       incomingCallId: rail.channelActivity.incomingCallIds().get(id),

--- a/apps/web/src/features/notifications/notification-source.ts
+++ b/apps/web/src/features/notifications/notification-source.ts
@@ -147,7 +147,10 @@ export function createNotificationSource(
 ): NotificationSource {
   const subscriptions: Set<SubscribeFn> = new Set();
 
-  const [mutedEntities, setMutedEntities] = createSignal<UserUnsubscribe[]>([]);
+  const [mutedEntitiesStore, setMutedEntities] = createStore<UserUnsubscribe[]>(
+    []
+  );
+  const mutedEntities = createMemo(() => [...mutedEntitiesStore]);
 
   const notificationsQuery = useUserNotificationsQuery(() => ({
     limit: QUERY_LIMIT,
@@ -258,8 +261,8 @@ export function createNotificationSource(
   };
 
   createEffect(() => {
-    if (!mutedEntitiesQuery.isSuccess) return;
-    const mutedEntities = mutedEntitiesQuery?.data ?? [];
+    const mutedEntities = mutedEntitiesQuery.data;
+    if (!mutedEntities) return;
     setMutedEntities(reconcile(mutedEntities));
   });
 

--- a/apps/web/src/features/notifications/tests/notification-source.test.ts
+++ b/apps/web/src/features/notifications/tests/notification-source.test.ts
@@ -1,5 +1,6 @@
 import type { ConnectionGatewayWebsocket } from '@service-connection/websocket';
-import { createMemo, createRoot } from 'solid-js';
+import type { UserUnsubscribe } from '@service-notification/generated/schemas/userUnsubscribe';
+import { createMemo, createRoot, createSignal } from 'solid-js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createNotificationSource } from '../notification-source';
 import type { UnifiedNotification } from '../types';
@@ -10,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   graphqlPatchCallback: undefined as
     | ((patch: Record<string, unknown>) => void)
     | undefined,
+  mutedEntitiesQuery: {} as Record<string, unknown>,
   notificationsQuery: {} as Record<string, unknown>,
   optimisticInsertNotification: vi.fn(),
   socketCallback: undefined as
@@ -71,12 +73,7 @@ vi.mock('@service-storage/graphql-soup-websocket', () => ({
 }));
 
 vi.mock('../queries/muted-entities-query', () => ({
-  createMutedEntitiesQuery: () => ({
-    data: undefined,
-    isLoading: false,
-    isSuccess: false,
-    refetch: vi.fn(),
-  }),
+  createMutedEntitiesQuery: () => mocks.mutedEntitiesQuery,
 }));
 
 function notification(
@@ -107,6 +104,51 @@ describe('createNotificationSource', () => {
     mocks.optimisticInsertNotification.mockReset();
     mocks.seenMutation.mutateAsync.mockReset().mockResolvedValue(undefined);
     mocks.doneMutation.mutateAsync.mockReset().mockResolvedValue(undefined);
+    mocks.mutedEntitiesQuery = {
+      data: undefined,
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+  });
+
+  it('reactively exposes muted entity cache updates', async () => {
+    const [mutedEntities, setMutedEntities] = createSignal<
+      UserUnsubscribe[] | undefined
+    >([]);
+    mocks.mutedEntitiesQuery = {
+      get data() {
+        return mutedEntities();
+      },
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+
+    let dispose = () => {};
+    let memoRuns = 0;
+    const mutedEntitiesValue = createRoot((rootDispose) => {
+      dispose = rootDispose;
+      const source = createNotificationSource({} as ConnectionGatewayWebsocket);
+      return createMemo(() => {
+        memoRuns += 1;
+        return source.mutedEntities();
+      });
+    });
+
+    try {
+      await Promise.resolve();
+      const initialMutedEntities = mutedEntitiesValue();
+      expect(initialMutedEntities).toHaveLength(0);
+      const runsBeforeUpdate = memoRuns;
+
+      setMutedEntities([{ item_id: 'channel-1', item_type: 'channel' }]);
+      await Promise.resolve();
+
+      expect(mutedEntitiesValue()).toHaveLength(1);
+      expect(mutedEntitiesValue()).not.toBe(initialMutedEntities);
+      expect(memoRuns).toBeGreaterThan(runsBeforeUpdate);
+    } finally {
+      dispose();
+    }
   });
 
   it('coalesces uncached GraphQL patches and ignores connection gateway notifications when enabled', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI and client-side notification state only; mute/unmute still goes through existing mutations and queries.
> 
> **Overview**
> Channel lists now show when a conversation’s notifications are **muted** (bell-slash indicator on expanded recents/browse rows, slim avatars when there’s no call badge, and mobile conversation cards).
> 
> **Right-click / long-press** on rail channel rows opens a context menu with **Open in new tab** and the shared **Soup entity actions** (including mute/unmute), and opening the menu syncs keyboard focus to that row.
> 
> **Notification source** keeps muted entities in a **Solid store** reconciled from the muted-entities query and exposes them through a memoized array so UI updates reactively when mute state changes; a unit test covers that behavior.
> 
> **Focus styling** on several rail tree items drops per-item `focus-visible` rings so focus is handled at the tree level without double rings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b67231b7b86a477a88245a6d9a74e53af867fb71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->