### PR TITLE
chore(calendar): drop the airplane icon from out-of-office surfaces

### DIFF
--- a/apps/web/src/features/calendar/components/EventDetails.tsx
+++ b/apps/web/src/features/calendar/components/EventDetails.tsx
@@ -9,7 +9,6 @@ import {
 import { plural } from '@core/util/string';
 import { openExternalUrl } from '@core/util/url';
 import { Collapsible } from '@kobalte/core/collapsible';
-import AirplaneTiltIcon from '@phosphor/airplane-tilt.svg';
 import ArrowSquareOutIcon from '@phosphor/arrow-square-out.svg';
 import BellSimpleIcon from '@phosphor/bell-simple.svg';
 import CalendarBlankIcon from '@phosphor/calendar-blank.svg';
@@ -552,8 +551,7 @@ export function EventDetails(props: {
           {formatEventSchedule(props.event, props.timeFormat)}
         </div>
         <Show when={props.event.eventType === 'out_of_office'}>
-          <div class="flex select-text items-center gap-1.5 text-sm text-ink-extra-muted sm:text-xs">
-            <AirplaneTiltIcon aria-hidden="true" class="size-4 sm:size-3.5" />
+          <div class="select-text text-sm text-ink-extra-muted sm:text-xs">
             Out of office
           </div>
         </Show>

--- a/apps/web/src/features/calendar/components/composer/EventForm.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventForm.tsx
@@ -1,5 +1,4 @@
 import { MarkdownTextarea } from '@core/component/LexicalMarkdown/component/core/MarkdownTextarea';
-import AirplaneTiltIcon from '@phosphor/airplane-tilt.svg';
 import SpinnerIcon from '@phosphor/spinner.svg';
 import { Button, cn, Layer } from '@ui';
 import { createEffect, createUniqueId, Show } from 'solid-js';
@@ -292,20 +291,17 @@ export function EventForm(props: EventFormProps) {
               <div
                 role="note"
                 aria-label="Out-of-office event"
-                class="flex items-start gap-2 rounded-lg border border-warning/40 bg-warning-bg p-3 text-xs text-warning-ink"
+                class="flex min-w-0 flex-col gap-1 rounded-lg border border-warning/40 bg-warning-bg p-3 text-xs text-warning-ink"
               >
-                <AirplaneTiltIcon class="mt-px size-4 shrink-0" />
-                <div class="flex min-w-0 flex-col gap-1">
-                  <span class="font-medium">Out-of-office event</span>
-                  <span>{notice().effect}</span>
-                  <Show when={notice().declineMessage}>
-                    {(message) => (
-                      <span class="italic">
-                        Auto-decline reply: “{message()}”
-                      </span>
-                    )}
-                  </Show>
-                </div>
+                <span class="font-medium">Out-of-office event</span>
+                <span>{notice().effect}</span>
+                <Show when={notice().declineMessage}>
+                  {(message) => (
+                    <span class="italic">
+                      Auto-decline reply: “{message()}”
+                    </span>
+                  )}
+                </Show>
               </div>
             )}
           </Show>


### PR DESCRIPTION
Removes the airplane icon from the two out-of-office surfaces, the event details line and the composer notice. The text labels are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change to calendar OOO labels and composer notice styling; no behavior or data handling changes.
> 
> **Overview**
> Removes the **airplane icon** from out-of-office UI in **event details** and the **event composer**, leaving the same copy (“Out of office”, “Out-of-office event”, effect text, and auto-decline reply).
> 
> In **EventDetails**, the OOO line is plain text under the schedule instead of a row with an icon. In **EventForm**, the warning notice drops the icon and uses a simple vertical stack for the same note content and accessibility labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bae62dabe16f194d128a6676221575d8fe13c3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->