### PR TITLE
feat(databases): Macro Databases — SQL-native user tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2550,6 +2550,26 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
@@ -4585,6 +4605,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "databases"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "entity_access",
+ "macro_authorization",
+ "macro_user_id",
+ "model-entity",
+ "model-error-response",
+ "models_properties",
+ "rootcause",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "utoipa",
+ "uuid",
+ "workspace-hack",
+]
+
+[[package]]
 name = "dataloss_prevention_handler"
 version = "0.1.0"
 dependencies = [
@@ -6220,6 +6265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7387,6 +7438,15 @@ dependencies = [
  "allocator-api2 0.2.21",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -8824,6 +8884,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8949,6 +9015,8 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "bindgen 0.69.5",
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -13546,7 +13614,7 @@ name = "rs-libreoffice-bindings"
 version = "0.0.7"
 source = "git+https://github.com/macro-inc/rs-libreoffice-bindings?rev=056a40ddfac1d9650be30b9f0b4b934e9266c7dc#056a40ddfac1d9650be30b9f0b4b934e9266c7dc"
 dependencies = [
- "bindgen",
+ "bindgen 0.71.1",
  "cc",
 ]
 
@@ -13569,6 +13637,20 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator 0.3.0",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -15203,7 +15285,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap 2.14.0",
  "log",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
   "crates/crm",
   "crates/cursor_api_key",
   "crates/cursor_cloud_agents",
+  "crates/databases",
   "crates/embedding",
   "crates/email_api_client",
   "crates/entity_mutation",
@@ -255,6 +256,21 @@ reqwest = { version = "0.13", default-features = false, features = [
 ] }
 rmcp = "1.6.0"
 rootcause = { version = "0.12", features = ["compat-anyhow1"] }
+# Embedded SQLite for the databases query engine: per-query in-memory
+# materializations, never persistent storage. `session` records changesets for
+# write-through, `column_metadata` gives result provenance, `limits`/`functions`
+# support sandboxing and HAS desugar.
+# Pinned to 0.32 so its libsqlite3-sys (0.30.x) unifies with sqlx-sqlite's —
+# cargo allows only one package linking the native `sqlite3`.
+rusqlite = { version = "0.32", features = [
+  "bundled",
+  "column_decltype",
+  "functions",
+  "hooks",
+  "limits",
+  "serialize",
+  "session",
+] }
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
 rootcause-tracing = "0.12.1"
 schemars = { version = "1.0.4", features = ["chrono04", "uuid1"] }

--- a/crates/databases/Cargo.toml
+++ b/crates/databases/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+edition = "2024"
+name = "databases"
+publish = false
+version = "0.1.0"
+
+[features]
+default = []
+# Axum HTTP router: the SQL-first API surface (exec, snapshot, schema ops).
+inbound = [
+  "dep:axum",
+  "dep:macro_authorization",
+  "dep:model-error-response",
+  "dep:utoipa",
+  "ports",
+]
+# Driven adapters share the port contracts.
+outbound = ["ports"]
+ports = ["dep:entity_access", "dep:tracing"]
+# Postgres persistence for databases/tables/columns/rows/links.
+postgres = ["dep:sqlx", "outbound"]
+# The embedded SQLite executor (analysis, sandboxed execution, changesets).
+sqlite = ["dep:rusqlite", "outbound"]
+
+[dependencies]
+axum = { workspace = true, optional = true }
+chrono = { workspace = true, features = ["serde"] }
+entity_access = { path = "../entity_access", optional = true, default-features = false, features = ["ports"] }
+macro_authorization = { path = "../macro_authorization", optional = true, default-features = false, features = ["axum"] }
+macro_user_id = { path = "../macro_user_id" }
+model-entity = { path = "../model-entity" }
+model-error-response = { path = "../model-error-response", optional = true }
+models_properties = { path = "../models_properties" }
+rootcause = { workspace = true }
+rusqlite = { workspace = true, optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true, optional = true }
+thiserror = { workspace = true }
+tracing = { workspace = true, optional = true }
+utoipa = { workspace = true, optional = true }
+uuid = { workspace = true }
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/databases/src/domain.rs
+++ b/crates/databases/src/domain.rs
@@ -1,0 +1,9 @@
+//! Domain layer: models, ports, and the service implementation.
+
+pub mod models;
+
+#[cfg(feature = "ports")]
+pub mod ports;
+
+#[cfg(feature = "ports")]
+pub mod service;

--- a/crates/databases/src/domain/models.rs
+++ b/crates/databases/src/domain/models.rs
@@ -1,0 +1,419 @@
+//! Domain models: entities, commands, the query/exec pipeline vocabulary,
+//! and domain errors.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use macro_user_id::user_id::MacroUserIdStr;
+use model_entity::EntityType;
+use models_properties::api::requests::SetPropertyValue;
+use models_properties::service::property_value::PropertyValue;
+use models_properties::shared::DataType;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// ===== Identifiers =====
+
+/// Identifier of a database (the shareable entity users see).
+pub type DatabaseId = Uuid;
+/// Identifier of one table (tab) within a database.
+pub type TableId = Uuid;
+/// Identifier of a column placement within a table.
+pub type ColumnId = Uuid;
+/// Identifier of a row.
+pub type RowId = Uuid;
+/// Identifier of a `models_properties` property definition bound as a column.
+pub type PropertyDefinitionId = Uuid;
+
+/// Monotonic per-table version, bumped on every row/column/link mutation.
+///
+/// The cache key for query materializations and the invalidation signal for
+/// live query chips.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct TableVersion(pub i64);
+
+// ===== Entities =====
+
+/// A database: a named collection of tables, owned and shared as one entity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Database {
+    /// Identifier.
+    pub id: DatabaseId,
+    /// Display name.
+    pub name: String,
+    /// Owning user.
+    pub owner_id: String,
+    /// Creation time.
+    pub created_at: DateTime<Utc>,
+    /// Set when trashed.
+    pub trashed_at: Option<DateTime<Utc>>,
+}
+
+/// One table (tab) of a database.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Table {
+    /// Identifier.
+    pub id: TableId,
+    /// Owning database.
+    pub database_id: DatabaseId,
+    /// Display name; also the basis of the table's SQL name.
+    pub name: String,
+    /// Fractional index for tab ordering.
+    pub position: String,
+    /// Current version.
+    pub version: TableVersion,
+}
+
+/// A column: the placement of a property definition on a table.
+///
+/// The definition carries name, [`DataType`], multi-select flag, and options;
+/// this carries only where it appears and column-kind configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Column {
+    /// Identifier of the placement.
+    pub id: ColumnId,
+    /// Table the column appears on.
+    pub table_id: TableId,
+    /// The bound property definition.
+    pub property_definition_id: PropertyDefinitionId,
+    /// Fractional index for column ordering.
+    pub position: String,
+    /// Column-kind specific configuration.
+    pub config: Option<ColumnConfig>,
+}
+
+/// Column-kind specific configuration stored on the placement.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum ColumnConfig {
+    /// A link column targeting another table; edges live in the junction.
+    Link {
+        /// Target database.
+        database_id: DatabaseId,
+        /// Target table.
+        table_id: TableId,
+    },
+    /// A derived lookup through a link or entity column on the same table.
+    Lookup {
+        /// The link/entity column the lookup reads through.
+        via_column_id: ColumnId,
+        /// Target field on the other side (a definition id or magic column name).
+        target: String,
+    },
+}
+
+/// A row: dense cells keyed by property definition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Row {
+    /// Identifier.
+    pub id: RowId,
+    /// Owning table.
+    pub table_id: TableId,
+    /// Fractional index for manual ordering.
+    pub position: String,
+    /// Cell values keyed by property definition id.
+    pub cells: HashMap<PropertyDefinitionId, PropertyValue>,
+}
+
+// ===== Schema operations (the structured, non-SQL part of the API) =====
+
+/// Command to create a database (with one starter table).
+#[derive(Debug, Clone)]
+pub struct CreateDatabase {
+    /// Display name.
+    pub name: String,
+    /// Owner.
+    pub owner_id: MacroUserIdStr<'static>,
+}
+
+/// Command to create a table in a database.
+#[derive(Debug, Clone)]
+pub struct CreateTable {
+    /// Owning database.
+    pub database_id: DatabaseId,
+    /// Display name.
+    pub name: String,
+}
+
+/// How a new column obtains its property definition.
+#[derive(Debug, Clone)]
+pub enum ColumnBinding {
+    /// Create a fresh definition scoped to the database.
+    NewDefinition {
+        /// Column display name.
+        name: String,
+        /// Value type.
+        data_type: DataType,
+        /// Whether the column holds multiple values.
+        is_multi_select: bool,
+    },
+    /// Bind an existing user/team/system definition.
+    ExistingDefinition(PropertyDefinitionId),
+}
+
+/// Command to add a column to a table.
+#[derive(Debug, Clone)]
+pub struct CreateColumn {
+    /// Table receiving the column.
+    pub table_id: TableId,
+    /// Definition source.
+    pub binding: ColumnBinding,
+    /// Column-kind configuration (links, lookups).
+    pub config: Option<ColumnConfig>,
+}
+
+// ===== The query/exec pipeline =====
+
+/// The acting viewer: every catalog build, materialization, and write is
+/// scoped to this identity. The catalog IS the authorization for SQL.
+#[derive(Debug, Clone)]
+pub struct Viewer {
+    /// The user running the statement.
+    pub user_id: MacroUserIdStr<'static>,
+}
+
+/// A request to execute SQL (any mix of reads and writes).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExecRequest {
+    /// The statements to run, executed in one transaction.
+    pub sql: String,
+    /// When set, writes are rejected unless every written table is still at
+    /// this version (compare-and-swap). When unset, cell-level last-write-wins.
+    pub base_versions: Option<HashMap<TableId, TableVersion>>,
+}
+
+/// SQL name and typed columns of one table in the viewer's catalog.
+#[derive(Debug, Clone)]
+pub struct TableSchema {
+    /// SQL-visible table name (e.g. `guests`, `guests__sessions`, `people`).
+    pub sql_name: String,
+    /// What this table is backed by.
+    pub source: TableSource,
+    /// Typed columns in declaration order.
+    pub columns: Vec<ColumnSchema>,
+}
+
+/// What a catalog table is backed by.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TableSource {
+    /// A user table ([`Table`]).
+    UserTable(TableId),
+    /// The junction view generated for a multi link/entity column.
+    Junction {
+        /// Owning user table.
+        table_id: TableId,
+        /// The link column the junction belongs to.
+        column_id: ColumnId,
+    },
+    /// A magic table (platform data, read-only).
+    Magic(String),
+}
+
+/// One column of a catalog table.
+#[derive(Debug, Clone)]
+pub struct ColumnSchema {
+    /// SQL-visible column name.
+    pub sql_name: String,
+    /// The property data type behind it, when property-backed.
+    pub data_type: Option<DataType>,
+    /// Entity type carried by id values in this column, for chip hydration
+    /// and join type-checking.
+    pub entity_type: Option<EntityType>,
+    /// Whether SQL writes to this column are translatable to a domain command.
+    pub writable: bool,
+}
+
+/// The viewer's whole queryable world: used to prepare statements and as the
+/// authorization boundary (an unreadable table is simply absent).
+#[derive(Debug, Clone)]
+pub struct Catalog {
+    /// Every table the viewer can reference.
+    pub tables: Vec<TableSchema>,
+}
+
+/// Tables and columns a prepared statement references, from the SQLite
+/// authorizer. Doubles as the liveness dependency set.
+#[derive(Debug, Clone)]
+pub struct TableDeps {
+    /// Referenced tables mapped to the columns actually read or written.
+    pub tables: HashMap<String, ReferencedTable>,
+}
+
+/// One referenced table with access details.
+#[derive(Debug, Clone)]
+pub struct ReferencedTable {
+    /// Columns read.
+    pub read_columns: Vec<String>,
+    /// Whether the statement writes to this table.
+    pub written: bool,
+}
+
+/// A value in the SQLite materialization, kept engine-agnostic so the domain
+/// never depends on rusqlite types.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SqlValue {
+    /// SQL NULL.
+    Null,
+    /// Integer (also booleans as 0/1).
+    Integer(i64),
+    /// Float.
+    Real(f64),
+    /// Text (also ids, dates as ISO-8601, resolved option display values).
+    Text(String),
+}
+
+/// One table's rows, ready to load into the scratch SQLite.
+#[derive(Debug, Clone)]
+pub struct MaterializedTable {
+    /// Schema (including compiled constraints).
+    pub schema: TableSchema,
+    /// Row tuples in column order. User tables carry their `row_id` as the
+    /// first column so changesets can be traced back.
+    pub rows: Vec<Vec<SqlValue>>,
+}
+
+/// A SELECT's result set with provenance for hydration and write-through.
+#[derive(Debug, Clone, Serialize)]
+pub struct QueryResult {
+    /// Result columns.
+    pub columns: Vec<ResultColumn>,
+    /// Row values (serialized as JSON scalars).
+    #[serde(skip)]
+    pub rows: Vec<Vec<SqlValue>>,
+}
+
+/// One result column with its origin.
+#[derive(Debug, Clone, Serialize)]
+pub struct ResultColumn {
+    /// Column name or alias.
+    pub name: String,
+    /// Entity type of id values, when known — drives chip rendering.
+    pub entity_type: Option<EntityType>,
+    /// Origin `(table, column)` when the column traces to a single base
+    /// column — the precondition for write-through.
+    pub origin: Option<(String, String)>,
+}
+
+/// The row-level changes a statement made, extracted from the SQLite session
+/// changeset and expressed in domain terms.
+#[derive(Debug, Clone)]
+pub enum RowChange {
+    /// A row inserted into a user table.
+    Insert {
+        /// Table written.
+        table_id: TableId,
+        /// Cell values keyed by definition, already converted and validated.
+        cells: HashMap<PropertyDefinitionId, SetPropertyValue>,
+    },
+    /// Cells updated on an existing row.
+    Update {
+        /// Table written.
+        table_id: TableId,
+        /// Row written.
+        row_id: RowId,
+        /// Changed cells only.
+        cells: HashMap<PropertyDefinitionId, SetPropertyValue>,
+    },
+    /// A row deleted (membership removed; referenced entities untouched).
+    Delete {
+        /// Table written.
+        table_id: TableId,
+        /// Row removed.
+        row_id: RowId,
+    },
+    /// A link edge added.
+    Link {
+        /// The link column.
+        column_id: ColumnId,
+        /// Source row.
+        source_row_id: RowId,
+        /// Target row.
+        target_row_id: RowId,
+    },
+    /// A link edge removed.
+    Unlink {
+        /// The link column.
+        column_id: ColumnId,
+        /// Source row.
+        source_row_id: RowId,
+        /// Target row.
+        target_row_id: RowId,
+    },
+}
+
+/// Result of applying a translated changeset: minted row ids (in changeset
+/// order) and the new version of every written table.
+pub type AppliedChanges = (Vec<RowId>, HashMap<TableId, TableVersion>);
+
+/// Outcome of an [`ExecRequest`].
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecOutcome {
+    /// Result sets of the SELECT statements, in order.
+    pub results: Vec<QueryResult>,
+    /// How many row changes were applied to Postgres.
+    pub changes_applied: usize,
+    /// Server-minted ids for rows the statement inserted.
+    pub inserted_row_ids: Vec<RowId>,
+    /// New versions of every written table, for client-side liveness.
+    pub new_versions: HashMap<TableId, TableVersion>,
+    /// Dependency set of the statement, for liveness subscription.
+    pub read_tables: Vec<TableId>,
+}
+
+/// A serialized SQLite snapshot of one database (takeout / local analysis).
+#[derive(Debug, Clone)]
+pub struct SqliteSnapshot {
+    /// The bytes of a complete SQLite database file.
+    pub bytes: Vec<u8>,
+    /// Versions of the contained tables at snapshot time.
+    pub versions: HashMap<TableId, TableVersion>,
+}
+
+// ===== Errors =====
+
+/// Errors for schema and persistence operations.
+#[derive(Debug, thiserror::Error)]
+pub enum DatabaseError {
+    /// The database, table, column, or row does not exist (or is invisible
+    /// to the viewer, which is deliberately indistinguishable).
+    #[error("not found")]
+    NotFound,
+    /// The caller lacks the permission the operation requires.
+    #[error("unauthorized")]
+    Unauthorized,
+    /// A schema operation was invalid (duplicate placement, bad binding, …).
+    #[error("invalid schema operation: {0}")]
+    InvalidSchemaOperation(String),
+    /// Persistence failure.
+    #[error("repository error: {0:?}")]
+    Repo(rootcause::Report),
+}
+
+/// Errors for SQL analysis, execution, and write-back.
+#[derive(Debug, thiserror::Error)]
+pub enum QueryError {
+    /// SQLite rejected the statement (syntax, unknown table/column, or a
+    /// compiled validity constraint). Surfaced verbatim — these errors are
+    /// the product's "broken query" state.
+    #[error("sql error: {0}")]
+    Sql(String),
+    /// The statement writes to a read-only table (magic tables, View-only
+    /// grants, derived columns).
+    #[error("read-only: {0}")]
+    ReadOnly(String),
+    /// `base_versions` was set and a written table has moved.
+    #[error("version conflict on table {table_id}")]
+    VersionConflict {
+        /// The table that changed underneath the caller.
+        table_id: TableId,
+    },
+    /// The statement exceeded the execution budget (time or row caps).
+    #[error("query budget exceeded")]
+    BudgetExceeded,
+    /// A changeset row could not be translated to a domain command.
+    #[error("untranslatable change: {0}")]
+    UntranslatableChange(String),
+    /// Materialization or apply-side persistence failure.
+    #[error("query infrastructure error: {0:?}")]
+    Infrastructure(rootcause::Report),
+}

