### PR TITLE
feat(calls): promote screen share in room-composite recordings

### DIFF
--- a/crates/call/src/domain/ports.rs
+++ b/crates/call/src/domain/ports.rs
@@ -500,7 +500,13 @@ pub trait CallRtcClient: Send + Sync + 'static {
         participant_identity: MacroUserIdStr<'a>,
     ) -> impl Future<Output = anyhow::Result<()>> + Send;
 
-    /// Start a room composite egress (recording). Returns the egress ID.
+    /// Start recording a room into the configured destination. Returns the
+    /// provider's egress ID.
+    ///
+    /// While nobody shares a screen, cameras fill the frame as equal tiles.
+    /// While someone shares, the shared screen fills the stage and cameras
+    /// move to a strip. The recording follows share start and stop for its
+    /// whole duration without further calls from the domain.
     fn start_room_composite_egress(
         &self,
         room_name: &str,
@@ -508,6 +514,9 @@ pub trait CallRtcClient: Send + Sync + 'static {
     ) -> impl Future<Output = anyhow::Result<String>> + Send;
 
     /// Stop an active egress by ID.
+    ///
+    /// Stopping does not change layout. The composition is chosen when
+    /// recording starts.
     fn stop_egress(&self, egress_id: &str) -> impl Future<Output = anyhow::Result<()>> + Send;
 
     /// Validate a webhook signature and parse the event from the raw body.

--- a/crates/call/src/outbound/livekit_rtc_client.rs
+++ b/crates/call/src/outbound/livekit_rtc_client.rs
@@ -9,12 +9,14 @@ mod test;
 use futures::future;
 use livekit_api::access_token::{AccessToken, TokenVerifier, VideoGrants};
 use livekit_api::services::agent_dispatch::AgentDispatchClient;
-use livekit_api::services::egress::{EgressClient, EgressOutput, RoomCompositeOptions, encoding};
+use livekit_api::services::egress::{
+    AudioMixing, EgressClient, EgressOutput, RoomCompositeOptions, encoding,
+};
 use livekit_api::services::room::{CreateRoomOptions, RoomClient};
 use livekit_api::webhooks::WebhookReceiver;
 use livekit_protocol::{
     AudioCodec, CreateAgentDispatchRequest, EncodedFileOutput, EncodedFileType, S3Upload,
-    VideoCodec, encoded_file_output,
+    encoded_file_output,
 };
 use macro_user_id::cowlike::CowLike;
 use macro_user_id::user_id::MacroUserIdStr;
