### PR TITLE
feat(notification_service): remove legacy alb

### DIFF
--- a/infra/stacks/notification-service/index.ts
+++ b/infra/stacks/notification-service/index.ts
@@ -5,6 +5,8 @@ import {
   config,
   getKafkaClusterPolicy,
   getMacroApiToken,
+  getServiceUrl,
+  ServiceUrl,
   stack,
 } from '../../packages/shared';
 import { get_coparse_api_vpc } from '../../packages/vpc';
@@ -147,7 +149,7 @@ export const notificationApnsVoipPlatformArn = notificationApnsVoipPlatform.arn;
 
 const MACRO_API_TOKENS = getMacroApiToken();
 
-const notificationService = new NotificationService('notification-service', {
+new NotificationService('notification-service', {
   vpc: coparse_api_vpc,
   tags,
   ecsClusterArn: cloudStorageClusterArn,
@@ -166,7 +168,6 @@ const notificationService = new NotificationService('notification-service', {
   snsPlatformArns: notificationSnsPlatformArns,
   extraManagedPolicyArns: [getKafkaClusterPolicy()],
   serviceContainerPort: 8080,
-  isPrivate: false,
   healthCheckPath: '/health',
   platform: { family: 'linux', architecture: 'amd64' },
   containerEnvVars: [
@@ -182,4 +183,6 @@ const notificationService = new NotificationService('notification-service', {
   ],
 });
 
-export const notificationServiceUrl = pulumi.interpolate`${notificationService.domain}`;
+export const notificationServiceUrl = getServiceUrl(
+  ServiceUrl.NOTIFICATION_SERVICE_URL
+);

--- a/infra/stacks/notification-service/service.ts
+++ b/infra/stacks/notification-service/service.ts
@@ -7,12 +7,10 @@ import {
   EcsDeploymentFailureAlarm,
   datadogAgentContainer,
   fargateLogRouterSidecarContainer,
-  serviceLoadBalancer,
   ServiceTargetGroup,
 } from '../../packages/resources';
 import { EcrImage } from '../../packages/service';
 import {
-  BASE_DOMAIN,
   CLOUD_TRAIL_SNS_TOPIC_ARN,
   DopplerEcsEnvironment,
   GatewayService,
@@ -25,21 +23,15 @@ const gatewayLoadBalancer = getGatewayAlb();
 const BASE_NAME = pulumi.getProject();
 const REPO_ROOT = '../../..';
 
-export const SERVICE_DOMAIN_NAME = `notifications${
-  stack === 'prod' ? '' : `-${stack}`
-}.${BASE_DOMAIN}`;
-
 type CreateNotificationServiceArgs = {
   cloudStorageClusterName: pulumi.Output<string> | string;
   ecsClusterArn: pulumi.Output<string> | string;
   vpc: {
     vpcId: pulumi.Output<string> | string;
-    publicSubnetIds: pulumi.Output<string[]> | string[];
     privateSubnetIds: pulumi.Output<string[]> | string[];
   };
   platform: { family: string; architecture: 'amd64' | 'arm64' };
   serviceContainerPort: number;
-  isPrivate?: boolean;
   containerEnvVars: { name: string; value: pulumi.Output<string> | string }[];
   healthCheckPath: string;
   secretKeyArns: (pulumi.Output<string> | string)[];
@@ -52,13 +44,9 @@ type CreateNotificationServiceArgs = {
 export class NotificationService extends pulumi.ComponentResource {
   public role: aws.iam.Role;
   public ecr: awsx.ecr.Repository;
-  public serviceAlbSg: aws.ec2.SecurityGroup;
   public serviceSg: aws.ec2.SecurityGroup;
   public targetGroup: aws.lb.TargetGroup;
-  public lb: aws.lb.LoadBalancer;
-  public listener: aws.lb.Listener;
   public service: awsx.ecs.FargateService;
-  public domain: string;
   public cloudStorageClusterName: pulumi.Output<string> | string;
   public tags: { [key: string]: string };
 
@@ -70,7 +58,6 @@ export class NotificationService extends pulumi.ComponentResource {
       platform,
       serviceContainerPort,
       healthCheckPath,
-      isPrivate,
       containerEnvVars,
       cloudStorageClusterName,
       queueArns,
@@ -85,7 +72,6 @@ export class NotificationService extends pulumi.ComponentResource {
     this.tags = tags;
 
     this.cloudStorageClusterName = cloudStorageClusterName;
-    this.domain = `https://${SERVICE_DOMAIN_NAME}`;
 
     // role
     const secretsManagerPolicy = new aws.iam.Policy(
@@ -228,12 +214,7 @@ export class NotificationService extends pulumi.ComponentResource {
     this.ecr = image.ecr;
 
     // sg
-    const sg = this.initializeSecurityGroups({
-      vpcId: vpc.vpcId,
-      serviceContainerPort,
-    });
-    this.serviceAlbSg = sg.serviceAlbSg;
-    this.serviceSg = sg.serviceSg;
+    this.serviceSg = this.initializeSecurityGroups({ vpcId: vpc.vpcId });
 
     const gatewayTargetGroup = new ServiceTargetGroup(
       `${stack}-${BASE_NAME}`,
@@ -251,19 +232,7 @@ export class NotificationService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // lb
-    const { targetGroup, lb, listener } = serviceLoadBalancer(this, {
-      serviceName: BASE_NAME, // service name
-      serviceContainerPort,
-      healthCheckPath,
-      vpc,
-      albSecurityGroupId: this.serviceAlbSg.id,
-      isPrivate,
-      tags,
-    });
-    this.targetGroup = targetGroup;
-    this.lb = lb;
-    this.listener = listener;
+    this.targetGroup = gatewayTargetGroup.target_group;
 
     const dopplerEcsEnvironment = new DopplerEcsEnvironment(
       BASE_NAME,
@@ -286,15 +255,8 @@ export class NotificationService extends pulumi.ComponentResource {
           enable: true,
           rollback: true,
         },
-        // An explicit `loadBalancers` replaces the list awsx derives from
-        // `portMappings.targetGroup`, so the legacy entry must be listed here
-        // too.
+        // Register tasks only with the shared gateway.
         loadBalancers: [
-          {
-            targetGroupArn: targetGroup.arn,
-            containerName: 'service',
-            containerPort: serviceContainerPort,
-          },
           {
             targetGroupArn: gatewayTargetGroup.target_group.arn,
             containerName: 'service',
@@ -317,13 +279,7 @@ export class NotificationService extends pulumi.ComponentResource {
               stopTimeout: 10, // 10 seconds to force kill the task
               cpu: stack === 'prod' ? 1024 : 256,
               memory: stack === 'prod' ? 2048 : 512,
-              environment: [
-                ...containerEnvVars,
-                {
-                  name: 'BASE_URL',
-                  value: this.domain,
-                },
-              ],
+              environment: containerEnvVars,
               secrets: [...dopplerEcsEnvironment.containerSecrets],
               logConfiguration: {
                 logDriver: 'awsfirelens',
@@ -343,7 +299,7 @@ export class NotificationService extends pulumi.ComponentResource {
                   name: `${BASE_NAME}-tcp-${stack}`,
                   hostPort: serviceContainerPort,
                   containerPort: serviceContainerPort,
-                  targetGroup,
+                  targetGroup: this.targetGroup,
                 },
               ],
             },
@@ -370,72 +326,22 @@ export class NotificationService extends pulumi.ComponentResource {
 
     this.service = service;
 
-    this.setupAutoScaling({
-      gatewayAlbArnSuffix: gatewayLoadBalancer.albArnSuffix,
-      gatewayTargetGroup: gatewayTargetGroup.target_group,
-    });
+    this.setupAutoScaling();
 
     this.setupServiceAlarms();
-
-    // domain record
-    const zone = aws.route53.getZoneOutput({ name: BASE_DOMAIN });
-
-    new aws.route53.Record(
-      `${BASE_NAME}-domain-record`,
-      {
-        name: SERVICE_DOMAIN_NAME,
-        type: 'A',
-        zoneId: zone.zoneId,
-        aliases: [
-          {
-            evaluateTargetHealth: false,
-            name: this.lb.dnsName,
-            zoneId: this.lb.zoneId,
-          },
-        ],
-      },
-      { parent: this }
-    );
   }
 
   initializeSecurityGroups({
     vpcId,
-    serviceContainerPort,
   }: {
     vpcId: pulumi.Output<string> | string;
-    serviceContainerPort: number;
   }) {
-    const serviceAlbSg = new aws.ec2.SecurityGroup(
-      `${BASE_NAME}-alb-sg-${stack}`,
-      {
-        name: `${BASE_NAME}-alb-sg-${stack}`,
-        description: `${BASE_NAME} application load balancer security group`,
-        vpcId,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
     const serviceSg = new aws.ec2.SecurityGroup(
       `${BASE_NAME}-sg-${stack}`,
       {
         name: `${BASE_NAME}-sg-${stack}`,
         vpcId,
         description: `${BASE_NAME} security group that is attached directly to the service`,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-alb-in`,
-      {
-        securityGroupId: serviceSg.id,
-        description: 'Allow inbound traffic from the services ALB',
-        referencedSecurityGroupId: serviceAlbSg.id,
-        fromPort: serviceContainerPort,
-        toPort: serviceContainerPort,
-        ipProtocol: 'tcp',
         tags: this.tags,
       },
       { parent: this }
@@ -453,59 +359,10 @@ export class NotificationService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    // ALB SG rules
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-http`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTP traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 80,
-        ipProtocol: 'tcp',
-        toPort: 80,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupIngressRule(
-      `${BASE_NAME}-https`,
-      {
-        securityGroupId: serviceAlbSg.id,
-        description: 'Allow inbound HTTPS traffic',
-        cidrIpv4: '0.0.0.0/0',
-        fromPort: 443,
-        ipProtocol: 'tcp',
-        toPort: 443,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    new aws.vpc.SecurityGroupEgressRule(
-      `${BASE_NAME}-out-service`,
-      {
-        description: 'Allow traffic to the service security group',
-        securityGroupId: serviceAlbSg.id,
-        referencedSecurityGroupId: serviceSg.id,
-        fromPort: serviceContainerPort,
-        ipProtocol: 'tcp',
-        toPort: serviceContainerPort,
-        tags: this.tags,
-      },
-      { parent: this }
-    );
-
-    return { serviceAlbSg, serviceSg };
+    return serviceSg;
   }
 
-  setupAutoScaling({
-    gatewayAlbArnSuffix,
-    gatewayTargetGroup,
-  }: {
-    gatewayAlbArnSuffix: pulumi.Output<string>;
-    gatewayTargetGroup: aws.lb.TargetGroup;
-  }) {
+  setupAutoScaling() {
     if (!this.service) return;
 
     const serviceScalableTarget = new aws.appautoscaling.Target(
@@ -521,7 +378,7 @@ export class NotificationService extends pulumi.ComponentResource {
       { parent: this }
     );
 
-    const resourceLabel = pulumi.interpolate`${gatewayAlbArnSuffix}/${gatewayTargetGroup.arnSuffix}`;
+    const resourceLabel = pulumi.interpolate`${gatewayLoadBalancer.albArnSuffix}/${this.targetGroup.arnSuffix}`;
 
     // Create an Auto Scaling policy for request count.
     new aws.appautoscaling.Policy(
@@ -645,7 +502,8 @@ export class NotificationService extends pulumi.ComponentResource {
       `${BASE_NAME}-http-5xx-alarm`,
       {
         name: `${BASE_NAME}-http-5xx-${stack}`,
-        metricName: 'HTTPCode_ELB_5XX_Count',
+        // Target-generated errors can be scoped to this service on the shared ALB.
+        metricName: 'HTTPCode_Target_5XX_Count',
         namespace: 'AWS/ApplicationELB',
         statistic: 'Sum',
         period: 180,
@@ -653,9 +511,10 @@ export class NotificationService extends pulumi.ComponentResource {
         threshold: 25,
         comparisonOperator: 'GreaterThanOrEqualToThreshold',
         dimensions: {
-          LoadBalancer: this.lb.arn,
+          LoadBalancer: gatewayLoadBalancer.albArnSuffix,
+          TargetGroup: this.targetGroup.arnSuffix,
         },
-        alarmDescription: `High HTTP 5XX count alarm for ${BASE_NAME} Load Balancer.`,
+        alarmDescription: `High HTTP 5XX count alarm for ${BASE_NAME} gateway target group.`,
         actionsEnabled: true,
         alarmActions: [CLOUD_TRAIL_SNS_TOPIC_ARN],
         tags: this.tags,

--- a/services/notification_service/src/config.rs
+++ b/services/notification_service/src/config.rs
@@ -10,20 +10,8 @@ use database_env_vars::{DatabaseUrl, RedisUri};
 use macro_auth::InternalApiKey;
 use macro_env::Environment;
 use macro_env_var::{env_var, env_vars, maybe_env_var};
-use std::sync::LazyLock;
-
-// We load this through `macro_config` at startup as part of [`Config`]. This lazy is retained for
-// older notification template code paths that do not receive `Config` directly.
-pub static BASE_URL: LazyLock<String> = LazyLock::new(|| {
-    BaseUrl::new()
-        .expect("BASE_URL must be provided via APP_SECRETS_JSON or env")
-        .as_ref()
-        .to_string()
-});
 
 env_vars! {
-    #[derive(Debug, Clone)]
-    pub(crate) struct BaseUrl;
     #[derive(Debug, Clone)]
     pub(crate) struct AppleBundleId;
     #[derive(Debug, Clone)]
@@ -55,10 +43,6 @@ env_var!(
 #[derive(macro_config::MacroConfig)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub struct Config {
-    /// The service's base url including the scheme.
-    #[allow(dead_code)]
-    pub(crate) base_url: BaseUrl,
-
     /// The connection URL for the Postgres database this application should use.
     pub(crate) database_url: DatabaseUrl,
 

--- a/services/notification_service/src/notification/send/email/mod.rs
+++ b/services/notification_service/src/notification/send/email/mod.rs
@@ -1,1 +1,0 @@
-pub mod template;

--- a/services/notification_service/src/notification/send/email/template.rs
+++ b/services/notification_service/src/notification/send/email/template.rs
@@ -1,8 +1,0 @@
-use crate::config::BASE_URL;
-
-/// Gets the unsubscribe url for an email
-#[allow(dead_code)]
-fn get_email_unsubscribe_url(email_unsubscribe_code: &str) -> String {
-    let base_url = &*BASE_URL;
-    format!("{}/unsubscribe/email/{}", base_url, email_unsubscribe_code)
-}

--- a/services/notification_service/src/notification/send/mod.rs
+++ b/services/notification_service/src/notification/send/mod.rs
@@ -1,2 +1,1 @@
-pub mod email;
 pub mod push;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Infrastructure cutover deletes the legacy ALB/DNS path; misconfigured gateway listener rules or URL consumers still pointing at the old hostname could cause outages until traffic fully uses the gateway URL.
> 
> **Overview**
> **Removes the notification service’s dedicated ALB, Route53 record, and per-service security groups**, so traffic is exposed only through the shared gateway ALB on `/notification` and `/notification/*`.
> 
> The Pulumi stack drops `isPrivate`, stops provisioning `serviceLoadBalancer`, and registers ECS tasks with a single gateway target group. Autoscaling and the HTTP 5xx CloudWatch alarm now key off the gateway ALB and that target group (`HTTPCode_Target_5XX_Count` instead of ELB-wide 5xx). **`notificationServiceUrl`** is sourced from **`getServiceUrl(ServiceUrl.NOTIFICATION_SERVICE_URL)`** instead of the component’s former `domain`.
> 
> On the Rust side, **`BASE_URL`** is removed from config and ECS env (no more `BASE_URL` injection), along with dead email template code that built unsubscribe links from that static base URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b34724bf2068aab5b7dccff3d9722f37d5dd505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->