--- a/crates/databases/src/domain/ports.rs
+++ b/crates/databases/src/domain/ports.rs
@@ -1,0 +1,213 @@
+//! Ports (trait contracts) for the databases domain.
+
+use std::collections::HashMap;
+
+use entity_access::domain::models::{EditAccessLevel, EntityAccessReceipt, ViewAccessLevel};
+use models_properties::service::property_definition_with_options::PropertyDefinitionWithOptions;
+
+use crate::domain::models::{
+    AppliedChanges, Catalog, ColumnBinding, ColumnId, CreateColumn, CreateDatabase, CreateTable,
+    Database, DatabaseError, DatabaseId, ExecOutcome, ExecRequest, MaterializedTable,
+    PropertyDefinitionId, QueryError, QueryResult, Row, RowChange, RowId, SqliteSnapshot, Table,
+    TableDeps, TableId, TableVersion, Viewer,
+};
+
+/// Outbound persistence port for databases, tables, column placements, rows,
+/// and link edges. Implemented by the Postgres repository.
+///
+/// The repo stores facts; every policy decision (who may do what, what a
+/// changeset is allowed to contain) lives in the domain service.
+pub trait DatabasesRepo: Send + Sync + 'static {
+    /// The error type returned by repository operations.
+    type Err: std::error::Error + Send + Sync + 'static;
+
+    /// Insert a database (and nothing else — the starter table is a separate call).
+    fn create_database(
+        &self,
+        cmd: &CreateDatabase,
+    ) -> impl Future<Output = Result<Database, Self::Err>> + Send;
+
+    /// Fetch a database with its tables and column placements.
+    fn get_database(
+        &self,
+        id: DatabaseId,
+    ) -> impl Future<Output = Result<Option<(Database, Vec<Table>)>, Self::Err>> + Send;
+
+    /// Insert a table.
+    fn create_table(
+        &self,
+        cmd: &CreateTable,
+    ) -> impl Future<Output = Result<Table, Self::Err>> + Send;
+
+    /// Insert a column placement.
+    fn create_column(
+        &self,
+        table_id: TableId,
+        property_definition_id: PropertyDefinitionId,
+        cmd: &CreateColumn,
+    ) -> impl Future<Output = Result<ColumnId, Self::Err>> + Send;
+
+    /// Fetch every row of a table.
+    fn fetch_rows(
+        &self,
+        table_id: TableId,
+    ) -> impl Future<Output = Result<Vec<Row>, Self::Err>> + Send;
+
+    /// Fetch the link edges for a link column.
+    fn fetch_links(
+        &self,
+        column_id: ColumnId,
+    ) -> impl Future<Output = Result<Vec<(RowId, RowId)>, Self::Err>> + Send;
+
+    /// Apply a translated changeset atomically: inserts (returning minted row
+    /// ids in changeset order), cell updates, deletes, and link edges, bumping
+    /// each written table's version exactly once.
+    fn apply_changes(
+        &self,
+        viewer: &Viewer,
+        changes: &[RowChange],
+    ) -> impl Future<Output = Result<AppliedChanges, Self::Err>> + Send;
+
+    /// Current versions for a set of tables (compare-and-swap support).
+    fn table_versions(
+        &self,
+        table_ids: &[TableId],
+    ) -> impl Future<Output = Result<HashMap<TableId, TableVersion>, Self::Err>> + Send;
+}
+
+/// Column definitions live in the properties system; this port wraps creating
+/// database-scoped definitions and reading definitions (with options) for
+/// catalog builds and schema compilation.
+pub trait ColumnDefinitionStore: Send + Sync + 'static {
+    /// The error type returned by definition operations.
+    type Err: std::error::Error + Send + Sync + 'static;
+
+    /// Resolve a binding: create a database-scoped definition or validate an
+    /// existing one, returning the definition id.
+    fn resolve_binding(
+        &self,
+        database_id: DatabaseId,
+        binding: &ColumnBinding,
+    ) -> impl Future<Output = Result<PropertyDefinitionId, Self::Err>> + Send;
+
+    /// Fetch the definitions (with options) behind a set of column placements.
+    fn definitions(
+        &self,
+        ids: &[PropertyDefinitionId],
+    ) -> impl Future<Output = Result<Vec<PropertyDefinitionWithOptions>, Self::Err>> + Send;
+
+    /// Resolve a select/tag display value to an option id for the definition,
+    /// used when translating changeset cell values back to `SetPropertyValue`.
+    fn resolve_option(
+        &self,
+        definition_id: PropertyDefinitionId,
+        display_value: &str,
+    ) -> impl Future<Output = Result<Option<uuid::Uuid>, Self::Err>> + Send;
+}
+
+/// Platform data exposed to SQL, permission-scoped per viewer. One
+/// implementation dispatches across every magic table (`people`, `documents`,
+/// `tasks`, …); the domain never knows which backends exist.
+pub trait MagicTables: Send + Sync + 'static {
+    /// The error type returned by magic-table operations.
+    type Err: std::error::Error + Send + Sync + 'static;
+
+    /// Schemas of every magic table, for the catalog. Cheap and static.
+    fn schemas(&self) -> Vec<crate::domain::models::TableSchema>;
+
+    /// Materialize one magic table for a viewer, restricted to the referenced
+    /// columns. Never called for tables absent from [`MagicTables::schemas`].
+    fn materialize(
+        &self,
+        viewer: &Viewer,
+        sql_name: &str,
+        columns: &[String],
+    ) -> impl Future<Output = Result<MaterializedTable, Self::Err>> + Send;
+}
+
+/// The embedded SQLite sandbox. Synchronous and CPU-bound; the service runs it
+/// on a blocking pool. Implemented by the rusqlite executor.
+pub trait SqlExecutor: Send + Sync + 'static {
+    /// Prepare `sql` against a schema-only build of `catalog` and report the
+    /// tables/columns it references and writes (via the authorizer), or the
+    /// SQLite error verbatim. No data is loaded and nothing executes.
+    fn analyze(&self, catalog: &Catalog, sql: &str) -> Result<TableDeps, QueryError>;
+
+    /// Load `tables` into a fresh in-memory database whose schema carries the
+    /// compiled validity constraints, execute `sql` inside one transaction
+    /// with a session recording changes, and return SELECT results plus the
+    /// recorded row changes. Enforces read-only tables, statement budget, and
+    /// row caps via the authorizer/interrupt handler.
+    fn execute(
+        &self,
+        catalog: &Catalog,
+        tables: Vec<MaterializedTable>,
+        sql: &str,
+    ) -> Result<(Vec<QueryResult>, Vec<RowChange>), QueryError>;
+
+    /// Serialize a set of materialized tables into a complete SQLite database
+    /// file (the takeout snapshot).
+    fn serialize_snapshot(&self, tables: Vec<MaterializedTable>) -> Result<Vec<u8>, QueryError>;
+}
+
+/// Liveness fan-out: announce that a table changed so subscribed surfaces
+/// re-run their queries. Implemented by the Redis publisher.
+pub trait TableEventPublisher: Send + Sync + 'static {
+    /// The error type returned by publish operations.
+    type Err: std::error::Error + Send + Sync + 'static;
+
+    /// Publish `{table_id, version}` to the gateway fan-out.
+    fn table_changed(
+        &self,
+        table_id: TableId,
+        version: TableVersion,
+    ) -> impl Future<Output = Result<(), Self::Err>> + Send;
+}
+
+/// The service trait inbound adapters call. All authorization policy beyond
+/// receipt minting, and all use-case orchestration, lives behind this trait.
+pub trait DatabasesService: Send + Sync + 'static {
+    /// Create a database (with one starter table) owned by the viewer.
+    fn create_database(
+        &self,
+        cmd: CreateDatabase,
+    ) -> impl Future<Output = Result<Database, DatabaseError>> + Send;
+
+    /// Fetch a database with tables, columns, and definitions for rendering.
+    fn get_database(
+        &self,
+        receipt: EntityAccessReceipt<ViewAccessLevel>,
+    ) -> impl Future<Output = Result<(Database, Vec<Table>), DatabaseError>> + Send;
+
+    /// Create a table.
+    fn create_table(
+        &self,
+        receipt: EntityAccessReceipt<EditAccessLevel>,
+        cmd: CreateTable,
+    ) -> impl Future<Output = Result<Table, DatabaseError>> + Send;
+
+    /// Create a column: resolve the definition binding, insert the placement.
+    fn create_column(
+        &self,
+        receipt: EntityAccessReceipt<EditAccessLevel>,
+        cmd: CreateColumn,
+    ) -> impl Future<Output = Result<ColumnId, DatabaseError>> + Send;
+
+    /// Execute SQL for a viewer — the whole read/write surface.
+    ///
+    /// Pipeline: build catalog → desugar → analyze → check writability &
+    /// `base_versions` → materialize referenced tables → sandboxed execute →
+    /// translate changeset → apply to Postgres → publish version events.
+    fn exec_sql(
+        &self,
+        viewer: Viewer,
+        req: ExecRequest,
+    ) -> impl Future<Output = Result<ExecOutcome, QueryError>> + Send;
+
+    /// Serialize one database into a SQLite file for takeout/local analysis.
+    fn sqlite_snapshot(
+        &self,
+        receipt: EntityAccessReceipt<ViewAccessLevel>,
+        viewer: Viewer,
+    ) -> impl Future<Output = Result<SqliteSnapshot, QueryError>> + Send;
+}