@@ -26,6 +28,9 @@ use crate::domain::models::{
 use crate::domain::ports::CallRtcClient;
 
 const VOIP_TOKEN_MINT_CONCURRENCY: usize = 16;
+
+/// Empty layout is not default grid. The stock template only promotes layouts that start with `grid`.
+const STOCK_TEMPLATE_LAYOUT: &str = "grid";
 
 /// LiveKit implementation of [`CallRtcClient`].
 pub struct LivekitRtcClient {
@@ -105,12 +110,15 @@ fn build_room_composite_egress_request(
     });
 
     let options = RoomCompositeOptions {
+        layout: STOCK_TEMPLATE_LAYOUT.to_owned(),
+        custom_base_url: String::new(),
+        audio_only: false,
+        video_only: false,
+        audio_mixing: AudioMixing::DefaultMixing,
         encoding: encoding::EncodingOptions {
             audio_codec: AudioCodec::Aac,
-            video_codec: VideoCodec::H264Main,
-            ..Default::default()
+            ..encoding::H264_1080P_30
         },
-        ..Default::default()
     };
 
     RoomCompositeEgressRequest {

--- a/crates/call/src/outbound/livekit_rtc_client.rs
+++ b/crates/call/src/outbound/livekit_rtc_client.rs
@@ -9,14 +9,12 @@ mod test;
 use futures::future;
 use livekit_api::access_token::{AccessToken, TokenVerifier, VideoGrants};
 use livekit_api::services::agent_dispatch::AgentDispatchClient;
-use livekit_api::services::egress::{
-    AudioMixing, EgressClient, EgressOutput, RoomCompositeOptions, encoding,
-};
+use livekit_api::services::egress::{EgressClient, EgressOutput, RoomCompositeOptions, encoding};
 use livekit_api::services::room::{CreateRoomOptions, RoomClient};
 use livekit_api::webhooks::WebhookReceiver;
 use livekit_protocol::{
     AudioCodec, CreateAgentDispatchRequest, EncodedFileOutput, EncodedFileType, S3Upload,
-    encoded_file_output,
+    VideoCodec, encoded_file_output,
 };
 use macro_user_id::cowlike::CowLike;
 use macro_user_id::user_id::MacroUserIdStr;
@@ -111,14 +109,12 @@ fn build_room_composite_egress_request(
 
     let options = RoomCompositeOptions {
         layout: STOCK_TEMPLATE_LAYOUT.to_owned(),
-        custom_base_url: String::new(),
-        audio_only: false,
-        video_only: false,
-        audio_mixing: AudioMixing::DefaultMixing,
         encoding: encoding::EncodingOptions {
             audio_codec: AudioCodec::Aac,
-            ..encoding::H264_1080P_30
+            video_codec: VideoCodec::H264Main,
+            ..Default::default()
         },
+        ..Default::default()
     };
 
     RoomCompositeEgressRequest {

--- a/crates/call/src/outbound/livekit_rtc_client/test.rs
+++ b/crates/call/src/outbound/livekit_rtc_client/test.rs
@@ -1,7 +1,18 @@
+use livekit_protocol::VideoCodec;
 use macro_user_id::user_id::MacroUserIdStr;
 
 use super::*;
+use crate::domain::models::EgressS3Config;
 use crate::domain::ports::CallRtcClient as _;
+
+fn s3_config() -> EgressS3Config {
+    EgressS3Config {
+        bucket: "recordings-bucket".to_string(),
+        region: "us-east-1".to_string(),
+        access_key: "test-access-key".to_string(),
+        secret: "test-secret".to_string(),
+    }
+}
 
 fn client() -> LivekitRtcClient {
     LivekitRtcClient::new(
@@ -47,4 +58,47 @@ async fn verify_access_token_rejects_token_signed_with_a_different_secret() {
 #[test]
 fn verify_access_token_rejects_garbage() {
     assert!(client().verify_access_token("not-a-jwt").is_err());
+}
+
+#[test]
+fn room_composite_request_asks_the_stock_template_to_stage_a_shared_screen() {
+    let request = build_room_composite_egress_request("room-1", &s3_config());
+    assert_eq!(request.options.layout, "grid");
+    assert!(request.options.custom_base_url.is_empty());
+}
+
+#[test]
+fn room_composite_request_writes_one_mp4_under_the_room_prefix() {
+    let request = build_room_composite_egress_request("room-1", &s3_config());
+    assert_eq!(request.outputs.len(), 1);
+    let EgressOutput::File(file) = &request.outputs[0] else {
+        panic!("expected one file output");
+    };
+    assert_eq!(file.filepath, "calls/room-1/{time}");
+    assert_eq!(file.file_type, EncodedFileType::Mp4 as i32);
+}
+
+#[test]
+fn room_composite_request_uploads_to_the_configured_bucket() {
+    let request = build_room_composite_egress_request("room-1", &s3_config());
+    let EgressOutput::File(file) = &request.outputs[0] else {
+        panic!("expected one file output");
+    };
+    let Some(encoded_file_output::Output::S3(s3)) = &file.output else {
+        panic!("expected S3 upload");
+    };
+    assert_eq!(s3.bucket, "recordings-bucket");
+    assert_eq!(s3.region, "us-east-1");
+}
+
+#[test]
+fn room_composite_request_encodes_for_browser_playback() {
+    let request = build_room_composite_egress_request("room-1", &s3_config());
+    let encoding = &request.options.encoding;
+    assert_eq!(encoding.width, 1920);
+    assert_eq!(encoding.height, 1080);
+    assert_eq!(encoding.framerate, 30);
+    assert_eq!(encoding.video_bitrate, 4500);
+    assert_eq!(encoding.video_codec, VideoCodec::H264Main);
+    assert_eq!(encoding.audio_codec, AudioCodec::Aac);
 }

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -80,6 +80,8 @@ Google's out-of-office event type.
 
 Tabs `All` / `Missed` / `Unattended`; `Call` button to start one. Recordings, transcriptions
 and summaries appear here; empty state notes "Calls are available to agents."
+New recordings stage a shared screen with cameras in a side strip. Older
+recordings stay an equal-tile grid.
 
 ## Customers (CRM) — `/app/component/companies`
 


### PR DESCRIPTION
An empty LiveKit layout stays a camera grid for the whole call. The stock template only promotes a share when layout starts with grid.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Recording layout and documentation only; no auth or call-control logic changes, with behavior covered by new egress request tests.
> 
> **Overview**
> Room-composite call recordings now pass LiveKit layout **`grid`** instead of leaving layout empty, so the stock composite template can switch from equal camera tiles to a full-stage screen share with cameras in a strip for the rest of the recording.
> 
> The **`CallRtcClient`** docs and the Calls surface guide describe that behavior for reviewers and users. **New unit tests** lock in the egress request: `grid` layout, no custom template URL, single MP4 under `calls/{room}/{time}`, S3 destination, and browser-friendly H.264/AAC encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fce50d888faecb02f73c05f4fa1cc8c459f74408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->