--- a/crates/databases/src/domain/service.rs
+++ b/crates/databases/src/domain/service.rs
@@ -1,0 +1,151 @@
+//! Databases service implementation.
+//!
+//! All authorization policy (beyond receipt minting at the edge) and all
+//! use-case orchestration live here, behind fake-able ports, so allow/deny and
+//! pipeline behavior are unit-testable without infrastructure.
+
+use entity_access::domain::models::{EditAccessLevel, EntityAccessReceipt, ViewAccessLevel};
+
+use crate::domain::models::{
+    ColumnId, CreateColumn, CreateDatabase, CreateTable, Database, DatabaseError, ExecOutcome,
+    ExecRequest, QueryError, SqliteSnapshot, Table, Viewer,
+};
+use crate::domain::ports::{
+    ColumnDefinitionStore, DatabasesRepo, DatabasesService, MagicTables, SqlExecutor,
+    TableEventPublisher,
+};
+
+/// Concrete databases service backed by the five ports.
+// Fields are read once the todo!() implementations land.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct DatabasesServiceImpl<Repo, Defs, Magic, Exec, Events> {
+    repo: Repo,
+    definitions: Defs,
+    magic: Magic,
+    executor: Exec,
+    events: Events,
+}
+
+impl<Repo, Defs, Magic, Exec, Events> DatabasesServiceImpl<Repo, Defs, Magic, Exec, Events>
+where
+    Repo: DatabasesRepo,
+    Defs: ColumnDefinitionStore,
+    Magic: MagicTables,
+    Exec: SqlExecutor,
+    Events: TableEventPublisher,
+{
+    /// Create a databases service from its port implementations.
+    pub fn new(
+        repo: Repo,
+        definitions: Defs,
+        magic: Magic,
+        executor: Exec,
+        events: Events,
+    ) -> Self {
+        Self {
+            repo,
+            definitions,
+            magic,
+            executor,
+            events,
+        }
+    }
+
+    /// Build the viewer's catalog: every table they can reference in SQL.
+    ///
+    /// This IS the authorization boundary for `exec_sql`: a database the
+    /// viewer cannot view contributes no tables, so statements against it fail
+    /// in prepare as "no such table"; tables from Edit-grant databases are
+    /// writable, View-grant read-only; junction views are derived from link
+    /// columns; magic-table schemas come from [`MagicTables::schemas`].
+    #[allow(dead_code)]
+    async fn build_catalog(
+        &self,
+        _viewer: &Viewer,
+    ) -> Result<crate::domain::models::Catalog, QueryError> {
+        todo!(
+            "collect viewer-visible tables via entity_access, derive junction views, append magic schemas"
+        )
+    }
+}
+
+impl<Repo, Defs, Magic, Exec, Events> DatabasesService
+    for DatabasesServiceImpl<Repo, Defs, Magic, Exec, Events>
+where
+    Repo: DatabasesRepo,
+    Defs: ColumnDefinitionStore,
+    Magic: MagicTables,
+    Exec: SqlExecutor,
+    Events: TableEventPublisher,
+{
+    #[tracing::instrument(skip(self), err)]
+    async fn create_database(&self, _cmd: CreateDatabase) -> Result<Database, DatabaseError> {
+        todo!(
+            "insert database + starter table via repo; grant owner entity_access; record activity"
+        )
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    async fn get_database(
+        &self,
+        _receipt: EntityAccessReceipt<ViewAccessLevel>,
+    ) -> Result<(Database, Vec<Table>), DatabaseError> {
+        todo!("load database + tables + column placements + definitions for the receipted entity")
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    async fn create_table(
+        &self,
+        _receipt: EntityAccessReceipt<EditAccessLevel>,
+        _cmd: CreateTable,
+    ) -> Result<Table, DatabaseError> {
+        todo!("validate name, insert table, bump nothing (new table starts at version 0)")
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    async fn create_column(
+        &self,
+        _receipt: EntityAccessReceipt<EditAccessLevel>,
+        _cmd: CreateColumn,
+    ) -> Result<ColumnId, DatabaseError> {
+        todo!(
+            "resolve_binding via ColumnDefinitionStore, validate link/lookup config, insert placement, bump table version"
+        )
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    async fn exec_sql(&self, viewer: Viewer, req: ExecRequest) -> Result<ExecOutcome, QueryError> {
+        // The whole SQL-first surface, end to end:
+        //
+        //  1. catalog   = self.build_catalog(&viewer)         — authz boundary
+        //  2. sql       = desugar HAS → json_each membership  — pure rewrite
+        //  3. deps      = self.executor.analyze(&catalog, sql) — tables/columns/writes
+        //  4. reject writes to read-only tables (magic, View-grant, derived cols);
+        //     if req.base_versions is set, compare against repo.table_versions
+        //  5. tables    = materialize deps: repo.fetch_rows / repo.fetch_links /
+        //     self.magic.materialize — permission-scoped, referenced columns only,
+        //     select options resolved to display values, schema compiled with
+        //     STRICT + CHECK(options) + FKs so SQLite enforces validity
+        //  6. (results, changes) = self.executor.execute(...) on a blocking pool
+        //  7. translate changes: display values → option ids via
+        //     definitions.resolve_option, cells → SetPropertyValue (validated),
+        //     junction rows → Link/Unlink
+        //  8. (row_ids, versions) = repo.apply_changes(&viewer, &changes)
+        //  9. events.table_changed for each written table
+        // 10. ExecOutcome { results, versions, deps for liveness }
+        let _ = (viewer, req);
+        todo!("implement the exec pipeline described above")
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    async fn sqlite_snapshot(
+        &self,
+        _receipt: EntityAccessReceipt<ViewAccessLevel>,
+        _viewer: Viewer,
+    ) -> Result<SqliteSnapshot, QueryError> {
+        todo!(
+            "materialize every table of the receipted database and executor.serialize_snapshot them"
+        )
+    }
+}

--- a/crates/databases/src/inbound.rs
+++ b/crates/databases/src/inbound.rs
@@ -1,0 +1,3 @@
+//! Driving adapters: the Axum HTTP router.
+
+pub mod axum_router;

--- a/crates/databases/src/inbound/axum_router.rs
+++ b/crates/databases/src/inbound/axum_router.rs
@@ -1,0 +1,247 @@
+//! Axum router for the databases endpoints.
+//!
+//! The surface is deliberately tiny and SQL-first:
+//!
+//! - `POST /exec` — run SQL (reads and writes) as the caller; the viewer's
+//!   catalog is the authorization boundary, enforced in the domain service.
+//! - `GET /{id}/sqlite` — download a database as a SQLite file (takeout).
+//! - `POST /` — create a database; `POST /{id}/tables`,
+//!   `POST /{id}/tables/{table_id}/columns` — schema operations, which stay
+//!   structured because property definitions carry configuration DDL cannot
+//!   express.
+//!
+//! Handlers are thin: extract identity/receipts, convert DTOs, call the
+//! service, map errors. No policy, no persistence.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    extract::{FromRef, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+};
+use macro_authorization::{
+    MacroAuthorizationExtractor, MacroAuthorizationService, MacroAuthorizationState, UserOrInternal,
+};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::domain::models::{
+    CreateDatabase, DatabaseError, ExecOutcome, ExecRequest, QueryError, TableVersion, Viewer,
+};
+use crate::domain::ports::DatabasesService;
+
+/// Router state for databases endpoints.
+pub struct DatabasesRouterState<S, Auth> {
+    service: Arc<S>,
+    authorization_state: MacroAuthorizationState<Auth>,
+}
+
+impl<S, Auth> Clone for DatabasesRouterState<S, Auth> {
+    fn clone(&self) -> Self {
+        Self {
+            service: self.service.clone(),
+            authorization_state: self.authorization_state.clone(),
+        }
+    }
+}
+
+impl<S, Auth> DatabasesRouterState<S, Auth>
+where
+    S: DatabasesService,
+{
+    /// Create router state from the service and authorization state.
+    pub fn new(service: Arc<S>, authorization_state: MacroAuthorizationState<Auth>) -> Self {
+        Self {
+            service,
+            authorization_state,
+        }
+    }
+}
+
+impl<S, Auth> FromRef<DatabasesRouterState<S, Auth>> for MacroAuthorizationState<Auth> {
+    fn from_ref(state: &DatabasesRouterState<S, Auth>) -> Self {
+        state.authorization_state.clone()
+    }
+}
+
+/// Build the databases router.
+pub fn databases_router<S, Auth, T>(state: DatabasesRouterState<S, Auth>) -> Router<T>
+where
+    S: DatabasesService,
+    Auth: MacroAuthorizationService,
+    T: Send + Sync + 'static,
+{
+    Router::new()
+        .route("/", post(create_database_handler::<S, Auth>))
+        .route("/exec", post(exec_handler::<S, Auth>))
+        .route("/{id}/sqlite", get(sqlite_snapshot_handler::<S, Auth>))
+        .route("/{id}/tables", post(create_table_handler::<S, Auth>))
+        .route(
+            "/{id}/tables/{table_id}/columns",
+            post(create_column_handler::<S, Auth>),
+        )
+        .with_state(state)
+}
+
+/// Request body for creating a database.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateDatabaseRequest {
+    /// Display name.
+    pub name: String,
+}
+
+/// Request body for `POST /exec`.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecRequestBody {
+    /// The statements to run, executed in one transaction.
+    pub sql: String,
+    /// Optional compare-and-swap: reject writes if any listed table has moved
+    /// past the given version. Omitted → cell-level last-write-wins.
+    #[schema(nullable = false)]
+    pub base_versions: Option<HashMap<Uuid, i64>>,
+}
+
+/// Create a database owned by the caller.
+pub async fn create_database_handler<S, Auth>(
+    State(state): State<DatabasesRouterState<S, Auth>>,
+    user: MacroAuthorizationExtractor<Auth, UserOrInternal>,
+    Json(req): Json<CreateDatabaseRequest>,
+) -> Result<(StatusCode, Json<crate::domain::models::Database>), DatabaseError>
+where
+    S: DatabasesService,
+    Auth: MacroAuthorizationService,
+{
+    let owner_id = user.authorization.user.macro_user_id.clone();
+    let database = state
+        .service
+        .create_database(CreateDatabase {
+            name: req.name,
+            owner_id,
+        })
+        .await?;
+    Ok((StatusCode::CREATED, Json(database)))
+}
+
+/// Execute SQL as the caller. The whole read/write surface.
+pub async fn exec_handler<S, Auth>(
+    State(state): State<DatabasesRouterState<S, Auth>>,
+    user: MacroAuthorizationExtractor<Auth, UserOrInternal>,
+    Json(req): Json<ExecRequestBody>,
+) -> Result<Json<ExecOutcome>, QueryError>
+where
+    S: DatabasesService,
+    Auth: MacroAuthorizationService,
+{
+    let viewer = Viewer {
+        user_id: user.authorization.user.macro_user_id.clone(),
+    };
+    let outcome = state
+        .service
+        .exec_sql(
+            viewer,
+            ExecRequest {
+                sql: req.sql,
+                base_versions: req.base_versions.map(|versions| {
+                    versions
+                        .into_iter()
+                        .map(|(table, version)| (table, TableVersion(version)))
+                        .collect()
+                }),
+            },
+        )
+        .await?;
+    Ok(Json(outcome))
+}
+
+/// Download a database as a SQLite file.
+pub async fn sqlite_snapshot_handler<S, Auth>(
+    State(_state): State<DatabasesRouterState<S, Auth>>,
+    _user: MacroAuthorizationExtractor<Auth, UserOrInternal>,
+) -> Result<impl IntoResponse, QueryError>
+where
+    S: DatabasesService,
+    Auth: MacroAuthorizationService,
+{
+    // TODO: mint an EntityAccessReceipt<ViewAccessLevel> for the database via
+    // a DatabaseAccessExtractor (blocked on EntityType::Database landing in
+    // model-entity + entity_access), then call service.sqlite_snapshot and
+    // stream the bytes as application/vnd.sqlite3.
+    todo!("snapshot handler blocked on EntityType::Database receipt extractor");
+    #[allow(unreachable_code)]
+    Ok(StatusCode::NOT_IMPLEMENTED)
+}
+
+/// Create a table in a database.
+pub async fn create_table_handler<S, Auth>(
+    State(_state): State<DatabasesRouterState<S, Auth>>,
+    _user: MacroAuthorizationExtractor<Auth, UserOrInternal>,
+) -> Result<StatusCode, DatabaseError>
+where
+    S: DatabasesService,
+    Auth: MacroAuthorizationService,
+{
+    // TODO: EntityAccessReceipt<EditAccessLevel> via DatabaseAccessExtractor,
+    // then service.create_table.
+    todo!("create_table handler blocked on EntityType::Database receipt extractor")
+}
+
+/// Add a column to a table.
+pub async fn create_column_handler<S, Auth>(
+    State(_state): State<DatabasesRouterState<S, Auth>>,
+    _user: MacroAuthorizationExtractor<Auth, UserOrInternal>,
+) -> Result<StatusCode, DatabaseError>
+where
+    S: DatabasesService,
+    Auth: MacroAuthorizationService,
+{
+    // TODO: EntityAccessReceipt<EditAccessLevel> via DatabaseAccessExtractor,
+    // then service.create_column (binding + link/lookup config DTOs).
+    todo!("create_column handler blocked on EntityType::Database receipt extractor")
+}
+
+impl IntoResponse for DatabaseError {
+    fn into_response(self) -> axum::response::Response {
+        let status = match &self {
+            DatabaseError::NotFound => StatusCode::NOT_FOUND,
+            DatabaseError::Unauthorized => StatusCode::FORBIDDEN,
+            DatabaseError::InvalidSchemaOperation(_) => StatusCode::BAD_REQUEST,
+            DatabaseError::Repo(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        let message = match &self {
+            DatabaseError::Repo(_) => {
+                tracing::error!(error = ?self, "databases internal server error");
+                "internal server error".to_string()
+            }
+            other => other.to_string(),
+        };
+        (status, message).into_response()
+    }
+}
+
+impl IntoResponse for QueryError {
+    fn into_response(self) -> axum::response::Response {
+        let status = match &self {
+            // SQLite's message is the product's "broken query" state — pass it
+            // through verbatim for chips to render.
+            QueryError::Sql(_) | QueryError::UntranslatableChange(_) => StatusCode::BAD_REQUEST,
+            QueryError::ReadOnly(_) => StatusCode::FORBIDDEN,
+            QueryError::VersionConflict { .. } => StatusCode::CONFLICT,
+            QueryError::BudgetExceeded => StatusCode::UNPROCESSABLE_ENTITY,
+            QueryError::Infrastructure(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        let message = match &self {
+            QueryError::Infrastructure(_) => {
+                tracing::error!(error = ?self, "databases query infrastructure error");
+                "internal server error".to_string()
+            }
+            other => other.to_string(),
+        };
+        (status, message).into_response()
+    }
+}

--- a/crates/databases/src/lib.rs
+++ b/crates/databases/src/lib.rs
@@ -1,0 +1,46 @@
+#![deny(missing_docs)]
+//! Macro Databases: user-facing tables of typed rows, queried and mutated
+//! through SQL, following the hexagonal architecture pattern.
+//!
+//! A database is a collection of tables (tabs). Columns are bindings to
+//! `models_properties` property definitions, so the existing property type
+//! system (data types, select options, entity references) carries directly
+//! over; cells are [`models_properties::service::PropertyValue`]s stored as
+//! JSONB per row. Entity cells store references only — display data is
+//! hydrated at read time.
+//!
+//! # The SQL-first surface
+//!
+//! There are no cell/row/link CRUD endpoints. The public write and read verb
+//! is SQL, executed against a per-request, permission-scoped, **in-memory
+//! SQLite materialization** of exactly the tables the statement references:
+//!
+//! 1. Build the viewer's catalog (their tables + junction views + magic tables).
+//! 2. Prepare the statement against a schema-only SQLite; the authorizer
+//!    callback yields the referenced tables and columns.
+//! 3. Materialize only those, permission-scoped, with the property model
+//!    compiled to constraints (`STRICT`, `CHECK` from select options, foreign
+//!    keys from links) so SQLite itself enforces validity.
+//! 4. Execute inside a transaction with a session recording the changeset.
+//! 5. Translate the changeset back into typed domain commands and apply them
+//!    to Postgres — the single write path shared with every other surface.
+//!
+//! Postgres is the only source of truth; the SQLite database is discarded
+//! after every request. Schema operations (create database/table/column)
+//! remain small structured endpoints because property definitions carry
+//! configuration DDL cannot express.
+//!
+//! # Architecture
+//!
+//! - **domain**: models, ports, and the service implementation (all policy).
+//! - **inbound**: the Axum router (SQL exec, snapshot download, schema ops).
+//! - **outbound**: Postgres repositories, the rusqlite executor, magic-table
+//!   sources, and the table-event publisher.
+
+pub mod domain;
+
+#[cfg(feature = "inbound")]
+pub mod inbound;
+
+#[cfg(feature = "outbound")]
+pub mod outbound;

--- a/crates/databases/src/outbound.rs
+++ b/crates/databases/src/outbound.rs
@@ -1,0 +1,12 @@
+//! Driven adapters: Postgres persistence, the rusqlite executor, magic-table
+//! sources, and the table-event publisher.
+
+#[cfg(feature = "postgres")]
+pub mod pg_databases_repo;
+
+#[cfg(feature = "sqlite")]
+pub mod rusqlite_executor;
+
+pub mod magic;
+
+pub mod redis_event_publisher;

--- a/crates/databases/src/outbound/magic.rs
+++ b/crates/databases/src/outbound/magic.rs
@@ -1,0 +1,57 @@
+//! Magic tables: platform data exposed to SQL, permission-scoped per viewer.
+//!
+//! Each magic table is a contract — a SQL name, a typed column list, and one
+//! blessed, permission-filtered query that can produce it on demand for a
+//! viewer, projected to only the referenced columns. Column-level laziness is
+//! what makes heavy fields (`documents.content_md`, `calls.transcript`) safe
+//! to offer. All magic tables are read-only (enforced by the executor's
+//! authorizer).
+//!
+//! Planned tables and their backing sources:
+//! - `people`      — ContactsDB: contacts + team members the viewer can see
+//! - `documents`   — MacroDB, entity_access-filtered; lazy `content_md`
+//! - `tasks`       — documents with the Task sub-type + property pivot
+//! - `companies`   — CRM tables + shared property pivot
+//! - `calls`       — call records; lazy `transcript`; participants junction
+//! - `email_threads` — threads + participants junction
+
+use crate::domain::models::{MaterializedTable, TableSchema, Viewer};
+use crate::domain::ports::MagicTables;
+
+/// Errors from magic-table materialization.
+#[derive(Debug, thiserror::Error)]
+pub enum MagicTablesError {
+    /// The named table is not part of the registry.
+    #[error("unknown magic table: {0}")]
+    Unknown(String),
+    /// A backing store failed.
+    #[error("magic table backend error: {0:?}")]
+    Backend(rootcause::Report),
+}
+
+/// The registry of every magic-table source, dispatched by SQL name.
+///
+/// Construction happens in the composition root, which is the only place that
+/// knows about ContactsDB clients and friends.
+#[derive(Debug, Clone, Default)]
+pub struct MagicTableRegistry {
+    // TODO: per-table sources (ContactsDB client, MacroDB pool, property
+    // pivot) injected here by the composition root.
+}
+
+impl MagicTables for MagicTableRegistry {
+    type Err = MagicTablesError;
+
+    fn schemas(&self) -> Vec<TableSchema> {
+        todo!("static schemas for people/documents/tasks/… incl. entity_type tags per column")
+    }
+
+    async fn materialize(
+        &self,
+        _viewer: &Viewer,
+        _sql_name: &str,
+        _columns: &[String],
+    ) -> Result<MaterializedTable, Self::Err> {
+        todo!("dispatch to the table's blessed permission-filtered query, projected to `columns`")
+    }
+}

--- a/crates/databases/src/outbound/pg_databases_repo.rs
+++ b/crates/databases/src/outbound/pg_databases_repo.rs
@@ -1,0 +1,95 @@
+//! Postgres repository for databases, tables, columns, rows, and links.
+//!
+//! Mechanics only: sqlx queries and transactions. Policy lives in the domain
+//! service. Tables: `databases`, `database_tables`, `database_columns`,
+//! `database_rows`, `database_row_links`
+//! (`crates/macro_db_client/migrations/20260908204308_add_databases.up.sql`).
+
+use std::collections::HashMap;
+
+use sqlx::PgPool;
+
+use crate::domain::models::{
+    AppliedChanges, ColumnId, CreateColumn, CreateDatabase, CreateTable, Database, DatabaseId,
+    PropertyDefinitionId, Row, RowChange, RowId, Table, TableId, TableVersion, Viewer,
+};
+use crate::domain::ports::DatabasesRepo;
+
+/// Errors from the Postgres repository.
+#[derive(Debug, thiserror::Error)]
+pub enum PgDatabasesRepoError {
+    /// Underlying database failure.
+    #[error("database error")]
+    Sqlx(#[from] sqlx::Error),
+}
+
+/// [`DatabasesRepo`] backed by MacroDB.
+#[derive(Debug, Clone)]
+pub struct PgDatabasesRepo {
+    pool: PgPool,
+}
+
+impl PgDatabasesRepo {
+    /// Create a repository over the given pool.
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+impl DatabasesRepo for PgDatabasesRepo {
+    type Err = PgDatabasesRepoError;
+
+    async fn create_database(&self, _cmd: &CreateDatabase) -> Result<Database, Self::Err> {
+        let _ = &self.pool;
+        todo!("INSERT INTO databases … RETURNING (sqlx query! once schema is prepared)")
+    }
+
+    async fn get_database(
+        &self,
+        _id: DatabaseId,
+    ) -> Result<Option<(Database, Vec<Table>)>, Self::Err> {
+        todo!("SELECT database + its tables ordered by position")
+    }
+
+    async fn create_table(&self, _cmd: &CreateTable) -> Result<Table, Self::Err> {
+        todo!("INSERT INTO database_tables … RETURNING")
+    }
+
+    async fn create_column(
+        &self,
+        _table_id: TableId,
+        _property_definition_id: PropertyDefinitionId,
+        _cmd: &CreateColumn,
+    ) -> Result<ColumnId, Self::Err> {
+        todo!("INSERT INTO database_columns …; bump table version in the same transaction")
+    }
+
+    async fn fetch_rows(&self, _table_id: TableId) -> Result<Vec<Row>, Self::Err> {
+        todo!(
+            "SELECT id, position, cells FROM database_rows WHERE table_id = $1 (one scan; decode cells JSONB into PropertyValue map)"
+        )
+    }
+
+    async fn fetch_links(&self, _column_id: ColumnId) -> Result<Vec<(RowId, RowId)>, Self::Err> {
+        todo!(
+            "SELECT source_row_id, target_row_id FROM database_row_links WHERE link_column_id = $1"
+        )
+    }
+
+    async fn apply_changes(
+        &self,
+        _viewer: &Viewer,
+        _changes: &[RowChange],
+    ) -> Result<AppliedChanges, Self::Err> {
+        todo!(
+            "one transaction: inserts (mint row ids), cell UPDATEs (jsonb merge), deletes, link edges; bump each written table's version once; return minted ids + new versions"
+        )
+    }
+
+    async fn table_versions(
+        &self,
+        _table_ids: &[TableId],
+    ) -> Result<HashMap<TableId, TableVersion>, Self::Err> {
+        todo!("SELECT id, version FROM database_tables WHERE id = ANY($1)")
+    }
+}

--- a/crates/databases/src/outbound/redis_event_publisher.rs
+++ b/crates/databases/src/outbound/redis_event_publisher.rs
@@ -1,0 +1,34 @@
+//! Table-changed fan-out toward connection_gateway.
+//!
+//! Publishes `{table_id, version}` so live query chips, embeds, and views
+//! re-run. Results are never pushed — every viewer re-executes as themselves.
+
+use crate::domain::models::{TableId, TableVersion};
+use crate::domain::ports::TableEventPublisher;
+
+/// Errors from event publishing.
+#[derive(Debug, thiserror::Error)]
+pub enum PublishError {
+    /// The transport rejected the publish.
+    #[error("publish failed: {0:?}")]
+    Transport(rootcause::Report),
+}
+
+/// [`TableEventPublisher`] over the gateway's Redis pub/sub.
+///
+/// TODO: hold the Redis connection/manager the composition root provides,
+/// matching how other gateway-bound events are published today.
+#[derive(Debug, Clone, Default)]
+pub struct RedisTableEventPublisher {}
+
+impl TableEventPublisher for RedisTableEventPublisher {
+    type Err = PublishError;
+
+    async fn table_changed(
+        &self,
+        _table_id: TableId,
+        _version: TableVersion,
+    ) -> Result<(), Self::Err> {
+        todo!("publish {{table_id, version}} on the gateway channel")
+    }
+}

--- a/crates/databases/src/outbound/rusqlite_executor.rs
+++ b/crates/databases/src/outbound/rusqlite_executor.rs
@@ -1,0 +1,95 @@
+//! The embedded SQLite executor: per-request in-memory databases used for
+//! analysis, sandboxed execution with changeset capture, and snapshot
+//! serialization. Nothing here persists — Postgres is the source of truth.
+//!
+//! rusqlite features in play:
+//! - `set_authorizer`: dependency discovery during [`SqlExecutor::analyze`]
+//!   and read-only/table-allowlist enforcement during execution.
+//! - `session`: records row-level changes made by the statement into a
+//!   changeset, which the domain service translates into typed commands.
+//! - `column_metadata`: origin table/column per result column (provenance for
+//!   chip hydration and write-through).
+//! - `limits` + `progress_handler`/`interrupt`: the execution budget.
+//! - `serialize`: the takeout snapshot bytes.
+
+use crate::domain::models::{
+    Catalog, MaterializedTable, QueryError, QueryResult, RowChange, TableDeps,
+};
+use crate::domain::ports::SqlExecutor;
+
+/// Execution budget knobs.
+#[derive(Debug, Clone)]
+pub struct ExecutorLimits {
+    /// Wall-clock budget per statement batch.
+    pub timeout_ms: u64,
+    /// Maximum rows a result set may return.
+    pub max_result_rows: usize,
+    /// Maximum row changes one exec may produce.
+    pub max_changes: usize,
+}
+
+impl Default for ExecutorLimits {
+    fn default() -> Self {
+        Self {
+            timeout_ms: 250,
+            max_result_rows: 10_000,
+            max_changes: 10_000,
+        }
+    }
+}
+
+/// [`SqlExecutor`] backed by rusqlite in-memory connections.
+#[derive(Debug, Clone)]
+pub struct RusqliteExecutor {
+    limits: ExecutorLimits,
+}
+
+impl RusqliteExecutor {
+    /// Create an executor with the given limits.
+    pub fn new(limits: ExecutorLimits) -> Self {
+        Self { limits }
+    }
+
+    /// Compile a catalog table's schema to SQLite DDL carrying the validity
+    /// model: `STRICT` typing, `CHECK (col IN (…))` from select options,
+    /// FOREIGN KEYs for junction tables, PRIMARY KEY on `row_id`.
+    #[allow(dead_code)]
+    fn compile_ddl(_schema: &crate::domain::models::TableSchema) -> String {
+        todo!("generate CREATE TABLE … STRICT with compiled constraints")
+    }
+}
+
+impl SqlExecutor for RusqliteExecutor {
+    fn analyze(&self, _catalog: &Catalog, _sql: &str) -> Result<TableDeps, QueryError> {
+        let _ = &self.limits;
+        todo!(
+            "open :memory:, create schema-only catalog via compile_ddl, set_authorizer \
+             collecting (table, column, write?) tuples, prepare each statement, map \
+             rusqlite errors to QueryError::Sql verbatim"
+        )
+    }
+
+    fn execute(
+        &self,
+        _catalog: &Catalog,
+        _tables: Vec<MaterializedTable>,
+        _sql: &str,
+    ) -> Result<(Vec<QueryResult>, Vec<RowChange>), QueryError> {
+        todo!(
+            "open :memory:, compile_ddl + bulk-insert materialized rows in one tx, \
+             attach a Session, set_authorizer denying writes to read-only tables, \
+             progress_handler enforcing timeout_ms, run statements collecting SELECT \
+             results with column_metadata provenance, extract the changeset, map it \
+             to RowChange (rowid → row_id via the materialized first column)"
+        )
+    }
+
+    fn serialize_snapshot(&self, _tables: Vec<MaterializedTable>) -> Result<Vec<u8>, QueryError> {
+        todo!("build the database as in execute (no session), then Connection::serialize")
+    }
+}
+
+// The dependency is wired even while the implementation is a stub so the
+// bundled build is validated by CI from day one.
+#[allow(unused_imports)]
+use rusqlite as _;

--- a/crates/macro_db_client/migrations/20260908204308_add_databases.down.sql
+++ b/crates/macro_db_client/migrations/20260908204308_add_databases.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS database_row_links;
+DROP TABLE IF EXISTS database_rows;
+DROP TABLE IF EXISTS database_columns;
+DROP TABLE IF EXISTS database_tables;
+DROP TABLE IF EXISTS databases;

--- a/crates/macro_db_client/migrations/20260908204308_add_databases.up.sql
+++ b/crates/macro_db_client/migrations/20260908204308_add_databases.up.sql
@@ -1,0 +1,85 @@
+-- Macro Databases: user-facing tables of typed rows, queried through SQL.
+--
+-- Design notes (see databases-plan/storage.md in the repo root):
+--   * Postgres is the only source of truth. User SQL runs against a per-query,
+--     permission-scoped, in-memory SQLite materialization — never against these tables.
+--   * A column IS a property_definitions row; database_columns holds placement only.
+--     Name, data_type, is_multi_select, and options all live on the definition.
+--   * A cell is a models_properties PropertyValue (the existing tagged-union JSONB),
+--     keyed by property_definition_id. Entity cells store references, never display data.
+--   * Link columns store edges in database_row_links (real junction), not in cells.
+
+CREATE TABLE databases (
+    id UUID PRIMARY KEY,
+    name TEXT NOT NULL,
+    owner_id TEXT NOT NULL REFERENCES "User"(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    trashed_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_databases_owner ON databases(owner_id);
+
+CREATE TABLE database_tables (
+    id UUID PRIMARY KEY,
+    database_id UUID NOT NULL REFERENCES databases(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    -- Fractional index for tab ordering.
+    position TEXT NOT NULL,
+    -- Bumped on every row/column/link mutation. Cache key for query
+    -- materializations and the invalidation signal for live query chips.
+    version BIGINT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_database_tables_database ON database_tables(database_id);
+
+-- Placement of a property definition as a column of one table. The definition
+-- (owned by the database via property_definitions ownership, or bound to a
+-- shared user/team definition) carries the column's name, type, and options.
+CREATE TABLE database_columns (
+    id UUID PRIMARY KEY,
+    table_id UUID NOT NULL REFERENCES database_tables(id) ON DELETE CASCADE,
+    property_definition_id UUID NOT NULL REFERENCES property_definitions(id),
+    -- Fractional index for column ordering.
+    position TEXT NOT NULL,
+    -- Column-kind specific configuration: link target {database_id, table_id},
+    -- lookup {via_column_id, target}, display width, etc.
+    config JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (table_id, property_definition_id)
+);
+
+CREATE INDEX idx_database_columns_table ON database_columns(table_id);
+
+-- One row per user row; cells are a JSONB object keyed by
+-- property_definition_id whose values are models_properties PropertyValue
+-- tagged unions, e.g. {"<def uuid>": {"type": "String", "value": "hello"}}.
+-- Dense per-row storage (unlike EAV entity_properties): a table fetch is one
+-- sequential scan, a row write is one UPDATE. Cell-level querying happens in
+-- the SQLite materialization, so no per-cell indexes here.
+CREATE TABLE database_rows (
+    id UUID PRIMARY KEY,
+    table_id UUID NOT NULL REFERENCES database_tables(id) ON DELETE CASCADE,
+    -- Fractional index for manual row ordering.
+    position TEXT NOT NULL,
+    cells JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_by TEXT NOT NULL REFERENCES "User"(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_database_rows_table ON database_rows(table_id);
+
+-- Many-to-many edges for link columns. One stored direction; the reverse
+-- ("linked from") column is computed at read time, so it can never drift.
+CREATE TABLE database_row_links (
+    link_column_id UUID NOT NULL REFERENCES database_columns(id) ON DELETE CASCADE,
+    source_row_id UUID NOT NULL REFERENCES database_rows(id) ON DELETE CASCADE,
+    target_row_id UUID NOT NULL REFERENCES database_rows(id) ON DELETE CASCADE,
+    position TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (link_column_id, source_row_id, target_row_id)
+);
+
+CREATE INDEX idx_database_row_links_target ON database_row_links(target_row_id);

--- a/databases-plan/backend-implementation.md
+++ b/databases-plan/backend-implementation.md
@@ -1,0 +1,243 @@
+# Backend implementation sketch
+
+The full shape of the Rust backend for databases: one new domain crate wired into
+document_storage_service, hexagonal throughout. `crates/reminders` is the structural
+template (smallest complete entity crate); `crates/properties` is the domain-logic
+template. Authorization crosses the boundary only as `EntityAccessReceipt<T>`; all policy
+lives in domain services.
+
+## Crate layout
+
+```
+crates/databases/
+  Cargo.toml                      # features: ports, service, inbound, outbound, axum, ai_tools
+  src/lib.rs                      # #![deny(missing_docs)]
+  src/domain/
+    models.rs                     # Database, Table, Column, Row, RowLink, TableVersion,
+                                  #   commands (CreateTable, UpdateCell, LinkRows, …)
+                                  #   QueryRequest, QueryResult, ColumnProvenance, TableDeps
+    models/test.rs
+    error.rs                      # DatabaseError (rootcause), QueryError (incl. SqlError{msg} passthrough)
+    ports.rs                      # the port traits (below)
+    service.rs                    # DatabaseService + QueryService traits (what inbound calls)
+    service_impl.rs               # policy + orchestration
+    service_impl/
+      rows.rs                     # cell writes: validate via models_properties, version bump
+      columns.rs                  # column create = property_definition create (Database owner)
+      links.rs                    # link/unlink, reverse-column semantics
+      query.rs                    # the run-query use case (see "Query pipeline")
+      test.rs                     # allow/deny + business-rule tests with fake ports
+    events.rs                     # DatabaseEvent { TableChanged { table_id, version }, … }
+    activity.rs                   # activity records (crates/activity integration)
+  src/outbound/
+    pg_database_repo.rs           # sqlx: databases / database_tables / database_columns
+    pg_row_repo.rs                # sqlx: database_rows (JSONB cells), database_row_links
+    pg_definition_repo.rs         # thin wrapper over crates/properties definition/option queries
+    rusqlite_executor.rs          # SqlExecutor port impl: prepare, authorizer, materialize-in, run
+    magic/
+      mod.rs                      # registry: name -> Box<dyn MagicTableSource>
+      people.rs                   # ContactsDB-backed
+      documents.rs                # entity_access-filtered MacroDB query
+      tasks.rs                    # documents with DocumentSubType::Task + property pivot
+      companies.rs / calls.rs / email_threads.rs
+    redis_event_publisher.rs      # TableEventPublisher port impl (connection_gateway fan-out)
+    sqs_search_indexer.rs         # optional v1 (Postgres-only search is fine initially)
+  src/inbound/
+    axum_router.rs                # nests the sub-routers, owns RouterState<S: DatabaseService, …>
+    axum_router/
+      databases.rs                # CRUD on the entity
+      tables.rs / columns.rs / rows.rs / links.rs
+      query.rs                    # POST /databases/query
+      test.rs
+    toolset.rs                    # AI tools: create_database, add_rows, update_cells,
+    toolset/                      #   query_database, describe_database_schema
+      …one file per tool
+```
+
+Plus a receipt extractor: `crates/entity_access/src/inbound/axum_extractors/database.rs`
+(copy the `reminder.rs` shape) minting `EntityAccessReceipt<View|Edit|OwnerAccessLevel>`
+for `EntityType::Database` from a path param.
+
+## Migrations (`crates/macro_db_client`, via `sqlx migrate add`)
+
+1. `add_databases` — `databases`, `database_tables` (with `version BIGINT`),
+   `database_columns` (placement over `property_definitions`), `database_rows`
+   (`cells JSONB`), `database_row_links` + indexes (see storage.md DDL).
+2. `add_database_property_owner` — extend `property_definitions` ownership with a
+   `database_id` dimension (mirrors the team-scoping migration) + uniqueness per scope.
+3. `add_database_entity_type` — add `DATABASE` to the entity-type enums that are Postgres
+   enums (`property_entity_type` etc. as needed).
+
+After each: `nix develop --command just prepare_db` from repo root.
+
+## Domain ports (`ports.rs`)
+
+```rust
+/// Rows/tables/columns persistence. Implemented by pg_* repos.
+#[async_trait]
+pub trait DatabaseRepo {
+    async fn create_database(&self, cmd: CreateDatabase) -> Result<Database, DatabaseError>;
+    async fn get_database(&self, id: &DatabaseId) -> Result<DatabaseWithTables, DatabaseError>;
+    async fn create_table(&self, cmd: CreateTable) -> Result<Table, DatabaseError>;
+    async fn fetch_rows(&self, table_id: &TableId) -> Result<Vec<Row>, DatabaseError>;
+    async fn update_cells(&self, cmd: UpdateCells) -> Result<TableVersion, DatabaseError>;
+    async fn insert_rows(&self, cmd: InsertRows) -> Result<Vec<Row>, DatabaseError>;
+    async fn link_rows(&self, cmd: LinkRows) -> Result<TableVersion, DatabaseError>;
+    // … delete/reorder/etc. Every mutation returns the bumped TableVersion.
+}
+
+/// Column definitions live in the properties system; this port wraps it.
+#[async_trait]
+pub trait ColumnDefinitionStore {
+    async fn create_definition(&self, scope: DatabaseScope, def: NewDefinition) -> …;
+    async fn definitions_for_tables(&self, ids: &[TableId]) -> …; // incl. options
+    async fn promote_to_owner(&self, def_id: Uuid, to: PropertyOwner) -> …;
+}
+
+/// One implementor per magic table. Registry lives in outbound, consumed via this trait.
+#[async_trait]
+pub trait MagicTableSource: Send + Sync {
+    fn schema(&self) -> TableSchema;                      // name + typed columns
+    async fn materialize(&self, viewer: &Viewer, columns: &[ColumnName])
+        -> Result<MaterializedTable, QueryError>;         // permission-scoped
+}
+
+/// The embedded SQLite sandbox. Implemented by rusqlite_executor.
+pub trait SqlExecutor: Send + Sync {
+    /// Prepare against a schema-only catalog; returns referenced tables+columns
+    /// (authorizer callback) or the SQLite error verbatim.
+    fn analyze(&self, catalog: &Catalog, sql: &str) -> Result<TableDeps, QueryError>;
+    /// Load materialized tables, execute read-only with timeout/row caps,
+    /// return typed rows + per-column provenance.
+    fn execute(&self, tables: Vec<MaterializedTable>, sql: &str, limits: Limits)
+        -> Result<QueryResult, QueryError>;
+}
+
+/// Liveness fan-out. Implemented by redis_event_publisher.
+#[async_trait]
+pub trait TableEventPublisher {
+    async fn table_changed(&self, table_id: &TableId, version: TableVersion) -> Result<(), DatabaseError>;
+}
+```
+
+Plus reuse of existing ports: activity recorder, clock/id-gen if the house style wants
+them injectable.
+
+## The query pipeline (`service_impl/query.rs`)
+
+The one genuinely novel use case. Domain service orchestrates; adapters do mechanics:
+
+```rust
+async fn run_query(&self, viewer: Viewer, req: QueryRequest) -> Result<QueryResult, QueryError> {
+    // 1. catalog: every table this viewer can see (their db tables via entity_access,
+    //    junction views derived from link columns, all magic table schemas)
+    let catalog = self.build_catalog(&viewer).await?;
+    // 2. sugar rewrite (HAS) — pure function in domain
+    let sql = desugar(&req.sql);
+    // 3. deps via prepare/authorizer (SqlExecutor port)
+    let deps = self.executor.analyze(&catalog, &sql)?;
+    // 4. materialize only referenced tables, permission-scoped:
+    //    user tables -> DatabaseRepo::fetch_rows + option/display resolution
+    //    junctions   -> DatabaseRepo link fetch
+    //    magic       -> MagicTableSource::materialize(viewer, referenced_columns)
+    let tables = self.materialize(&viewer, &deps).await?;
+    // 5. execute sandboxed; result carries per-column provenance
+    //    { origin: Table.Column, entity_type: Option<EntityType>, writable: bool }
+    //    and per-row base row ids when the plan is 1:1 (write-through support)
+    let result = self.executor.execute(tables, &sql, Limits::default())?;
+    // 6. attach deps+versions for client-side liveness subscription
+    Ok(result.with_deps(deps))
+}
+```
+
+Authorization note: `POST /databases/query` takes no single entity receipt — the query may
+span tables. The *catalog itself is the authorization*: it is built from the viewer's
+`entity_access` grants, so an unreadable table never exists in the prepare catalog (query
+against it fails as "no such table") and unreadable rows/entities are never materialized.
+That policy lives in `build_catalog`/`materialize` in the domain service, tested with fake
+ports.
+
+rusqlite specifics (outbound): `Connection::open_in_memory()`, `set_authorizer` for both
+dep-collection during `analyze` and SELECT-only enforcement during `execute`,
+`progress_handler`/`interrupt` for the ~100ms budget, deterministic bulk insert in one
+transaction. Add `rusqlite` (bundled feature) to the workspace — first embedded-SQLite dep
+in the repo; `bundled` avoids any system libsqlite dependency in nix.
+
+## Inbound surface
+
+Routes (nested in DSS at `/databases`):
+
+| route | receipt | service call |
+|---|---|---|
+| `POST /databases` | authenticated identity | `create_database` |
+| `GET /databases/:id` | `View` | `get_database` (tables+columns+defs) |
+| `GET /databases/:id/tables/:tid/rows` | `View` | `fetch_rows` (paginated) |
+| `POST …/tables` `PATCH …/tables/:tid` | `Edit` | table CRUD |
+| `POST …/columns` `PATCH/DELETE …/columns/:cid` | `Edit` | column ops (definition create/bind/promote) |
+| `POST …/rows` `PATCH …/rows/:rid/cells` `DELETE …/rows/:rid` | `Edit` | row ops |
+| `POST/DELETE …/links` | `Edit` | link ops |
+| `POST /databases/query` | identity only (catalog is the authz) | `run_query` |
+
+Handlers: extract receipt via the new database extractor, parse DTO, call service, map
+errors. No policy, no persistence, per the hexagonal guard. Rename/trash/share/move come
+free from implementing the `entity_mutation` capability traits
+(`RenameEntity`, `TrashEntity`, …) registered in
+`services/document_storage_service/src/service/entity_mutation.rs`.
+
+AI tools (`inbound/toolset/`, via the create-ai-tool skill): `describe_database_schema`,
+`query_database` (returns typed rows for the model), `add_rows`, `update_cells`,
+`create_database`. These are thin wrappers over the same domain services with the actor's
+receipt.
+
+## Entity plumbing (the ~26-file checklist)
+
+- `EntityType::Database` in `crates/model-entity` (+ `is_valid_entity_access_entity` → true)
+- `GraphqlEntityType`, `SoupItem::Database` + soup repo/loaders/objects, soup `ItemType`
+- `models_properties::EntityType` only if entities-in-cells need to *target* databases
+- Search: start Postgres-only (the `CrmCompanies` precedent); OpenSearch later
+- `crates/entity_access` extractor + delete cascade in `macro_db_client/item_access/delete.rs`
+- Webhook/activity ingestion touch points (trace `EntityType::Reminder` for the full list)
+
+## Composition root
+
+`services/document_storage_service/src/api.rs`: construct
+`DatabaseServiceImpl::new(pg_database_repo, pg_row_repo, definition_store, magic_registry,
+rusqlite_executor, redis_publisher, activity)` and nest
+`databases::inbound::axum_router(state)`. Magic registry construction is the one place
+that knows about ContactsDB clients etc.
+
+## Cross-cutting conventions
+
+- Errors: `rootcause`; `#[tracing::instrument(err)]` on Result-returning service methods.
+- sqlx compile-time macros everywhere; `just prepare_db` after query changes; tests in
+  `foo/test.rs` submodules; fixtures for pg repo tests; run
+  `cargo test -p databases` (needs `bash .cursor/infra.sh` once for pg/redis).
+- Env vars (limits, feature flag) via `macro_env_var` macros.
+- OpenAPI via utoipa on inbound DTOs → SDK wrapping per add-sdk-endpoint
+  (`packages/sdk/src/entities/databases/`, `just coverage` enforces).
+
+## Phasing (PR-sized)
+
+1. **Migration + entity skeleton**: tables, `EntityType::Database`, enum plumbing,
+   entity_access extractor, entity_mutation capabilities, empty crate compiling.
+2. **CRUD spine**: domain models/ports/service, pg repos, routers for
+   database/table/column/row/link ops, `PropertyOwner::Database` + definition store.
+   App can create databases and edit cells (grid works end-to-end).
+3. **Query engine**: rusqlite executor + catalog/materializer for user tables and
+   junctions, `POST /databases/query`, `HAS` desugar, provenance. Chips work.
+4. **Magic tables**: `people` first, then `documents`/`tasks`; property-pivot
+   materializer shared.
+5. **Liveness**: version events → Redis → connection_gateway; client invalidation.
+6. **AI tools + SDK**: toolset, openapi, SDK wrappers.
+
+Steps 3–6 are independent enough to parallelize after 2.
+
+## Open implementation questions
+
+- Does `run_query` execution belong on a `spawn_blocking` pool (rusqlite is sync/CPU) —
+  yes, decide pool sizing/limits.
+- Pagination + max row counts for `fetch_rows` and materialization caps (env-var'd).
+- Whether `database_rows.position` uses the existing fractional-index helper (find what
+  soup/tasks ordering uses) or we vendor one.
+- Cell-write batching shape (`PATCH …/cells` takes a map of column→SetPropertyValue —
+  one version bump per request).

--- a/databases-plan/frontend-block.md
+++ b/databases-plan/frontend-block.md
@@ -1,0 +1,85 @@
+# The database block (frontend)
+
+The full-screen surface at `/app/database/<id>`: tabs are tables, columns are property
+bindings, cells are the property editors. Notion-database-pilled, not spreadsheet-pilled:
+no A1 references, no per-cell formulas — the escape hatch for computation is SQL chips.
+
+Interactive mock: https://claude.ai/code/artifact/635f0600-3d70-4a70-8564-f37af63042aa
+
+## Block registration (the well-worn path)
+
+1. `'database'` in `BlockRegistry` (`apps/web/src/lib/core/block.ts`) + entries in
+   `NonDocumentBlockTypes`, `_ValidBlockCombinations` / `ValidNestingCombinations`
+   (exhaustive records — TS points at every touch point).
+2. `apps/web/src/features/block-database/definition.ts` — `defineBlock({...})`;
+   `features/block-agent/definition.ts` is the 30-line template.
+3. `BlockComponentProps` / `BlockComponentLoadData` typing entries.
+4. Launcher: `TOKENS.create.database` in `lib/core/hotkey/tokens.ts`, one
+   `CREATABLE_BLOCKS` entry + one `runCreateAction` case in
+   `features/command/Launcher.tsx` (`c` → `b`), icon.
+5. Entity plumbing: `buildEntityData.ts`, `entity-icon.tsx`, `blockNameToItemType`,
+   soup filter configs, `category-search-filters.ts`. (Grep `'agent'` across
+   `apps/web/src` for the exact touch-point set — most recent addition.)
+6. Splits, sharing modal, routing come free from the split-layout system.
+
+## The grid
+
+**Hand-rolled, house style — no grid library.** Extract the existing pattern into a shared
+primitive:
+
+- Column-definition convention from
+  `features/next-soup/soup-view/views/companies/company-grid-template.ts` (typed column
+  array → `grid-template-columns` / `grid-template-areas` strings).
+- Row layout from `company-grid-layout.tsx` / `tasks/task-grid-layout.tsx`.
+- Virtualization: `virtua/solid` `Virtualizer` (soup-view does this at ~1400 lines; ours
+  starts smaller).
+- Cell editors and renderers ARE `features/property/` — `Property.Root/Icon/Text/Chips`
+  slots, `editors/` for inline editing, `CreatePropertyModal`'s type picker for "change
+  column type". Entity cells use the existing mentions typeahead.
+- Selection/keyboard: `components/list/` (`create-list-controller`,
+  `create-selection-state`) for row selection; cell-level keyboard nav is new work.
+
+## Surfaces & affordances
+
+- **Tabs** = tables, `+` adds one, double-click renames. The only place the
+  "database is a collection" concept surfaces.
+- **Views strip**: Table only in v1. Kanban is **punted entirely** — the
+  grouping/write-back model isn't fleshed out (what does dragging a card mean for
+  multi-select columns? group by lookup?); revisit post-v1 with `CompanyKanban.tsx` as
+  the eventual precedent. View configs (filters/sorts/column layout) still persist to
+  `crates/saved_views`.
+- **Filter pills compile to predicates** shared with SQL. "view as SQL" shows the query
+  the clicks built — the GUI path and the SQL path are one engine, so they can't drift.
+  It's also the best SQL-literacy funnel we have.
+- **New row**: ghost row at the bottom ("+ New row — or type @ to add an existing
+  person"). For link/entity-restricted tables, the add affordance leads with search
+  (you don't author a call); for authorable types it leads with create.
+- **Bare rows**: name cell as plain text, no entity. Hover hint `⌘↵ make contact`.
+  Hydration keeps property values.
+- **Type restriction is inferred, not asked**: start untyped; when every row is (say) a
+  person, a quiet banner offers "Restrict to People?" — the payoff is type-specific
+  suggested columns (email, company). Never a creation-time modal.
+- **Row menu** distinguishes `Remove from table` (membership edge — never deletes the
+  entity) from `Delete entity…` (the scary one). Getting this crisp is what makes users
+  trust databases with real entities.
+- **Column header menu**: rename / sort / hide / delete / change type; a note that a
+  column is a database-scoped property, promotable to workspace.
+
+## Column add menu
+
+Primitive types (Text/Number/Select/Person/Checkbox/Date), then:
+
+- `Link to table…` → target picker (see [links-and-lookups.md](links-and-lookups.md)).
+- Per existing link column: a "Through <link> 🔗" section offering lookups + rollups.
+
+## Naming
+
+Users only ever see **"table"**; "database" appears nowhere in UI copy. Launcher letter
+TBD (`b` for base vs `t` — `t` may collide with task).
+
+## Data flow
+
+Grid mutations go through the databases API (never SQL). Local edits echo optimistically;
+remote edits arrive via the liveness channel ([liveness.md](liveness.md)) keyed on table
+version counters. Server-state via `@tanstack/solid-query` in `service-clients` per house
+rules; queries in `src/lib/queries` if shared.

--- a/databases-plan/lexical-nodes.md
+++ b/databases-plan/lexical-nodes.md
@@ -1,0 +1,73 @@
+# Lexical nodes (doc surfaces)
+
+Four surfaces, one rule: **nodes persist queries and references, never results or rows.**
+Results differ per viewer (permissions), storing them would churn the Loro CRDT on every
+table edit, and re-run-on-mount makes live-on-open the default behavior.
+
+All nodes follow the house 5-step registration (node class in `packages/lexical-core/nodes/`
+→ `node-list.ts` → `decoratorRegistry.ts` → transformer in `transformers/` → Solid
+decorator + `setDecorator` in `init.ts`), single-XML-tag-with-JSON-body markdown form,
+`UnknownMentionNode` fallback for forward compat, and a version counter bump in
+`LexicalMarkdown/version.ts`.
+
+## The nodes
+
+### Query chip — inline
+- Shape: `DocumentMentionNode` (inline `DecoratorNode`, keyboard-selectable).
+- Persists: `{ sql, prompt, displayMode: 'scalar' }`.
+- Renders: number-chip with a ⚡ glyph; click → popover with SQL (read + edit via the
+  [sql-editor](sql-editor.md)), live status, row count.
+- Transformer: `<m-db-query>{json}</m-db-query>`.
+
+### Query block — block
+- Same node family, `displayMode: 'table'` — scalar vs table is chosen automatically from
+  result shape (1×1 → inline chip; else block).
+- Renders: header (name, live dot, row count, source link, SQL toggle) + read-only result
+  grid with hydrated chips + the prompt/editor drawer.
+
+### View — block
+- Persists: `{ sql, prompt, viewConfig }`. A query wearing a grid: columns are the
+  query's projection, cells use the full property editors **where writable** (a result
+  column is editable iff it traces to a single base column — Postgres updatable-view
+  rule), membership belongs to the WHERE clause so there is no "new row" affordance.
+- Footer states the predicate ("rows enter and leave as they match …").
+
+### Chart — block
+- Persists: `{ sql, prompt, chartConfig: {kind: 'line' | 'bar', x, y} }`. Same query
+  object as a view with a different renderer. Follows the dataviz conventions already in
+  the mock (single-series → no legend, recessive grid, hover crosshair + tooltip,
+  emphasized live endpoint).
+- Note: kanban as a view/renderer kind is **punted entirely** — the grouping/write-back
+  model isn't fleshed out; revisit after v1.
+
+### Database embed — block
+- Shape: `DocumentCardNode` (block `DecoratorBlockNode` with the reference+preview split).
+- Persists: `{ databaseId, tableId, viewConfig }` only. Renders the full editable grid
+  inline (same grid primitive as the block, internal scroll past ~300px), header with
+  source link + synced indicator.
+- Degrades to a "table no longer exists" state if the ref breaks; renders with the
+  viewer's permissions in shared docs.
+- Transformer: `<m-database>{json}</m-database>`.
+
+## Insertion
+
+- `/` actions menu: Database (→ table picker), View, Chart, Query.
+- `@` mentions menu: a "databases" bucket (`BucketConfig` in `MentionsMenuController`) —
+  pick a database → pick a table/saved view or "write a query".
+- AI: the create-ai-tool path so agents can insert chips/views/charts with generated SQL.
+
+## Rendering discipline
+
+- `LazyDecorator` (viewport-gated, shared IntersectionObserver) wraps every query-running
+  decorator — only visible blocks execute and subscribe.
+- `AwaitNode`-style pending shimmer while a query is in flight.
+- Ephemeral state (results, generation-in-progress) lives in the decorator component,
+  never in node state — node state round-trips through markdown XML and the Loro schema.
+- Broken states are first-class renders (missing table, missing column, permission-empty),
+  never crashes: `⚠ column "status" no longer exists — edit query`.
+
+## Liveness hookup
+
+Each mounted decorator registers its dependency set (returned by the executor) with the
+invalidation channel; see [liveness.md](liveness.md). Local mutations from an embedded
+grid echo immediately; the same mutation's version bump updates every other surface.

--- a/databases-plan/links-and-lookups.md
+++ b/databases-plan/links-and-lookups.md
@@ -1,0 +1,90 @@
+# Links, lookups, rollups
+
+Design stance: **the GUI never has a "join" feature.** It has link columns (write),
+lookups/rollups (read), and one-hop filters (query) — each desugaring to the same junction
+views the SQL surface exposes. The word JOIN appears exactly once in the product: the
+"view as SQL" readout.
+
+## Link columns (relations)
+
+- Created from the `+` column menu: `Link to table…` → target table picker. Person and
+  Company columns are secretly this same thing with a magic-table target — pin `people` /
+  `companies` at the top of the picker.
+- **Many-to-many** via `database_row_links` (see [storage.md](storage.md)). Cardinality
+  UI ("each guest links one vendor" vs "many") is a creation-time option; storage is
+  always the junction, cardinality is a constraint.
+- **Two-way by default**: creating "Sessions" on Guests adds a "Guests" column to
+  Sessions. The reverse column is *derived* (computed from forward links), never stored —
+  so it can't drift.
+- Deleting a link column orphans the reverse column gracefully (renders em-dashes),
+  mirroring the broken-lookup degradation.
+
+## Cell UX
+
+- Linked rows render as **row chips**: target row's primary cell as the label (a person
+  primary shows a person chip *through* the link), row-card hovercard showing the target's
+  first ~4 fields.
+- Click chip → small menu: `Open <table> ↗` / `Remove link` (+ note: removing a link never
+  deletes the row on the other side).
+- Click cell / ghost `+` → **row picker**: mentions-menu scoped to the target table's
+  rows, searched by primary label, with `+ New row "<typed>"` that creates-and-links in
+  one motion (half of linking is creating the other side on the fly).
+
+## Lookups & rollups ("through the link")
+
+Once a link column exists, the `+` column menu grows a contextual section:
+
+```
+Through Sessions 🔗
+  room        (text)      → lookup column "⇢ Room (via Sessions)"
+  starts_at   (date)
+  speaker     (person)
+  Σ count of sessions     → rollup column
+```
+
+- Lookup/rollup columns are **derived, query-time-only** — nothing stored, computed during
+  materialization/desugar. Read-only, styled recessive (italic muted, `⇢` prefix, accent
+  `via <link>` badge) so derivation reads at a glance.
+- Rollups v1: count. min/max/sum by type later.
+- Broken references (deleted link column or target column) degrade to a visible
+  "broken lookup" cell state, never an error page.
+
+## Lookups through entity columns
+
+An entity column is a link to a magic table, so the same "through" section applies: a
+Task column offers `status / assignee / due date` (the tasks magic table's fields = its
+system/shared properties), a Company column offers its CRM fields, a Person column offers
+email/org, etc.
+
+- Read path: identical to link lookups — derived column, `⇢` + `via` badge, desugars to
+  `LEFT JOIN tasks ON tasks.id = v.follow_up`.
+- **Write path**: a magic-table field that is a shared/system property traces to a single
+  editable base field, so the lookup cell is *editable* — changing "Status (via
+  Follow-up)" writes the task's actual status through the normal task mutation path,
+  visible in the Tasks module and everywhere else. This is the shared-property-binding
+  rule from storage.md applied through one hop. Computed/system-owned fields
+  (`created_at`, counts) stay read-only.
+- The `via` badge carries the semantics: you are editing the entity itself, not a
+  database-local note about it. A database-scoped "our status" column and a reflected
+  "the task's status" column can coexist; the badge is the difference.
+
+## SQL desugar
+
+Link column + lookup =
+
+```sql
+SELECT g.*, s1.room AS "room_via_sessions"
+FROM   guests g
+LEFT JOIN guests__sessions j1 ON j1.row_id = g.row_id
+LEFT JOIN sessions s1         ON s1.row_id = j1.linked_id
+```
+
+Shown in "view as SQL". Conversely, in the SQL editor, typing `JOIN` offers link columns
+as pre-baked join paths ("through Sessions 🔗" inserts the junction pair) — hand-written
+SQL reuses the relationships the GUI declared. See [sql-editor.md](sql-editor.md).
+
+## Filtering across the link
+
+Filter pills support exactly **one hop**: `( Sessions 🔗 → room ) is "Main Hall"`. Deeper
+chains are genuinely queries; the affordance is an "edit as SQL" escape hatch, not a chain
+builder. One hop covers ~95% of real use.

--- a/databases-plan/liveness.md
+++ b/databases-plan/liveness.md
@@ -1,0 +1,82 @@
+# Liveness
+
+How chips, views, charts, and embeds stay live. One sentence: *nodes store queries; the
+executor's prepare step yields each query's table dependencies; version counters + the
+existing gateway broadcast "changed"; every viewer re-runs as themselves, debounced.*
+
+## The invariant
+
+Results are never stored, synced, or shared. Three reasons:
+
+1. Results differ per viewer (permission-scoped materialization) — there is no single
+   correct value to sync.
+2. Writing results into the Loro doc would turn every table edit into CRDT churn across
+   every doc embedding a chip on that table.
+3. Re-run-on-mount makes "live on open" the zero-machinery baseline; push-invalidation is
+   an enhancement layer, not a correctness requirement.
+
+The sync-service keeps the *document* collaborative; query results are ephemeral decorator
+state riding alongside it.
+
+## Dependency tracking
+
+The executor already discovers each query's table set via SQLite's authorizer during
+prepare ([query-engine.md](query-engine.md)). Every query response includes
+`deps: [tableIds]` and `versions: {tableId: n}`. The discovery needed for materialization
+doubles as the reactivity graph — no separate SQL analysis, can't drift.
+
+## Invalidation protocol
+
+- Every mutation (row/column/link change) bumps `database_tables.version` and publishes
+  `{tableId, version}` — Redis pub/sub behind `connection_gateway`, the same WebSocket
+  path that delivers live updates everywhere else (block definitions'
+  `liveTrackingEnabled` is precedent).
+- We push **"something changed", never rows** — each viewer must re-execute as themselves.
+- Client: a mounted decorator holding `deps` sees `tbl_x → v42 > its v41` → re-runs,
+  debounced ~300ms to coalesce bursts (someone typing across cells).
+- `@tanstack/solid-query` mapping: the version event is
+  `invalidateQueries(['dbquery', nodeId])`.
+
+## Refinements
+
+- **Local echo**: when this client caused the mutation (grid or embed edit), bump the
+  local version and re-run immediately — don't wait for the round trip. This is what
+  makes it *feel* live; the gateway path is for other people's edits.
+- **Viewport gating**: only mounted-and-visible decorators subscribe (`LazyDecorator`).
+  Thirty chips in a doc → three subscriptions.
+- **Fan-out bound**: an edit costs (open docs watching that table) × (one ms-scale query
+  each), at human edit rates over human-scale tables. Nothing to shard for years.
+- Embeds and write-through views are the same machinery: their own mutation triggers the
+  same version bump that refreshes every other surface.
+
+## Bidirectional updates in practice
+
+There is no bidirectional sync — one write path, one read path, every surface uses both:
+
+- Every editable cell anywhere (grid, embed, view, query-result pill) resolves to
+  `(rowId, columnId, value)` via result provenance and calls the same mutation API.
+  Nothing writes "to a result"; provenance only addresses the write. SQL never mutates.
+- The mutation does permission check → Postgres UPDATE (or `entity_properties` for
+  shared-bound columns) → activity → version bump → publish. Then the normal read half
+  refreshes every subscriber.
+- Conflicts: **last-write-wins per cell** (version counters are invalidation signals, not
+  locks); cell granularity means edits to different cells of one row never conflict.
+- Two-way links: one stored edge (`database_row_links`); the reverse column is computed at
+  read time — nothing to keep in sync. The write bumps both tables' versions.
+- Shared-property bindings: one write to `entity_properties`; the Tasks module and the
+  database each refresh through their own subscription. Two subscribers, one write.
+- UX costs to budget: disappearing-row animation when an edit makes a row stop matching a
+  view's WHERE ("moved out of this view", not silent removal), and echo suppression
+  (mutation-id dedup so your own optimistic update doesn't re-apply on the return event).
+
+## Magic-table tier
+
+`deps: [people]` is noisier than a user table ("any contact changed"), and versioning all
+magic data per user is real work. Tiered:
+
+- **v1**: magic-table deps get re-run on mount + window refocus. Staleness measured in
+  seconds; invisible for a contact rename.
+- **v2**: coarse per-magic-table version signals if usage demands.
+
+The chip architecture is identical across tiers — only the freshness of the invalidation
+signal changes — so nothing gets repainted into a corner.

--- a/databases-plan/magic-tables.md
+++ b/databases-plan/magic-tables.md
@@ -1,0 +1,78 @@
+# Magic tables
+
+Magic tables expose Macro's own data to SQL: `people`, `documents`, `tasks`, `companies`,
+`calls`, `email_threads`, `channels`, `calendar_events`, `projects`. None of them exist as
+stored tables anywhere. Each is a **contract**: a name, a column list, and one blessed,
+permission-filtered Postgres query that can produce it for a given user on demand.
+
+They're what makes user tables join against the platform:
+
+```sql
+SELECT p.email
+FROM   guests g
+JOIN   people p ON p.id = g.guest      -- people: magic table, every contact you can see
+WHERE  g.status = 'Going'
+```
+
+## How a magic table gets into a query
+
+1. Its schema is always present in the prepare catalog (columns declared, no data).
+2. The authorizer reports it referenced — **with columns**, e.g. `people(id, email)`.
+3. Its blessed query runs scoped to the requesting user, projected to only the referenced
+   columns, and bulk-inserts into the scratch SQLite.
+4. The join is then an ordinary SQLite join: cell ids and magic-table `id` columns are the
+   same id space (typed prefixes: `usr_`, `doc_`, `call_`…).
+
+Column-level laziness is the key affordance: heavy fields (`documents.content_md`,
+`calls.transcript`) can be real columns whose cost is only paid when a query names them.
+
+## Column contracts (initial sketch)
+
+Every magic table = system fields + the entity's system/shared property definitions
+(materialized from `entity_properties`). Adding a workspace property "Region" to companies
+makes `companies.region` appear in SQL for free.
+
+| table | system columns (beyond id, created_at) | heavy/lazy columns |
+|---|---|---|
+| `people` | name, email, org, is_team_member | — |
+| `documents` | title, owner_id, project_id, updated_at | content_md |
+| `tasks` | title, status, assignee, due_date (system props) | — |
+| `companies` | name, domain + CRM system props | — |
+| `calls` | title, started_at, duration, participants (junction) | transcript, summary |
+| `email_threads` | subject, participants (junction), last_message_at | — |
+| `channels` | name, member_count | — |
+| `calendar_events` | title, starts_at, ends_at, attendees (junction) | — |
+| `projects` | name | — |
+
+Multi-valued fields (call participants, event attendees) materialize as junction views
+(`calls__participants(call_id, user_id)`), same pattern as user-table multi columns.
+
+Blessed-query sources: ContactsDB for `people` (contacts + team members the user can see),
+`entity_access`-filtered MacroDB queries for the rest. Each contract lives next to its
+domain crate; the databases crate defines the trait
+(`fn schema() -> TableSchema; async fn materialize(user, columns) -> Rows`).
+
+## Permission scoping
+
+The blessed query IS the permission check. A viewer's scratch DB only ever contains
+entities they can access, so joins silently drop what they can't see. No filtering inside
+user SQL, no way to leak by clever query construction — the data was never materialized.
+
+## Read-only
+
+`UPDATE people SET ...` is rejected at the authorizer with a pointer to the SDK
+(`macro.contacts.update(...)`). Write-through for clean-provenance columns is a possible
+later tier, same traceability rule as updatable views.
+
+## Relationship to properties
+
+`entity_properties` is what makes magic tables rich: `tasks.due_date` exists because "Due
+date" is a system property. The materializer for property-backed columns is one shared
+implementation (pivot the EAV rows for the referenced definitions), reused by every magic
+table.
+
+## Liveness tier
+
+Magic-table dependencies get the weak tier first: re-run on mount + window focus (staleness
+of seconds, invisible for a contact rename). Coarse version signals per magic table are v2
+if usage demands. See [liveness.md](liveness.md).

--- a/databases-plan/permissions.md
+++ b/databases-plan/permissions.md
@@ -1,0 +1,61 @@
+# Permissions & sharing semantics
+
+The least fun questions and the ones that most constrain everything else — decide these
+early. Mechanically, permissions ride the standard rails: `EntityType::Database` +
+`entity_access` (share the database; tables/rows inherit), receipts via a new axum
+extractor, enforcement in the domain layer. This doc is about the *semantics*.
+
+## Settled by the architecture
+
+- **Query scoping is structural.** A viewer's scratch SQLite is materialized from their
+  view of the world; magic tables come pre-filtered by their access. The same shared chip
+  legitimately returns different results for different viewers — correct, not a bug. No
+  permission checks inside SQL exist to get wrong.
+- **Chips in shared docs run as the viewer**, never as the author. Persisting queries
+  (never results) is what makes this workable.
+- **Membership is an edge.** "Remove from table" touches the edge; the referenced entity
+  and its permissions are untouched. Removing a link never deletes the row/entity on the
+  other side.
+
+## To decide: rows referencing entities the viewer can't access
+
+A shared database of Calls where the viewer lacks access to some calls. Options per cell
+and per row:
+
+1. **Redacted chip** (visible row, "restricted" pill for the cell) — preserves table
+   shape, honest about existence, mild metadata leak (the row's other, database-scoped
+   cells are visible).
+2. **Hidden row** — no leak, but viewers see different row counts and aggregates, and
+   collaborative confusion follows ("I see 12 rows, you see 9").
+3. **Redacted + request-access affordance** — the Macro-native move; the share modal flow
+   already exists for docs.
+
+Lean: **(1)/(3) for cells, never (2) for rows whose membership itself isn't secret** —
+the row was put in the table on purpose; the *entity* is what's protected. But: a
+database restricted to type Call where the row IS the entity makes (1) equal to leaking
+that a call exists. Proposed rule: cell-level redaction for entity cells; row-level
+hiding only when the row's identity column is the inaccessible entity AND the database is
+type-restricted. Needs a pass with real cases before v1 ships sharing.
+
+Whatever we choose must hold identically in: the grid, embeds, query results (the
+materializer simply omits inaccessible entities from magic tables — so SQL naturally
+behaves like (2) for joins; reconcile the story), and exports.
+
+## To decide: what edit access means
+
+- View access: read grid, run chips (as self), no mutations.
+- Edit access: row/cell mutations, add columns? (column changes are schema-ish — maybe
+  owner-only, like Notion's "can edit content" vs "full access").
+- Owner: share, delete, restrict type, promote columns.
+
+## To decide: bare-row hydration ownership
+
+Hydrating a bare row mints a real entity — owned by the hydrator or the database owner?
+Lean: the hydrator, consistent with "entities are people's things; databases hold edges."
+
+## Deliberately deferred
+
+- Per-table sharing within a database (schema supports it later).
+- Public/link sharing of databases and of docs containing embeds (embed renders as viewer
+  → anonymous viewers see only what anonymous access allows, likely nothing — fine).
+- Cross-workspace/team scoping beyond what `entity_access` already models.

--- a/databases-plan/query-engine.md
+++ b/databases-plan/query-engine.md
@@ -1,0 +1,112 @@
+# Query engine
+
+**Ephemeral, in-process SQLite per query.** Postgres owns the data; SQLite is the query
+engine. `rusqlite`, `:memory:`, no network, no daemon, no files. This is what makes
+"arbitrary SQL" implementable in a week: we never write a parser, a planner, or a sync
+pipeline — and user SQL never touches Postgres.
+
+## Lifecycle of a query
+
+For `SELECT p.email FROM guests g JOIN people p ON p.id = g.guest WHERE g.status = 'Going'`:
+
+1. **Open** `Connection::open_in_memory()` (~10–50µs — it's a malloc, not a database
+   server).
+2. **Prepare against a schema-only catalog**: every table the user can see (their database
+   tables, junction views, magic tables) declared with columns but no data. Prepare
+   failure → return SQLite's error verbatim (that's the chip's "broken query" state; the
+   errors are good).
+3. **Discover dependencies**: SQLite's authorizer callback reports exactly which tables
+   *and columns* the statement reads. No hand-rolled SQL parsing. This set is also the
+   liveness dependency graph (see [liveness.md](liveness.md)).
+4. **Materialize only what's referenced**, permission-filtered for the requesting user:
+   - user tables: `SELECT id, cells FROM database_rows WHERE table_id = $1`, JSONB
+     unpacked into columns per `property_data_type`;
+   - junction views: straight from `database_row_links`;
+   - magic tables: their blessed queries (see [magic-tables.md](magic-tables.md)),
+     projected to only the referenced columns.
+   Bulk-insert in one transaction. Human-scale tables → single-digit ms.
+5. **Execute with guardrails**: read-only connection; authorizer denies everything except
+   SELECT on the materialized set; `sqlite3_interrupt` on a ~100ms timeout; row and
+   result-size caps.
+6. **Return typed results**: column provenance from the prepare step tags result columns
+   ("came from `people.id`" → entity type `user`) so the frontend hydrates chips.
+7. **Drop it.** Nothing persists.
+
+Cost budget per query: open ~µs · Postgres fetch 1–5ms (dominates; we were paying it to
+render the table anyway) · bulk insert ~2–5ms for ~5k rows · execute µs–ms. Cost scales
+with the tables the query touches, not with user or database count.
+
+## Security model
+
+The blast radius of arbitrary user/AI SQL is a scratch database containing only data the
+user was already allowed to read. Permissioning is **structural**: each viewer's scratch
+DB is materialized from their view of the world, so there is no per-row permission check
+inside SQL to get wrong, and the same shared chip legitimately returns different results
+for different viewers.
+
+## Type mapping
+
+| property_data_type | SQLite | notes |
+|---|---|---|
+| String / Link(URL) | TEXT | |
+| Number | REAL | |
+| Boolean | INTEGER | 0/1 |
+| Date | TEXT | ISO-8601; SQLite date functions work |
+| Select / Tag (single) | TEXT | option display value |
+| Select / Tag (multi) | TEXT JSON array | + junction view |
+| Entity (single) | TEXT | typed id, provenance-tagged |
+| Entity (multi) / link column | TEXT JSON array | + junction view `t__col(row_id, linked_id)` |
+| lookup / rollup | not materialized | desugared into the SQL (see links-and-lookups.md) |
+
+Junction views keep joins flat and hand-writable; the raw JSON array coexists for
+`json_each` power users.
+
+Note (from the properties code): select/tag cells store **option UUIDs**, and entity cells
+store `EntityReference` objects — the materializer resolves options to their display
+values (join `property_options` during the Postgres fetch) and projects entity refs to
+their ids, tagging the SQLite column with the `entity_type` for result provenance. Users
+write `status = 'Going'`, never option ids.
+
+## Sugar
+
+Ruthlessly minimal — AI writes the long tail, sugar is for queries humans read:
+
+- `expr HAS value` → membership test on a multi-valued column, desugars to
+  `EXISTS (SELECT 1 FROM json_each(expr) WHERE value = ...)` (or a junction-view
+  semijoin when the planner can). The single most common predicate on entity columns.
+- That's it for v1.
+
+Applied as a text-level rewrite before prepare; the readout always shows the sugared form,
+"expand" shows the desugared form.
+
+## Writes
+
+Rejected in v1 at the authorizer, with an error pointing to SDK helpers
+(`macro.dbs.byName(...).insert(...)`) that go through the normal Rust mutation path
+(activity, permissions, notifications, version bumps). Later: updatable-view semantics
+using the Postgres traceability rule — a result column is writable iff it maps to a single
+base column with no expressions/aggregates. Same rule powers write-through view blocks.
+
+## Caching (deferred until profiling says so)
+
+- Key: `(user_id, sorted table ids, their version counters)` → a warm materialized
+  in-memory DB. A doc with five chips over `guests` builds once.
+- Batch: run all of a doc's chips against one materialization in one request.
+- Only much later: long-lived incrementally-maintained per-user SQLite — the point where
+  the Turso/DO conversation reopens, with data.
+
+## Where it runs
+
+CPU-bound, stateless → start inside document_storage_service (one new route:
+`POST /databases/query` with `{sql}` → `{columns: [{name, type, entityType?}], rows,
+deps, versions}`), trivially extractable to its own service later.
+
+## Not doing
+
+- Turso / per-user persistent SQLite files as storage — breaks sharing (whose file?),
+  breaks cross-database refs and magic-table joins (no cross-instance JOIN), creates a
+  Postgres→SQLite sync pipeline for permissions and magic data, new ops surface, new
+  client stack. Nothing in the v1 design leaks the storage engine to users, so this stays
+  reversible forever.
+- SQL-to-Postgres transpilation — subset semantics, endless edge cases, and it points user
+  SQL at the production database.

--- a/databases-plan/sketch.md
+++ b/databases-plan/sketch.md
@@ -1,0 +1,74 @@
+# Macro Databases — sketch
+
+This folder is the working plan for Macro Databases. This file is the overview and index;
+each piece has its own doc.
+
+## What we're building
+
+A new top-level primitive: a **database** — a collection of tables, presented to users as
+"just a table" (tabs within one database block). Databases cover the fat tail of use cases
+we won't build bespoke modules for (applicant trackers, party planning, vendor lists). CRM
+and Tasks stay best-in-class separate modules — visually similar, deliberately not merged
+("we must resist elegance").
+
+What makes ours more capable than Notion's:
+
+1. **Rows can be Macro entities** — people, documents, calls, companies, email threads:
+   real entities with permissions, hovercards, click-through.
+2. **SQL is the query surface** — live query chips, query-backed views, and charts on any
+   lexical surface. AI writes most of the SQL; it stays inspectable.
+3. **Magic tables** expose Macro's own data (`people`, `documents`, `tasks`, `calls`, …)
+   to SQL, permission-scoped per viewer, so user tables join against the platform.
+
+Interactive mock of the whole surface:
+https://claude.ai/code/artifact/635f0600-3d70-4a70-8564-f37af63042aa
+
+## The architecture in one paragraph
+
+Postgres stores it, `entity_access` guards it, a per-query **ephemeral in-memory SQLite**
+runs it. Cells store typed entity ids only (`usr_…`, `doc_…`); display data is hydrated at
+read time (chips in the UI, magic-table joins in SQL). Query chips persist the query,
+never results — every viewer re-executes as themselves, which makes liveness and
+permissions correct by construction. No Turso, no per-user SQLite files, no user SQL ever
+touching Postgres.
+
+## Doc map
+
+| doc | covers |
+|---|---|
+| [backend-implementation.md](backend-implementation.md) | the full Rust shape: crate layout, ports, query pipeline, routes, entity plumbing, PR-sized phases |
+| [storage.md](storage.md) | Postgres schema, JSONB cells vs EAV, columns as property bindings, entity plumbing checklist |
+| [query-engine.md](query-engine.md) | ephemeral SQLite lifecycle, authorizer-driven deps, type mapping, `HAS` sugar, guardrails, why not Turso |
+| [magic-tables.md](magic-tables.md) | per-entity table contracts, blessed queries, column-level lazy materialization, permission scoping |
+| [frontend-block.md](frontend-block.md) | block registration, hand-rolled grid on property editors, bare rows, inferred type restriction, filter-pills-are-SQL |
+| [links-and-lookups.md](links-and-lookups.md) | link columns (two-way, junction-backed), row chips + picker, lookups/rollups, "JOIN appears exactly once" |
+| [lexical-nodes.md](lexical-nodes.md) | query chip / query block / view / chart / embed node schemas, transformers, insertion, rendering discipline |
+| [sql-editor.md](sql-editor.md) | CodeMirror extension suite, chips-in-SQL, styles-of-magic comparison (joins vs functions vs arrows), agent authoring UX |
+| [liveness.md](liveness.md) | version counters → gateway invalidation, per-viewer re-execution, local echo, magic-table tiers |
+| [permissions.md](permissions.md) | shared-viewer semantics (the decide-early doc), edit levels, hydration ownership |
+
+## Explicitly punted
+
+- **Kanban** (and any non-table view renderer) — the grouping/write-back model isn't
+  fleshed out; revisit post-v1.
+- Projects integration (v1 is user-global scope); folders-as-databases (do the cheap
+  "view folder as table" experiment first); template marketplace; Notion DB import.
+- Workflows: code as substrate, AI as authoring UI, triggers (row added / column changed /
+  cron / slash command) — likely bots + SDK (`macro.dbs.byName(...)`), run log as the
+  trust surface. Own doc when we get there.
+- SDK/app persistence for AI-generated blocks: per-app SQLite — DO SQLite (sync-service
+  precedent) before Turso; entity databases exposed into that runtime as magic tables via
+  the same materializer.
+- Write-through SQL (updatable views), deep magic-table invalidation, persistent/cached
+  SQLite — only if profiling demands.
+
+## Open questions (cross-doc)
+
+- Shared-database viewer semantics for inaccessible referenced entities — see
+  [permissions.md](permissions.md); constrains the membership model, decide early.
+- ~~Which style of magic for hand-written SQL~~ — **decided: explicit magic-table joins
+  only** (functions/arrows rejected; arrows collide with SQLite's JSON `->`). See
+  [sql-editor.md](sql-editor.md).
+- Naming: users only ever see "table"; launcher letter (`b`? `t`?).
+- Where the query endpoint lives (start in document_storage_service, extract later).
+- Rate/size limits for chips (per-doc query budget, result row caps).

--- a/databases-plan/sql-editor.md
+++ b/databases-plan/sql-editor.md
@@ -1,0 +1,82 @@
+# The SQL editor (CodeMirror)
+
+One reusable editor component used by query chips, views, charts, and (later) a
+full-screen query console. We already ship CodeMirror in
+`apps/web/src/features/block-code/component/CodeMirror.tsx` with several
+`@codemirror/lang-*` packages — add `@codemirror/lang-sql` and build the databases editor
+as an extension suite on top, themed with the existing block-code CM theme so it inherits
+Macro Dark/Light tokens.
+
+## Extension inventory
+
+- **Schema-aware autocomplete.** `lang-sql` accepts a schema object — feed it the same
+  catalog the executor prepares against (user tables, junction views, magic tables, all
+  with columns), kept fresh via the table version counters. Table names after
+  `FROM`/`JOIN`, columns scoped by alias, `HAS` offered after multi/entity columns.
+- **Chips inside SQL.** `@` opens the mentions typeahead; picked entities render as CM
+  widget decorations — real chips (`Decoration.replace` + atomic ranges) that compile to
+  typed id literals. Same mechanism for `@table` / `@column` references. Chips survive
+  copy/paste as their literal form.
+- **Join-path suggestions.** After `JOIN`, offer link columns as pre-baked paths
+  ("through Sessions 🔗" inserts the junction join pair). Hand-written SQL reuses the
+  relationships the GUI declared.
+- **Inline diagnostics.** Debounced prepare against the schema-only catalog (no data);
+  SQLite's errors surface as CM lint diagnostics ("no such column: guets.status") with
+  fix-its for near-miss identifiers.
+- **Live result preview.** Debounced execute-on-idle: first N rows below the editor
+  (entity columns hydrated as chips), row count, and the dependency readout
+  ("reads: guests, people").
+
+## Styles of magic — DECIDED: explicit joins only
+
+Hydration is always an explicit magic-table join. No function sugar, no path syntax:
+
+```sql
+SELECT p.email
+FROM   guests g
+JOIN   people p ON p.id = g.guest
+WHERE  g.status = 'Going'
+```
+
+Rationale:
+
+- One way to do it; standard SQL semantics; nothing new to teach humans or the model
+  (AI emits joins with strong priors already).
+- Hydration functions (`email(g.guest)`) would be easy — SQLite application-defined
+  functions via `rusqlite::create_scalar_function` over the same materializer — but a
+  second spelling of every hydration is complexity with no new capability. Rejected.
+- Arrow deref (`g.guest->email`) is rejected outright: `->`/`->>` are SQLite's native
+  JSON extraction operators (3.38+), so it either shadows real syntax or needs an
+  ambiguous rewrite.
+
+The editor makes joins cheap instead of making syntax terse: join-path completions after
+`JOIN` (link columns and entity columns offer their pre-baked join pair), so the cost of
+"explicit" is two keystrokes.
+
+`HAS` (membership on multi-valued columns) is the one sugar that ships — a single-keyword
+text-level rewrite, common enough to earn syntax. Revisit even that if it causes any
+trouble.
+
+## Agent authoring UX
+
+Natural language is the primary authoring path; SQL is the inspectable artifact.
+
+- **The prompt line** lives above the SQL, persisted with the query
+  (`{prompt, sql}` both stored on the node): `✦ "everyone we still need to invite"`.
+- Typing a new prompt (or editing the existing one) and hitting Enter streams a generated
+  query into the editor. The model gets the schema catalog, the current query, column
+  types, and sample rows.
+- **Diff-accept flow**: generated SQL lands highlighted with a Keep / Undo bar — never
+  silently replacing a query the user hand-edited. Regenerate (`↻`) re-runs the same
+  prompt.
+- Generation runs the prepare step before presenting: if the model emitted invalid SQL, it
+  self-repairs against the diagnostic before the user ever sees it.
+- The result preview re-runs automatically on accept, so the loop is
+  prompt → SQL → rows without leaving the popover.
+
+## Component boundaries
+
+`features/database-sql-editor/` exporting `<SqlEditor schema={...} value onChange
+onRun>`; consumers (chip popover, view/chart config, console) own persistence and layout.
+No queries/mutations inside the component (house rule: composed primitives stay decoupled
+from use-case context).

--- a/databases-plan/storage.md
+++ b/databases-plan/storage.md
@@ -1,0 +1,162 @@
+# Storage
+
+Postgres (MacroDB) is the only source of truth. SQLite never stores anything (see
+[query-engine.md](query-engine.md)). Design rule: Postgres's job is storage, permissions,
+and transactions — deliberately boring. Querying happens elsewhere, so we don't need
+per-cell indexing tricks here.
+
+## Schema
+
+```sql
+-- the entity users see ("Summer Offsite") — one row per database
+CREATE TABLE databases (
+  id          TEXT PRIMARY KEY,          -- db_...
+  name        TEXT NOT NULL,
+  owner_id    TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  trashed_at  TIMESTAMPTZ
+);
+
+-- tabs
+CREATE TABLE database_tables (
+  id          TEXT PRIMARY KEY,          -- tbl_...
+  database_id TEXT NOT NULL REFERENCES databases(id),
+  name        TEXT NOT NULL,
+  position    TEXT NOT NULL,             -- fractional index for tab order
+  version     BIGINT NOT NULL DEFAULT 0  -- bumped on any row/column change
+);
+
+-- columns = placement metadata over property_definitions (see "Columns are bindings")
+-- The column's name, data_type, multi-select flag, and options all live on the bound
+-- property_definitions row; this table only says where it appears.
+CREATE TABLE database_columns (
+  id                     TEXT PRIMARY KEY,   -- col_...
+  table_id               TEXT NOT NULL REFERENCES database_tables(id),
+  property_definition_id UUID NOT NULL,      -- FK to property_definitions
+  position               TEXT NOT NULL,
+  config                 JSONB               -- link target {database_id, table_id}, lookup {via, target}, width
+);
+
+-- rows: one Postgres row per user row, cells as one JSONB object
+CREATE TABLE database_rows (
+  id         TEXT PRIMARY KEY,           -- row_...
+  table_id   TEXT NOT NULL REFERENCES database_tables(id),
+  position   TEXT NOT NULL,
+  cells      JSONB NOT NULL,             -- { "col_a": {"t":"string","v":"..."}, "col_b": {"t":"entity","v":"usr_.."} }
+  created_by TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- link columns get a real junction, not JSONB arrays
+CREATE TABLE database_row_links (
+  link_column_id TEXT NOT NULL REFERENCES database_columns(id) ON DELETE CASCADE,
+  source_row_id  TEXT NOT NULL REFERENCES database_rows(id) ON DELETE CASCADE,
+  target_row_id  TEXT NOT NULL REFERENCES database_rows(id) ON DELETE CASCADE,
+  position       TEXT,
+  PRIMARY KEY (link_column_id, source_row_id, target_row_id)
+);
+```
+
+Indexes: `database_rows(table_id)`, `database_row_links(target_row_id)` (reverse-link
+lookups), `database_columns(table_id)`.
+
+## Why JSONB cells per row, not EAV
+
+`entity_properties` is EAV (one row per entity×property) — right for sparse annotations
+across millions of heterogeneous entities. Database cells are the opposite: dense, always
+read and written together. One JSONB object per row means:
+
+- Fetching a table for materialization is one sequential scan
+  (`SELECT id, cells FROM database_rows WHERE table_id = $1`).
+- A row write is one UPDATE.
+- The shape matches what both the grid and the SQLite materializer consume.
+
+We give up per-cell Postgres indexing, which we don't need because user SQL runs in
+SQLite. Do NOT shove rows into `entity_properties`; the access patterns are opposite.
+
+## Cell value encoding
+
+**A cell IS a `models_properties::service::PropertyValue`** — the existing serde tagged
+union (`{"type": "EntityReference", "value": [...]}`), reused verbatim:
+`cells = { "<property_definition_id>": PropertyValue }`. Consequences, confirmed against
+the code:
+
+- Write path reuses `SetPropertyValue` + `validate_compatibility(data_type,
+  is_multi_select)` (`models_properties/src/api/requests.rs`) unchanged — zero new
+  validation code.
+- Select values are **option UUIDs**, not display strings (resolved via
+  `property_options`); the SQLite materializer joins options to expose display values.
+- Entity cells store `EntityReference { entity_type, entity_id, specific_message_id? }` —
+  the type rides *next to* the id (no id-prefix sniffing); renderer and materializer key
+  off `entity_type`. No denormalized names/titles ever — display data is hydrated at read
+  time (chips in UI, magic-table joins in SQL), so staleness is impossible.
+- **Bare cells**: `{"t":"bare","v":"Priya's partner"}` — text where an entity could be.
+  Hydration (⌘↵) swaps the text for a freshly minted entity id. Joins skip bare cells
+  naturally (no id, nothing to join).
+
+Tombstones: never garbage-collect ids from cells when an entity is deleted — the chip
+renders a "deleted" ghost, joins drop it, and trash-restore brings it back.
+
+## Columns are bindings
+
+A column IS a `property_definitions` row; `database_columns` holds only placement
+(table, position, link/lookup config). Name, `data_type`, `is_multi_select`, and options
+all live on the definition, so options/colors/tag machinery/promotion are shared code and
+shared tables, not copies. The only new storage in the whole feature is the *value* side
+(`database_rows.cells` replacing EAV `entity_properties` for row-local values).
+
+- **Default**: creating a column creates a `property_definitions` row scoped to the
+  database — add a `Database { database_id }` variant to `PropertyOwner`
+  (`models_properties/src/shared/property_owner.rs`, currently `User | Team | System`);
+  the team-scoping migration (`20260622223029_kill_org_properties_add_team.sql`) is the
+  precedent for adding an owner dimension. Two databases with a "Status" column don't
+  collide.
+- **Bind**: the column picker also offers existing workspace/team definitions.
+- **Promote**: a database-scoped definition can be promoted later —
+  `crates/properties/src/outbound/tag_promotion_queries.rs` is the working precedent.
+
+Semantics that fall out: the same entity in two databases has *different* statuses if the
+columns are database-scoped, the *same* status if both bind to a shared definition.
+
+**The payoff junction**: when a row references an entity and its column is bound to a
+shared definition, the cell reads/writes `entity_properties` for that entity — edit a
+task's "Due date" in the database and it changes in the Tasks module, the side panel,
+everywhere. A database over entities is largely a view over the properties they already
+have; database-scoped columns layer collection-local data on top.
+
+## Entity plumbing checklist
+
+`EntityType::Database` in `crates/model-entity/src/lib.rs` — the blast radius is ~26 files
+of exhaustive matches (trace `EntityType::Reminder` / `EntityType::AgentSession`, the two
+most recent additions). Highlights:
+
+- `model-entity` (`is_valid_entity_access_entity` — yes, permissions come from
+  `entity_access`), `graphql_common`, `models_soup::SoupItem`,
+  `models_properties::EntityType` + the `property_entity_type` PG enum,
+  `models_opensearch` (or start Postgres-only like `CrmCompanies`), soup `ItemType`.
+- New domain crate `crates/databases/` — hexagonal layout per
+  `.claude/skills/cloud-storage-hexagonal-architecture`; `crates/reminders/` is the
+  smallest complete worked example to copy (domain/ports/service, outbound pg repo,
+  inbound axum router + toolset, feature flags mirroring `crates/projects/Cargo.toml`).
+- Permissions: `entity_access` table + a new axum extractor in
+  `crates/entity_access/src/inbound/axum_extractors/`; handlers take
+  `EntityAccessReceipt<T>` and never branch on access level.
+- Generic mutations: implement `RenameEntity`/`MoveEntity`/`TrashEntity`/… capability
+  traits in `crates/entity_mutation`; register in
+  `services/document_storage_service/src/service/entity_mutation.rs`. Gets
+  rename/trash/share/move-to-project for free.
+- Routes mount into document_storage_service's router composition
+  (`services/document_storage_service/src/api.rs`).
+- Migrations: `sqlx migrate add` in `crates/macro_db_client` (paired .up/.down), then
+  `nix develop --command just prepare_db` from repo root.
+- SDK: `packages/sdk/src/entities/databases/` per the add-sdk-endpoint skill; `just
+  coverage` enforces it.
+
+## Open items
+
+- Sharing granularity: v1 shares the database; tables/rows inherit. Per-table sharing is a
+  possible v2 (schema supports it — entity_access rows against table ids).
+- Whether `database_rows.cells` wants a GIN index for admin/debug tooling (not for the
+  product query path).
+- Fractional-index library choice for `position` (check what soup/tasks ordering uses).


### PR DESCRIPTION
## Macro Databases — SQL-native user tables

Rebased onto `main` as a single commit (granular history: `backup/databases-fable-yolo-pre-rebase`). Design docs in `databases-plan/`.

**Backend (`crates/databases`)** — Postgres is the source of truth (`databases`, `database_tables`, `database_columns` → `property_definitions` with a new `PropertyOwner::Database`, `database_rows` with `PropertyValue` cells, `database_row_links`). Every row read/write goes through `POST /databases/exec`: a per-request in-memory SQLite is materialised from the viewer's catalog (permission-filtered, plus `documents`/`people` magic tables), statements run under an authorizer sandbox with a STRICT/CHECK compiled schema and budgets, and the session changeset is translated back into typed `RowChange`s applied with compare-and-set on table versions. Schema ops stay structured (`/databases`, `/tables`, `/columns`, `/columns/{id}/options`, `/sqlite` snapshot). `EntityType::Database` plumbing, entity-mutation rename/trash/restore/delete, gateway liveness (`database_table_changed`).

**AI/MCP tools** — `ListDatabases`, `DescribeDatabase`, `QueryDatabase`, `CreateDatabase`, `CreateTable`, `AddColumn`, `AddColumnOptions`, wired into the storage, MCP, cognition and memory hosts.

**Web** — `database` block (`c` → `b`): table tabs, grid with inline property editors and versioned writes, add column/select options, SQL console (CodeMirror + schema completion, Cmd/Ctrl+Enter), `.sqlite` download, tool renderers, live refresh from the gateway.

**SDK** — `macro.databases` namespace with `Database` / `DatabaseTable` / `DatabaseColumn` handles; `just coverage` passes.

**Testing** — 134 crate tests (round-trip/fuzz/authorizer/changeset/budget suites, Postgres repo tests, toolset tests), 436 entity_access tests; exercised end-to-end in a browser and over MCP on a local stack (grid writes, console reads/writes, STRICT/CHECK rejections, select options, liveness). Two Opus audits; all blockers and should-fixes addressed.

**Follow-ups** — column/table rename, entity cells as chips, grid virtualisation, option rename/delete, magic-table row cap as env var.
