### PR TITLE
feat(web): Magic Chip header, latest-passage body, and every elicitation kind answered in place

### DIFF
--- a/apps/web/src/features/block-agent/component/AgentSplitHeader.tsx
+++ b/apps/web/src/features/block-agent/component/AgentSplitHeader.tsx
@@ -24,16 +24,9 @@ import type { AgentSessionResponse } from '@service-agent-harness/generated/sche
 import { createSignal, For, Show } from 'solid-js';
 import { useAgentSession } from '../context/AgentSessionContext';
 import { AgentRenameModal } from './AgentRenameModal';
+import { harnessTitle } from './compose-agent-session-options';
 
-/** 'claude-code' → 'Claude Code'; the fallback when the fold has no title. */
-export function harnessTitle(harness: string | undefined): string {
-  if (!harness) return 'Agent session';
-  return harness
-    .split(/[-_]/)
-    .filter(Boolean)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
-}
+export { harnessTitle };
 
 /**
  * Agent-session identity in the split header chrome plus the standard split

--- a/apps/web/src/features/block-agent/component/compose-agent-session-options.ts
+++ b/apps/web/src/features/block-agent/component/compose-agent-session-options.ts
@@ -41,6 +41,24 @@ export function isManagedHarness(harness: string): boolean {
   );
 }
 
+/** 'claude-code' → 'Claude Code'; the fallback when nothing names a harness. */
+export function harnessTitle(harness: string | undefined): string {
+  if (!harness) return 'Agent session';
+  return harness
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/** A model's display name, or its id when the runtime lists no name for it. */
+export function modelDisplayName(
+  id: string,
+  available: readonly Pick<ModelOption, 'id' | 'name'>[]
+): string {
+  return available.find((model) => model.id === id)?.name ?? id;
+}
+
 /**
  * User-facing name for the runtime a persona runs on. Harness ids are
  * plumbing ("in-memory", "sandbox"); the product names are the coders.
@@ -124,9 +142,7 @@ export function personaDefaultLabel(
 ): string {
   const defaultModel = persona?.defaultModel;
   if (!defaultModel) return 'Agent default';
-  const name =
-    available.find((model) => model.id === defaultModel)?.name ?? defaultModel;
-  return `Agent default · ${name}`;
+  return `Agent default · ${modelDisplayName(defaultModel, available)}`;
 }
 
 /** Short label for the closed model pill. */
@@ -135,12 +151,8 @@ export function modelPillLabel(
   persona: PersonaOption | undefined,
   available: readonly ModelOption[]
 ): string {
-  if (override) {
-    return available.find((model) => model.id === override)?.name ?? override;
-  }
+  if (override) return modelDisplayName(override, available);
   const defaultModel = persona?.defaultModel;
   if (!defaultModel) return 'Default model';
-  return (
-    available.find((model) => model.id === defaultModel)?.name ?? defaultModel
-  );
+  return modelDisplayName(defaultModel, available);
 }

--- a/apps/web/src/features/block-agent/component/parts/ElicitationPart.tsx
+++ b/apps/web/src/features/block-agent/component/parts/ElicitationPart.tsx
@@ -33,11 +33,7 @@ import { match, P } from 'ts-pattern';
 import { useAgentSession } from '../../context/AgentSessionContext';
 import { createElicitationReviewSink } from '../../state/elicitation-review-sink';
 import { ToolCard } from '../../ui';
-import {
-  LiveForm,
-  LiveQuestion,
-  type RespondToElicitation,
-} from './LiveElicitation';
+import { LiveQuestionCard, type RespondToElicitation } from './LiveElicitation';
 import { UserToolCall } from './UserToolCall';
 
 type ElicitationPartData = Extract<MessagePart, { kind: 'elicitation' }>;
@@ -107,7 +103,7 @@ export function ElicitationPart(props: { part: ElicitationPartData }) {
             .with(
               { kind: P.union('form', 'url', 'unrecognized') },
               (request) => (
-                <LiveQuestion
+                <LiveQuestionCard
                   request={request}
                   locked={locked()}
                   onRespond={elicitation.respond}
@@ -154,8 +150,8 @@ function LiveUserTool(props: {
   return (
     <Switch
       fallback={
-        <LiveForm
-          schema={props.request.schema}
+        <LiveQuestionCard
+          request={{ kind: 'form', schema: props.request.schema }}
           locked={props.locked}
           onRespond={props.onRespond}
         />

--- a/apps/web/src/features/block-agent/component/parts/ElicitationPart.tsx
+++ b/apps/web/src/features/block-agent/component/parts/ElicitationPart.tsx
@@ -15,32 +15,25 @@
  * under review opens the tool's own composer here.
  */
 
-import { CalendarDraftComposer } from '@core/component/AI/component/tool/calendar/DraftComposer';
-import { EmailDraftComposer } from '@core/component/AI/component/tool/email/DraftComposer';
 import type {
   AnsweredField,
   AnsweredValue,
   MessagePart,
 } from '@service-agent-fold/generated/types';
-import { deserializeToolCall } from '@service-cognition/generated/tools/tool';
-import type {
-  CreateCalendarEvent,
-  SendEmail,
-} from '@service-cognition/generated/tools/types';
-import { Button } from '@ui';
-import { createMemo, For, Match, Show, Switch } from 'solid-js';
+import { createMemo, For, Show } from 'solid-js';
 import { match, P } from 'ts-pattern';
 import { useAgentSession } from '../../context/AgentSessionContext';
-import { createElicitationReviewSink } from '../../state/elicitation-review-sink';
 import { ToolCard } from '../../ui';
-import { LiveQuestionCard, type RespondToElicitation } from './LiveElicitation';
+import {
+  LiveQuestionCard,
+  parseDraftedTool,
+  type RespondToElicitation,
+  UserToolComposer,
+  type UserToolRequest,
+} from './LiveElicitation';
 import { UserToolCall } from './UserToolCall';
 
 type ElicitationPartData = Extract<MessagePart, { kind: 'elicitation' }>;
-type UserToolRequest = Extract<
-  ElicitationPartData['request'],
-  { kind: 'user_tool' }
->;
 
 function outcomeLabel(part: ElicitationPartData): string {
   return match(part.outcome)
@@ -118,11 +111,11 @@ export function ElicitationPart(props: { part: ElicitationPartData }) {
 }
 
 /**
- * A Macro user tool under review, in the tool's own composer: the calendar
- * event form for `CreateCalendarEvent`, the email compose for `SendEmail`.
- * The composer's Create/Send accepts the review with the whole edited draft;
- * Cancel declines it. A draft the tool's schema rejects, or a tool with no
- * composer here, falls back to the flat form the agent also sent.
+ * A Macro user tool under review, in the tool's own composer. A draft the
+ * tool's schema rejects, or a tool with no composer here, falls back to the
+ * flat form the agent also sent. The email composer has only Send, so the
+ * card adds a Cancel: without it the turn could only be refused from the
+ * chip, or by stopping it.
  */
 function LiveUserTool(props: {
   request: UserToolRequest;
@@ -131,66 +124,33 @@ function LiveUserTool(props: {
   onRespond: RespondToElicitation;
 }) {
   const { elicitation } = useAgentSession();
-  const typed = createMemo(() => {
-    const call = deserializeToolCall({
-      id: props.toolCall,
-      name: props.request.tool,
-      json: props.request.draft,
-    });
-    return call.isOk() ? call.value : undefined;
-  });
-  const sink = <T,>() =>
-    createElicitationReviewSink<T>({
-      canAnswer: elicitation.canAnswer,
-      ownerName: elicitation.ownerName,
-      answering: elicitation.answering,
-      respond: props.onRespond,
-    });
-
+  const drafted = createMemo(() =>
+    parseDraftedTool(props.request, props.toolCall)
+  );
+  const fallback = (
+    <LiveQuestionCard
+      request={{ kind: 'form', schema: props.request.schema }}
+      locked={props.locked}
+      onRespond={props.onRespond}
+    />
+  );
   return (
-    <Switch
-      fallback={
-        <LiveQuestionCard
-          request={{ kind: 'form', schema: props.request.schema }}
-          locked={props.locked}
-          onRespond={props.onRespond}
+    <Show when={drafted()} fallback={fallback}>
+      {(tool) => (
+        <UserToolComposer
+          tool={tool()}
+          toolCall={props.toolCall}
+          cancel
+          fallback={fallback}
+          review={{
+            canAnswer: elicitation.canAnswer,
+            ownerName: elicitation.ownerName,
+            answering: elicitation.answering,
+            respond: props.onRespond,
+          }}
         />
-      }
-    >
-      <Match when={typed()?.name === 'CreateCalendarEvent' && typed()}>
-        {(tool) => (
-          <CalendarDraftComposer
-            initialData={tool().data as CreateCalendarEvent}
-            sink={sink<CreateCalendarEvent>()}
-            previewKey={props.toolCall}
-          />
-        )}
-      </Match>
-      <Match when={typed()?.name === 'SendEmail' && typed()}>
-        {(tool) => (
-          <div class="flex flex-col gap-2">
-            <EmailDraftComposer
-              initialData={tool().data as SendEmail}
-              sink={sink<SendEmail>()}
-              debugName={`agent-review:${props.toolCall}`}
-            />
-            {/* The email composer has only Send; the calendar one answers a
-                decline through the sink's `onReject`. Without this the turn
-                could only be refused from the chip, or by stopping it. */}
-            <div class="flex items-center gap-2">
-              <Button
-                variant="outline"
-                size="xs"
-                disabled={props.locked}
-                onClick={() => void props.onRespond({ action: 'decline' })}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
-      </Match>
-    </Switch>
+      )}
+    </Show>
   );
 }
 

--- a/apps/web/src/features/block-agent/component/parts/ElicitationPart.tsx
+++ b/apps/web/src/features/block-agent/component/parts/ElicitationPart.tsx
@@ -10,9 +10,9 @@
  * another viewer sees the same live card with its controls disabled and the
  * owner named as the one it waits on.
  *
- * URL mode never opens anything on its own. The card shows the full URL and
- * its host, and only after the user presses Open does it send the consent and
- * open a new tab - never an iframe, never a prefetch.
+ * The form, URL consent, and unrecognized-request controls are the
+ * `LiveElicitation` ones the channel's Magic Chip shares; a Macro user tool
+ * under review opens the tool's own composer here.
  */
 
 import { CalendarDraftComposer } from '@core/component/AI/component/tool/calendar/DraftComposer';
@@ -22,25 +22,22 @@ import type {
   AnsweredValue,
   MessagePart,
 } from '@service-agent-fold/generated/types';
-import type { ElicitationAnswer } from '@service-agent-harness/generated/schemas';
 import { deserializeToolCall } from '@service-cognition/generated/tools/tool';
 import type {
   CreateCalendarEvent,
   SendEmail,
 } from '@service-cognition/generated/tools/types';
 import { Button } from '@ui';
-import { createMemo, createSignal, For, Match, Show, Switch } from 'solid-js';
-import { createStore } from 'solid-js/store';
-import { match } from 'ts-pattern';
+import { createMemo, For, Match, Show, Switch } from 'solid-js';
+import { match, P } from 'ts-pattern';
 import { useAgentSession } from '../../context/AgentSessionContext';
-import {
-  type FieldValue,
-  initialValues,
-  toContent,
-  validate,
-} from '../../state/elicitation-form';
 import { createElicitationReviewSink } from '../../state/elicitation-review-sink';
-import { ElicitationForm, ToolCard } from '../../ui';
+import { ToolCard } from '../../ui';
+import {
+  LiveForm,
+  LiveQuestion,
+  type RespondToElicitation,
+} from './LiveElicitation';
 import { UserToolCall } from './UserToolCall';
 
 type ElicitationPartData = Extract<MessagePart, { kind: 'elicitation' }>;
@@ -99,13 +96,6 @@ export function ElicitationPart(props: { part: ElicitationPartData }) {
             </div>
           </Show>
           {match(props.part.request)
-            .with({ kind: 'form' }, (request) => (
-              <LiveForm
-                schema={request.schema}
-                locked={locked()}
-                onRespond={elicitation.respond}
-              />
-            ))
             .with({ kind: 'user_tool' }, (request) => (
               <LiveUserTool
                 request={request}
@@ -114,98 +104,20 @@ export function ElicitationPart(props: { part: ElicitationPartData }) {
                 onRespond={elicitation.respond}
               />
             ))
-            .with({ kind: 'url' }, (request) => (
-              <LiveUrl
-                url={request.url}
-                locked={locked()}
-                onRespond={elicitation.respond}
-              />
-            ))
-            .with({ kind: 'unrecognized' }, (request) => (
-              <div class="flex flex-col gap-2">
-                <div class="text-xs text-ink-extra-muted italic">
-                  This client cannot display a "{request.mode}" request.
-                </div>
-                <DeclineCancel
+            .with(
+              { kind: P.union('form', 'url', 'unrecognized') },
+              (request) => (
+                <LiveQuestion
+                  request={request}
                   locked={locked()}
                   onRespond={elicitation.respond}
                 />
-              </div>
-            ))
+              )
+            )
             .exhaustive()}
         </div>
       </ToolCard>
     </Show>
-  );
-}
-
-function DeclineCancel(props: {
-  locked: boolean;
-  onRespond: (answer: { action: 'decline' } | { action: 'cancel' }) => unknown;
-}) {
-  return (
-    <>
-      <Button
-        variant="outline"
-        size="xs"
-        disabled={props.locked}
-        onClick={() => props.onRespond({ action: 'decline' })}
-      >
-        Decline
-      </Button>
-      <Button
-        variant="ghost"
-        size="xs"
-        disabled={props.locked}
-        onClick={() => props.onRespond({ action: 'cancel' })}
-      >
-        Cancel
-      </Button>
-    </>
-  );
-}
-
-function LiveForm(props: {
-  schema: Extract<ElicitationPartData['request'], { kind: 'form' }>['schema'];
-  locked: boolean;
-  onRespond: (answer: ElicitationAnswer) => unknown;
-}) {
-  const [values, setValues] = createStore(initialValues(props.schema));
-  const [touched, setTouched] = createSignal(false);
-  const errors = createMemo(() => validate(props.schema, values));
-  const shownErrors = () => (touched() ? errors() : {});
-
-  const submit = () => {
-    if (props.locked) return;
-    setTouched(true);
-    if (Object.keys(errors()).length > 0) return;
-    props.onRespond({
-      action: 'accept',
-      content: toContent(props.schema, values),
-    });
-  };
-
-  return (
-    <div class="flex flex-col gap-3">
-      <ElicitationForm
-        schema={props.schema}
-        values={values}
-        errors={shownErrors()}
-        disabled={props.locked}
-        onChange={(name: string, value: FieldValue) => setValues(name, value)}
-      />
-      <div class="flex items-center gap-2">
-        <Button
-          variant="cta"
-          size="xs"
-          disabled={props.locked}
-          onClick={submit}
-        >
-          Submit
-        </Button>
-        <DeclineCancel locked={props.locked} onRespond={props.onRespond} />
-      </div>
-    </div>
   );
 }
 
@@ -220,7 +132,7 @@ function LiveUserTool(props: {
   request: UserToolRequest;
   toolCall: string;
   locked: boolean;
-  onRespond: (answer: ElicitationAnswer) => Promise<boolean>;
+  onRespond: RespondToElicitation;
 }) {
   const { elicitation } = useAgentSession();
   const typed = createMemo(() => {
@@ -286,40 +198,6 @@ function LiveUserTool(props: {
   );
 }
 
-function LiveUrl(props: {
-  url: string;
-  locked: boolean;
-  onRespond: (answer: {
-    action: 'accept' | 'decline' | 'cancel';
-  }) => Promise<boolean> | unknown;
-}) {
-  const host = () => urlHost(props.url);
-  const open = async () => {
-    if (props.locked) return;
-    // Consent goes to the agent first so it learns the user agreed even if
-    // the popup is blocked; the link below stays as the fallback.
-    const accepted = await props.onRespond({ action: 'accept' });
-    if (accepted === false) return;
-    window.open(props.url, '_blank', 'noopener,noreferrer');
-  };
-  return (
-    <div class="flex flex-col gap-2">
-      <div class="text-xs text-ink-muted">
-        Opens <span class="font-medium text-ink">{host()}</span> in a new tab.
-      </div>
-      <div class="rounded-md border border-edge-muted bg-surface px-2 py-1 font-mono text-xs text-ink-muted break-all">
-        {props.url}
-      </div>
-      <div class="flex items-center gap-2">
-        <Button variant="cta" size="xs" disabled={props.locked} onClick={open}>
-          Open
-        </Button>
-        <DeclineCancel locked={props.locked} onRespond={props.onRespond} />
-      </div>
-    </div>
-  );
-}
-
 function ResolvedElicitation(props: { part: ElicitationPartData }) {
   // A reviewed user tool that has reported back reads as the tool: the draft
   // it ran with and what it did - the same card the chat block's user tools
@@ -354,15 +232,6 @@ function ResolvedElicitation(props: { part: ElicitationPartData }) {
       )}
     </Show>
   );
-}
-
-/** The host of a URL-mode request, for the consent card, or the raw text. */
-function urlHost(url: string): string {
-  try {
-    return new URL(url).host;
-  } catch {
-    return url;
-  }
 }
 
 /** One answer as a line of text. The fold has already resolved the values. */

--- a/apps/web/src/features/block-agent/component/parts/LiveElicitation.tsx
+++ b/apps/web/src/features/block-agent/component/parts/LiveElicitation.tsx
@@ -1,18 +1,25 @@
 /**
  * The live controls for a question the agent is waiting on, shared by the
- * session's card and the channel's Magic Chip: the form with its Submit, the
- * URL consent, and the refusal of a request this client cannot display.
+ * session's card and the channel's Magic Chip: a form's fields and Submit,
+ * a URL's consent, and the refusal of a request this client cannot display.
  *
- * A Macro user tool under review is each surface's own - the session opens
- * the tool's composer, the chip a read-only summary - so it is not here; a
- * surface that cannot show the tool falls back to `LiveForm` over the flat
- * schema the agent also sent.
+ * Fields and decisions are separate components over one draft so a surface
+ * can place them apart - the chip scrolls the fields in a side pane and
+ * keeps the decisions on its bottom row - while `LiveQuestionCard` stacks
+ * them for the session. A Macro user tool under review is each surface's
+ * own (the session opens the tool's composer, the chip a read-only summary);
+ * a surface that cannot show the tool answers the flat form the agent also
+ * sent through these.
  */
 
-import type { ElicitationRequest } from '@service-agent-fold/generated/types';
+import type {
+  ElicitationRequest,
+  ElicitationSchema,
+} from '@service-agent-fold/generated/types';
 import type { ElicitationAnswer } from '@service-agent-harness/generated/schemas';
 import { Button } from '@ui';
 import {
+  type Accessor,
   createMemo,
   createSignal,
   type JSX,
@@ -23,6 +30,7 @@ import {
 import { createStore } from 'solid-js/store';
 import {
   type FieldValue,
+  type FormValues,
   initialValues,
   toContent,
   validate,
@@ -39,177 +47,66 @@ export type LiveQuestionRequest = Exclude<
   { kind: 'user_tool' }
 >;
 
-type LiveProps = {
-  locked: boolean;
-  onRespond: RespondToElicitation;
-  /** Right-aligned in the action row, after the decisions. */
-  trailing?: JSX.Element;
+/** A form being filled in: what was typed, and what is wrong with it. */
+export type FormDraft = {
+  schema: ElicitationSchema;
+  values: FormValues;
+  /** Problems shown to the user - none until the first submit attempt. */
+  errors: Accessor<Record<string, string>>;
+  setValue: (name: string, value: FieldValue) => void;
+  /**
+   * The content to accept with, or undefined while the draft is not valid -
+   * from then on the problems show.
+   */
+  content: () => ReturnType<typeof toContent> | undefined;
 };
 
-function form(request: LiveQuestionRequest) {
-  return request.kind === 'form' ? request : undefined;
-}
+/** A question with the state its controls need, made once per request. */
+export type LiveQuestion =
+  | { kind: 'form'; draft: FormDraft }
+  | { kind: 'url'; url: string }
+  | { kind: 'unrecognized'; mode: string };
 
-function url(request: LiveQuestionRequest) {
-  return request.kind === 'url' ? request : undefined;
-}
-
-function unrecognized(request: LiveQuestionRequest) {
-  return request.kind === 'unrecognized' ? request : undefined;
-}
-
-export function LiveQuestion(
-  props: LiveProps & { request: LiveQuestionRequest }
-) {
-  return (
-    <Switch>
-      <Match when={form(props.request)}>
-        {(request) => (
-          <LiveForm
-            schema={request().schema}
-            locked={props.locked}
-            onRespond={props.onRespond}
-            trailing={props.trailing}
-          />
-        )}
-      </Match>
-      <Match when={url(props.request)}>
-        {(request) => (
-          <LiveUrl
-            url={request().url}
-            locked={props.locked}
-            onRespond={props.onRespond}
-            trailing={props.trailing}
-          />
-        )}
-      </Match>
-      <Match when={unrecognized(props.request)}>
-        {(request) => (
-          <div class="flex flex-col gap-2">
-            <div class="text-xs text-ink-extra-muted italic">
-              This client cannot display a "{request().mode}" request.
-            </div>
-            <Actions
-              locked={props.locked}
-              onRespond={props.onRespond}
-              trailing={props.trailing}
-            />
-          </div>
-        )}
-      </Match>
-    </Switch>
-  );
-}
-
-/** Decline and Cancel, after an optional primary, with the trailing slot. */
-function Actions(props: LiveProps & { children?: JSX.Element }) {
-  return (
-    <div class="flex flex-wrap items-center gap-2">
-      {props.children}
-      <Button
-        variant="outline"
-        size="xs"
-        disabled={props.locked}
-        onClick={() => void props.onRespond({ action: 'decline' })}
-      >
-        Decline
-      </Button>
-      <Button
-        variant="ghost"
-        size="xs"
-        disabled={props.locked}
-        onClick={() => void props.onRespond({ action: 'cancel' })}
-      >
-        Cancel
-      </Button>
-      <Show when={props.trailing}>
-        <span class="ml-auto">{props.trailing}</span>
-      </Show>
-    </div>
-  );
-}
-
-export function LiveForm(
-  props: LiveProps & {
-    schema: Extract<ElicitationRequest, { kind: 'form' }>['schema'];
-  }
-) {
-  const [values, setValues] = createStore(initialValues(props.schema));
+function createFormDraft(schema: ElicitationSchema): FormDraft {
+  const [values, setValues] = createStore(initialValues(schema));
   const [touched, setTouched] = createSignal(false);
-  const errors = createMemo(() => validate(props.schema, values));
-  const shownErrors = () => (touched() ? errors() : {});
-
-  const submit = () => {
-    if (props.locked) return;
-    setTouched(true);
-    if (Object.keys(errors()).length > 0) return;
-    void props.onRespond({
-      action: 'accept',
-      content: toContent(props.schema, values),
-    });
+  const problems = createMemo(() => validate(schema, values));
+  return {
+    schema,
+    values,
+    errors: () => (touched() ? problems() : {}),
+    setValue: (name, value) => setValues(name, value),
+    content: () => {
+      setTouched(true);
+      return Object.keys(problems()).length > 0
+        ? undefined
+        : toContent(schema, values);
+    },
   };
-
-  return (
-    <div class="flex flex-col gap-3">
-      <ElicitationForm
-        schema={props.schema}
-        values={values}
-        errors={shownErrors()}
-        disabled={props.locked}
-        onChange={(name: string, value: FieldValue) => setValues(name, value)}
-      />
-      <Actions
-        locked={props.locked}
-        onRespond={props.onRespond}
-        trailing={props.trailing}
-      >
-        <Button
-          variant="cta"
-          size="xs"
-          disabled={props.locked}
-          onClick={submit}
-        >
-          Submit
-        </Button>
-      </Actions>
-    </div>
-  );
 }
 
-/**
- * URL mode never opens anything on its own. The card shows the full URL and
- * its host, and only after the user presses Open does it send the consent and
- * open a new tab - never an iframe, never a prefetch.
- */
-function LiveUrl(props: LiveProps & { url: string }) {
-  const host = () => urlHost(props.url);
-  const open = async () => {
-    if (props.locked) return;
-    // Consent goes to the agent first so it learns the user agreed even if
-    // the popup is blocked; the link below stays as the fallback.
-    const accepted = await props.onRespond({ action: 'accept' });
-    if (!accepted) return;
-    window.open(props.url, '_blank', 'noopener,noreferrer');
-  };
-  return (
-    <div class="flex flex-col gap-2">
-      <div class="text-xs text-ink-muted">
-        Opens <span class="font-medium text-ink">{host()}</span> in a new tab.
-      </div>
-      <div class="rounded-md border border-edge-muted bg-surface px-2 py-1 font-mono text-xs text-ink-muted break-all">
-        {props.url}
-      </div>
-      <Actions
-        locked={props.locked}
-        onRespond={props.onRespond}
-        trailing={props.trailing}
-      >
-        <Button variant="cta" size="xs" disabled={props.locked} onClick={open}>
-          Open
-        </Button>
-      </Actions>
-    </div>
-  );
+/** The question's state; call it once per request, under a reactive owner. */
+export function createLiveQuestion(request: LiveQuestionRequest): LiveQuestion {
+  switch (request.kind) {
+    case 'form':
+      return { kind: 'form', draft: createFormDraft(request.schema) };
+    case 'url':
+      return { kind: 'url', url: request.url };
+    case 'unrecognized':
+      return { kind: 'unrecognized', mode: request.mode };
+  }
+}
+
+function form(question: LiveQuestion) {
+  return question.kind === 'form' ? question : undefined;
+}
+
+function url(question: LiveQuestion) {
+  return question.kind === 'url' ? question : undefined;
+}
+
+function unrecognized(question: LiveQuestion) {
+  return question.kind === 'unrecognized' ? question : undefined;
 }
 
 /** The host of a URL-mode request, for the consent card, or the raw text. */
@@ -219,4 +116,159 @@ function urlHost(url: string): string {
   } catch {
     return url;
   }
+}
+
+/**
+ * What a question shows: a form's fields, a URL and its host, or the notice
+ * for a mode this client cannot display.
+ */
+export function QuestionFields(props: {
+  question: LiveQuestion;
+  locked: boolean;
+}) {
+  return (
+    <Switch>
+      <Match when={form(props.question)}>
+        {(question) => (
+          <ElicitationForm
+            schema={question().draft.schema}
+            values={question().draft.values}
+            errors={question().draft.errors()}
+            disabled={props.locked}
+            onChange={question().draft.setValue}
+          />
+        )}
+      </Match>
+      <Match when={url(props.question)}>
+        {(question) => (
+          <div class="flex flex-col gap-2">
+            <div class="text-xs text-ink-muted">
+              Opens{' '}
+              <span class="font-medium text-ink">
+                {urlHost(question().url)}
+              </span>{' '}
+              in a new tab.
+            </div>
+            <div class="rounded-md border border-edge-muted bg-surface px-2 py-1 font-mono text-xs text-ink-muted break-all">
+              {question().url}
+            </div>
+          </div>
+        )}
+      </Match>
+      <Match when={unrecognized(props.question)}>
+        {(question) => (
+          <div class="text-xs text-ink-extra-muted italic">
+            This client cannot display a "{question().mode}" request.
+          </div>
+        )}
+      </Match>
+    </Switch>
+  );
+}
+
+/**
+ * The decisions, as buttons for the caller's row: the question's own
+ * (Submit, Open) then Decline and, unless the row is short of room, Cancel.
+ *
+ * URL mode never opens anything on its own: only after the user presses Open
+ * does it send the consent and open a new tab - never an iframe, never a
+ * prefetch. Consent goes to the agent first so it learns the user agreed even
+ * if the popup is blocked; the URL shown in the fields stays as the fallback.
+ */
+export function QuestionActions(props: {
+  question: LiveQuestion;
+  locked: boolean;
+  onRespond: RespondToElicitation;
+  /** Whether Cancel joins Decline; default yes. */
+  cancel?: boolean;
+}) {
+  const respond = (answer: ElicitationAnswer) => {
+    if (props.locked) return;
+    void props.onRespond(answer);
+  };
+  const submit = (draft: FormDraft) => {
+    const content = draft.content();
+    if (content) respond({ action: 'accept', content });
+  };
+  const open = async (target: string) => {
+    if (props.locked) return;
+    const accepted = await props.onRespond({ action: 'accept' });
+    if (!accepted) return;
+    window.open(target, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <>
+      <Switch>
+        <Match when={form(props.question)}>
+          {(question) => (
+            <Button
+              variant="cta"
+              size="xs"
+              disabled={props.locked}
+              onClick={() => submit(question().draft)}
+            >
+              Submit
+            </Button>
+          )}
+        </Match>
+        <Match when={url(props.question)}>
+          {(question) => (
+            <Button
+              variant="cta"
+              size="xs"
+              disabled={props.locked}
+              onClick={() => void open(question().url)}
+            >
+              Open
+            </Button>
+          )}
+        </Match>
+      </Switch>
+      <Button
+        variant="outline"
+        size="xs"
+        disabled={props.locked}
+        onClick={() => respond({ action: 'decline' })}
+      >
+        Decline
+      </Button>
+      <Show when={props.cancel ?? true}>
+        <Button
+          variant="ghost"
+          size="xs"
+          disabled={props.locked}
+          onClick={() => respond({ action: 'cancel' })}
+        >
+          Cancel
+        </Button>
+      </Show>
+    </>
+  );
+}
+
+/** The fields over the decisions, as the session's card lays them out. */
+export function LiveQuestionCard(props: {
+  request: LiveQuestionRequest;
+  locked: boolean;
+  onRespond: RespondToElicitation;
+  trailing?: JSX.Element;
+}) {
+  // A part's request never changes, so its state is made once.
+  const question = createLiveQuestion(props.request);
+  return (
+    <div class="flex flex-col gap-3">
+      <QuestionFields question={question} locked={props.locked} />
+      <div class="flex flex-wrap items-center gap-2">
+        <QuestionActions
+          question={question}
+          locked={props.locked}
+          onRespond={props.onRespond}
+        />
+        <Show when={props.trailing}>
+          <span class="ml-auto">{props.trailing}</span>
+        </Show>
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/features/block-agent/component/parts/LiveElicitation.tsx
+++ b/apps/web/src/features/block-agent/component/parts/LiveElicitation.tsx
@@ -181,6 +181,8 @@ export function QuestionActions(props: {
   onRespond: RespondToElicitation;
   /** Whether Cancel joins Decline; default yes. */
   cancel?: boolean;
+  /** Decline before the question's own button, as the chip's row reads. */
+  declineFirst?: boolean;
 }) {
   const respond = (answer: ElicitationAnswer) => {
     if (props.locked) return;
@@ -197,42 +199,49 @@ export function QuestionActions(props: {
     window.open(target, '_blank', 'noopener,noreferrer');
   };
 
+  const primary = (
+    <Switch>
+      <Match when={form(props.question)}>
+        {(question) => (
+          <Button
+            variant="cta"
+            size="xs"
+            disabled={props.locked}
+            onClick={() => submit(question().draft)}
+          >
+            Submit
+          </Button>
+        )}
+      </Match>
+      <Match when={url(props.question)}>
+        {(question) => (
+          <Button
+            variant="cta"
+            size="xs"
+            disabled={props.locked}
+            onClick={() => void open(question().url)}
+          >
+            Open
+          </Button>
+        )}
+      </Match>
+    </Switch>
+  );
+  const decline = (
+    <Button
+      variant="outline"
+      size="xs"
+      disabled={props.locked}
+      onClick={() => respond({ action: 'decline' })}
+    >
+      Decline
+    </Button>
+  );
+
   return (
     <>
-      <Switch>
-        <Match when={form(props.question)}>
-          {(question) => (
-            <Button
-              variant="cta"
-              size="xs"
-              disabled={props.locked}
-              onClick={() => submit(question().draft)}
-            >
-              Submit
-            </Button>
-          )}
-        </Match>
-        <Match when={url(props.question)}>
-          {(question) => (
-            <Button
-              variant="cta"
-              size="xs"
-              disabled={props.locked}
-              onClick={() => void open(question().url)}
-            >
-              Open
-            </Button>
-          )}
-        </Match>
-      </Switch>
-      <Button
-        variant="outline"
-        size="xs"
-        disabled={props.locked}
-        onClick={() => respond({ action: 'decline' })}
-      >
-        Decline
-      </Button>
+      {props.declineFirst ? decline : primary}
+      {props.declineFirst ? primary : decline}
       <Show when={props.cancel ?? true}>
         <Button
           variant="ghost"

--- a/apps/web/src/features/block-agent/component/parts/LiveElicitation.tsx
+++ b/apps/web/src/features/block-agent/component/parts/LiveElicitation.tsx
@@ -4,19 +4,25 @@
  * a URL's consent, and the refusal of a request this client cannot display.
  *
  * Fields and decisions are separate components over one draft so a surface
- * can place them apart - the chip scrolls the fields in a side pane and
- * keeps the decisions on its bottom row - while `LiveQuestionCard` stacks
- * them for the session. A Macro user tool under review is each surface's
- * own (the session opens the tool's composer, the chip a read-only summary);
- * a surface that cannot show the tool answers the flat form the agent also
- * sent through these.
+ * can place them apart - the chip crops the fields in its area and keeps the
+ * decisions on the row beneath - while `LiveQuestionCard` stacks them for
+ * the session. A Macro user tool under review opens in the tool's own
+ * composer (`UserToolComposer`); a draft the tool's schema rejects falls
+ * back to the flat form the agent also sent, through these.
  */
 
+import { CalendarDraftComposer } from '@core/component/AI/component/tool/calendar/DraftComposer';
+import { EmailDraftComposer } from '@core/component/AI/component/tool/email/DraftComposer';
 import type {
   ElicitationRequest,
   ElicitationSchema,
 } from '@service-agent-fold/generated/types';
 import type { ElicitationAnswer } from '@service-agent-harness/generated/schemas';
+import { deserializeToolCall } from '@service-cognition/generated/tools/tool';
+import type {
+  CreateCalendarEvent,
+  SendEmail,
+} from '@service-cognition/generated/tools/types';
 import { Button } from '@ui';
 import {
   type Accessor,
@@ -36,6 +42,7 @@ import {
   toContent,
   validate,
 } from '../../state/elicitation-form';
+import { createElicitationReviewSink } from '../../state/elicitation-review-sink';
 import { ElicitationForm } from '../../ui';
 
 export type RespondToElicitation = (
@@ -286,5 +293,95 @@ export function LiveQuestionCard(props: {
         </Show>
       </div>
     </div>
+  );
+}
+
+export type UserToolRequest = Extract<
+  ElicitationRequest,
+  { kind: 'user_tool' }
+>;
+
+/** A drafted Macro user tool, as its schema reads it. */
+export type DraftedTool = { name: string; data: unknown };
+
+/** What a review needs to know to act: the session's or the chip's answer. */
+export type ReviewInputs = Parameters<typeof createElicitationReviewSink>[0];
+
+/**
+ * The draft as the tool's schema reads it, or undefined for a tool this
+ * client has no schema for. A draft that a known tool's schema rejects is a
+ * contract break between the agent and this build: it is reported, not
+ * rendered around, before the caller falls back to the flat form.
+ */
+export function parseDraftedTool(
+  request: UserToolRequest,
+  toolCall: string
+): DraftedTool | undefined {
+  const call = deserializeToolCall({
+    id: toolCall,
+    name: request.tool,
+    json: request.draft,
+  });
+  if (call.isOk()) return { name: call.value.name, data: call.value.data };
+  if (call.error.some((problem) => problem.code === 'parse_error')) {
+    console.error(
+      '[elicitation] a user tool draft was rejected by its schema',
+      {
+        tool: request.tool,
+        problems: call.error,
+      }
+    );
+  }
+  return undefined;
+}
+
+/**
+ * A drafted Macro user tool in the tool's own composer: the calendar event
+ * form for `CreateCalendarEvent`, the email compose for `SendEmail`. The
+ * composer's Create/Send accepts the review with the whole edited draft; its
+ * Cancel, where it has one, declines. The email composer has only Send, so
+ * `cancel` adds a Cancel beneath it for a surface with no other refusal.
+ * `fallback` renders a tool this client has no composer for.
+ */
+export function UserToolComposer(props: {
+  tool: DraftedTool;
+  toolCall: string;
+  review: ReviewInputs;
+  cancel?: boolean;
+  fallback?: JSX.Element;
+}) {
+  const sink = <T,>() => createElicitationReviewSink<T>(props.review);
+  const locked = () => !props.review.canAnswer() || props.review.answering();
+  return (
+    <Switch fallback={props.fallback}>
+      <Match when={props.tool.name === 'CreateCalendarEvent'}>
+        <CalendarDraftComposer
+          initialData={props.tool.data as CreateCalendarEvent}
+          sink={sink<CreateCalendarEvent>()}
+          previewKey={props.toolCall}
+        />
+      </Match>
+      <Match when={props.tool.name === 'SendEmail'}>
+        <div class="flex flex-col gap-2">
+          <EmailDraftComposer
+            initialData={props.tool.data as SendEmail}
+            sink={sink<SendEmail>()}
+            debugName={`agent-review:${props.toolCall}`}
+          />
+          <Show when={props.cancel}>
+            <div class="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="xs"
+                disabled={locked()}
+                onClick={() => void props.review.respond({ action: 'decline' })}
+              >
+                Cancel
+              </Button>
+            </div>
+          </Show>
+        </div>
+      </Match>
+    </Switch>
   );
 }

--- a/apps/web/src/features/block-agent/component/parts/LiveElicitation.tsx
+++ b/apps/web/src/features/block-agent/component/parts/LiveElicitation.tsx
@@ -1,0 +1,222 @@
+/**
+ * The live controls for a question the agent is waiting on, shared by the
+ * session's card and the channel's Magic Chip: the form with its Submit, the
+ * URL consent, and the refusal of a request this client cannot display.
+ *
+ * A Macro user tool under review is each surface's own - the session opens
+ * the tool's composer, the chip a read-only summary - so it is not here; a
+ * surface that cannot show the tool falls back to `LiveForm` over the flat
+ * schema the agent also sent.
+ */
+
+import type { ElicitationRequest } from '@service-agent-fold/generated/types';
+import type { ElicitationAnswer } from '@service-agent-harness/generated/schemas';
+import { Button } from '@ui';
+import {
+  createMemo,
+  createSignal,
+  type JSX,
+  Match,
+  Show,
+  Switch,
+} from 'solid-js';
+import { createStore } from 'solid-js/store';
+import {
+  type FieldValue,
+  initialValues,
+  toContent,
+  validate,
+} from '../../state/elicitation-form';
+import { ElicitationForm } from '../../ui';
+
+export type RespondToElicitation = (
+  answer: ElicitationAnswer
+) => Promise<boolean>;
+
+/** Every request the shared controls answer; a user tool is the surface's. */
+export type LiveQuestionRequest = Exclude<
+  ElicitationRequest,
+  { kind: 'user_tool' }
+>;
+
+type LiveProps = {
+  locked: boolean;
+  onRespond: RespondToElicitation;
+  /** Right-aligned in the action row, after the decisions. */
+  trailing?: JSX.Element;
+};
+
+function form(request: LiveQuestionRequest) {
+  return request.kind === 'form' ? request : undefined;
+}
+
+function url(request: LiveQuestionRequest) {
+  return request.kind === 'url' ? request : undefined;
+}
+
+function unrecognized(request: LiveQuestionRequest) {
+  return request.kind === 'unrecognized' ? request : undefined;
+}
+
+export function LiveQuestion(
+  props: LiveProps & { request: LiveQuestionRequest }
+) {
+  return (
+    <Switch>
+      <Match when={form(props.request)}>
+        {(request) => (
+          <LiveForm
+            schema={request().schema}
+            locked={props.locked}
+            onRespond={props.onRespond}
+            trailing={props.trailing}
+          />
+        )}
+      </Match>
+      <Match when={url(props.request)}>
+        {(request) => (
+          <LiveUrl
+            url={request().url}
+            locked={props.locked}
+            onRespond={props.onRespond}
+            trailing={props.trailing}
+          />
+        )}
+      </Match>
+      <Match when={unrecognized(props.request)}>
+        {(request) => (
+          <div class="flex flex-col gap-2">
+            <div class="text-xs text-ink-extra-muted italic">
+              This client cannot display a "{request().mode}" request.
+            </div>
+            <Actions
+              locked={props.locked}
+              onRespond={props.onRespond}
+              trailing={props.trailing}
+            />
+          </div>
+        )}
+      </Match>
+    </Switch>
+  );
+}
+
+/** Decline and Cancel, after an optional primary, with the trailing slot. */
+function Actions(props: LiveProps & { children?: JSX.Element }) {
+  return (
+    <div class="flex flex-wrap items-center gap-2">
+      {props.children}
+      <Button
+        variant="outline"
+        size="xs"
+        disabled={props.locked}
+        onClick={() => void props.onRespond({ action: 'decline' })}
+      >
+        Decline
+      </Button>
+      <Button
+        variant="ghost"
+        size="xs"
+        disabled={props.locked}
+        onClick={() => void props.onRespond({ action: 'cancel' })}
+      >
+        Cancel
+      </Button>
+      <Show when={props.trailing}>
+        <span class="ml-auto">{props.trailing}</span>
+      </Show>
+    </div>
+  );
+}
+
+export function LiveForm(
+  props: LiveProps & {
+    schema: Extract<ElicitationRequest, { kind: 'form' }>['schema'];
+  }
+) {
+  const [values, setValues] = createStore(initialValues(props.schema));
+  const [touched, setTouched] = createSignal(false);
+  const errors = createMemo(() => validate(props.schema, values));
+  const shownErrors = () => (touched() ? errors() : {});
+
+  const submit = () => {
+    if (props.locked) return;
+    setTouched(true);
+    if (Object.keys(errors()).length > 0) return;
+    void props.onRespond({
+      action: 'accept',
+      content: toContent(props.schema, values),
+    });
+  };
+
+  return (
+    <div class="flex flex-col gap-3">
+      <ElicitationForm
+        schema={props.schema}
+        values={values}
+        errors={shownErrors()}
+        disabled={props.locked}
+        onChange={(name: string, value: FieldValue) => setValues(name, value)}
+      />
+      <Actions
+        locked={props.locked}
+        onRespond={props.onRespond}
+        trailing={props.trailing}
+      >
+        <Button
+          variant="cta"
+          size="xs"
+          disabled={props.locked}
+          onClick={submit}
+        >
+          Submit
+        </Button>
+      </Actions>
+    </div>
+  );
+}
+
+/**
+ * URL mode never opens anything on its own. The card shows the full URL and
+ * its host, and only after the user presses Open does it send the consent and
+ * open a new tab - never an iframe, never a prefetch.
+ */
+function LiveUrl(props: LiveProps & { url: string }) {
+  const host = () => urlHost(props.url);
+  const open = async () => {
+    if (props.locked) return;
+    // Consent goes to the agent first so it learns the user agreed even if
+    // the popup is blocked; the link below stays as the fallback.
+    const accepted = await props.onRespond({ action: 'accept' });
+    if (!accepted) return;
+    window.open(props.url, '_blank', 'noopener,noreferrer');
+  };
+  return (
+    <div class="flex flex-col gap-2">
+      <div class="text-xs text-ink-muted">
+        Opens <span class="font-medium text-ink">{host()}</span> in a new tab.
+      </div>
+      <div class="rounded-md border border-edge-muted bg-surface px-2 py-1 font-mono text-xs text-ink-muted break-all">
+        {props.url}
+      </div>
+      <Actions
+        locked={props.locked}
+        onRespond={props.onRespond}
+        trailing={props.trailing}
+      >
+        <Button variant="cta" size="xs" disabled={props.locked} onClick={open}>
+          Open
+        </Button>
+      </Actions>
+    </div>
+  );
+}
+
+/** The host of a URL-mode request, for the consent card, or the raw text. */
+function urlHost(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}

--- a/apps/web/src/features/block-agent/component/parts/LiveElicitation.tsx
+++ b/apps/web/src/features/block-agent/component/parts/LiveElicitation.tsx
@@ -28,6 +28,7 @@ import {
   Switch,
 } from 'solid-js';
 import { createStore } from 'solid-js/store';
+import { match } from 'ts-pattern';
 import {
   type FieldValue,
   type FormValues,
@@ -87,14 +88,20 @@ function createFormDraft(schema: ElicitationSchema): FormDraft {
 
 /** The question's state; call it once per request, under a reactive owner. */
 export function createLiveQuestion(request: LiveQuestionRequest): LiveQuestion {
-  switch (request.kind) {
-    case 'form':
-      return { kind: 'form', draft: createFormDraft(request.schema) };
-    case 'url':
-      return { kind: 'url', url: request.url };
-    case 'unrecognized':
-      return { kind: 'unrecognized', mode: request.mode };
-  }
+  return match(request)
+    .with(
+      { kind: 'form' },
+      ({ schema }): LiveQuestion => ({
+        kind: 'form',
+        draft: createFormDraft(schema),
+      })
+    )
+    .with({ kind: 'url' }, ({ url }): LiveQuestion => ({ kind: 'url', url }))
+    .with(
+      { kind: 'unrecognized' },
+      ({ mode }): LiveQuestion => ({ kind: 'unrecognized', mode })
+    )
+    .exhaustive();
 }
 
 function form(question: LiveQuestion) {

--- a/apps/web/src/features/block-agent/debug/Gallery.tsx
+++ b/apps/web/src/features/block-agent/debug/Gallery.tsx
@@ -443,7 +443,10 @@ const FIXTURE_ELICITATION: ElicitationSchema = {
   ],
 };
 
-const GALLERY_CHIP_HEADER = { agent: 'cursor', model: 'Claude Opus 5 High' };
+const GALLERY_CHIP_HEADER = {
+  agent: 'Cursor Agent',
+  model: 'Claude Opus 5 High',
+};
 
 /** The chip through a turn: booting, writing, and done. */
 function MagicChipStateDemo(props: { presentation: MagicChipPresentation }) {

--- a/apps/web/src/features/block-agent/debug/Gallery.tsx
+++ b/apps/web/src/features/block-agent/debug/Gallery.tsx
@@ -443,6 +443,20 @@ const FIXTURE_ELICITATION: ElicitationSchema = {
   ],
 };
 
+const GALLERY_CHIP_HEADER = { agent: 'cursor', model: 'Claude Opus 5 High' };
+
+/** The chip through a turn: booting, writing, and done. */
+function MagicChipStateDemo(props: { presentation: MagicChipPresentation }) {
+  return (
+    <MagicChipView
+      agentSessionId="gallery"
+      presentation={props.presentation}
+      header={GALLERY_CHIP_HEADER}
+      onOpen={() => console.log('[gallery] open session')}
+    />
+  );
+}
+
 /** The chip asking, one per request kind; answers land in the console. */
 function MagicChipAskingDemo(props: {
   request: PendingElicitation['request'];
@@ -468,6 +482,7 @@ function MagicChipAskingDemo(props: {
     <MagicChipView
       agentSessionId="gallery"
       presentation={presentation}
+      header={GALLERY_CHIP_HEADER}
       answer={{
         answering: false,
         respond: async (answer) => {
@@ -506,6 +521,38 @@ export default function AgentUiGallery() {
         <div class="mx-auto flex max-w-3xl flex-col gap-8 px-6 py-8">
           <Item label="ElicitationForm (live validation)">
             <ElicitationFormDemo />
+          </Item>
+
+          <Item label="MagicChip (booting, writing, done)">
+            <MagicChipStateDemo
+              presentation={{
+                kind: 'working',
+                activity: {
+                  label: 'Booting agent',
+                  detail: 'Preparing workspace',
+                  busy: true,
+                },
+              }}
+            />
+            <MagicChipStateDemo
+              presentation={{
+                kind: 'answering',
+                markdown:
+                  'The failing test is in `agent_fold`: the batch fold re-derives every message per frame, so the',
+                activity: {
+                  label: 'Running command',
+                  detail: 'cargo test -p agent_fold',
+                  busy: true,
+                },
+              }}
+            />
+            <MagicChipStateDemo
+              presentation={{
+                kind: 'settled',
+                markdown:
+                  '**Fixed.** The incremental machine now handles the replay; `cargo test -p agent_fold` passes.',
+              }}
+            />
           </Item>
 
           <Item label="MagicChip asking (form, quiet form, url, tool draft)">

--- a/apps/web/src/features/block-agent/debug/Gallery.tsx
+++ b/apps/web/src/features/block-agent/debug/Gallery.tsx
@@ -460,12 +460,10 @@ function MagicChipStateDemo(props: { presentation: MagicChipPresentation }) {
 /** The chip asking, one per request kind; answers land in the console. */
 function MagicChipAskingDemo(props: {
   request: PendingElicitation['request'];
-  /** The agent asked without saying anything first. */
-  quiet?: boolean;
 }) {
   const presentation: MagicChipPresentation = {
     kind: 'asking',
-    markdown: props.quiet ? '' : 'Happy to. One quick question before I go on.',
+    markdown: 'Happy to. One quick question before I go on.',
     asking: {
       question: {
         requestId: 0,
@@ -555,13 +553,9 @@ export default function AgentUiGallery() {
             />
           </Item>
 
-          <Item label="MagicChip asking (form, quiet form, url, tool draft)">
+          <Item label="MagicChip asking (form, url, tool draft)">
             <MagicChipAskingDemo
               request={{ kind: 'form', schema: FIXTURE_ELICITATION }}
-            />
-            <MagicChipAskingDemo
-              request={{ kind: 'form', schema: FIXTURE_ELICITATION }}
-              quiet
             />
             <MagicChipAskingDemo
               request={{

--- a/apps/web/src/features/block-agent/debug/Gallery.tsx
+++ b/apps/web/src/features/block-agent/debug/Gallery.tsx
@@ -446,10 +446,12 @@ const FIXTURE_ELICITATION: ElicitationSchema = {
 /** The chip asking, one per request kind; answers land in the console. */
 function MagicChipAskingDemo(props: {
   request: PendingElicitation['request'];
+  /** The agent asked without saying anything first. */
+  quiet?: boolean;
 }) {
   const presentation: MagicChipPresentation = {
     kind: 'asking',
-    markdown: 'Happy to. One quick question before I go on.',
+    markdown: props.quiet ? '' : 'Happy to. One quick question before I go on.',
     asking: {
       question: {
         requestId: 0,
@@ -506,9 +508,13 @@ export default function AgentUiGallery() {
             <ElicitationFormDemo />
           </Item>
 
-          <Item label="MagicChip asking (form / url / tool draft)">
+          <Item label="MagicChip asking (form, quiet form, url, tool draft)">
             <MagicChipAskingDemo
               request={{ kind: 'form', schema: FIXTURE_ELICITATION }}
+            />
+            <MagicChipAskingDemo
+              request={{ kind: 'form', schema: FIXTURE_ELICITATION }}
+              quiet
             />
             <MagicChipAskingDemo
               request={{

--- a/apps/web/src/features/block-agent/debug/Gallery.tsx
+++ b/apps/web/src/features/block-agent/debug/Gallery.tsx
@@ -5,10 +5,13 @@
  */
 
 import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
+import { MagicChipView } from '@core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView';
+import type { MagicChipPresentation } from '@core/component/LexicalMarkdown/component/decorator/MagicChip/presentation';
 import type {
   ElicitationSchema,
   FoldedMessage,
   ModelOption,
+  PendingElicitation,
   ToolStatus,
 } from '@service-agent-fold/generated/types';
 import { createSignal, type JSX, onCleanup } from 'solid-js';
@@ -440,6 +443,41 @@ const FIXTURE_ELICITATION: ElicitationSchema = {
   ],
 };
 
+/** The chip asking, one per request kind; answers land in the console. */
+function MagicChipAskingDemo(props: {
+  request: PendingElicitation['request'];
+}) {
+  const presentation: MagicChipPresentation = {
+    kind: 'asking',
+    markdown: 'Happy to. One quick question before I go on.',
+    asking: {
+      question: {
+        requestId: 0,
+        turn: 0,
+        toolCall: null,
+        message: 'Which colour, and where should it run?',
+        request: props.request,
+      },
+      canAnswer: true,
+      ownerName: 'You',
+    },
+  };
+  return (
+    <MagicChipView
+      agentSessionId="gallery"
+      presentation={presentation}
+      answer={{
+        answering: false,
+        respond: async (answer) => {
+          console.log('[gallery] elicitation answer', answer);
+          return true;
+        },
+      }}
+      onOpen={() => console.log('[gallery] open session')}
+    />
+  );
+}
+
 function ElicitationFormDemo() {
   const [values, setValues] = createStore(initialValues(FIXTURE_ELICITATION));
   const errors = () => validate(FIXTURE_ELICITATION, values);
@@ -466,6 +504,39 @@ export default function AgentUiGallery() {
         <div class="mx-auto flex max-w-3xl flex-col gap-8 px-6 py-8">
           <Item label="ElicitationForm (live validation)">
             <ElicitationFormDemo />
+          </Item>
+
+          <Item label="MagicChip asking (form / url / tool draft)">
+            <MagicChipAskingDemo
+              request={{ kind: 'form', schema: FIXTURE_ELICITATION }}
+            />
+            <MagicChipAskingDemo
+              request={{
+                kind: 'url',
+                elicitationId: 'gh-1',
+                url: 'https://github.com/login/device?user_code=ABCD-1234',
+              }}
+            />
+            <MagicChipAskingDemo
+              request={{
+                kind: 'user_tool',
+                tool: 'CreateCalendarEvent',
+                draft: {
+                  title: 'Q3 sync',
+                  time: {
+                    kind: 'timed',
+                    startsAt: '2026-08-20T17:00:00Z',
+                    endsAt: '2026-08-20T17:30:00Z',
+                    timeZone: 'UTC',
+                  },
+                  attendees: [],
+                  recurrenceLines: [],
+                  addGoogleMeet: false,
+                  eventType: 'default',
+                },
+                schema: FIXTURE_ELICITATION,
+              }}
+            />
           </Item>
 
           <Item label="ComposerNotice">

--- a/apps/web/src/features/block-agent/ui/ElicitationForm.test.tsx
+++ b/apps/web/src/features/block-agent/ui/ElicitationForm.test.tsx
@@ -120,6 +120,38 @@ describe('single-choice elicitation', () => {
     expect(view.answer()).toEqual({ colour: 'red' });
   });
 
+  it('is one tab stop whose arrow keys move the choice, Other included', () => {
+    const view = form(question('colour_custom'));
+    const red = view.getByRole('radio', { name: 'Red' });
+    const literal = view.getByRole('radio', { name: 'A literal option' });
+    const other = view.getByRole('radio', { name: 'Other' });
+    expect(red.tabIndex).toBe(0);
+    expect(literal.tabIndex).toBe(-1);
+    expect(other.tabIndex).toBe(-1);
+    expect(view.getByRole('radiogroup').getAttribute('aria-labelledby')).toBe(
+      view.getByText('Colour').id
+    );
+
+    fireEvent.keyDown(red, { key: 'ArrowDown' });
+    expect(view.checked(literal)).toBe(true);
+    expect(literal.tabIndex).toBe(0);
+    expect(red.tabIndex).toBe(-1);
+    expect(document.activeElement).toBe(literal);
+
+    fireEvent.keyDown(literal, { key: 'ArrowDown' });
+    expect(view.checked(other)).toBe(true);
+    expect(view.answer()).toEqual({});
+
+    // Wraps, and the Other text box keeps its own arrows.
+    fireEvent.keyDown(other, { key: 'ArrowRight' });
+    expect(view.checked(red)).toBe(true);
+    fireEvent.click(other);
+    fireEvent.keyDown(view.getByPlaceholderText('Type your own answer'), {
+      key: 'ArrowUp',
+    });
+    expect(view.checked(other)).toBe(true);
+  });
+
   it('typing directly selects Other and keeps an empty Other selected', () => {
     const view = form(question('colour_custom'));
     const text = view.getByPlaceholderText('Type your own answer');

--- a/apps/web/src/features/block-agent/ui/ElicitationForm.test.tsx
+++ b/apps/web/src/features/block-agent/ui/ElicitationForm.test.tsx
@@ -3,13 +3,9 @@
 import type { ElicitationSchema } from '@service-agent-fold/generated/types';
 import { cleanup, fireEvent, render } from '@solidjs/testing-library';
 import { createStore } from 'solid-js/store';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { initialValues, toContent, validate } from '../state/elicitation-form';
 import { ElicitationForm } from './ElicitationForm';
-
-// These cases exercise the real radio and text inputs, without loading the
-// unrelated checkbox's UI dependencies.
-vi.mock('@ui', () => ({ Checkbox: () => null }));
 
 afterEach(cleanup);
 
@@ -41,8 +37,34 @@ function question(customField: string | null): ElicitationSchema {
   };
 }
 
+function regions(customField: string | null): ElicitationSchema {
+  return {
+    title: null,
+    description: null,
+    required: [],
+    properties: [
+      {
+        name: 'regions',
+        title: 'Regions',
+        description: null,
+        schema: {
+          type: 'multi_select',
+          minItems: null,
+          maxItems: null,
+          default: ['us'],
+          options: [
+            { value: 'us', title: 'US', description: null },
+            { value: 'eu', title: 'EU', description: null },
+          ],
+          customField,
+        },
+      },
+    ],
+  };
+}
+
 function form(schema: ElicitationSchema) {
-  return render(() => {
+  const view = render(() => {
     const [values, setValues] = createStore(initialValues(schema));
     return (
       <>
@@ -58,51 +80,54 @@ function form(schema: ElicitationSchema) {
       </>
     );
   });
+  const answer = () => JSON.parse(view.getByTestId('answer').textContent!);
+  const checked = (element: HTMLElement) =>
+    element.getAttribute('aria-checked') === 'true';
+  return { ...view, answer, checked };
 }
 
 describe('single-choice elicitation', () => {
   it('switches from the default option to empty Other, custom text, and back', () => {
     const view = form(question('colour_custom'));
-    const red = view.getByRole('radio', { name: 'Red' }) as HTMLInputElement;
-    const other = view.getByRole('radio', {
-      name: 'Other',
-    }) as HTMLInputElement;
+    const red = view.getByRole('radio', { name: 'Red' });
+    const other = view.getByRole('radio', { name: 'Other' });
     const text = view.getByPlaceholderText(
       'Type your own answer'
     ) as HTMLInputElement;
-    const answer = () => JSON.parse(view.getByTestId('answer').textContent!);
 
-    expect(red.checked).toBe(true);
-    expect(answer()).toEqual({ colour: 'red' });
+    expect(view.checked(red)).toBe(true);
+    expect(view.answer()).toEqual({ colour: 'red' });
 
     fireEvent.click(other);
-    expect(other.checked).toBe(true);
-    expect(red.checked).toBe(false);
+    expect(view.checked(other)).toBe(true);
+    expect(view.checked(red)).toBe(false);
     expect(view.getByText('Required')).toBeTruthy();
-    expect(answer()).toEqual({});
+    expect(view.answer()).toEqual({});
 
     fireEvent.input(text, { target: { value: 'teal' } });
-    expect(other.checked).toBe(true);
+    expect(view.checked(other)).toBe(true);
     expect(view.queryByText('Required')).toBeNull();
-    expect(answer()).toEqual({ colour_custom: 'teal' });
+    expect(view.answer()).toEqual({ colour_custom: 'teal' });
+
+    // Pressing Other again keeps what was typed.
+    fireEvent.click(other);
+    expect(text.value).toBe('teal');
 
     fireEvent.click(red);
-    expect(red.checked).toBe(true);
-    expect(other.checked).toBe(false);
+    expect(view.checked(red)).toBe(true);
+    expect(view.checked(other)).toBe(false);
     expect(text.value).toBe('');
-    expect(answer()).toEqual({ colour: 'red' });
+    expect(view.answer()).toEqual({ colour: 'red' });
   });
 
   it('typing directly selects Other and keeps an empty Other selected', () => {
     const view = form(question('colour_custom'));
     const text = view.getByPlaceholderText('Type your own answer');
-    const other = view.getByRole('radio', {
-      name: 'Other',
-    }) as HTMLInputElement;
+    const other = view.getByRole('radio', { name: 'Other' });
     fireEvent.input(text, { target: { value: 'teal' } });
-    expect(other.checked).toBe(true);
+    expect(view.checked(other)).toBe(true);
     fireEvent.input(text, { target: { value: '' } });
-    expect(other.checked).toBe(true);
+    expect(view.checked(other)).toBe(true);
     expect(view.getByText('Required')).toBeTruthy();
     expect(view.getByTestId('answer').textContent).toBe('{}');
   });
@@ -112,8 +137,36 @@ describe('single-choice elicitation', () => {
     expect(view.queryByRole('radio', { name: 'Other' })).toBeNull();
     expect(view.queryByPlaceholderText('Type your own answer')).toBeNull();
     fireEvent.click(view.getByRole('radio', { name: 'A literal option' }));
-    expect(JSON.parse(view.getByTestId('answer').textContent!)).toEqual({
-      colour: '__custom',
-    });
+    expect(view.answer()).toEqual({ colour: '__custom' });
+  });
+});
+
+describe('multi-choice elicitation', () => {
+  it('toggles options and never sends them alongside a custom answer', () => {
+    const view = form(regions('regions_custom'));
+    const us = view.getByRole('checkbox', { name: 'US' });
+    const eu = view.getByRole('checkbox', { name: 'EU' });
+    const other = view.getByRole('checkbox', { name: 'Other' });
+    const text = view.getByPlaceholderText('Type your own answer');
+
+    expect(view.checked(us)).toBe(true);
+    expect(view.answer()).toEqual({ regions: ['us'] });
+
+    fireEvent.click(eu);
+    expect(view.answer()).toEqual({ regions: ['us', 'eu'] });
+
+    fireEvent.input(text, { target: { value: 'mars' } });
+    expect(view.checked(other)).toBe(true);
+    expect(view.checked(us)).toBe(false);
+    expect(view.answer()).toEqual({ regions_custom: 'mars' });
+
+    fireEvent.click(us);
+    expect(view.checked(other)).toBe(false);
+    expect(view.answer()).toEqual({ regions: ['us'] });
+  });
+
+  it('has no Other row when the schema allows none', () => {
+    const view = form(regions(null));
+    expect(view.queryByRole('checkbox', { name: 'Other' })).toBeNull();
   });
 });

--- a/apps/web/src/features/block-agent/ui/ElicitationForm.tsx
+++ b/apps/web/src/features/block-agent/ui/ElicitationForm.tsx
@@ -2,14 +2,24 @@
  * The fields of an elicitation form, props-in JSX-out. The caller owns the
  * draft values and validation (`state/elicitation-form.ts`) and the card
  * chrome; this renders one control per property and reports edits.
+ *
+ * Choices are rows in the app's menu idiom - a box that fills accent when
+ * chosen, round for one answer and square for several - rather than the
+ * browser's radio and checkbox glyphs, so a question reads like the rest of
+ * the session. The rows keep their ARIA roles (`radio`, `checkbox`) so the
+ * form is navigable the way the native controls were.
  */
 
+import CheckIcon from '@phosphor/check.svg';
 import type {
+  ElicitationOption,
   ElicitationProperty,
+  ElicitationPropertySchema,
   ElicitationSchema,
 } from '@service-agent-fold/generated/types';
-import { Checkbox } from '@ui';
-import { For, Show } from 'solid-js';
+import { cn } from '@ui';
+import { For, type JSX, Show } from 'solid-js';
+import { match, P } from 'ts-pattern';
 import type {
   FieldValue,
   FormValues,
@@ -30,13 +40,319 @@ function textOf(value: FieldValue | undefined): string {
 }
 
 const INPUT_CLASS =
-  'w-full rounded-md border border-edge-muted bg-surface px-2 py-1 text-sm text-ink placeholder:text-ink-placeholder focus:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50';
+  'h-8 w-full rounded-md border border-edge-muted bg-transparent px-2 text-sm text-ink outline-none transition-colors placeholder:text-ink-placeholder hover:border-edge focus:border-accent disabled:opacity-50';
+
+const ROW_CLASS =
+  'group flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-ink outline-none';
+
+const ROW_INTERACTIVE_CLASS =
+  'not-disabled:hover:bg-ink/5 focus-visible:bg-ink/5 disabled:opacity-50';
+
+type SingleSelect = Extract<ElicitationPropertySchema, { type: 'string' }>;
+type MultiSelect = Extract<ElicitationPropertySchema, { type: 'multi_select' }>;
+type MultiSelectValue = Extract<FieldValue, { kind: 'multi_select' }>;
+
+/** The box beside a choice: round for one answer, square for several. */
+function ChoiceBox(props: { checked: boolean; multiple: boolean }) {
+  return (
+    <span
+      aria-hidden="true"
+      class={cn(
+        'mt-0.5 inline-flex size-3.5 shrink-0 items-center justify-center border text-surface transition-colors',
+        props.multiple ? 'rounded-sm' : 'rounded-full',
+        props.checked
+          ? 'border-accent bg-accent'
+          : 'border-edge-muted bg-transparent group-hover:border-edge'
+      )}
+    >
+      <CheckIcon class={cn('size-2.5', !props.checked && 'hidden')} />
+    </span>
+  );
+}
+
+function OptionText(props: { option: ElicitationOption }) {
+  return (
+    <span class="flex min-w-0 flex-col">
+      <span>{props.option.title ?? props.option.value}</span>
+      <Show when={props.option.description}>
+        {(description) => (
+          <span class="text-xs text-ink-extra-muted">{description()}</span>
+        )}
+      </Show>
+    </span>
+  );
+}
+
+function ChoiceRow(props: {
+  role: 'radio' | 'checkbox';
+  checked: boolean;
+  disabled?: boolean;
+  onSelect: () => void;
+  option: ElicitationOption;
+}) {
+  return (
+    <button
+      type="button"
+      role={props.role}
+      aria-checked={props.checked}
+      class={cn(ROW_CLASS, ROW_INTERACTIVE_CLASS)}
+      disabled={props.disabled}
+      onClick={props.onSelect}
+    >
+      <ChoiceBox checked={props.checked} multiple={props.role === 'checkbox'} />
+      <OptionText option={props.option} />
+    </button>
+  );
+}
+
+/**
+ * The free-text escape a select may offer: its box selects it like any other
+ * choice, and typing selects it too.
+ */
+function OtherRow(props: {
+  role: 'radio' | 'checkbox';
+  checked: boolean;
+  disabled?: boolean;
+  text: string;
+  onSelect: () => void;
+  onInput: (text: string) => void;
+}) {
+  return (
+    <div
+      class={cn(ROW_CLASS, 'items-center', props.disabled && 'opacity-50')}
+      classList={{ 'hover:bg-ink/5': !props.disabled }}
+    >
+      <button
+        type="button"
+        role={props.role}
+        aria-checked={props.checked}
+        aria-label="Other"
+        class="flex items-center outline-none"
+        disabled={props.disabled}
+        onClick={props.onSelect}
+      >
+        <ChoiceBox
+          checked={props.checked}
+          multiple={props.role === 'checkbox'}
+        />
+      </button>
+      <input
+        type="text"
+        class="min-w-0 flex-1 bg-transparent text-sm text-ink outline-none placeholder:text-ink-placeholder"
+        placeholder="Type your own answer"
+        disabled={props.disabled}
+        value={props.text}
+        onInput={(event) => props.onInput(event.currentTarget.value)}
+      />
+    </div>
+  );
+}
+
+function SingleChoice(props: {
+  field: SingleSelect;
+  value: FieldValue | undefined;
+  disabled?: boolean;
+  onChange: (next: FieldValue) => void;
+}) {
+  const selection = (): SingleSelection =>
+    props.value?.kind === 'single_select'
+      ? props.value.selection
+      : { kind: 'none' };
+  const pick = (selection: SingleSelection) =>
+    props.onChange({ kind: 'single_select', selection });
+  const chosen = (option: ElicitationOption) => {
+    const current = selection();
+    return current.kind === 'option' && current.value === option.value;
+  };
+  const customText = () => {
+    const current = selection();
+    return current.kind === 'custom' ? current.text : '';
+  };
+
+  return (
+    <div role="radiogroup" class="flex flex-col">
+      <For each={props.field.options}>
+        {(option) => (
+          <ChoiceRow
+            role="radio"
+            option={option}
+            checked={chosen(option)}
+            disabled={props.disabled}
+            onSelect={() => pick({ kind: 'option', value: option.value })}
+          />
+        )}
+      </For>
+      <Show when={props.field.customField}>
+        <OtherRow
+          role="radio"
+          checked={selection().kind === 'custom'}
+          disabled={props.disabled}
+          text={customText()}
+          onSelect={() => {
+            if (selection().kind !== 'custom')
+              pick({ kind: 'custom', text: '' });
+          }}
+          onInput={(text) => pick({ kind: 'custom', text })}
+        />
+      </Show>
+    </div>
+  );
+}
+
+function MultiChoice(props: {
+  field: MultiSelect;
+  value: FieldValue | undefined;
+  disabled?: boolean;
+  onChange: (next: FieldValue) => void;
+}) {
+  const current = (): MultiSelectValue =>
+    props.value?.kind === 'multi_select'
+      ? props.value
+      : { kind: 'multi_select', values: [], custom: undefined };
+  // A custom answer and chosen options never travel together, so picking one
+  // side clears the other.
+  const toggle = (option: ElicitationOption) => {
+    const { values } = current();
+    props.onChange({
+      kind: 'multi_select',
+      values: values.includes(option.value)
+        ? values.filter((item) => item !== option.value)
+        : [...values, option.value],
+      custom: undefined,
+    });
+  };
+  const custom = () => current().custom;
+
+  return (
+    <div role="group" class="flex flex-col">
+      <For each={props.field.options}>
+        {(option) => (
+          <ChoiceRow
+            role="checkbox"
+            option={option}
+            checked={current().values.includes(option.value)}
+            disabled={props.disabled}
+            onSelect={() => toggle(option)}
+          />
+        )}
+      </For>
+      <Show when={props.field.customField}>
+        <OtherRow
+          role="checkbox"
+          checked={custom() !== undefined}
+          disabled={props.disabled}
+          text={custom() ?? ''}
+          onSelect={() =>
+            props.onChange({
+              kind: 'multi_select',
+              values: [],
+              custom: custom() === undefined ? '' : undefined,
+            })
+          }
+          onInput={(text) =>
+            props.onChange({ kind: 'multi_select', values: [], custom: text })
+          }
+        />
+      </Show>
+    </div>
+  );
+}
+
+const YES: ElicitationOption = {
+  value: 'true',
+  title: 'Yes',
+  description: null,
+};
+
+function FieldControl(props: {
+  field: ElicitationPropertySchema;
+  value: FieldValue | undefined;
+  disabled?: boolean;
+  onChange: (next: FieldValue) => void;
+}): JSX.Element {
+  return (
+    <>
+      {match(props.field)
+        .with(
+          { type: 'string', options: P.when((options) => options.length > 0) },
+          (field) => (
+            <SingleChoice
+              field={field}
+              value={props.value}
+              disabled={props.disabled}
+              onChange={props.onChange}
+            />
+          )
+        )
+        .with({ type: 'string' }, (field) => (
+          <input
+            type={
+              field.format === 'email'
+                ? 'email'
+                : field.format === 'uri'
+                  ? 'url'
+                  : 'text'
+            }
+            class={INPUT_CLASS}
+            disabled={props.disabled}
+            value={textOf(props.value)}
+            onInput={(event) =>
+              props.onChange({ kind: 'text', text: event.currentTarget.value })
+            }
+          />
+        ))
+        .with({ type: 'number' }, { type: 'integer' }, (field) => (
+          <input
+            type="number"
+            class={INPUT_CLASS}
+            disabled={props.disabled}
+            step={field.type === 'integer' ? 1 : 'any'}
+            min={field.minimum ?? undefined}
+            max={field.maximum ?? undefined}
+            value={textOf(props.value)}
+            onInput={(event) =>
+              props.onChange({ kind: 'text', text: event.currentTarget.value })
+            }
+          />
+        ))
+        .with({ type: 'boolean' }, () => {
+          const checked = () =>
+            props.value?.kind === 'boolean' && props.value.checked;
+          return (
+            <ChoiceRow
+              role="checkbox"
+              option={YES}
+              checked={checked()}
+              disabled={props.disabled}
+              onSelect={() =>
+                props.onChange({ kind: 'boolean', checked: !checked() })
+              }
+            />
+          );
+        })
+        .with({ type: 'multi_select' }, (field) => (
+          <MultiChoice
+            field={field}
+            value={props.value}
+            disabled={props.disabled}
+            onChange={props.onChange}
+          />
+        ))
+        .with({ type: 'unrecognized' }, (field) => (
+          <div class="text-xs text-ink-extra-muted italic">
+            This client cannot display a {field.typeName} field.
+          </div>
+        ))
+        .exhaustive()}
+    </>
+  );
+}
 
 function Field(props: {
   property: ElicitationProperty;
   required: boolean;
   error?: string;
-  children: unknown;
+  children: JSX.Element;
 }) {
   return (
     <div class="flex flex-col gap-1">
@@ -53,7 +369,7 @@ function Field(props: {
           <div class="text-xs text-ink-extra-muted">{description()}</div>
         )}
       </Show>
-      {props.children as never}
+      {props.children}
       <Show when={props.error}>
         {(error) => <div class="text-xs text-failure">{error()}</div>}
       </Show>
@@ -72,220 +388,20 @@ export function ElicitationForm(props: ElicitationFormProps) {
         )}
       </Show>
       <For each={props.schema.properties}>
-        {(property) => {
-          const value = () => props.values[property.name];
-          const selection = (): SingleSelection => {
-            const current = value();
-            return current?.kind === 'single_select'
-              ? current.selection
-              : { kind: 'none' };
-          };
-          const field = property.schema;
-          const set = (next: FieldValue) => props.onChange(property.name, next);
-          return (
-            <Field
-              property={property}
-              required={required(property.name)}
-              error={props.errors[property.name]}
-            >
-              {field.type === 'string' && field.options.length > 0 ? (
-                <div class="flex flex-col gap-1" role="radiogroup">
-                  <For each={field.options}>
-                    {(option) => {
-                      const checked = () => {
-                        const current = selection();
-                        return (
-                          current.kind === 'option' &&
-                          current.value === option.value
-                        );
-                      };
-                      return (
-                        <label class="flex items-start gap-2 text-sm text-ink">
-                          <input
-                            type="radio"
-                            class="mt-1 accent-accent"
-                            name={`elicitation-${property.name}`}
-                            value={option.value}
-                            checked={checked()}
-                            disabled={props.disabled}
-                            onChange={() =>
-                              set({
-                                kind: 'single_select',
-                                selection: {
-                                  kind: 'option',
-                                  value: option.value,
-                                },
-                              })
-                            }
-                          />
-                          <span class="flex flex-col">
-                            <span>{option.title ?? option.value}</span>
-                            <Show when={option.description}>
-                              {(description) => (
-                                <span class="text-xs text-ink-extra-muted">
-                                  {description()}
-                                </span>
-                              )}
-                            </Show>
-                          </span>
-                        </label>
-                      );
-                    }}
-                  </For>
-                  <Show when={field.customField}>
-                    <label class="flex items-start gap-2 text-sm text-ink">
-                      <input
-                        type="radio"
-                        class="mt-1 accent-accent"
-                        name={`elicitation-${property.name}`}
-                        checked={selection().kind === 'custom'}
-                        disabled={props.disabled}
-                        onChange={() =>
-                          set({
-                            kind: 'single_select',
-                            selection: { kind: 'custom', text: '' },
-                          })
-                        }
-                      />
-                      <span class="flex min-w-0 flex-1 flex-col gap-1">
-                        <span>Other</span>
-                        <input
-                          type="text"
-                          class={INPUT_CLASS}
-                          placeholder="Type your own answer"
-                          disabled={props.disabled}
-                          value={(() => {
-                            const current = selection();
-                            return current.kind === 'custom'
-                              ? current.text
-                              : '';
-                          })()}
-                          onInput={(event) =>
-                            set({
-                              kind: 'single_select',
-                              selection: {
-                                kind: 'custom',
-                                text: event.currentTarget.value,
-                              },
-                            })
-                          }
-                        />
-                      </span>
-                    </label>
-                  </Show>
-                </div>
-              ) : field.type === 'string' ? (
-                <input
-                  type={
-                    field.format === 'email'
-                      ? 'email'
-                      : field.format === 'uri'
-                        ? 'url'
-                        : 'text'
-                  }
-                  class={INPUT_CLASS}
-                  disabled={props.disabled}
-                  value={textOf(value())}
-                  onInput={(event) =>
-                    set({ kind: 'text', text: event.currentTarget.value })
-                  }
-                />
-              ) : field.type === 'number' || field.type === 'integer' ? (
-                <input
-                  type="number"
-                  class={INPUT_CLASS}
-                  disabled={props.disabled}
-                  step={field.type === 'integer' ? 1 : 'any'}
-                  min={field.minimum ?? undefined}
-                  max={field.maximum ?? undefined}
-                  value={textOf(value())}
-                  onInput={(event) =>
-                    set({ kind: 'text', text: event.currentTarget.value })
-                  }
-                />
-              ) : field.type === 'boolean' ? (
-                <Checkbox
-                  checked={(() => {
-                    const current = value();
-                    return current?.kind === 'boolean' && current.checked;
-                  })()}
-                  disabled={props.disabled}
-                  onChange={(checked) => set({ kind: 'boolean', checked })}
-                >
-                  <Checkbox.Control />
-                  <Checkbox.Label class="text-sm text-ink">Yes</Checkbox.Label>
-                </Checkbox>
-              ) : field.type === 'multi_select' ? (
-                <div class="flex flex-col gap-1">
-                  <For each={field.options}>
-                    {(option) => {
-                      const selected = () => {
-                        const current = value();
-                        return current?.kind === 'multi_select'
-                          ? current.values
-                          : [];
-                      };
-                      return (
-                        <Checkbox
-                          checked={selected().includes(option.value)}
-                          disabled={props.disabled}
-                          onChange={(checked) =>
-                            set({
-                              kind: 'multi_select',
-                              values: checked
-                                ? [...selected(), option.value]
-                                : selected().filter(
-                                    (item) => item !== option.value
-                                  ),
-                              custom: undefined,
-                            })
-                          }
-                        >
-                          <Checkbox.Control />
-                          <Checkbox.Label class="flex flex-col text-sm text-ink">
-                            <span>{option.title ?? option.value}</span>
-                            <Show when={option.description}>
-                              {(description) => (
-                                <span class="text-xs text-ink-extra-muted">
-                                  {description()}
-                                </span>
-                              )}
-                            </Show>
-                          </Checkbox.Label>
-                        </Checkbox>
-                      );
-                    }}
-                  </For>
-                  <Show when={field.customField}>
-                    <input
-                      type="text"
-                      class={INPUT_CLASS}
-                      placeholder="Or type your own answer"
-                      disabled={props.disabled}
-                      value={(() => {
-                        const current = value();
-                        return current?.kind === 'multi_select'
-                          ? (current.custom ?? '')
-                          : '';
-                      })()}
-                      onInput={(event) =>
-                        set({
-                          kind: 'multi_select',
-                          values: [],
-                          custom: event.currentTarget.value,
-                        })
-                      }
-                    />
-                  </Show>
-                </div>
-              ) : (
-                <div class="text-xs text-ink-extra-muted italic">
-                  This client cannot display a {field.typeName} field.
-                </div>
-              )}
-            </Field>
-          );
-        }}
+        {(property) => (
+          <Field
+            property={property}
+            required={required(property.name)}
+            error={props.errors[property.name]}
+          >
+            <FieldControl
+              field={property.schema}
+              value={props.values[property.name]}
+              disabled={props.disabled}
+              onChange={(next) => props.onChange(property.name, next)}
+            />
+          </Field>
+        )}
       </For>
     </div>
   );

--- a/apps/web/src/features/block-agent/ui/ElicitationForm.tsx
+++ b/apps/web/src/features/block-agent/ui/ElicitationForm.tsx
@@ -6,8 +6,9 @@
  * Choices are rows in the app's menu idiom - a box that fills accent when
  * chosen, round for one answer and square for several - rather than the
  * browser's radio and checkbox glyphs, so a question reads like the rest of
- * the session. The rows keep their ARIA roles (`radio`, `checkbox`) so the
- * form is navigable the way the native controls were.
+ * the session. The rows keep their ARIA roles (`radio`, `checkbox`); a radio
+ * group keeps one tab stop and moves its choice with the arrow keys, as the
+ * native control does.
  */
 
 import CheckIcon from '@phosphor/check.svg';
@@ -102,6 +103,8 @@ function ChoiceRow(props: {
   role: 'radio' | 'checkbox';
   checked: boolean;
   disabled?: boolean;
+  /** A radio group's one tab stop is its chosen (or first) row. */
+  tabIndex?: number;
   onSelect: () => void;
   option: ElicitationOption;
 }) {
@@ -110,6 +113,7 @@ function ChoiceRow(props: {
       type="button"
       role={props.role}
       aria-checked={props.checked}
+      tabIndex={props.tabIndex}
       class="group flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-ink outline-none not-disabled:hover:bg-ink/5 focus-visible:bg-ink/5 disabled:opacity-50"
       disabled={props.disabled}
       onClick={props.onSelect}
@@ -128,6 +132,7 @@ function OtherRow(props: {
   role: 'radio' | 'checkbox';
   checked: boolean;
   disabled?: boolean;
+  tabIndex?: number;
   text: string;
   onSelect: () => void;
   onInput: (text: string) => void;
@@ -145,6 +150,7 @@ function OtherRow(props: {
         role={props.role}
         aria-checked={props.checked}
         aria-label="Other"
+        tabIndex={props.tabIndex}
         class="flex items-center outline-none"
         disabled={props.disabled}
         onClick={props.onSelect}
@@ -166,12 +172,19 @@ function OtherRow(props: {
   );
 }
 
+/**
+ * One answer from several, with the keyboard behavior of a native radio
+ * group: one tab stop (the chosen row, or the first), and the arrow keys
+ * move the choice - onto the Other row too, when there is one.
+ */
 function SingleChoice(props: {
   field: SingleSelect;
   value: FieldValue | undefined;
   disabled?: boolean;
+  labelId: string;
   onChange: (next: FieldValue) => void;
 }) {
+  let group: HTMLDivElement | undefined;
   const selection = (): SingleSelection =>
     props.value?.kind === 'single_select'
       ? props.value.selection
@@ -186,16 +199,60 @@ function SingleChoice(props: {
     const current = selection();
     return current.kind === 'custom' ? current.text : '';
   };
+  // The rows in order, Other last; the tab stop is the chosen one, else the
+  // first.
+  const rowCount = () =>
+    props.field.options.length + (props.field.customField ? 1 : 0);
+  const chosenIndex = () => {
+    const current = selection();
+    if (current.kind === 'option') {
+      const index = props.field.options.findIndex(
+        (option) => option.value === current.value
+      );
+      return index === -1 ? 0 : index;
+    }
+    return current.kind === 'custom' ? props.field.options.length : 0;
+  };
+  const tabIndex = (index: number) => (index === chosenIndex() ? 0 : -1);
+  const choose = (index: number) => {
+    const option = props.field.options[index];
+    if (option) pick({ kind: 'option', value: option.value });
+    else if (selection().kind !== 'custom') pick({ kind: 'custom', text: '' });
+    group?.querySelectorAll<HTMLElement>('[role="radio"]')[index]?.focus();
+  };
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (props.disabled) return;
+    // Arrows inside the Other text box edit it; only a row moves the choice.
+    if (
+      !(event.target instanceof Element) ||
+      event.target.getAttribute('role') !== 'radio'
+    )
+      return;
+    const step = match(event.key)
+      .with('ArrowDown', 'ArrowRight', () => 1)
+      .with('ArrowUp', 'ArrowLeft', () => -1)
+      .otherwise(() => 0);
+    if (step === 0) return;
+    event.preventDefault();
+    choose((chosenIndex() + step + rowCount()) % rowCount());
+  };
 
   return (
-    <div role="radiogroup" class="flex flex-col">
+    <div
+      ref={group}
+      role="radiogroup"
+      aria-labelledby={props.labelId}
+      class="flex flex-col"
+      onKeyDown={onKeyDown}
+    >
       <For each={props.field.options}>
-        {(option) => (
+        {(option, index) => (
           <ChoiceRow
             role="radio"
             option={option}
             checked={chosen(option)}
             disabled={props.disabled}
+            tabIndex={tabIndex(index())}
             onSelect={() => pick({ kind: 'option', value: option.value })}
           />
         )}
@@ -205,6 +262,7 @@ function SingleChoice(props: {
           role="radio"
           checked={selection().kind === 'custom'}
           disabled={props.disabled}
+          tabIndex={tabIndex(props.field.options.length)}
           text={customText()}
           onSelect={() => {
             if (selection().kind !== 'custom')
@@ -221,6 +279,7 @@ function MultiChoice(props: {
   field: MultiSelect;
   value: FieldValue | undefined;
   disabled?: boolean;
+  labelId: string;
   onChange: (next: FieldValue) => void;
 }) {
   const current = (): MultiSelectValue =>
@@ -242,7 +301,7 @@ function MultiChoice(props: {
   const custom = () => current().custom;
 
   return (
-    <div role="group" class="flex flex-col">
+    <div role="group" aria-labelledby={props.labelId} class="flex flex-col">
       <For each={props.field.options}>
         {(option) => (
           <ChoiceRow
@@ -286,6 +345,8 @@ function FieldControl(props: {
   field: ElicitationPropertySchema;
   value: FieldValue | undefined;
   disabled?: boolean;
+  /** The id of the field's title, for the groups' `aria-labelledby`. */
+  labelId: string;
   onChange: (next: FieldValue) => void;
 }): JSX.Element {
   return (
@@ -298,6 +359,7 @@ function FieldControl(props: {
               field={field}
               value={props.value}
               disabled={props.disabled}
+              labelId={props.labelId}
               onChange={props.onChange}
             />
           )
@@ -347,6 +409,7 @@ function FieldControl(props: {
             field={field}
             value={props.value}
             disabled={props.disabled}
+            labelId={props.labelId}
             onChange={props.onChange}
           />
         ))
@@ -360,6 +423,11 @@ function FieldControl(props: {
   );
 }
 
+/** The id of a field's title, which its group of choices is labelled by. */
+function labelIdOf(property: ElicitationProperty) {
+  return `elicitation-${property.name}-label`;
+}
+
 function Field(props: {
   property: ElicitationProperty;
   required: boolean;
@@ -369,7 +437,9 @@ function Field(props: {
   return (
     <div class="flex flex-col gap-1">
       <div class="flex items-baseline gap-1 text-xs text-ink-muted">
-        <span>{props.property.title ?? props.property.name}</span>
+        <span id={labelIdOf(props.property)}>
+          {props.property.title ?? props.property.name}
+        </span>
         <Show when={props.required}>
           <span aria-hidden="true" class="text-failure">
             *
@@ -410,6 +480,7 @@ export function ElicitationForm(props: ElicitationFormProps) {
               field={property.schema}
               value={props.values[property.name]}
               disabled={props.disabled}
+              labelId={labelIdOf(property)}
               onChange={(next) => props.onChange(property.name, next)}
             />
           </Field>

--- a/apps/web/src/features/block-agent/ui/ElicitationForm.tsx
+++ b/apps/web/src/features/block-agent/ui/ElicitationForm.tsx
@@ -39,14 +39,29 @@ function textOf(value: FieldValue | undefined): string {
   return value?.kind === 'text' ? value.text : '';
 }
 
-const INPUT_CLASS =
-  'h-8 w-full rounded-md border border-edge-muted bg-transparent px-2 text-sm text-ink outline-none transition-colors placeholder:text-ink-placeholder hover:border-edge focus:border-accent disabled:opacity-50';
-
-const ROW_CLASS =
-  'group flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-ink outline-none';
-
-const ROW_INTERACTIVE_CLASS =
-  'not-disabled:hover:bg-ink/5 focus-visible:bg-ink/5 disabled:opacity-50';
+/** A typed answer: free text, or a number while it is being typed. */
+function TextInput(props: {
+  type: 'text' | 'email' | 'url' | 'number';
+  value: string;
+  disabled?: boolean;
+  step?: number | 'any';
+  min?: number;
+  max?: number;
+  onInput: (text: string) => void;
+}) {
+  return (
+    <input
+      type={props.type}
+      class="h-8 w-full rounded-md border border-edge-muted bg-transparent px-2 text-sm text-ink outline-none transition-colors placeholder:text-ink-placeholder hover:border-edge focus:border-accent disabled:opacity-50"
+      disabled={props.disabled}
+      step={props.step}
+      min={props.min}
+      max={props.max}
+      value={props.value}
+      onInput={(event) => props.onInput(event.currentTarget.value)}
+    />
+  );
+}
 
 type SingleSelect = Extract<ElicitationPropertySchema, { type: 'string' }>;
 type MultiSelect = Extract<ElicitationPropertySchema, { type: 'multi_select' }>;
@@ -95,7 +110,7 @@ function ChoiceRow(props: {
       type="button"
       role={props.role}
       aria-checked={props.checked}
-      class={cn(ROW_CLASS, ROW_INTERACTIVE_CLASS)}
+      class="group flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-ink outline-none not-disabled:hover:bg-ink/5 focus-visible:bg-ink/5 disabled:opacity-50"
       disabled={props.disabled}
       onClick={props.onSelect}
     >
@@ -119,8 +134,11 @@ function OtherRow(props: {
 }) {
   return (
     <div
-      class={cn(ROW_CLASS, 'items-center', props.disabled && 'opacity-50')}
-      classList={{ 'hover:bg-ink/5': !props.disabled }}
+      class="group flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-ink outline-none"
+      classList={{
+        'hover:bg-ink/5': !props.disabled,
+        'opacity-50': props.disabled,
+      }}
     >
       <button
         type="button"
@@ -285,7 +303,7 @@ function FieldControl(props: {
           )
         )
         .with({ type: 'string' }, (field) => (
-          <input
+          <TextInput
             type={
               field.format === 'email'
                 ? 'email'
@@ -293,26 +311,20 @@ function FieldControl(props: {
                   ? 'url'
                   : 'text'
             }
-            class={INPUT_CLASS}
             disabled={props.disabled}
             value={textOf(props.value)}
-            onInput={(event) =>
-              props.onChange({ kind: 'text', text: event.currentTarget.value })
-            }
+            onInput={(text) => props.onChange({ kind: 'text', text })}
           />
         ))
         .with({ type: 'number' }, { type: 'integer' }, (field) => (
-          <input
+          <TextInput
             type="number"
-            class={INPUT_CLASS}
             disabled={props.disabled}
             step={field.type === 'integer' ? 1 : 'any'}
             min={field.minimum ?? undefined}
             max={field.maximum ?? undefined}
             value={textOf(props.value)}
-            onInput={(event) =>
-              props.onChange({ kind: 'text', text: event.currentTarget.value })
-            }
+            onInput={(text) => props.onChange({ kind: 'text', text })}
           />
         ))
         .with({ type: 'boolean' }, () => {

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChip.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChip.tsx
@@ -13,6 +13,7 @@ export const MagicChip: Component<MagicChipDecoratorProps> = (props) => {
     <MagicChipView
       agentSessionId={props.agentSessionId}
       presentation={model.presentation()}
+      header={model.header()}
       answer={{
         answering: model.elicitation.answering(),
         respond: model.elicitation.respond,

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -37,9 +37,31 @@ function answerArea(container: HTMLElement) {
   return container.querySelector('[data-magic-chip-answer]');
 }
 
+function header(container: HTMLElement) {
+  return container.querySelector('[data-magic-chip-header]');
+}
+
+/** The header's label, which opens the session and carries the preview. */
+function headerLabel(container: HTMLElement) {
+  return header(container)?.querySelector('button');
+}
+
+/** The pane a form or URL question's fields live in, beside the answer. */
+function pane(container: HTMLElement) {
+  return container.querySelector('[data-magic-chip-pane]');
+}
+
+const respond = vi.fn<(answer: ElicitationAnswer) => Promise<boolean>>();
+const onOpen = vi.fn();
+
+beforeEach(() => {
+  respond.mockReset();
+  respond.mockResolvedValue(true);
+  onOpen.mockReset();
+});
+
 describe('MagicChipView', () => {
-  it('reserves the answer height and shows the activity row while working', () => {
-    const onOpen = vi.fn();
+  it('reserves the answer height and reads the activity in the header while working', () => {
     const { container } = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -53,28 +75,43 @@ describe('MagicChipView', () => {
 
     const card = container.querySelector('[data-magic-chip-preview]');
     expect(card?.className).toContain('rounded-lg');
-    expect(card?.className).not.toContain('border-accent');
 
     expect(answerArea(container)?.className).toContain('h-22');
     expect(container.querySelector('[data-testid="chip-markdown"]')).toBeNull();
     expect(container.querySelector('[data-magic-chip-pending]')).toBeTruthy();
-    expect(container.querySelector('.bg-skeleton')).toBeNull();
 
-    const footer = card?.querySelector('button');
-    expect(footer?.textContent).toContain('Booting agent');
-    expect(footer?.getAttribute('data-message-reply-preview')).toBe(
+    const label = headerLabel(container);
+    expect(label?.textContent).toContain('Booting agent');
+    expect(label?.getAttribute('data-message-reply-preview')).toBe(
       'Booting agent'
     );
 
     // Nothing to expand yet, so the answer area leads to the session too.
     expect(answerArea(container)?.getAttribute('aria-expanded')).toBeNull();
     fireEvent.click(answerArea(container)!);
-    fireEvent.click(footer!);
-    expect(onOpen).toHaveBeenCalledTimes(2);
+    fireEvent.click(label!);
+    fireEvent.click(screen.getByLabelText('Open in session'));
+    expect(onOpen).toHaveBeenCalledTimes(3);
+  });
+
+  it('names the bot and its model in the header', () => {
+    const { container } = render(() => (
+      <MagicChipView
+        agentSessionId="session"
+        presentation={{
+          kind: 'working',
+          activity: { label: 'Thinking', busy: true },
+        }}
+        header={{ agent: 'cursor', model: 'Claude Opus 5' }}
+      />
+    ));
+    const label = headerLabel(container);
+    expect(label?.textContent).toContain('@cursor');
+    expect(label?.textContent).toContain('Claude Opus 5');
+    expect(label?.textContent).toContain('Thinking');
   });
 
   it('keeps the same answer height once the answer streams in', () => {
-    const onOpen = vi.fn();
     const { container } = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -92,19 +129,19 @@ describe('MagicChipView', () => {
 
     const clip = container.querySelector('[data-magic-chip-clip]');
     expect(clip?.className).toContain('overflow-hidden');
+    // With prose in the area, the reply previews it, not the header.
     const preview = container.querySelector('[data-message-reply-preview]');
     expect(preview?.textContent).toBe('Hello from the agent');
+    expect(
+      headerLabel(container)?.getAttribute('data-message-reply-preview')
+    ).toBeNull();
 
-    const footer = container.querySelector('[data-magic-chip-preview] button');
-    expect(footer?.textContent).toContain('Writing response');
-    expect(footer?.textContent).not.toContain('Open session');
-
-    fireEvent.click(footer!);
+    expect(headerLabel(container)?.textContent).toContain('Writing response');
+    fireEvent.click(screen.getByLabelText('Open in session'));
     expect(onOpen).toHaveBeenCalledTimes(1);
   });
 
   it('expands the answer in place on click and collapses again', () => {
-    const onOpen = vi.fn();
     const { container } = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -153,8 +190,7 @@ describe('MagicChipView', () => {
     ).toBe('All done');
   });
 
-  it('labels the settled footer Open session', () => {
-    const onOpen = vi.fn();
+  it('reads Done in the header once the turn settles', () => {
     const { container } = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -164,9 +200,9 @@ describe('MagicChipView', () => {
     ));
 
     expect(answerArea(container)?.className).toContain('h-22');
-    const footer = container.querySelector('[data-magic-chip-preview] button');
-    expect(footer?.textContent).toContain('Open session');
-    fireEvent.click(footer!);
+    expect(headerLabel(container)?.textContent).toContain('Done');
+    expect(headerLabel(container)?.textContent).not.toContain('Open session');
+    fireEvent.click(headerLabel(container)!);
     expect(onOpen).toHaveBeenCalledTimes(1);
   });
 
@@ -191,15 +227,6 @@ describe('MagicChipView', () => {
     expect(screen.getByText(LONG_PATH).className).toContain('truncate');
   });
 });
-
-vi.mock('@app/features/block-agent/component/parts/UserToolCall', () => ({
-  EventDraft: (props: { event: { title: string } }) => (
-    <div data-testid="event-draft">{props.event.title}</div>
-  ),
-  EmailDraft: (props: { email: { subject: string } }) => (
-    <div data-testid="email-draft">{props.email.subject}</div>
-  ),
-}));
 
 const draft = {
   title: 'Q3 sync',
@@ -239,27 +266,8 @@ function asking(canAnswer: boolean, markdown = ''): MagicChipPresentation {
   };
 }
 
-const respond = vi.fn<(answer: ElicitationAnswer) => Promise<boolean>>();
-const onOpen = vi.fn();
-
-beforeEach(() => {
-  respond.mockReset();
-  respond.mockResolvedValue(true);
-  onOpen.mockReset();
-});
-
-/** The pane the question's fields live in, beside the answer. */
-function pane(container: HTMLElement) {
-  return container.querySelector('[data-magic-chip-pane]');
-}
-
-/** The bottom row that holds the decisions while a question is live. */
-function decisions(container: HTMLElement) {
-  return container.querySelector('[data-magic-chip-asking]');
-}
-
-describe('MagicChipView asking', () => {
-  it('keeps the chip at its height, with the draft in a side pane and the decisions on the row', () => {
+describe('MagicChipView reviewing a tool draft', () => {
+  it('offers only the go-ahead, in the header, and leaves the rest to the session', () => {
     const view = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -272,37 +280,27 @@ describe('MagicChipView asking', () => {
       'Setting that up.'
     );
     expect(answerArea(view.container)?.className).toContain('h-22');
+    expect(pane(view.container)).toBeNull();
 
-    const side = pane(view.container);
-    expect(side?.textContent).toContain('Waiting for you');
-    expect(side?.textContent).toContain('Create calendar event?');
+    const top = header(view.container);
+    expect(top?.textContent).toContain('Waiting for you');
+    expect(top?.contains(view.getByText('Create event'))).toBe(true);
+    expect(view.queryByText('Cancel')).toBeNull();
+    expect(view.queryByText('Edit in session')).toBeNull();
     expect(
-      side?.querySelector('[data-testid="event-draft"]')?.textContent
-    ).toBe('Q3 sync');
-    // The pane stretches to the chip and scrolls inside it, beside the answer.
-    expect(side?.className).toContain('border-l');
-    expect(side?.firstElementChild?.className).toContain('absolute inset-0');
-    expect(side?.querySelector('.overflow-y-auto')).not.toBeNull();
-    expect(answerArea(view.container)?.className).not.toContain('hidden');
-
-    const row = decisions(view.container);
-    expect(row?.className).toContain('min-h-9');
-    expect(row?.getAttribute('data-message-reply-preview')).toBe(
-      'Waiting for you · Create calendar event?'
-    );
+      headerLabel(view.container)?.getAttribute('data-message-reply-preview')
+    ).toBeNull();
 
     fireEvent.click(view.getByText('Create event'));
     expect(respond).toHaveBeenCalledWith({
       action: 'accept',
       content: { draft: JSON.stringify(draft) },
     });
-    fireEvent.click(view.getByText('Cancel'));
-    expect(respond).toHaveBeenLastCalledWith({ action: 'decline' });
     fireEvent.click(view.getByLabelText('Open in session'));
     expect(onOpen).toHaveBeenCalledOnce();
   });
 
-  it('gives the question the whole card while the agent has said nothing', () => {
+  it('shows nothing in the answer area while the agent has said nothing', () => {
     const view = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -310,14 +308,15 @@ describe('MagicChipView asking', () => {
         answer={{ answering: false, respond }}
       />
     ));
-    expect(answerArea(view.container)?.className).toContain('hidden');
+    expect(answerArea(view.container)?.className).toContain('h-22');
+    expect(answerArea(view.container)?.className).not.toContain('hidden');
     expect(
       view.container.querySelector('[data-magic-chip-pending]')
     ).toBeNull();
-    const side = pane(view.container);
-    expect(side?.className).toContain('flex-1');
-    expect(side?.className).not.toContain('border-l');
-    expect(side?.textContent).toContain('Q3 sync');
+    expect(view.queryByTestId('chip-markdown')).toBeNull();
+    expect(
+      headerLabel(view.container)?.getAttribute('data-message-reply-preview')
+    ).toBe('Waiting for you · Create calendar event?');
   });
 
   it('a viewer who is not the owner sees who is being waited on and can only open the session', () => {
@@ -329,17 +328,16 @@ describe('MagicChipView asking', () => {
         onOpen={onOpen}
       />
     ));
-    expect(view.getAllByText('Waiting for Alice Owner').length).toBeGreaterThan(
-      0
+    expect(header(view.container)?.textContent).toContain(
+      'Waiting for Alice Owner'
     );
     expect(view.queryByText('Create event')).toBeNull();
-    expect(view.queryByText('Cancel')).toBeNull();
     fireEvent.click(view.getByLabelText('Open in session'));
     expect(onOpen).toHaveBeenCalled();
     expect(respond).not.toHaveBeenCalled();
   });
 
-  it('holds the buttons while an answer is on the wire', () => {
+  it('holds the button while an answer is on the wire', () => {
     const view = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -348,12 +346,9 @@ describe('MagicChipView asking', () => {
       />
     ));
     fireEvent.click(view.getByText('Create event'));
-    fireEvent.click(view.getByText('Cancel'));
     expect(respond).not.toHaveBeenCalled();
   });
-});
 
-describe('MagicChipView review transition', () => {
   it('keeps the expanded answer while a review appears and the agent continues', () => {
     const [presentation, setPresentation] = createSignal<MagicChipPresentation>(
       {
@@ -376,18 +371,15 @@ describe('MagicChipView review transition', () => {
 
     setPresentation(asking(true, 'Setting that up.'));
     expect(view.getByText('Create event')).toBeTruthy();
-    expect(pane(view.container)).not.toBeNull();
     expect(answerArea(view.container)).toBe(area);
     expect(area.getAttribute('aria-expanded')).toBe('true');
 
     setPresentation({ kind: 'settled', markdown: 'Created the event.' });
     expect(view.queryByText('Create event')).toBeNull();
-    expect(pane(view.container)).toBeNull();
     expect(view.getByText('Created the event.')).toBeTruthy();
+    expect(header(view.container)?.textContent).toContain('Done');
     expect(answerArea(view.container)).toBe(area);
     expect(area.getAttribute('aria-expanded')).toBe('true');
-    fireEvent.click(view.getByText('Open session'));
-    expect(onOpen).toHaveBeenCalledOnce();
   });
 });
 
@@ -425,28 +417,27 @@ function askingQuestion(
     MagicChipPresentation,
     { kind: 'asking' }
   >['asking']['question']['request'],
-  canAnswer = true,
-  requestId = 0
+  options: { canAnswer?: boolean; requestId?: number; markdown?: string } = {}
 ): MagicChipPresentation {
   return {
     kind: 'asking',
-    markdown: '',
+    markdown: options.markdown ?? '',
     asking: {
       question: {
-        requestId,
+        requestId: options.requestId ?? 0,
         turn: 0,
         toolCall: null,
         message: "What's the best colour?",
         request,
       },
-      canAnswer,
+      canAnswer: options.canAnswer ?? true,
       ownerName: 'Alice Owner',
     },
   };
 }
 
 describe('MagicChipView asking a form', () => {
-  it('offers the choices in the pane and submits the one picked from the row', () => {
+  it('offers the choices in the pane and the decisions in the header', () => {
     const view = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -455,14 +446,16 @@ describe('MagicChipView asking a form', () => {
         onOpen={onOpen}
       />
     ));
-    expect(answerArea(view.container)?.className).toContain('h-22');
     expect(
       pane(view.container)?.contains(view.getByRole('radio', { name: 'Red' }))
     ).toBe(true);
-    expect(decisions(view.container)?.contains(view.getByText('Submit'))).toBe(
+    expect(pane(view.container)?.textContent).toContain(
+      "What's the best colour?"
+    );
+    expect(header(view.container)?.contains(view.getByText('Submit'))).toBe(
       true
     );
-    // The row is short of room, so Cancel stays in the session.
+    // The header is short of room, so Cancel stays in the session.
     expect(view.queryByText('Cancel')).toBeNull();
 
     // A required question refuses an empty submit.
@@ -481,6 +474,40 @@ describe('MagicChipView asking a form', () => {
     expect(respond).toHaveBeenLastCalledWith({ action: 'decline' });
     fireEvent.click(view.getByLabelText('Open in session'));
     expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it('gives the question the whole card while the agent has said nothing, and the right side once it has', () => {
+    const [presentation, setPresentation] = createSignal(
+      askingQuestion(colourForm)
+    );
+    const view = render(() => (
+      <MagicChipView
+        agentSessionId="session"
+        presentation={presentation()}
+        answer={{ answering: false, respond }}
+      />
+    ));
+    expect(answerArea(view.container)?.className).toContain('hidden');
+    expect(
+      view.container.querySelector('[data-magic-chip-pending]')
+    ).toBeNull();
+    expect(pane(view.container)?.className).toContain('flex-1');
+    expect(pane(view.container)?.className).not.toContain('border-l');
+    // The pane stretches to the chip and scrolls inside it.
+    expect(pane(view.container)?.firstElementChild?.className).toContain(
+      'absolute inset-0'
+    );
+    expect(pane(view.container)?.firstElementChild?.className).toContain(
+      'overflow-y-auto'
+    );
+
+    setPresentation(
+      askingQuestion(colourForm, { markdown: 'Let me ask you something.' })
+    );
+    expect(answerArea(view.container)?.className).not.toContain('hidden');
+    expect(answerArea(view.container)?.className).toContain('h-22');
+    expect(pane(view.container)?.className).toContain('border-l');
+    expect(pane(view.container)?.className).not.toContain('flex-1');
   });
 
   it('types a custom answer and sends it under the custom key', () => {
@@ -520,7 +547,7 @@ describe('MagicChipView asking a form', () => {
       view.getByRole('radio', { name: 'Blue' }).getAttribute('aria-checked')
     ).toBe('true');
 
-    setPresentation(askingQuestion(colourForm, true, 1));
+    setPresentation(askingQuestion(colourForm, { requestId: 1 }));
     expect(
       view.getByRole('radio', { name: 'Blue' }).getAttribute('aria-checked')
     ).toBe('false');
@@ -530,13 +557,13 @@ describe('MagicChipView asking a form', () => {
     const view = render(() => (
       <MagicChipView
         agentSessionId="session"
-        presentation={askingQuestion(colourForm, false)}
+        presentation={askingQuestion(colourForm, { canAnswer: false })}
         answer={{ answering: false, respond }}
         onOpen={onOpen}
       />
     ));
-    expect(view.getAllByText('Waiting for Alice Owner').length).toBeGreaterThan(
-      0
+    expect(header(view.container)?.textContent).toContain(
+      'Waiting for Alice Owner'
     );
     const red = view.getByRole('radio', { name: 'Red' }) as HTMLButtonElement;
     expect(red.disabled).toBe(true);

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -90,7 +90,7 @@ describe('MagicChipView', () => {
     const card = container.querySelector('[data-magic-chip-preview]');
     expect(card?.className).toContain('rounded-lg');
 
-    expect(answerArea(container)?.className).toContain('h-22');
+    expect(answerArea(container)?.className).toContain('h-41');
     expect(container.querySelector('[data-testid="chip-markdown"]')).toBeNull();
     expect(container.querySelector('[data-magic-chip-pending]')).toBeTruthy();
 
@@ -138,7 +138,7 @@ describe('MagicChipView', () => {
       />
     ));
 
-    expect(answerArea(container)?.className).toContain('h-22');
+    expect(answerArea(container)?.className).toContain('h-41');
     expect(container.querySelector('[data-magic-chip-pending]')).toBeNull();
 
     const clip = container.querySelector('[data-magic-chip-clip]');
@@ -168,13 +168,13 @@ describe('MagicChipView', () => {
     const clip = () => container.querySelector('[data-magic-chip-clip]');
     const fade = () => container.querySelector('[data-magic-chip-fade]');
     expect(area.getAttribute('aria-expanded')).toBe('false');
-    expect(area.className).toContain('h-22');
+    expect(area.className).toContain('h-41');
     expect(fade()).toBeTruthy();
     expect(area.textContent).toContain('Show more');
 
     fireEvent.click(area);
     expect(area.getAttribute('aria-expanded')).toBe('true');
-    expect(area.className).not.toContain('h-22');
+    expect(area.className).not.toContain('h-41');
     expect(clip()?.className).not.toContain('overflow-hidden');
     expect(fade()).toBeNull();
     expect(area.textContent).toContain('Show less');
@@ -182,7 +182,7 @@ describe('MagicChipView', () => {
 
     fireEvent.keyDown(area, { key: 'Enter' });
     expect(area.getAttribute('aria-expanded')).toBe('false');
-    expect(area.className).toContain('h-22');
+    expect(area.className).toContain('h-41');
     expect(clip()?.className).toContain('overflow-hidden');
     expect(fade()).toBeTruthy();
     expect(area.textContent).toContain('Show more');
@@ -213,7 +213,7 @@ describe('MagicChipView', () => {
       />
     ));
 
-    expect(answerArea(container)?.className).toContain('h-22');
+    expect(answerArea(container)?.className).toContain('h-41');
     expect(headerLabel(container)?.textContent).toContain('Done');
     expect(headerLabel(container)?.textContent).not.toContain('Open session');
     fireEvent.click(headerLabel(container)!);
@@ -293,7 +293,7 @@ describe('MagicChipView reviewing a tool draft', () => {
     // The question takes the area; the passage waits underneath.
     expect(answerArea(view.container)?.className).toContain('hidden');
     const body = askingBody(view.container);
-    expect(body?.className).toContain('h-22');
+    expect(body?.className).toContain('h-41');
     expect(body?.textContent).toContain('Create calendar event?');
     expect(body?.contains(view.getByTestId('event-draft'))).toBe(true);
     expect(view.getByTestId('event-draft').textContent).toBe('Q3 sync');
@@ -452,7 +452,7 @@ describe('MagicChipView asking a form', () => {
       />
     ));
     const body = askingBody(view.container);
-    expect(body?.className).toContain('h-22');
+    expect(body?.className).toContain('h-41');
     expect(body?.contains(view.getByRole('radio', { name: 'Red' }))).toBe(true);
     expect(body?.textContent).toContain("What's the best colour?");
     // The fields stretch to the area and scroll inside it.

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -399,6 +399,9 @@ describe('MagicChipView reviewing a tool draft', () => {
   });
 
   it('keeps the expanded answer while a review takes the area and gives it back', () => {
+    // Answering unmounts the question while the composer's effects wind
+    // down; nothing may read a `<Show>` accessor that has gone stale.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const [presentation, setPresentation] = createSignal<MagicChipPresentation>(
       {
         kind: 'answering',
@@ -423,6 +426,7 @@ describe('MagicChipView reviewing a tool draft', () => {
     expect(view.queryByTestId('chip-markdown')).toBeNull();
     expect(answerArea(view.container)).toBe(area);
 
+    fireEvent.click(view.getByText('Dismiss'));
     setPresentation({ kind: 'settled', markdown: 'Created the event.' });
     expect(view.queryByTestId('calendar-composer')).toBeNull();
     expect(askingBody(view.container)).toBeNull();
@@ -430,6 +434,10 @@ describe('MagicChipView reviewing a tool draft', () => {
     expect(header(view.container)?.textContent).toContain('Done');
     expect(answerArea(view.container)).toBe(area);
     expect(area.getAttribute('aria-expanded')).toBe('true');
+    expect(
+      warn.mock.calls.some((call) => String(call[0]).includes('stale'))
+    ).toBe(false);
+    warn.mockRestore();
   });
 });
 

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -248,9 +248,19 @@ beforeEach(() => {
   onOpen.mockReset();
 });
 
+/** The pane the question's fields live in, beside the answer. */
+function pane(container: HTMLElement) {
+  return container.querySelector('[data-magic-chip-pane]');
+}
+
+/** The bottom row that holds the decisions while a question is live. */
+function decisions(container: HTMLElement) {
+  return container.querySelector('[data-magic-chip-asking]');
+}
+
 describe('MagicChipView asking', () => {
-  it('summarizes the draft and sends it whole on Create, declines on Cancel', () => {
-    const { getByTestId, getByText } = render(() => (
+  it('keeps the chip at its height, with the draft in a side pane and the decisions on the row', () => {
+    const view = render(() => (
       <MagicChipView
         agentSessionId="session"
         presentation={asking(true, 'Setting that up.')}
@@ -258,23 +268,40 @@ describe('MagicChipView asking', () => {
         onOpen={onOpen}
       />
     ));
-    expect(getByTestId('chip-markdown').textContent).toBe('Setting that up.');
-    expect(getByTestId('event-draft').textContent).toBe('Q3 sync');
-    expect(getByText('Waiting for you')).not.toBeNull();
+    expect(view.getByTestId('chip-markdown').textContent).toBe(
+      'Setting that up.'
+    );
+    expect(answerArea(view.container)?.className).toContain('h-22');
 
-    fireEvent.click(getByText('Create event'));
+    const side = pane(view.container);
+    expect(side?.textContent).toContain('Waiting for you');
+    expect(side?.textContent).toContain('Create calendar event?');
+    expect(
+      side?.querySelector('[data-testid="event-draft"]')?.textContent
+    ).toBe('Q3 sync');
+    // The pane stretches to the chip and scrolls inside it.
+    expect(side?.firstElementChild?.className).toContain('absolute inset-0');
+    expect(side?.firstElementChild?.className).toContain('overflow-y-auto');
+
+    const row = decisions(view.container);
+    expect(row?.className).toContain('min-h-9');
+    expect(row?.getAttribute('data-message-reply-preview')).toBe(
+      'Waiting for you · Create calendar event?'
+    );
+
+    fireEvent.click(view.getByText('Create event'));
     expect(respond).toHaveBeenCalledWith({
       action: 'accept',
       content: { draft: JSON.stringify(draft) },
     });
-    fireEvent.click(getByText('Cancel'));
+    fireEvent.click(view.getByText('Cancel'));
     expect(respond).toHaveBeenLastCalledWith({ action: 'decline' });
-    fireEvent.click(getByText('Edit in session'));
-    expect(onOpen).toHaveBeenCalled();
+    fireEvent.click(view.getByLabelText('Edit in session'));
+    expect(onOpen).toHaveBeenCalledOnce();
   });
 
   it('a viewer who is not the owner sees who is being waited on and can only open the session', () => {
-    const { queryByText, getByText } = render(() => (
+    const view = render(() => (
       <MagicChipView
         agentSessionId="session"
         presentation={asking(false)}
@@ -282,23 +309,26 @@ describe('MagicChipView asking', () => {
         onOpen={onOpen}
       />
     ));
-    expect(getByText('Waiting for Alice Owner')).not.toBeNull();
-    expect(queryByText('Create event')).toBeNull();
-    expect(queryByText('Cancel')).toBeNull();
-    fireEvent.click(getByText('Open session'));
+    expect(view.getAllByText('Waiting for Alice Owner').length).toBeGreaterThan(
+      0
+    );
+    expect(view.queryByText('Create event')).toBeNull();
+    expect(view.queryByText('Cancel')).toBeNull();
+    fireEvent.click(view.getByLabelText('Open session'));
     expect(onOpen).toHaveBeenCalled();
     expect(respond).not.toHaveBeenCalled();
   });
 
   it('holds the buttons while an answer is on the wire', () => {
-    const { getByText } = render(() => (
+    const view = render(() => (
       <MagicChipView
         agentSessionId="session"
         presentation={asking(true)}
         answer={{ answering: true, respond }}
       />
     ));
-    fireEvent.click(getByText('Create event'));
+    fireEvent.click(view.getByText('Create event'));
+    fireEvent.click(view.getByText('Cancel'));
     expect(respond).not.toHaveBeenCalled();
   });
 });
@@ -326,11 +356,13 @@ describe('MagicChipView review transition', () => {
 
     setPresentation(asking(true, 'Setting that up.'));
     expect(view.getByText('Create event')).toBeTruthy();
+    expect(pane(view.container)).not.toBeNull();
     expect(answerArea(view.container)).toBe(area);
     expect(area.getAttribute('aria-expanded')).toBe('true');
 
     setPresentation({ kind: 'settled', markdown: 'Created the event.' });
     expect(view.queryByText('Create event')).toBeNull();
+    expect(pane(view.container)).toBeNull();
     expect(view.getByText('Created the event.')).toBeTruthy();
     expect(answerArea(view.container)).toBe(area);
     expect(area.getAttribute('aria-expanded')).toBe('true');
@@ -373,14 +405,15 @@ function askingQuestion(
     MagicChipPresentation,
     { kind: 'asking' }
   >['asking']['question']['request'],
-  canAnswer = true
+  canAnswer = true,
+  requestId = 0
 ): MagicChipPresentation {
   return {
     kind: 'asking',
     markdown: '',
     asking: {
       question: {
-        requestId: 0,
+        requestId,
         turn: 0,
         toolCall: null,
         message: "What's the best colour?",
@@ -393,7 +426,7 @@ function askingQuestion(
 }
 
 describe('MagicChipView asking a form', () => {
-  it('offers the choices in the thread and submits the one picked', () => {
+  it('offers the choices in the pane and submits the one picked from the row', () => {
     const view = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -402,8 +435,15 @@ describe('MagicChipView asking a form', () => {
         onOpen={onOpen}
       />
     ));
-    expect(view.getByText("What's the best colour?")).toBeTruthy();
-    expect(view.getByRole('radio', { name: 'Red' })).toBeTruthy();
+    expect(answerArea(view.container)?.className).toContain('h-22');
+    expect(
+      pane(view.container)?.contains(view.getByRole('radio', { name: 'Red' }))
+    ).toBe(true);
+    expect(decisions(view.container)?.contains(view.getByText('Submit'))).toBe(
+      true
+    );
+    // The row is short of room, so Cancel stays in the session.
+    expect(view.queryByText('Cancel')).toBeNull();
 
     // A required question refuses an empty submit.
     fireEvent.click(view.getByText('Submit'));
@@ -419,7 +459,7 @@ describe('MagicChipView asking a form', () => {
 
     fireEvent.click(view.getByText('Decline'));
     expect(respond).toHaveBeenLastCalledWith({ action: 'decline' });
-    fireEvent.click(view.getByText('Open session'));
+    fireEvent.click(view.getByLabelText('Open session'));
     expect(onOpen).toHaveBeenCalledOnce();
   });
 
@@ -441,7 +481,32 @@ describe('MagicChipView asking a form', () => {
     });
   });
 
-  it('a viewer who is not the owner sees the choices locked', () => {
+  it('keeps what was typed across a refresh of the same question, and starts clean for a new one', () => {
+    const [presentation, setPresentation] = createSignal(
+      askingQuestion(colourForm)
+    );
+    const view = render(() => (
+      <MagicChipView
+        agentSessionId="session"
+        presentation={presentation()}
+        answer={{ answering: false, respond }}
+      />
+    ));
+    fireEvent.click(view.getByRole('radio', { name: 'Blue' }));
+
+    // The same request, pushed again by a metadata refresh.
+    setPresentation(askingQuestion(colourForm));
+    expect(
+      view.getByRole('radio', { name: 'Blue' }).getAttribute('aria-checked')
+    ).toBe('true');
+
+    setPresentation(askingQuestion(colourForm, true, 1));
+    expect(
+      view.getByRole('radio', { name: 'Blue' }).getAttribute('aria-checked')
+    ).toBe('false');
+  });
+
+  it('a viewer who is not the owner sees the choices locked and no decisions', () => {
     const view = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -450,11 +515,13 @@ describe('MagicChipView asking a form', () => {
         onOpen={onOpen}
       />
     ));
-    expect(view.getByText('Waiting for Alice Owner')).toBeTruthy();
+    expect(view.getAllByText('Waiting for Alice Owner').length).toBeGreaterThan(
+      0
+    );
     const red = view.getByRole('radio', { name: 'Red' }) as HTMLButtonElement;
     expect(red.disabled).toBe(true);
-    fireEvent.click(view.getByText('Submit'));
-    expect(respond).not.toHaveBeenCalled();
+    expect(view.queryByText('Submit')).toBeNull();
+    expect(view.queryByText('Decline')).toBeNull();
   });
 
   it('a url request shows the host and opens only after consent', async () => {
@@ -471,6 +538,7 @@ describe('MagicChipView asking a form', () => {
       />
     ));
     expect(view.getByText('agent.example.com')).toBeTruthy();
+    expect(open).not.toHaveBeenCalled();
     fireEvent.click(view.getByText('Open'));
     await Promise.resolve();
     await Promise.resolve();

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -56,13 +56,35 @@ function decisions(container: HTMLElement) {
   return container.querySelector('[data-magic-chip-decisions]');
 }
 
-vi.mock('@app/features/block-agent/component/parts/UserToolCall', () => ({
-  EventDraft: (props: { event: { title: string } }) => (
-    <div data-testid="event-draft">{props.event.title}</div>
-  ),
-  EmailDraft: (props: { email: { subject: string } }) => (
-    <div data-testid="email-draft">{props.email.subject}</div>
-  ),
+// The composers are the chat block's real editors over calendar and email
+// queries; the chip's job is to mount the right one and wire its sink, so
+// each stub exposes the sink through two buttons.
+type StubSink = {
+  canAct: () => boolean;
+  onExecute: (args: unknown) => Promise<boolean>;
+  onReject: () => Promise<boolean>;
+};
+function composerStub(kind: string) {
+  return (props: { initialData: unknown; sink: StubSink }) => (
+    <div data-testid={`${kind}-composer`} data-can-act={props.sink.canAct()}>
+      <button
+        type="button"
+        data-testid="composer-execute"
+        onClick={() => void props.sink.onExecute(props.initialData)}
+      />
+      <button
+        type="button"
+        data-testid="composer-reject"
+        onClick={() => void props.sink.onReject()}
+      />
+    </div>
+  );
+}
+vi.mock('@core/component/AI/component/tool/calendar/DraftComposer', () => ({
+  CalendarDraftComposer: composerStub('calendar'),
+}));
+vi.mock('@core/component/AI/component/tool/email/DraftComposer', () => ({
+  EmailDraftComposer: composerStub('email'),
 }));
 
 const respond = vi.fn<(answer: ElicitationAnswer) => Promise<boolean>>();
@@ -170,14 +192,12 @@ describe('MagicChipView', () => {
     expect(area.getAttribute('aria-expanded')).toBe('false');
     expect(area.className).toContain('h-41');
     expect(fade()).toBeTruthy();
-    expect(area.textContent).toContain('Show more');
 
     fireEvent.click(area);
     expect(area.getAttribute('aria-expanded')).toBe('true');
     expect(area.className).not.toContain('h-41');
     expect(clip()?.className).not.toContain('overflow-hidden');
     expect(fade()).toBeNull();
-    expect(area.textContent).toContain('Show less');
     expect(onOpen).not.toHaveBeenCalled();
 
     fireEvent.keyDown(area, { key: 'Enter' });
@@ -185,23 +205,7 @@ describe('MagicChipView', () => {
     expect(area.className).toContain('h-41');
     expect(clip()?.className).toContain('overflow-hidden');
     expect(fade()).toBeTruthy();
-    expect(area.textContent).toContain('Show more');
     expect(onOpen).not.toHaveBeenCalled();
-  });
-
-  it('keeps the disclosure hint out of the reply preview text', () => {
-    const { container } = render(() => (
-      <MagicChipView
-        agentSessionId="session"
-        presentation={{ kind: 'settled', markdown: 'All done' }}
-      />
-    ));
-
-    fireEvent.click(answerArea(container)!);
-    expect(answerArea(container)?.textContent).toContain('Show less');
-    expect(
-      container.querySelector('[data-message-reply-preview]')?.textContent
-    ).toBe('All done');
   });
 
   it('reads Done in the header once the turn settles', () => {
@@ -288,7 +292,7 @@ function decisionLabels(container: HTMLElement) {
 }
 
 describe('MagicChipView reviewing a tool draft', () => {
-  it('shows the draft in the area with Dismiss, the go-ahead, and the session on the row', () => {
+  it('mounts the draft in its composer with Dismiss and the session on the row', () => {
     const view = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -304,26 +308,27 @@ describe('MagicChipView reviewing a tool draft', () => {
     const body = askingBody(view.container);
     expect(area.contains(body)).toBe(true);
     expect(body?.textContent).toContain('Create calendar event?');
-    expect(view.getByTestId('event-draft').textContent).toBe('Q3 sync');
+    // The tool's own composer, editable in place, with Create as its own.
+    const composer = view.getByTestId('calendar-composer');
+    expect(body?.contains(composer)).toBe(true);
+    expect(composer.dataset.canAct).toBe('true');
 
     expect(decisionLabels(view.container)).toEqual([
       'Dismiss',
-      'Create event',
       'Open in session',
     ]);
     expect(header(view.container)?.textContent).toContain('Waiting for you');
     expect(
-      header(view.container)?.contains(view.getByText('Create event'))
-    ).toBe(false);
-    expect(
       headerLabel(view.container)?.getAttribute('data-message-reply-preview')
     ).toBe('Waiting for you · Create calendar event?');
 
-    fireEvent.click(view.getByText('Create event'));
+    fireEvent.click(view.getByTestId('composer-execute'));
     expect(respond).toHaveBeenCalledWith({
       action: 'accept',
       content: { draft: JSON.stringify(draft) },
     });
+    fireEvent.click(view.getByTestId('composer-reject'));
+    expect(respond).toHaveBeenLastCalledWith({ action: 'decline' });
     fireEvent.click(view.getByText('Dismiss'));
     expect(respond).toHaveBeenLastCalledWith({ action: 'decline' });
     fireEvent.click(view.getByText('Open in session'));
@@ -345,9 +350,9 @@ describe('MagicChipView reviewing a tool draft', () => {
     expect(area.getAttribute('aria-expanded')).toBe('false');
     expect(clip()?.className).toContain('overflow-hidden');
     expect(view.container.querySelector('[data-magic-chip-fade]')).toBeTruthy();
-    expect(area.textContent).toContain('Show more');
 
     fireEvent.click(view.getByText('Dismiss'));
+    fireEvent.click(view.getByTestId('composer-execute'));
     expect(area.getAttribute('aria-expanded')).toBe('false');
 
     fireEvent.click(area);
@@ -355,7 +360,6 @@ describe('MagicChipView reviewing a tool draft', () => {
     expect(area.className).not.toContain('h-41');
     expect(clip()?.className).not.toContain('overflow-hidden');
     expect(view.container.querySelector('[data-magic-chip-fade]')).toBeNull();
-    expect(area.textContent).toContain('Show less');
     expect(onOpen).not.toHaveBeenCalled();
   });
 
@@ -371,9 +375,10 @@ describe('MagicChipView reviewing a tool draft', () => {
     expect(header(view.container)?.textContent).toContain(
       'Waiting for Alice Owner'
     );
-    expect(view.getByTestId('event-draft')).toBeTruthy();
+    // The composer is there to read, but cannot act for a viewer.
+    expect(view.getByTestId('calendar-composer').dataset.canAct).toBe('false');
+    fireEvent.click(view.getByTestId('composer-execute'));
     expect(decisions(view.container)).toBeNull();
-    expect(view.queryByText('Create event')).toBeNull();
     fireEvent.click(view.getByLabelText('Open in session'));
     expect(onOpen).toHaveBeenCalled();
     expect(respond).not.toHaveBeenCalled();
@@ -387,7 +392,8 @@ describe('MagicChipView reviewing a tool draft', () => {
         answer={{ answering: true, respond }}
       />
     ));
-    fireEvent.click(view.getByText('Create event'));
+    expect(view.getByTestId('calendar-composer').dataset.canAct).toBe('false');
+    fireEvent.click(view.getByTestId('composer-execute'));
     fireEvent.click(view.getByText('Dismiss'));
     expect(respond).not.toHaveBeenCalled();
   });
@@ -413,12 +419,12 @@ describe('MagicChipView reviewing a tool draft', () => {
     expect(area.getAttribute('aria-expanded')).toBe('true');
 
     setPresentation(asking(true, 'Setting that up.'));
-    expect(view.getByText('Create event')).toBeTruthy();
+    expect(view.getByTestId('calendar-composer')).toBeTruthy();
     expect(view.queryByTestId('chip-markdown')).toBeNull();
     expect(answerArea(view.container)).toBe(area);
 
     setPresentation({ kind: 'settled', markdown: 'Created the event.' });
-    expect(view.queryByText('Create event')).toBeNull();
+    expect(view.queryByTestId('calendar-composer')).toBeNull();
     expect(askingBody(view.container)).toBeNull();
     expect(view.getByText('Created the event.')).toBeTruthy();
     expect(header(view.container)?.textContent).toContain('Done');

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -108,7 +108,7 @@ describe('MagicChipView', () => {
     expect(onOpen).toHaveBeenCalledTimes(3);
   });
 
-  it('names the bot and its model in the header', () => {
+  it('names the persona and its model in the header', () => {
     const { container } = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -116,11 +116,11 @@ describe('MagicChipView', () => {
           kind: 'working',
           activity: { label: 'Thinking', busy: true },
         }}
-        header={{ agent: 'cursor', model: 'Claude Opus 5' }}
+        header={{ agent: 'Cursor Agent', model: 'Claude Opus 5' }}
       />
     ));
     const label = headerLabel(container);
-    expect(label?.textContent).toContain('@cursor');
+    expect(label?.textContent).toContain('Cursor Agent');
     expect(label?.textContent).toContain('Claude Opus 5');
     expect(label?.textContent).toContain('Thinking');
   });
@@ -280,8 +280,15 @@ function asking(canAnswer: boolean, markdown = ''): MagicChipPresentation {
   };
 }
 
+/** The text of the decisions row, in order. */
+function decisionLabels(container: HTMLElement) {
+  return [...(decisions(container)?.querySelectorAll('button') ?? [])].map(
+    (button) => button.textContent?.trim()
+  );
+}
+
 describe('MagicChipView reviewing a tool draft', () => {
-  it('shows the draft in the area with only the go-ahead, bottom right', () => {
+  it('shows the draft in the area with Dismiss, the go-ahead, and the session on the row', () => {
     const view = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -290,19 +297,20 @@ describe('MagicChipView reviewing a tool draft', () => {
         onOpen={onOpen}
       />
     ));
-    // The question takes the area; the passage waits underneath.
-    expect(answerArea(view.container)?.className).toContain('hidden');
+    // The question takes the area in the passage's place.
+    const area = answerArea(view.container)!;
+    expect(area.className).toContain('h-41');
+    expect(view.queryByTestId('chip-markdown')).toBeNull();
     const body = askingBody(view.container);
-    expect(body?.className).toContain('h-41');
+    expect(area.contains(body)).toBe(true);
     expect(body?.textContent).toContain('Create calendar event?');
-    expect(body?.contains(view.getByTestId('event-draft'))).toBe(true);
     expect(view.getByTestId('event-draft').textContent).toBe('Q3 sync');
 
-    expect(
-      decisions(view.container)?.contains(view.getByText('Create event'))
-    ).toBe(true);
-    expect(view.queryByText('Cancel')).toBeNull();
-    expect(view.queryByText('Edit in session')).toBeNull();
+    expect(decisionLabels(view.container)).toEqual([
+      'Dismiss',
+      'Create event',
+      'Open in session',
+    ]);
     expect(header(view.container)?.textContent).toContain('Waiting for you');
     expect(
       header(view.container)?.contains(view.getByText('Create event'))
@@ -316,8 +324,39 @@ describe('MagicChipView reviewing a tool draft', () => {
       action: 'accept',
       content: { draft: JSON.stringify(draft) },
     });
+    fireEvent.click(view.getByText('Dismiss'));
+    expect(respond).toHaveBeenLastCalledWith({ action: 'decline' });
+    fireEvent.click(view.getByText('Open in session'));
     fireEvent.click(view.getByLabelText('Open in session'));
-    expect(onOpen).toHaveBeenCalledOnce();
+    expect(onOpen).toHaveBeenCalledTimes(2);
+  });
+
+  it('expands the question in place, and its buttons do not toggle it', () => {
+    const view = render(() => (
+      <MagicChipView
+        agentSessionId="session"
+        presentation={asking(true)}
+        answer={{ answering: false, respond }}
+        onOpen={onOpen}
+      />
+    ));
+    const area = answerArea(view.container)!;
+    const clip = () => view.container.querySelector('[data-magic-chip-clip]');
+    expect(area.getAttribute('aria-expanded')).toBe('false');
+    expect(clip()?.className).toContain('overflow-hidden');
+    expect(view.container.querySelector('[data-magic-chip-fade]')).toBeTruthy();
+    expect(area.textContent).toContain('Show more');
+
+    fireEvent.click(view.getByText('Dismiss'));
+    expect(area.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(area);
+    expect(area.getAttribute('aria-expanded')).toBe('true');
+    expect(area.className).not.toContain('h-41');
+    expect(clip()?.className).not.toContain('overflow-hidden');
+    expect(view.container.querySelector('[data-magic-chip-fade]')).toBeNull();
+    expect(area.textContent).toContain('Show less');
+    expect(onOpen).not.toHaveBeenCalled();
   });
 
   it('a viewer who is not the owner sees the draft read-only and who is being waited on', () => {
@@ -340,7 +379,7 @@ describe('MagicChipView reviewing a tool draft', () => {
     expect(respond).not.toHaveBeenCalled();
   });
 
-  it('holds the button while an answer is on the wire', () => {
+  it('holds the buttons while an answer is on the wire', () => {
     const view = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -349,6 +388,7 @@ describe('MagicChipView reviewing a tool draft', () => {
       />
     ));
     fireEvent.click(view.getByText('Create event'));
+    fireEvent.click(view.getByText('Dismiss'));
     expect(respond).not.toHaveBeenCalled();
   });
 
@@ -374,8 +414,8 @@ describe('MagicChipView reviewing a tool draft', () => {
 
     setPresentation(asking(true, 'Setting that up.'));
     expect(view.getByText('Create event')).toBeTruthy();
+    expect(view.queryByTestId('chip-markdown')).toBeNull();
     expect(answerArea(view.container)).toBe(area);
-    expect(area.className).toContain('hidden');
 
     setPresentation({ kind: 'settled', markdown: 'Created the event.' });
     expect(view.queryByText('Create event')).toBeNull();
@@ -383,7 +423,6 @@ describe('MagicChipView reviewing a tool draft', () => {
     expect(view.getByText('Created the event.')).toBeTruthy();
     expect(header(view.container)?.textContent).toContain('Done');
     expect(answerArea(view.container)).toBe(area);
-    expect(area.className).not.toContain('hidden');
     expect(area.getAttribute('aria-expanded')).toBe('true');
   });
 });
@@ -442,7 +481,7 @@ function askingQuestion(
 }
 
 describe('MagicChipView asking a form', () => {
-  it('offers the choices in the area and the decisions at its bottom right', () => {
+  it('offers the choices in the area and Decline, Submit, the session on the row', () => {
     const view = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -451,19 +490,16 @@ describe('MagicChipView asking a form', () => {
         onOpen={onOpen}
       />
     ));
+    const area = answerArea(view.container)!;
+    expect(area.className).toContain('h-41');
     const body = askingBody(view.container);
-    expect(body?.className).toContain('h-41');
     expect(body?.contains(view.getByRole('radio', { name: 'Red' }))).toBe(true);
     expect(body?.textContent).toContain("What's the best colour?");
-    // The fields stretch to the area and scroll inside it.
-    expect(body?.querySelector('.overflow-y-auto')?.className).toContain(
-      'absolute inset-0'
-    );
-    expect(decisions(view.container)?.contains(view.getByText('Submit'))).toBe(
-      true
-    );
-    expect(decisions(view.container)?.className).toContain('justify-end');
-    // The row is short of room, so Cancel stays in the session.
+    expect(decisionLabels(view.container)).toEqual([
+      'Decline',
+      'Submit',
+      'Open in session',
+    ]);
     expect(view.queryByText('Cancel')).toBeNull();
     expect(
       view.container.querySelector('[data-magic-chip-pending]')
@@ -474,7 +510,9 @@ describe('MagicChipView asking a form', () => {
     expect(respond).not.toHaveBeenCalled();
     expect(view.getByText('Required')).toBeTruthy();
 
+    // Picking a choice is the choice's, not a toggle of the area.
     fireEvent.click(view.getByRole('radio', { name: 'Blue' }));
+    expect(area.getAttribute('aria-expanded')).toBe('false');
     fireEvent.click(view.getByText('Submit'));
     expect(respond).toHaveBeenCalledWith({
       action: 'accept',
@@ -483,7 +521,7 @@ describe('MagicChipView asking a form', () => {
 
     fireEvent.click(view.getByText('Decline'));
     expect(respond).toHaveBeenLastCalledWith({ action: 'decline' });
-    fireEvent.click(view.getByLabelText('Open in session'));
+    fireEvent.click(view.getByText('Open in session'));
     expect(onOpen).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -112,7 +112,7 @@ describe('MagicChipView', () => {
     const card = container.querySelector('[data-magic-chip-preview]');
     expect(card?.className).toContain('rounded-lg');
 
-    expect(answerArea(container)?.className).toContain('h-41');
+    expect(answerArea(container)?.className).toMatch(/(^|\s)h-41(\s|$)/);
     expect(container.querySelector('[data-testid="chip-markdown"]')).toBeNull();
     expect(container.querySelector('[data-magic-chip-pending]')).toBeTruthy();
 
@@ -160,7 +160,7 @@ describe('MagicChipView', () => {
       />
     ));
 
-    expect(answerArea(container)?.className).toContain('h-41');
+    expect(answerArea(container)?.className).toMatch(/(^|\s)h-41(\s|$)/);
     expect(container.querySelector('[data-magic-chip-pending]')).toBeNull();
 
     const clip = container.querySelector('[data-magic-chip-clip]');
@@ -190,19 +190,20 @@ describe('MagicChipView', () => {
     const clip = () => container.querySelector('[data-magic-chip-clip]');
     const fade = () => container.querySelector('[data-magic-chip-fade]');
     expect(area.getAttribute('aria-expanded')).toBe('false');
-    expect(area.className).toContain('h-41');
+    expect(area.className).toMatch(/(^|\s)h-41(\s|$)/);
     expect(fade()).toBeTruthy();
 
     fireEvent.click(area);
     expect(area.getAttribute('aria-expanded')).toBe('true');
-    expect(area.className).not.toContain('h-41');
+    expect(area.className).not.toMatch(/(^|\s)h-41(\s|$)/);
+    expect(area.className).toContain('min-h-41');
     expect(clip()?.className).not.toContain('overflow-hidden');
     expect(fade()).toBeNull();
     expect(onOpen).not.toHaveBeenCalled();
 
     fireEvent.keyDown(area, { key: 'Enter' });
     expect(area.getAttribute('aria-expanded')).toBe('false');
-    expect(area.className).toContain('h-41');
+    expect(area.className).toMatch(/(^|\s)h-41(\s|$)/);
     expect(clip()?.className).toContain('overflow-hidden');
     expect(fade()).toBeTruthy();
     expect(onOpen).not.toHaveBeenCalled();
@@ -217,7 +218,7 @@ describe('MagicChipView', () => {
       />
     ));
 
-    expect(answerArea(container)?.className).toContain('h-41');
+    expect(answerArea(container)?.className).toMatch(/(^|\s)h-41(\s|$)/);
     expect(headerLabel(container)?.textContent).toContain('Done');
     expect(headerLabel(container)?.textContent).not.toContain('Open session');
     fireEvent.click(headerLabel(container)!);
@@ -303,7 +304,7 @@ describe('MagicChipView reviewing a tool draft', () => {
     ));
     // The question takes the area in the passage's place.
     const area = answerArea(view.container)!;
-    expect(area.className).toContain('h-41');
+    expect(area.className).toMatch(/(^|\s)h-41(\s|$)/);
     expect(view.queryByTestId('chip-markdown')).toBeNull();
     const body = askingBody(view.container);
     expect(area.contains(body)).toBe(true);
@@ -357,7 +358,8 @@ describe('MagicChipView reviewing a tool draft', () => {
 
     fireEvent.click(area);
     expect(area.getAttribute('aria-expanded')).toBe('true');
-    expect(area.className).not.toContain('h-41');
+    expect(area.className).not.toMatch(/(^|\s)h-41(\s|$)/);
+    expect(area.className).toContain('min-h-41');
     expect(clip()?.className).not.toContain('overflow-hidden');
     expect(view.container.querySelector('[data-magic-chip-fade]')).toBeNull();
     expect(onOpen).not.toHaveBeenCalled();
@@ -505,7 +507,7 @@ describe('MagicChipView asking a form', () => {
       />
     ));
     const area = answerArea(view.container)!;
-    expect(area.className).toContain('h-41');
+    expect(area.className).toMatch(/(^|\s)h-41(\s|$)/);
     const body = askingBody(view.container);
     expect(body?.contains(view.getByRole('radio', { name: 'Red' }))).toBe(true);
     expect(body?.textContent).toContain("What's the best colour?");

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -20,6 +20,14 @@ vi.mock('@core/component/LexicalMarkdown/theme', () => ({
   channelTheme: {},
 }));
 
+// The chip answers a form with the real `ElicitationForm`; the rest of the
+// block-agent ui barrel reaches the composer, comments, and a socket.
+vi.mock('@app/features/block-agent/ui', async () => ({
+  ElicitationForm: (
+    await import('@app/features/block-agent/ui/ElicitationForm')
+  ).ElicitationForm,
+}));
+
 afterEach(cleanup);
 
 const LONG_PATH =
@@ -328,5 +336,167 @@ describe('MagicChipView review transition', () => {
     expect(area.getAttribute('aria-expanded')).toBe('true');
     fireEvent.click(view.getByText('Open session'));
     expect(onOpen).toHaveBeenCalledOnce();
+  });
+});
+
+const colourForm = {
+  kind: 'form' as const,
+  schema: {
+    title: null,
+    description: null,
+    required: ['question_0'],
+    properties: [
+      {
+        name: 'question_0',
+        title: 'Best colour',
+        description: null,
+        schema: {
+          type: 'string' as const,
+          minLength: null,
+          maxLength: null,
+          pattern: null,
+          format: null,
+          default: null,
+          options: [
+            { value: 'Red', title: 'Red', description: null },
+            { value: 'Blue', title: 'Blue', description: null },
+          ],
+          customField: 'question_0_custom',
+        },
+      },
+    ],
+  },
+};
+
+function askingQuestion(
+  request: Extract<
+    MagicChipPresentation,
+    { kind: 'asking' }
+  >['asking']['question']['request'],
+  canAnswer = true
+): MagicChipPresentation {
+  return {
+    kind: 'asking',
+    markdown: '',
+    asking: {
+      question: {
+        requestId: 0,
+        turn: 0,
+        toolCall: null,
+        message: "What's the best colour?",
+        request,
+      },
+      canAnswer,
+      ownerName: 'Alice Owner',
+    },
+  };
+}
+
+describe('MagicChipView asking a form', () => {
+  it('offers the choices in the thread and submits the one picked', () => {
+    const view = render(() => (
+      <MagicChipView
+        agentSessionId="session"
+        presentation={askingQuestion(colourForm)}
+        answer={{ answering: false, respond }}
+        onOpen={onOpen}
+      />
+    ));
+    expect(view.getByText("What's the best colour?")).toBeTruthy();
+    expect(view.getByRole('radio', { name: 'Red' })).toBeTruthy();
+
+    // A required question refuses an empty submit.
+    fireEvent.click(view.getByText('Submit'));
+    expect(respond).not.toHaveBeenCalled();
+    expect(view.getByText('Required')).toBeTruthy();
+
+    fireEvent.click(view.getByRole('radio', { name: 'Blue' }));
+    fireEvent.click(view.getByText('Submit'));
+    expect(respond).toHaveBeenCalledWith({
+      action: 'accept',
+      content: { question_0: 'Blue' },
+    });
+
+    fireEvent.click(view.getByText('Decline'));
+    expect(respond).toHaveBeenLastCalledWith({ action: 'decline' });
+    fireEvent.click(view.getByText('Open session'));
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it('types a custom answer and sends it under the custom key', () => {
+    const view = render(() => (
+      <MagicChipView
+        agentSessionId="session"
+        presentation={askingQuestion(colourForm)}
+        answer={{ answering: false, respond }}
+      />
+    ));
+    fireEvent.input(view.getByPlaceholderText('Type your own answer'), {
+      target: { value: 'teal' },
+    });
+    fireEvent.click(view.getByText('Submit'));
+    expect(respond).toHaveBeenCalledWith({
+      action: 'accept',
+      content: { question_0_custom: 'teal' },
+    });
+  });
+
+  it('a viewer who is not the owner sees the choices locked', () => {
+    const view = render(() => (
+      <MagicChipView
+        agentSessionId="session"
+        presentation={askingQuestion(colourForm, false)}
+        answer={{ answering: false, respond }}
+        onOpen={onOpen}
+      />
+    ));
+    expect(view.getByText('Waiting for Alice Owner')).toBeTruthy();
+    const red = view.getByRole('radio', { name: 'Red' }) as HTMLButtonElement;
+    expect(red.disabled).toBe(true);
+    fireEvent.click(view.getByText('Submit'));
+    expect(respond).not.toHaveBeenCalled();
+  });
+
+  it('a url request shows the host and opens only after consent', async () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const view = render(() => (
+      <MagicChipView
+        agentSessionId="session"
+        presentation={askingQuestion({
+          kind: 'url',
+          elicitationId: 'gh-1',
+          url: 'https://agent.example.com/connect?e=gh-1',
+        })}
+        answer={{ answering: false, respond }}
+      />
+    ));
+    expect(view.getByText('agent.example.com')).toBeTruthy();
+    fireEvent.click(view.getByText('Open'));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(respond).toHaveBeenCalledWith({ action: 'accept' });
+    expect(open).toHaveBeenCalledWith(
+      'https://agent.example.com/connect?e=gh-1',
+      '_blank',
+      'noopener,noreferrer'
+    );
+    open.mockRestore();
+  });
+
+  it('a request this client cannot display can still be declined', () => {
+    const view = render(() => (
+      <MagicChipView
+        agentSessionId="session"
+        presentation={askingQuestion({
+          kind: 'unrecognized',
+          mode: 'hologram',
+          raw: {},
+        })}
+        answer={{ answering: false, respond }}
+      />
+    ));
+    expect(view.getByText(/cannot display a "hologram" request/)).toBeTruthy();
+    fireEvent.click(view.getByText('Decline'));
+    expect(respond).toHaveBeenCalledWith({ action: 'decline' });
   });
 });

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -46,10 +46,24 @@ function headerLabel(container: HTMLElement) {
   return header(container)?.querySelector('button');
 }
 
-/** The pane a form or URL question's fields live in, beside the answer. */
-function pane(container: HTMLElement) {
-  return container.querySelector('[data-magic-chip-pane]');
+/** The question, in the answer area's place while one is live. */
+function askingBody(container: HTMLElement) {
+  return container.querySelector('[data-magic-chip-asking]');
 }
+
+/** The decisions at the bottom right of the question. */
+function decisions(container: HTMLElement) {
+  return container.querySelector('[data-magic-chip-decisions]');
+}
+
+vi.mock('@app/features/block-agent/component/parts/UserToolCall', () => ({
+  EventDraft: (props: { event: { title: string } }) => (
+    <div data-testid="event-draft">{props.event.title}</div>
+  ),
+  EmailDraft: (props: { email: { subject: string } }) => (
+    <div data-testid="email-draft">{props.email.subject}</div>
+  ),
+}));
 
 const respond = vi.fn<(answer: ElicitationAnswer) => Promise<boolean>>();
 const onOpen = vi.fn();
@@ -267,7 +281,7 @@ function asking(canAnswer: boolean, markdown = ''): MagicChipPresentation {
 }
 
 describe('MagicChipView reviewing a tool draft', () => {
-  it('offers only the go-ahead, in the header, and leaves the rest to the session', () => {
+  it('shows the draft in the area with only the go-ahead, bottom right', () => {
     const view = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -276,20 +290,26 @@ describe('MagicChipView reviewing a tool draft', () => {
         onOpen={onOpen}
       />
     ));
-    expect(view.getByTestId('chip-markdown').textContent).toBe(
-      'Setting that up.'
-    );
-    expect(answerArea(view.container)?.className).toContain('h-22');
-    expect(pane(view.container)).toBeNull();
+    // The question takes the area; the passage waits underneath.
+    expect(answerArea(view.container)?.className).toContain('hidden');
+    const body = askingBody(view.container);
+    expect(body?.className).toContain('h-22');
+    expect(body?.textContent).toContain('Create calendar event?');
+    expect(body?.contains(view.getByTestId('event-draft'))).toBe(true);
+    expect(view.getByTestId('event-draft').textContent).toBe('Q3 sync');
 
-    const top = header(view.container);
-    expect(top?.textContent).toContain('Waiting for you');
-    expect(top?.contains(view.getByText('Create event'))).toBe(true);
+    expect(
+      decisions(view.container)?.contains(view.getByText('Create event'))
+    ).toBe(true);
     expect(view.queryByText('Cancel')).toBeNull();
     expect(view.queryByText('Edit in session')).toBeNull();
+    expect(header(view.container)?.textContent).toContain('Waiting for you');
+    expect(
+      header(view.container)?.contains(view.getByText('Create event'))
+    ).toBe(false);
     expect(
       headerLabel(view.container)?.getAttribute('data-message-reply-preview')
-    ).toBeNull();
+    ).toBe('Waiting for you · Create calendar event?');
 
     fireEvent.click(view.getByText('Create event'));
     expect(respond).toHaveBeenCalledWith({
@@ -300,26 +320,7 @@ describe('MagicChipView reviewing a tool draft', () => {
     expect(onOpen).toHaveBeenCalledOnce();
   });
 
-  it('shows nothing in the answer area while the agent has said nothing', () => {
-    const view = render(() => (
-      <MagicChipView
-        agentSessionId="session"
-        presentation={asking(true)}
-        answer={{ answering: false, respond }}
-      />
-    ));
-    expect(answerArea(view.container)?.className).toContain('h-22');
-    expect(answerArea(view.container)?.className).not.toContain('hidden');
-    expect(
-      view.container.querySelector('[data-magic-chip-pending]')
-    ).toBeNull();
-    expect(view.queryByTestId('chip-markdown')).toBeNull();
-    expect(
-      headerLabel(view.container)?.getAttribute('data-message-reply-preview')
-    ).toBe('Waiting for you · Create calendar event?');
-  });
-
-  it('a viewer who is not the owner sees who is being waited on and can only open the session', () => {
+  it('a viewer who is not the owner sees the draft read-only and who is being waited on', () => {
     const view = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -331,6 +332,8 @@ describe('MagicChipView reviewing a tool draft', () => {
     expect(header(view.container)?.textContent).toContain(
       'Waiting for Alice Owner'
     );
+    expect(view.getByTestId('event-draft')).toBeTruthy();
+    expect(decisions(view.container)).toBeNull();
     expect(view.queryByText('Create event')).toBeNull();
     fireEvent.click(view.getByLabelText('Open in session'));
     expect(onOpen).toHaveBeenCalled();
@@ -349,7 +352,7 @@ describe('MagicChipView reviewing a tool draft', () => {
     expect(respond).not.toHaveBeenCalled();
   });
 
-  it('keeps the expanded answer while a review appears and the agent continues', () => {
+  it('keeps the expanded answer while a review takes the area and gives it back', () => {
     const [presentation, setPresentation] = createSignal<MagicChipPresentation>(
       {
         kind: 'answering',
@@ -372,13 +375,15 @@ describe('MagicChipView reviewing a tool draft', () => {
     setPresentation(asking(true, 'Setting that up.'));
     expect(view.getByText('Create event')).toBeTruthy();
     expect(answerArea(view.container)).toBe(area);
-    expect(area.getAttribute('aria-expanded')).toBe('true');
+    expect(area.className).toContain('hidden');
 
     setPresentation({ kind: 'settled', markdown: 'Created the event.' });
     expect(view.queryByText('Create event')).toBeNull();
+    expect(askingBody(view.container)).toBeNull();
     expect(view.getByText('Created the event.')).toBeTruthy();
     expect(header(view.container)?.textContent).toContain('Done');
     expect(answerArea(view.container)).toBe(area);
+    expect(area.className).not.toContain('hidden');
     expect(area.getAttribute('aria-expanded')).toBe('true');
   });
 });
@@ -437,7 +442,7 @@ function askingQuestion(
 }
 
 describe('MagicChipView asking a form', () => {
-  it('offers the choices in the pane and the decisions in the header', () => {
+  it('offers the choices in the area and the decisions at its bottom right', () => {
     const view = render(() => (
       <MagicChipView
         agentSessionId="session"
@@ -446,17 +451,23 @@ describe('MagicChipView asking a form', () => {
         onOpen={onOpen}
       />
     ));
-    expect(
-      pane(view.container)?.contains(view.getByRole('radio', { name: 'Red' }))
-    ).toBe(true);
-    expect(pane(view.container)?.textContent).toContain(
-      "What's the best colour?"
+    const body = askingBody(view.container);
+    expect(body?.className).toContain('h-22');
+    expect(body?.contains(view.getByRole('radio', { name: 'Red' }))).toBe(true);
+    expect(body?.textContent).toContain("What's the best colour?");
+    // The fields stretch to the area and scroll inside it.
+    expect(body?.querySelector('.overflow-y-auto')?.className).toContain(
+      'absolute inset-0'
     );
-    expect(header(view.container)?.contains(view.getByText('Submit'))).toBe(
+    expect(decisions(view.container)?.contains(view.getByText('Submit'))).toBe(
       true
     );
-    // The header is short of room, so Cancel stays in the session.
+    expect(decisions(view.container)?.className).toContain('justify-end');
+    // The row is short of room, so Cancel stays in the session.
     expect(view.queryByText('Cancel')).toBeNull();
+    expect(
+      view.container.querySelector('[data-magic-chip-pending]')
+    ).toBeNull();
 
     // A required question refuses an empty submit.
     fireEvent.click(view.getByText('Submit'));
@@ -474,40 +485,6 @@ describe('MagicChipView asking a form', () => {
     expect(respond).toHaveBeenLastCalledWith({ action: 'decline' });
     fireEvent.click(view.getByLabelText('Open in session'));
     expect(onOpen).toHaveBeenCalledOnce();
-  });
-
-  it('gives the question the whole card while the agent has said nothing, and the right side once it has', () => {
-    const [presentation, setPresentation] = createSignal(
-      askingQuestion(colourForm)
-    );
-    const view = render(() => (
-      <MagicChipView
-        agentSessionId="session"
-        presentation={presentation()}
-        answer={{ answering: false, respond }}
-      />
-    ));
-    expect(answerArea(view.container)?.className).toContain('hidden');
-    expect(
-      view.container.querySelector('[data-magic-chip-pending]')
-    ).toBeNull();
-    expect(pane(view.container)?.className).toContain('flex-1');
-    expect(pane(view.container)?.className).not.toContain('border-l');
-    // The pane stretches to the chip and scrolls inside it.
-    expect(pane(view.container)?.firstElementChild?.className).toContain(
-      'absolute inset-0'
-    );
-    expect(pane(view.container)?.firstElementChild?.className).toContain(
-      'overflow-y-auto'
-    );
-
-    setPresentation(
-      askingQuestion(colourForm, { markdown: 'Let me ask you something.' })
-    );
-    expect(answerArea(view.container)?.className).not.toContain('hidden');
-    expect(answerArea(view.container)?.className).toContain('h-22');
-    expect(pane(view.container)?.className).toContain('border-l');
-    expect(pane(view.container)?.className).not.toContain('flex-1');
   });
 
   it('types a custom answer and sends it under the custom key', () => {
@@ -567,6 +544,7 @@ describe('MagicChipView asking a form', () => {
     );
     const red = view.getByRole('radio', { name: 'Red' }) as HTMLButtonElement;
     expect(red.disabled).toBe(true);
+    expect(decisions(view.container)).toBeNull();
     expect(view.queryByText('Submit')).toBeNull();
     expect(view.queryByText('Decline')).toBeNull();
   });

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -67,6 +67,8 @@ type StubSink = {
 function composerStub(kind: string) {
   return (props: { initialData: unknown; sink: StubSink }) => (
     <div data-testid={`${kind}-composer`} data-can-act={props.sink.canAct()}>
+      {/* A widget the area cannot recognize as a control. */}
+      <div data-testid="composer-surface" />
       <button
         type="button"
         data-testid="composer-execute"
@@ -354,6 +356,7 @@ describe('MagicChipView reviewing a tool draft', () => {
 
     fireEvent.click(view.getByText('Dismiss'));
     fireEvent.click(view.getByTestId('composer-execute'));
+    fireEvent.click(view.getByTestId('composer-surface'));
     expect(area.getAttribute('aria-expanded')).toBe('false');
 
     fireEvent.click(area);

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.test.tsx
@@ -279,9 +279,11 @@ describe('MagicChipView asking', () => {
     expect(
       side?.querySelector('[data-testid="event-draft"]')?.textContent
     ).toBe('Q3 sync');
-    // The pane stretches to the chip and scrolls inside it.
+    // The pane stretches to the chip and scrolls inside it, beside the answer.
+    expect(side?.className).toContain('border-l');
     expect(side?.firstElementChild?.className).toContain('absolute inset-0');
-    expect(side?.firstElementChild?.className).toContain('overflow-y-auto');
+    expect(side?.querySelector('.overflow-y-auto')).not.toBeNull();
+    expect(answerArea(view.container)?.className).not.toContain('hidden');
 
     const row = decisions(view.container);
     expect(row?.className).toContain('min-h-9');
@@ -296,8 +298,26 @@ describe('MagicChipView asking', () => {
     });
     fireEvent.click(view.getByText('Cancel'));
     expect(respond).toHaveBeenLastCalledWith({ action: 'decline' });
-    fireEvent.click(view.getByLabelText('Edit in session'));
+    fireEvent.click(view.getByLabelText('Open in session'));
     expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it('gives the question the whole card while the agent has said nothing', () => {
+    const view = render(() => (
+      <MagicChipView
+        agentSessionId="session"
+        presentation={asking(true)}
+        answer={{ answering: false, respond }}
+      />
+    ));
+    expect(answerArea(view.container)?.className).toContain('hidden');
+    expect(
+      view.container.querySelector('[data-magic-chip-pending]')
+    ).toBeNull();
+    const side = pane(view.container);
+    expect(side?.className).toContain('flex-1');
+    expect(side?.className).not.toContain('border-l');
+    expect(side?.textContent).toContain('Q3 sync');
   });
 
   it('a viewer who is not the owner sees who is being waited on and can only open the session', () => {
@@ -314,7 +334,7 @@ describe('MagicChipView asking', () => {
     );
     expect(view.queryByText('Create event')).toBeNull();
     expect(view.queryByText('Cancel')).toBeNull();
-    fireEvent.click(view.getByLabelText('Open session'));
+    fireEvent.click(view.getByLabelText('Open in session'));
     expect(onOpen).toHaveBeenCalled();
     expect(respond).not.toHaveBeenCalled();
   });
@@ -459,7 +479,7 @@ describe('MagicChipView asking a form', () => {
 
     fireEvent.click(view.getByText('Decline'));
     expect(respond).toHaveBeenLastCalledWith({ action: 'decline' });
-    fireEvent.click(view.getByLabelText('Open session'));
+    fireEvent.click(view.getByLabelText('Open in session'));
     expect(onOpen).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -382,6 +382,14 @@ export const MagicChipView: Component<{
         locked ? false : ((await props.answer?.respond(answer)) ?? false),
     };
   };
+  // The question's state, kept through its own teardown: once the answer
+  // lands the pending question clears while the composer's effects are still
+  // winding down, and a prop getter reading a `<Show>` accessor then would
+  // read a stale one. Children key on the request id and read this instead.
+  const held = createMemo<ChipAsking | undefined>(
+    (previous) => chipAsking() ?? previous,
+    undefined
+  );
   // There is something to expand once the agent has written, or asked.
   const expandable = () => Boolean(markdown()) || Boolean(chipAsking());
   // While the answer area has no prose, a reply to the message previews the
@@ -441,7 +449,8 @@ export const MagicChipView: Component<{
             data-magic-chip-clip
           >
             <Show
-              when={chipAsking()}
+              when={requestKey()}
+              keyed
               fallback={
                 <Show
                   when={markdown()}
@@ -451,7 +460,8 @@ export const MagicChipView: Component<{
                 </Show>
               }
             >
-              {(current) => <Question {...current()} />}
+              {/* `held` is set whenever a request id is. */}
+              <Question {...held()!} />
             </Show>
             {/* Cropped content fades out; expanding shows it whole. */}
             <Show when={expandable() && !expanded()}>
@@ -461,15 +471,13 @@ export const MagicChipView: Component<{
               />
             </Show>
           </div>
-          <Show when={chipAsking()?.asking.canAnswer && chipAsking()}>
-            {(current) => (
-              <div
-                class="flex shrink-0 items-center justify-end gap-2 px-3 pb-2"
-                data-magic-chip-decisions
-              >
-                <AskingActions {...current()} onOpen={props.onOpen} />
-              </div>
-            )}
+          <Show when={requestKey() && held()?.asking.canAnswer}>
+            <div
+              class="flex shrink-0 items-center justify-end gap-2 px-3 pb-2"
+              data-magic-chip-decisions
+            >
+              <AskingActions {...held()!} onOpen={props.onOpen} />
+            </div>
           </Show>
         </div>
       </div>

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -337,7 +337,8 @@ const Question: Component<ChipAsking> = (props) => {
  * the agent is busy before it writes, the passage as it streams, the final
  * passage once the turn ends - or, while the agent waits on a question, the
  * question itself with its decisions on the row beneath. The area is cropped
- * with a fade; clicking it expands it in place.
+ * with a fade; clicking it expands it in place, never below the cropped
+ * height, so a short passage does not shrink the card.
  */
 export const MagicChipView: Component<{
   agentSessionId: string;
@@ -431,7 +432,7 @@ export const MagicChipView: Component<{
           role="button"
           tabIndex={0}
           aria-expanded={expandable() ? expanded() : undefined}
-          class="flex min-w-0 flex-col text-left"
+          class="flex min-h-41 min-w-0 flex-col text-left"
           classList={{ 'h-41': !expanded() }}
           data-magic-chip-answer
           onClick={onAreaClick}

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -1,6 +1,8 @@
 import {
-  LiveQuestion,
-  type LiveQuestionRequest,
+  createLiveQuestion,
+  type LiveQuestion,
+  QuestionActions,
+  QuestionFields,
   type RespondToElicitation,
 } from '@app/features/block-agent/component/parts/LiveElicitation';
 import {
@@ -30,6 +32,7 @@ import {
   Match,
   Show,
   Switch,
+  untrack,
 } from 'solid-js';
 import { match } from 'ts-pattern';
 import type {
@@ -66,152 +69,195 @@ export type MagicChipAnswer = {
   respond: (answer: ElicitationAnswer) => Promise<boolean>;
 };
 
+/** A Macro user tool the agent drafted, read back for review. */
+type ReviewedTool = { name: string; data: unknown; draft: unknown };
+
 /**
- * A question the agent stopped to ask, answered in the thread: a form's
- * fields, a URL's consent, or a Macro user tool's draft summarized read-only
- * with the two decisions. The same controls the session shows, so the chip
- * offers everything the session would except editing a tool's draft, which
- * needs the tool's composer - `Edit in session` opens it. Anyone but the
- * session's owner sees the question locked and who is being waited on.
+ * The chip's side of a question: the shared live state for a form, URL, or
+ * unknown mode, or the draft of a recognized Macro user tool. A draft the
+ * tool's schema rejects falls back to the flat form the agent also sent, as
+ * the session does.
  */
-const AskingCard: Component<{
-  agentSessionId: string;
-  asking: MagicChipQuestion;
-  answer?: MagicChipAnswer;
-  onOpen?: () => void;
-}> = (props) => {
-  const request = () => props.asking.question.request;
-  const userTool = createMemo(() => {
-    const current = request();
-    if (current.kind !== 'user_tool') return undefined;
-    const call = deserializeToolCall({
-      id:
-        props.asking.question.toolCall ??
-        String(props.asking.question.requestId),
-      name: current.tool,
-      json: current.draft,
-    });
-    return call.isOk() ? { tool: call.value, draft: current.draft } : undefined;
+type ChipQuestion = LiveQuestion | { kind: 'user_tool'; tool: ReviewedTool };
+
+function createChipQuestion(asking: MagicChipQuestion): ChipQuestion {
+  const request = asking.question.request;
+  if (request.kind !== 'user_tool') return createLiveQuestion(request);
+  const call = deserializeToolCall({
+    id: asking.question.toolCall ?? String(asking.question.requestId),
+    name: request.tool,
+    json: request.draft,
   });
-  // Everything but a recognized user tool goes through the shared controls; a
-  // draft the tool's schema rejects falls back to the flat form the agent
-  // also sent, as the session does.
-  const question = (): LiveQuestionRequest | undefined => {
-    const current = request();
-    if (current.kind !== 'user_tool') return current;
-    return userTool() ? undefined : { kind: 'form', schema: current.schema };
-  };
-  const locked = () =>
-    !props.asking.canAnswer || !props.answer || props.answer.answering;
+  return call.isOk()
+    ? {
+        kind: 'user_tool',
+        tool: {
+          name: call.value.name,
+          data: call.value.data,
+          draft: request.draft,
+        },
+      }
+    : createLiveQuestion({ kind: 'form', schema: request.schema });
+}
+
+function reviewedTool(question: ChipQuestion) {
+  return question.kind === 'user_tool' ? question.tool : undefined;
+}
+
+function liveQuestion(question: ChipQuestion): LiveQuestion | undefined {
+  return question.kind === 'user_tool' ? undefined : question;
+}
+
+/** What the chip is waiting on, with the state behind its controls. */
+type ChipAsking = {
+  asking: MagicChipQuestion;
+  question: ChipQuestion;
+  locked: boolean;
+  respond: RespondToElicitation;
+};
+
+/**
+ * The question, beside the answer: who is being waited on, the prompt, and
+ * the fields - a form's choices, a URL and its host, a tool draft summarized
+ * read-only. The pane takes the chip's height and scrolls inside it, so a
+ * long form never grows the card; it contributes no height of its own.
+ */
+const AskingPane: Component<ChipAsking> = (props) => {
   const waitingFor = () =>
     props.asking.canAnswer
       ? 'Waiting for you'
       : `Waiting for ${props.asking.ownerName}`;
-  const confirmLabel = () =>
-    match(userTool()?.tool.name)
-      .with('CreateCalendarEvent', () => 'Create event')
-      .with('SendEmail', () => 'Send email')
-      .otherwise(() => 'Confirm');
-  const respond: RespondToElicitation = async (answer) => {
-    if (locked()) return false;
-    return (await props.answer?.respond(answer)) ?? false;
-  };
-  // The chip sends the draft as the agent wrote it; edits need the session's
-  // composer.
-  const accept = () =>
-    void respond({
-      action: 'accept',
-      content: { [DRAFT_FIELD]: JSON.stringify(userTool()?.draft ?? {}) },
-    });
-  const openSession = (label: string) => (
-    <Button
-      variant="ghost"
-      size="xs"
-      disabled={!props.onOpen}
-      onMouseDown={(event) => event.preventDefault()}
-      onClick={props.onOpen}
-    >
-      {label}
-    </Button>
-  );
-
   return (
     <div
-      class="flex w-full min-w-0 flex-col gap-2 border-t border-edge-muted px-3 py-2.5"
-      data-magic-chip={props.agentSessionId}
-      data-magic-chip-asking
-      data-message-reply-preview={`${waitingFor()} · ${props.asking.question.message}`}
+      class="relative w-[45%] min-w-40 max-w-72 shrink-0 border-l border-edge-muted"
+      data-magic-chip-pane
     >
-      <div class="flex flex-col gap-0.5">
-        <span class="text-xs font-semibold text-ink-muted" aria-live="polite">
-          {waitingFor()}
-        </span>
-        <span class="text-sm text-ink wrap-break-word">
-          {props.asking.question.message}
-        </span>
-      </div>
-      <Switch>
-        <Match when={userTool()}>
-          {(reviewed) => (
-            <>
+      <div class="absolute inset-0 flex flex-col gap-2 overflow-y-auto px-3 py-2">
+        <div class="flex flex-col gap-0.5">
+          <span class="text-xs font-semibold text-ink-muted" aria-live="polite">
+            {waitingFor()}
+          </span>
+          <span class="text-sm leading-5 text-ink wrap-break-word">
+            {props.asking.question.message}
+          </span>
+        </div>
+        <Switch>
+          <Match when={reviewedTool(props.question)}>
+            {(tool) => (
               <Switch>
-                <Match when={reviewed().tool.name === 'CreateCalendarEvent'}>
-                  <EventDraft
-                    event={reviewed().tool.data as CreateCalendarEvent}
-                  />
+                <Match when={tool().name === 'CreateCalendarEvent'}>
+                  <EventDraft event={tool().data as CreateCalendarEvent} />
                 </Match>
-                <Match when={reviewed().tool.name === 'SendEmail'}>
+                <Match when={tool().name === 'SendEmail'}>
                   <EmailDraft
-                    email={reviewed().tool.data as SendEmail}
+                    email={tool().data as SendEmail}
                     inFlight={false}
                   />
                 </Match>
               </Switch>
-              <div class="flex flex-wrap items-center gap-2">
-                <Show when={props.asking.canAnswer}>
-                  <Button
-                    variant="cta"
-                    size="xs"
-                    disabled={locked()}
-                    onMouseDown={(event) => event.preventDefault()}
-                    onClick={accept}
-                  >
-                    {confirmLabel()}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="xs"
-                    disabled={locked()}
-                    onMouseDown={(event) => event.preventDefault()}
-                    onClick={() => void respond({ action: 'decline' })}
-                  >
-                    Cancel
-                  </Button>
-                </Show>
-                <span class="ml-auto">
-                  {openSession(
-                    props.asking.canAnswer ? 'Edit in session' : 'Open session'
-                  )}
-                </span>
-              </div>
-            </>
-          )}
-        </Match>
-        <Match when={question()}>
-          {(live) => (
-            // Keyed on the request so a new question starts a fresh draft
-            // while metadata refreshes of the same one keep what was typed.
-            <Show when={String(props.asking.question.requestId)} keyed>
-              <LiveQuestion
-                request={live()}
-                locked={locked()}
-                onRespond={respond}
-                trailing={openSession('Open session')}
+            )}
+          </Match>
+          <Match when={liveQuestion(props.question)}>
+            {(question) => (
+              <QuestionFields question={question()} locked={props.locked} />
+            )}
+          </Match>
+        </Switch>
+      </div>
+      {/* The pane clips; the fade says there is more below. */}
+      <div
+        aria-hidden="true"
+        class="pointer-events-none absolute inset-x-0 bottom-0 h-4 bg-linear-to-t from-surface to-transparent"
+      />
+    </div>
+  );
+};
+
+/**
+ * The decisions on the chip's bottom row, in the footer's place: Submit or
+ * Open with Decline for a question, Create/Send with Cancel for a tool
+ * draft, then the way into the session. Anyone but the owner gets only that
+ * last one. The chip sends a tool draft as the agent wrote it; editing it
+ * needs the session's composer.
+ */
+const AskingActions: Component<ChipAsking & { onOpen?: () => void }> = (
+  props
+) => {
+  const confirmLabel = (tool: ReviewedTool) =>
+    match(tool.name)
+      .with('CreateCalendarEvent', () => 'Create event')
+      .with('SendEmail', () => 'Send email')
+      .otherwise(() => 'Confirm');
+  const accept = (tool: ReviewedTool) =>
+    void props.respond({
+      action: 'accept',
+      content: { [DRAFT_FIELD]: JSON.stringify(tool.draft ?? {}) },
+    });
+  const waitingFor = () =>
+    props.asking.canAnswer
+      ? 'Waiting for you'
+      : `Waiting for ${props.asking.ownerName}`;
+  return (
+    <div
+      class="flex min-h-9 items-center gap-2 border-t border-edge-muted px-3 py-1.5 text-xs leading-5"
+      data-magic-chip-asking
+      data-message-reply-preview={`${waitingFor()} · ${props.asking.question.message}`}
+    >
+      <Show
+        when={props.asking.canAnswer}
+        fallback={
+          <span class="min-w-0 truncate text-ink-muted">{waitingFor()}</span>
+        }
+      >
+        <Switch>
+          <Match when={reviewedTool(props.question)}>
+            {(tool) => (
+              <>
+                <Button
+                  variant="cta"
+                  size="xs"
+                  disabled={props.locked}
+                  onClick={() => accept(tool())}
+                >
+                  {confirmLabel(tool())}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="xs"
+                  disabled={props.locked}
+                  onClick={() => void props.respond({ action: 'decline' })}
+                >
+                  Cancel
+                </Button>
+              </>
+            )}
+          </Match>
+          <Match when={liveQuestion(props.question)}>
+            {(question) => (
+              <QuestionActions
+                question={question()}
+                locked={props.locked}
+                onRespond={props.respond}
+                cancel={false}
               />
-            </Show>
-          )}
-        </Match>
-      </Switch>
+            )}
+          </Match>
+        </Switch>
+      </Show>
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        class="ml-auto"
+        aria-label={
+          props.asking.canAnswer && reviewedTool(props.question)
+            ? 'Edit in session'
+            : 'Open session'
+        }
+        disabled={!props.onOpen}
+        onClick={props.onOpen}
+      >
+        <ArrowUpRight />
+      </Button>
     </div>
   );
 };
@@ -344,6 +390,34 @@ export const MagicChipView: Component<{
   const activity = () => currentActivity(props.presentation);
   const [expanded, setExpanded] = createSignal(false);
 
+  // One draft per question: keyed on the request id so metadata refreshes of
+  // the same question keep what was typed, and a new question starts clean.
+  const requestKey = createMemo(() => {
+    const current = asking();
+    return current ? String(current.question.requestId) : undefined;
+  });
+  const question = createMemo(() => {
+    if (!requestKey()) return undefined;
+    return untrack(() => {
+      const current = asking();
+      return current ? createChipQuestion(current) : undefined;
+    });
+  });
+  const chipAsking = (): ChipAsking | undefined => {
+    const current = asking();
+    const state = question();
+    if (!current || !state) return undefined;
+    const locked =
+      !current.canAnswer || !props.answer || props.answer.answering;
+    return {
+      asking: current,
+      question: state,
+      locked,
+      respond: async (answer) =>
+        locked ? false : ((await props.answer?.respond(answer)) ?? false),
+    };
+  };
+
   // Before there is an answer there is nothing to expand, so the whole card
   // leads to the session.
   const onAnswerClick = () => {
@@ -354,7 +428,7 @@ export const MagicChipView: Component<{
   return (
     <Layer depth={2}>
       <div
-        class="my-2 w-full min-w-0 max-w-full overflow-hidden rounded-lg border border-edge-muted bg-surface"
+        class="my-2 flex w-full min-w-0 max-w-full overflow-hidden rounded-lg border border-edge-muted bg-surface"
         data-magic-chip={props.agentSessionId}
         data-magic-chip-preview
         onMouseDown={(event) => {
@@ -363,61 +437,61 @@ export const MagicChipView: Component<{
           if (!isTextEntry(event.target)) event.preventDefault();
         }}
       >
-        <div
-          role="button"
-          tabIndex={0}
-          aria-expanded={markdown() ? expanded() : undefined}
-          class="group/answer px-3 py-1 text-left hover:bg-hover"
-          classList={{ 'h-22': !expanded() }}
-          data-magic-chip-answer
-          onClick={onAnswerClick}
-          onKeyDown={(event) => {
-            if (event.key !== 'Enter' && event.key !== ' ') return;
-            event.preventDefault();
-            onAnswerClick();
-          }}
-        >
-          <Show
-            when={markdown()}
-            fallback={<AnswerPending busy={activity()?.busy ?? false} />}
+        <div class="flex min-w-0 flex-1 flex-col">
+          <div
+            role="button"
+            tabIndex={0}
+            aria-expanded={markdown() ? expanded() : undefined}
+            class="group/answer px-3 py-1 text-left hover:bg-hover"
+            classList={{ 'h-22': !expanded() }}
+            data-magic-chip-answer
+            onClick={onAnswerClick}
+            onKeyDown={(event) => {
+              if (event.key !== 'Enter' && event.key !== ' ') return;
+              event.preventDefault();
+              onAnswerClick();
+            }}
           >
-            {(answer) => (
-              <AnswerBody markdown={answer()} expanded={expanded()} />
+            <Show
+              when={markdown()}
+              fallback={<AnswerPending busy={activity()?.busy ?? false} />}
+            >
+              {(answer) => (
+                <AnswerBody markdown={answer()} expanded={expanded()} />
+              )}
+            </Show>
+          </div>
+          <Show
+            when={chipAsking()}
+            fallback={
+              <button
+                type="button"
+                class="flex min-h-9 w-full items-center gap-1.5 border-t border-edge-muted px-3 py-2 text-left text-xs leading-5 text-ink-extra-muted hover:bg-hover"
+                data-message-reply-preview={
+                  markdown() ? undefined : replyPreview(activity())
+                }
+                disabled={!props.onOpen}
+                onClick={props.onOpen}
+              >
+                <span class="flex min-w-0 flex-1 items-center gap-1.5">
+                  <Show
+                    when={activity()}
+                    fallback={<span class="text-ink-muted">Open session</span>}
+                  >
+                    {(current) => <ActivityText activity={current()} />}
+                  </Show>
+                </span>
+                <ArrowUpRight aria-hidden="true" class="size-3 shrink-0" />
+              </button>
+            }
+          >
+            {(current) => (
+              <AskingActions {...current()} onOpen={props.onOpen} />
             )}
           </Show>
         </div>
-        <Show
-          when={asking()}
-          fallback={
-            <button
-              type="button"
-              class="flex min-h-9 w-full items-center gap-1.5 border-t border-edge-muted px-3 py-2 text-left text-xs leading-5 text-ink-extra-muted hover:bg-hover"
-              data-message-reply-preview={
-                markdown() ? undefined : replyPreview(activity())
-              }
-              disabled={!props.onOpen}
-              onClick={props.onOpen}
-            >
-              <span class="flex min-w-0 flex-1 items-center gap-1.5">
-                <Show
-                  when={activity()}
-                  fallback={<span class="text-ink-muted">Open session</span>}
-                >
-                  {(current) => <ActivityText activity={current()} />}
-                </Show>
-              </span>
-              <ArrowUpRight aria-hidden="true" class="size-3 shrink-0" />
-            </button>
-          }
-        >
-          {(question) => (
-            <AskingCard
-              agentSessionId={props.agentSessionId}
-              asking={question()}
-              answer={props.answer}
-              onOpen={props.onOpen}
-            />
-          )}
+        <Show when={chipAsking()}>
+          {(current) => <AskingPane {...current()} />}
         </Show>
       </div>
     </Layer>

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -1,4 +1,9 @@
 import {
+  LiveQuestion,
+  type LiveQuestionRequest,
+  type RespondToElicitation,
+} from '@app/features/block-agent/component/parts/LiveElicitation';
+import {
   EmailDraft,
   EventDraft,
 } from '@app/features/block-agent/component/parts/UserToolCall';
@@ -43,6 +48,12 @@ function currentActivity(presentation: MagicChipPresentation) {
     : undefined;
 }
 
+function isTextEntry(target: EventTarget | null) {
+  return (
+    target instanceof Element && target.closest('input, textarea') !== null
+  );
+}
+
 function replyPreview(activity: MagicChipActivity | undefined) {
   if (!activity) return 'Open session';
   return `${activity.label}${activity.detail ? ` ${activity.detail}` : ''}`;
@@ -56,11 +67,12 @@ export type MagicChipAnswer = {
 };
 
 /**
- * A question the agent stopped to ask, kept small for a channel thread: what
- * is being asked, a read-only summary of a user tool's draft, and the two
- * decisions. Editing the draft, or answering a form field by field, happens
- * in the session - "Edit in session" opens it. Anyone but the session's
- * owner sees the summary and who is being waited on.
+ * A question the agent stopped to ask, answered in the thread: a form's
+ * fields, a URL's consent, or a Macro user tool's draft summarized read-only
+ * with the two decisions. The same controls the session shows, so the chip
+ * offers everything the session would except editing a tool's draft, which
+ * needs the tool's composer - `Edit in session` opens it. Anyone but the
+ * session's owner sees the question locked and who is being waited on.
  */
 const AskingCard: Component<{
   agentSessionId: string;
@@ -81,8 +93,16 @@ const AskingCard: Component<{
     });
     return call.isOk() ? { tool: call.value, draft: current.draft } : undefined;
   });
+  // Everything but a recognized user tool goes through the shared controls; a
+  // draft the tool's schema rejects falls back to the flat form the agent
+  // also sent, as the session does.
+  const question = (): LiveQuestionRequest | undefined => {
+    const current = request();
+    if (current.kind !== 'user_tool') return current;
+    return userTool() ? undefined : { kind: 'form', schema: current.schema };
+  };
   const locked = () =>
-    !props.asking.canAnswer || props.answer?.answering === true;
+    !props.asking.canAnswer || !props.answer || props.answer.answering;
   const waitingFor = () =>
     props.asking.canAnswer
       ? 'Waiting for you'
@@ -92,90 +112,106 @@ const AskingCard: Component<{
       .with('CreateCalendarEvent', () => 'Create event')
       .with('SendEmail', () => 'Send email')
       .otherwise(() => 'Confirm');
-  const respond = (answer: ElicitationAnswer) => {
-    if (locked()) return;
-    void props.answer?.respond(answer);
+  const respond: RespondToElicitation = async (answer) => {
+    if (locked()) return false;
+    return (await props.answer?.respond(answer)) ?? false;
   };
   // The chip sends the draft as the agent wrote it; edits need the session's
   // composer.
   const accept = () =>
-    respond({
+    void respond({
       action: 'accept',
-      content:
-        request().kind === 'user_tool'
-          ? { [DRAFT_FIELD]: JSON.stringify(userTool()?.draft ?? {}) }
-          : {},
+      content: { [DRAFT_FIELD]: JSON.stringify(userTool()?.draft ?? {}) },
     });
+  const openSession = (label: string) => (
+    <Button
+      variant="ghost"
+      size="xs"
+      disabled={!props.onOpen}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={props.onOpen}
+    >
+      {label}
+    </Button>
+  );
 
   return (
     <div
-      class="flex w-full min-w-0 flex-col gap-2 rounded-lg border border-edge-muted bg-surface p-3"
+      class="flex w-full min-w-0 flex-col gap-2 border-t border-edge-muted px-3 py-2.5"
       data-magic-chip={props.agentSessionId}
       data-magic-chip-asking
       data-message-reply-preview={`${waitingFor()} · ${props.asking.question.message}`}
     >
-      <div class="flex items-center gap-2 text-xs">
-        <span class="shrink-0 font-semibold text-ink-muted" aria-live="polite">
+      <div class="flex flex-col gap-0.5">
+        <span class="text-xs font-semibold text-ink-muted" aria-live="polite">
           {waitingFor()}
         </span>
-        <span class="min-w-0 truncate text-ink">
+        <span class="text-sm text-ink wrap-break-word">
           {props.asking.question.message}
         </span>
       </div>
       <Switch>
-        <Match
-          when={userTool()?.tool.name === 'CreateCalendarEvent' && userTool()}
-        >
+        <Match when={userTool()}>
           {(reviewed) => (
-            <EventDraft event={reviewed().tool.data as CreateCalendarEvent} />
+            <>
+              <Switch>
+                <Match when={reviewed().tool.name === 'CreateCalendarEvent'}>
+                  <EventDraft
+                    event={reviewed().tool.data as CreateCalendarEvent}
+                  />
+                </Match>
+                <Match when={reviewed().tool.name === 'SendEmail'}>
+                  <EmailDraft
+                    email={reviewed().tool.data as SendEmail}
+                    inFlight={false}
+                  />
+                </Match>
+              </Switch>
+              <div class="flex flex-wrap items-center gap-2">
+                <Show when={props.asking.canAnswer}>
+                  <Button
+                    variant="cta"
+                    size="xs"
+                    disabled={locked()}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={accept}
+                  >
+                    {confirmLabel()}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    disabled={locked()}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => void respond({ action: 'decline' })}
+                  >
+                    Cancel
+                  </Button>
+                </Show>
+                <span class="ml-auto">
+                  {openSession(
+                    props.asking.canAnswer ? 'Edit in session' : 'Open session'
+                  )}
+                </span>
+              </div>
+            </>
           )}
         </Match>
-        <Match when={userTool()?.tool.name === 'SendEmail' && userTool()}>
-          {(reviewed) => (
-            <EmailDraft
-              email={reviewed().tool.data as SendEmail}
-              inFlight={false}
-            />
+        <Match when={question()}>
+          {(live) => (
+            // Keyed on the request so a new question starts a fresh draft
+            // while metadata refreshes of the same one keep what was typed.
+            <Show when={String(props.asking.question.requestId)} keyed>
+              <LiveQuestion
+                request={live()}
+                locked={locked()}
+                onRespond={respond}
+                trailing={openSession('Open session')}
+              />
+            </Show>
           )}
         </Match>
       </Switch>
-      <div class="flex flex-wrap items-center gap-2">
-        <Show when={props.asking.canAnswer}>
-          <Show when={userTool()}>
-            <Button
-              variant="cta"
-              size="xs"
-              disabled={locked()}
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={accept}
-            >
-              {confirmLabel()}
-            </Button>
-          </Show>
-          <Button
-            variant="outline"
-            size="xs"
-            disabled={locked()}
-            onMouseDown={(event) => event.preventDefault()}
-            onClick={() => respond({ action: 'decline' })}
-          >
-            {userTool() ? 'Cancel' : 'Decline'}
-          </Button>
-        </Show>
-        <Button
-          variant="ghost"
-          size="xs"
-          disabled={!props.onOpen}
-          onMouseDown={(event) => event.preventDefault()}
-          onClick={props.onOpen}
-        >
-          {props.asking.canAnswer
-            ? userTool()
-              ? 'Edit in session'
-              : 'Answer in session'
-            : 'Open session'}
-        </Button>
-      </div>
     </div>
   );
 };
@@ -321,7 +357,11 @@ export const MagicChipView: Component<{
         class="my-2 w-full min-w-0 max-w-full overflow-hidden rounded-lg border border-edge-muted bg-surface"
         data-magic-chip={props.agentSessionId}
         data-magic-chip-preview
-        onMouseDown={(event) => event.preventDefault()}
+        onMouseDown={(event) => {
+          // The chip sits in a Lexical message; a press must not move the
+          // editor's selection, unless it is landing in one of its own inputs.
+          if (!isTextEntry(event.target)) event.preventDefault();
+        }}
       >
         <div
           role="button"

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -5,11 +5,9 @@ import {
   QuestionFields,
   type RespondToElicitation,
 } from '@app/features/block-agent/component/parts/LiveElicitation';
-import {
-  EmailDraft,
-  EventDraft,
-} from '@app/features/block-agent/component/parts/UserToolCall';
-import { DRAFT_FIELD } from '@app/features/block-agent/state/elicitation-review-sink';
+import { createElicitationReviewSink } from '@app/features/block-agent/state/elicitation-review-sink';
+import { CalendarDraftComposer } from '@core/component/AI/component/tool/calendar/DraftComposer';
+import { EmailDraftComposer } from '@core/component/AI/component/tool/email/DraftComposer';
 import {
   StaticMarkdown,
   StaticMarkdownContext,
@@ -17,7 +15,6 @@ import {
 import { channelTheme } from '@core/component/LexicalMarkdown/theme';
 import { PulsingStar } from '@entity/components/PulsingStar';
 import ArrowUpRight from '@phosphor/arrow-up-right.svg';
-import CaretRight from '@phosphor/caret-right.svg';
 import type { ElicitationAnswer } from '@service-agent-harness/generated/schemas';
 import { deserializeToolCall } from '@service-cognition/generated/tools/tool';
 import type {
@@ -34,7 +31,6 @@ import {
   Switch,
   untrack,
 } from 'solid-js';
-import { match } from 'ts-pattern';
 import {
   type MagicChipActivity,
   type MagicChipHeader,
@@ -47,18 +43,23 @@ function answerMarkdown(presentation: MagicChipPresentation) {
   return presentation.kind === 'working' ? undefined : presentation.markdown;
 }
 
-/** A press on one of the area's own controls is that control's, not a toggle. */
-function isControl(target: EventTarget | null) {
-  return (
-    target instanceof Element &&
-    target.closest('button, input, textarea, a, label') !== null
-  );
+const TEXT_ENTRY =
+  'input, textarea, [contenteditable]:not([contenteditable="false"])';
+
+const CONTROL = `${TEXT_ENTRY}, button, select, a, label, [role="button"], [role="option"], [role="menuitem"]`;
+
+/**
+ * A press on one of the area's own controls is that control's, not a toggle
+ * of the area (which is itself a button, so the search stops at it).
+ */
+function isControl(target: EventTarget | null, area: Element) {
+  if (!(target instanceof Element) || target === area) return false;
+  const control = target.closest(CONTROL);
+  return control !== null && control !== area && area.contains(control);
 }
 
 function isTextEntry(target: EventTarget | null) {
-  return (
-    target instanceof Element && target.closest('input, textarea') !== null
-  );
+  return target instanceof Element && target.closest(TEXT_ENTRY) !== null;
 }
 
 /** What the chip's answer to a question does. */
@@ -68,8 +69,8 @@ export type MagicChipAnswer = {
   respond: (answer: ElicitationAnswer) => Promise<boolean>;
 };
 
-/** A Macro user tool the agent drafted, awaiting the user's go-ahead. */
-type ReviewedTool = { name: string; data: unknown; draft: unknown };
+/** A Macro user tool the agent drafted, for the tool's own composer. */
+type ReviewedTool = { name: string; data: unknown };
 
 /**
  * The chip's side of a question: the shared live state for a form, URL, or
@@ -90,11 +91,7 @@ function createChipQuestion(asking: MagicChipQuestion): ChipQuestion {
   return call.isOk()
     ? {
         kind: 'user_tool',
-        tool: {
-          name: call.value.name,
-          data: call.value.data,
-          draft: request.draft,
-        },
+        tool: { name: call.value.name, data: call.value.data },
       }
     : createLiveQuestion({ kind: 'form', schema: request.schema });
 }
@@ -148,72 +145,47 @@ const ActivityText: Component<{ activity: MagicChipActivity }> = (props) => (
 
 /**
  * The decisions for a live question, on the row under the area: the refusal
- * first (`Dismiss` for a tool draft, `Decline` for a question), then the
- * go-ahead (`Send email`, `Create event`, `Submit`, `Open`), then the way
- * into the session. The chip sends a tool draft as the agent wrote it;
- * editing it is the session's.
+ * first (`Dismiss` for a tool draft, `Decline` for a question), the go-ahead
+ * for a question (`Submit`, `Open`), then the way into the session. A tool
+ * draft's go-ahead is its composer's own Send or Create, in the area.
  */
 const AskingActions: Component<ChipAsking & { onOpen?: () => void }> = (
   props
-) => {
-  const confirmLabel = (tool: ReviewedTool) =>
-    match(tool.name)
-      .with('CreateCalendarEvent', () => 'Create event')
-      .with('SendEmail', () => 'Send email')
-      .otherwise(() => 'Confirm');
-  const accept = (tool: ReviewedTool) =>
-    void props.respond({
-      action: 'accept',
-      content: { [DRAFT_FIELD]: JSON.stringify(tool.draft ?? {}) },
-    });
-  return (
-    <>
-      <Switch>
-        <Match when={reviewedTool(props.question)}>
-          {(tool) => (
-            <>
-              <Button
-                variant="outline"
-                size="xs"
-                disabled={props.locked}
-                onClick={() => void props.respond({ action: 'decline' })}
-              >
-                Dismiss
-              </Button>
-              <Button
-                variant="cta"
-                size="xs"
-                disabled={props.locked}
-                onClick={() => accept(tool())}
-              >
-                {confirmLabel(tool())}
-              </Button>
-            </>
-          )}
-        </Match>
-        <Match when={liveQuestion(props.question)}>
-          {(question) => (
-            <QuestionActions
-              question={question()}
-              locked={props.locked}
-              onRespond={props.respond}
-              cancel={false}
-              declineFirst
-            />
-          )}
-        </Match>
-      </Switch>
-      <Button
-        variant="ghost"
-        size="xs"
-        disabled={!props.onOpen}
-        onClick={props.onOpen}
-      >
-        Open in session
-      </Button>
-    </>
-  );
-};
+) => (
+  <>
+    <Switch>
+      <Match when={reviewedTool(props.question)}>
+        <Button
+          variant="outline"
+          size="xs"
+          disabled={props.locked}
+          onClick={() => void props.respond({ action: 'decline' })}
+        >
+          Dismiss
+        </Button>
+      </Match>
+      <Match when={liveQuestion(props.question)}>
+        {(question) => (
+          <QuestionActions
+            question={question()}
+            locked={props.locked}
+            onRespond={props.respond}
+            cancel={false}
+            declineFirst
+          />
+        )}
+      </Match>
+    </Switch>
+    <Button
+      variant="ghost"
+      size="xs"
+      disabled={!props.onOpen}
+      onClick={props.onOpen}
+    >
+      Open in session
+    </Button>
+  </>
+);
 
 /**
  * The chip's top row: who is answering (`Macro Agent · model`), what the turn is
@@ -308,57 +280,55 @@ const Passage: Component<{ markdown: string }> = (props) => (
 
 /**
  * The question in the passage's place: the prompt and what is asked - a
- * tool draft summarized read-only, a form's fields, a URL and its host.
+ * Macro user tool's draft in the tool's own composer (the calendar event
+ * form, the email compose), editable in place and sent from there; a form's
+ * fields; a URL and its host. Cropped at the chip's height until expanded.
  */
-const Question: Component<ChipAsking> = (props) => (
-  <div class="flex min-w-0 flex-col gap-2" data-magic-chip-asking>
-    <span class="text-sm leading-5 text-ink wrap-break-word">
-      {props.asking.question.message}
-    </span>
-    <Switch>
-      <Match when={reviewedTool(props.question)}>
-        {(tool) => (
-          <Switch>
-            <Match when={tool().name === 'CreateCalendarEvent'}>
-              <EventDraft event={tool().data as CreateCalendarEvent} />
-            </Match>
-            <Match when={tool().name === 'SendEmail'}>
-              <EmailDraft email={tool().data as SendEmail} inFlight={false} />
-            </Match>
-          </Switch>
-        )}
-      </Match>
-      <Match when={liveQuestion(props.question)}>
-        {(question) => (
-          <QuestionFields question={question()} locked={props.locked} />
-        )}
-      </Match>
-    </Switch>
-  </div>
-);
-
-/**
- * The disclosure cue: `Show more` over the fade, `Show less` under the text.
- * The collapsed cue steps aside while the area is hovered so it never sits
- * on top of the text the hover is inviting you to read.
- */
-const ExpandHint: Component<{ expanded: boolean }> = (props) => (
-  <span
-    class="pointer-events-none flex items-center gap-1 text-xs text-ink-extra-muted transition-opacity motion-reduce:transition-none"
-    classList={{
-      'absolute right-0 bottom-0 pb-0.5 group-hover/answer:opacity-0':
-        !props.expanded,
-      'pt-1 pb-0.5': props.expanded,
-    }}
-    aria-hidden="true"
-  >
-    <CaretRight
-      class="size-3 shrink-0 transition-transform motion-reduce:transition-none"
-      classList={{ 'rotate-90': props.expanded }}
-    />
-    {props.expanded ? 'Show less' : 'Show more'}
-  </span>
-);
+const Question: Component<ChipAsking> = (props) => {
+  const reviewKey = () =>
+    props.asking.question.toolCall ?? String(props.asking.question.requestId);
+  const sink = <T,>() =>
+    createElicitationReviewSink<T>({
+      canAnswer: () => props.asking.canAnswer,
+      ownerName: () => props.asking.ownerName,
+      answering: () => props.locked && props.asking.canAnswer,
+      respond: props.respond,
+    });
+  return (
+    <div class="flex min-w-0 flex-col gap-2" data-magic-chip-asking>
+      <span class="text-sm leading-5 text-ink wrap-break-word">
+        {props.asking.question.message}
+      </span>
+      <Switch>
+        <Match when={reviewedTool(props.question)}>
+          {(tool) => (
+            <Switch>
+              <Match when={tool().name === 'CreateCalendarEvent'}>
+                <CalendarDraftComposer
+                  initialData={tool().data as CreateCalendarEvent}
+                  sink={sink<CreateCalendarEvent>()}
+                  previewKey={reviewKey()}
+                />
+              </Match>
+              <Match when={tool().name === 'SendEmail'}>
+                <EmailDraftComposer
+                  initialData={tool().data as SendEmail}
+                  sink={sink<SendEmail>()}
+                  debugName={`magic-chip-review:${reviewKey()}`}
+                />
+              </Match>
+            </Switch>
+          )}
+        </Match>
+        <Match when={liveQuestion(props.question)}>
+          {(question) => (
+            <QuestionFields question={question()} locked={props.locked} />
+          )}
+        </Match>
+      </Switch>
+    </div>
+  );
+};
 
 /**
  * One card for the whole turn, at one height: a header naming the persona,
@@ -366,7 +336,7 @@ const ExpandHint: Component<{ expanded: boolean }> = (props) => (
  * over an area that holds the agent's latest passage - a pulsing star while
  * the agent is busy before it writes, the passage as it streams, the final
  * passage once the turn ends - or, while the agent waits on a question, the
- * question itself with its decisions on the row beneath. The area is clipped
+ * question itself with its decisions on the row beneath. The area is cropped
  * with a fade; clicking it expands it in place.
  */
 export const MagicChipView: Component<{
@@ -425,8 +395,8 @@ export const MagicChipView: Component<{
   };
 
   // Before there is anything to expand, the whole card leads to the session.
-  const onAreaClick = (event: MouseEvent) => {
-    if (isControl(event.target)) return;
+  const onAreaClick = (event: MouseEvent & { currentTarget: Element }) => {
+    if (isControl(event.target, event.currentTarget)) return;
     if (expandable()) setExpanded((open) => !open);
     else props.onOpen?.();
   };
@@ -453,7 +423,7 @@ export const MagicChipView: Component<{
           role="button"
           tabIndex={0}
           aria-expanded={expandable() ? expanded() : undefined}
-          class="group/answer flex min-w-0 flex-col text-left hover:bg-hover"
+          class="flex min-w-0 flex-col text-left"
           classList={{ 'h-41': !expanded() }}
           data-magic-chip-answer
           onClick={onAreaClick}
@@ -483,21 +453,12 @@ export const MagicChipView: Component<{
             >
               {(current) => <Question {...current()} />}
             </Show>
-            <Show when={expandable()}>
-              <Show
-                when={expanded()}
-                fallback={
-                  <>
-                    <div
-                      class="pointer-events-none absolute inset-x-0 top-1/2 bottom-0 bg-linear-to-b from-transparent via-surface/80 to-surface group-hover/answer:via-hover/80 group-hover/answer:to-hover"
-                      data-magic-chip-fade
-                    />
-                    <ExpandHint expanded={false} />
-                  </>
-                }
-              >
-                <ExpandHint expanded />
-              </Show>
+            {/* Cropped content fades out; expanding shows it whole. */}
+            <Show when={expandable() && !expanded()}>
+              <div
+                class="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-linear-to-t from-surface to-transparent"
+                data-magic-chip-fade
+              />
             </Show>
           </div>
           <Show when={chipAsking()?.asking.canAnswer && chipAsking()}>

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -5,6 +5,10 @@ import {
   QuestionFields,
   type RespondToElicitation,
 } from '@app/features/block-agent/component/parts/LiveElicitation';
+import {
+  EmailDraft,
+  EventDraft,
+} from '@app/features/block-agent/component/parts/UserToolCall';
 import { DRAFT_FIELD } from '@app/features/block-agent/state/elicitation-review-sink';
 import {
   StaticMarkdown,
@@ -16,12 +20,15 @@ import ArrowUpRight from '@phosphor/arrow-up-right.svg';
 import CaretRight from '@phosphor/caret-right.svg';
 import type { ElicitationAnswer } from '@service-agent-harness/generated/schemas';
 import { deserializeToolCall } from '@service-cognition/generated/tools/tool';
+import type {
+  CreateCalendarEvent,
+  SendEmail,
+} from '@service-cognition/generated/tools/types';
 import { Button, Layer } from '@ui';
 import {
   type Component,
   createMemo,
   createSignal,
-  type JSX,
   Match,
   Show,
   Switch,
@@ -54,7 +61,7 @@ export type MagicChipAnswer = {
 };
 
 /** A Macro user tool the agent drafted, awaiting the user's go-ahead. */
-type ReviewedTool = { name: string; draft: unknown };
+type ReviewedTool = { name: string; data: unknown; draft: unknown };
 
 /**
  * The chip's side of a question: the shared live state for a form, URL, or
@@ -75,7 +82,11 @@ function createChipQuestion(asking: MagicChipQuestion): ChipQuestion {
   return call.isOk()
     ? {
         kind: 'user_tool',
-        tool: { name: call.value.name, draft: request.draft },
+        tool: {
+          name: call.value.name,
+          data: call.value.data,
+          draft: request.draft,
+        },
       }
     : createLiveQuestion({ kind: 'form', schema: request.schema });
 }
@@ -128,8 +139,8 @@ const ActivityText: Component<{ activity: MagicChipActivity }> = (props) => (
 );
 
 /**
- * The decisions for a live question, as buttons for the header: Submit or
- * Open with Decline for a question; a Macro user tool's single go-ahead
+ * The decisions for a live question, at the bottom right of the body: Submit
+ * or Open with Decline for a question; a Macro user tool's single go-ahead
  * (Create event, Send email), the rest of the review being the session's.
  * The chip sends a tool draft as the agent wrote it.
  */
@@ -175,15 +186,13 @@ const AskingActions: Component<ChipAsking> = (props) => {
 /**
  * The chip's top row: who is answering (`@bot · model`), what the turn is
  * doing, and the way into the session. The whole label opens the session,
- * as does the arrow; while a question is live its decisions sit before the
- * arrow.
+ * as does the arrow.
  */
 const ChipHeader: Component<{
   header?: MagicChipHeader;
   status: MagicChipActivity;
   /** The reply preview, while the answer area has nothing to offer. */
   preview?: string;
-  decisions?: JSX.Element;
   onOpen?: () => void;
 }> = (props) => (
   <div
@@ -224,7 +233,6 @@ const ChipHeader: Component<{
       </Show>
       <ActivityText activity={props.status} />
     </button>
-    {props.decisions}
     <Button
       variant="ghost"
       size="icon-xs"
@@ -315,34 +323,55 @@ const ExpandHint: Component<{ expanded: boolean }> = (props) => (
 );
 
 /**
- * A form or URL question's prompt and fields, scrolling inside the chip's
- * height. The pane contributes no height of its own, so a long form never
- * grows the card. Beside an answer it takes the right side; when the agent
- * wrote nothing it is the whole card. Its decisions are in the header.
+ * The question in the answer area's place: the prompt and what is asked - a
+ * form's fields, a URL and its host, a tool draft summarized read-only -
+ * scrolling inside the chip's height, with the decisions at the bottom
+ * right. Anyone but the owner sees it read-only.
  */
-const AskingPane: Component<
-  ChipAsking & { question: LiveQuestion; beside: boolean }
-> = (props) => (
-  <div
-    class="relative"
-    classList={{
-      'w-[45%] min-w-40 max-w-72 shrink-0 border-l border-edge-muted':
-        props.beside,
-      'min-w-0 flex-1': !props.beside,
-    }}
-    data-magic-chip-pane
-  >
-    <div class="absolute inset-0 flex flex-col gap-2 overflow-y-auto px-3 py-2">
-      <span class="text-sm leading-5 text-ink wrap-break-word">
-        {props.asking.question.message}
-      </span>
-      <QuestionFields question={props.question} locked={props.locked} />
+const AskingBody: Component<ChipAsking> = (props) => (
+  <div class="flex h-22 min-w-0 flex-col" data-magic-chip-asking>
+    <div class="relative min-h-0 flex-1">
+      <div class="absolute inset-0 flex flex-col gap-2 overflow-y-auto px-3 pt-2 pb-3">
+        <span class="text-sm leading-5 text-ink wrap-break-word">
+          {props.asking.question.message}
+        </span>
+        <Switch>
+          <Match when={reviewedTool(props.question)}>
+            {(tool) => (
+              <Switch>
+                <Match when={tool().name === 'CreateCalendarEvent'}>
+                  <EventDraft event={tool().data as CreateCalendarEvent} />
+                </Match>
+                <Match when={tool().name === 'SendEmail'}>
+                  <EmailDraft
+                    email={tool().data as SendEmail}
+                    inFlight={false}
+                  />
+                </Match>
+              </Switch>
+            )}
+          </Match>
+          <Match when={liveQuestion(props.question)}>
+            {(question) => (
+              <QuestionFields question={question()} locked={props.locked} />
+            )}
+          </Match>
+        </Switch>
+      </div>
+      {/* The area clips; the fade says there is more below. */}
+      <div
+        aria-hidden="true"
+        class="pointer-events-none absolute inset-x-0 bottom-0 h-4 bg-linear-to-t from-surface to-transparent"
+      />
     </div>
-    {/* The pane clips; the fade says there is more below. */}
-    <div
-      aria-hidden="true"
-      class="pointer-events-none absolute inset-x-0 bottom-0 h-4 bg-linear-to-t from-surface to-transparent"
-    />
+    <Show when={props.asking.canAnswer}>
+      <div
+        class="flex shrink-0 items-center justify-end gap-2 px-3 pb-2"
+        data-magic-chip-decisions
+      >
+        <AskingActions {...props} />
+      </div>
+    </Show>
   </div>
 );
 
@@ -352,9 +381,8 @@ const AskingPane: Component<
  * an area that holds the agent's latest passage - a pulsing star while the
  * agent is busy before it writes, the passage as it streams, and the final
  * passage once the turn ends. Clicking the passage expands it in place. A
- * question the agent stops to ask puts its fields in a pane beside the
- * passage (or in its place, when nothing was said) and its decisions in the
- * header.
+ * question the agent stops to ask takes the area instead, its decisions at
+ * the bottom right, until it is answered.
  */
 export const MagicChipView: Component<{
   agentSessionId: string;
@@ -399,22 +427,13 @@ export const MagicChipView: Component<{
         locked ? false : ((await props.answer?.respond(answer)) ?? false),
     };
   };
-  // A form or URL has fields to show; a tool review is its one button.
-  const pane = () => {
-    const current = chipAsking();
-    const live = current && liveQuestion(current.question);
-    return current && live ? { ...current, question: live } : undefined;
-  };
-  // The agent's side is shown while it has said something, or while there is
-  // no question to give the room to.
-  const showAnswer = () => Boolean(markdown()) || !pane();
   // While the answer area has no prose, a reply to the message previews the
   // header's line instead.
   const preview = () => {
-    if (markdown()) return undefined;
+    const live = asking();
+    if (markdown() && !live) return undefined;
     const current = status();
     const line = `${current.label}${current.detail ? ` ${current.detail}` : ''}`;
-    const live = asking();
     return live ? `${line} · ${live.question.message}` : line;
   };
 
@@ -441,45 +460,36 @@ export const MagicChipView: Component<{
           header={props.header}
           status={status()}
           preview={preview()}
-          decisions={
-            <Show when={chipAsking()}>
-              {(current) => (
-                <Show when={current().asking.canAnswer}>
-                  <AskingActions {...current()} />
-                </Show>
-              )}
-            </Show>
-          }
           onOpen={props.onOpen}
         />
-        <div class="flex min-h-22">
-          <div
-            role="button"
-            tabIndex={0}
-            aria-expanded={markdown() ? expanded() : undefined}
-            class="group/answer min-w-0 flex-1 px-3 py-1 text-left hover:bg-hover"
-            classList={{ 'h-22': !expanded(), hidden: !showAnswer() }}
-            data-magic-chip-answer
-            onClick={onAnswerClick}
-            onKeyDown={(event) => {
-              if (event.key !== 'Enter' && event.key !== ' ') return;
-              event.preventDefault();
-              onAnswerClick();
-            }}
+        {/* The passage stays mounted under a question so its expanded state
+            survives the question being answered. */}
+        <div
+          role="button"
+          tabIndex={0}
+          aria-expanded={markdown() ? expanded() : undefined}
+          class="group/answer min-w-0 px-3 py-1 text-left hover:bg-hover"
+          classList={{ 'h-22': !expanded(), hidden: Boolean(chipAsking()) }}
+          data-magic-chip-answer
+          onClick={onAnswerClick}
+          onKeyDown={(event) => {
+            if (event.key !== 'Enter' && event.key !== ' ') return;
+            event.preventDefault();
+            onAnswerClick();
+          }}
+        >
+          <Show
+            when={markdown()}
+            fallback={<AnswerPending busy={status().busy} />}
           >
-            <Show
-              when={markdown()}
-              fallback={<AnswerPending busy={status().busy} />}
-            >
-              {(answer) => (
-                <AnswerBody markdown={answer()} expanded={expanded()} />
-              )}
-            </Show>
-          </div>
-          <Show when={pane()}>
-            {(current) => <AskingPane {...current()} beside={showAnswer()} />}
+            {(answer) => (
+              <AnswerBody markdown={answer()} expanded={expanded()} />
+            )}
           </Show>
         </div>
+        <Show when={chipAsking()}>
+          {(current) => <AskingBody {...current()} />}
+        </Show>
       </div>
     </Layer>
   );

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -329,7 +329,7 @@ const ExpandHint: Component<{ expanded: boolean }> = (props) => (
  * right. Anyone but the owner sees it read-only.
  */
 const AskingBody: Component<ChipAsking> = (props) => (
-  <div class="flex h-22 min-w-0 flex-col" data-magic-chip-asking>
+  <div class="flex h-41 min-w-0 flex-col" data-magic-chip-asking>
     <div class="relative min-h-0 flex-1">
       <div class="absolute inset-0 flex flex-col gap-2 overflow-y-auto px-3 pt-2 pb-3">
         <span class="text-sm leading-5 text-ink wrap-break-word">
@@ -469,7 +469,7 @@ export const MagicChipView: Component<{
           tabIndex={0}
           aria-expanded={markdown() ? expanded() : undefined}
           class="group/answer min-w-0 px-3 py-1 text-left hover:bg-hover"
-          classList={{ 'h-22': !expanded(), hidden: Boolean(chipAsking()) }}
+          classList={{ 'h-41': !expanded(), hidden: Boolean(chipAsking()) }}
           data-magic-chip-answer
           onClick={onAnswerClick}
           onKeyDown={(event) => {

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -1,13 +1,13 @@
 import {
   createLiveQuestion,
+  type DraftedTool,
   type LiveQuestion,
+  parseDraftedTool,
   QuestionActions,
   QuestionFields,
   type RespondToElicitation,
+  UserToolComposer,
 } from '@app/features/block-agent/component/parts/LiveElicitation';
-import { createElicitationReviewSink } from '@app/features/block-agent/state/elicitation-review-sink';
-import { CalendarDraftComposer } from '@core/component/AI/component/tool/calendar/DraftComposer';
-import { EmailDraftComposer } from '@core/component/AI/component/tool/email/DraftComposer';
 import {
   StaticMarkdown,
   StaticMarkdownContext,
@@ -16,11 +16,6 @@ import { channelTheme } from '@core/component/LexicalMarkdown/theme';
 import { PulsingStar } from '@entity/components/PulsingStar';
 import ArrowUpRight from '@phosphor/arrow-up-right.svg';
 import type { ElicitationAnswer } from '@service-agent-harness/generated/schemas';
-import { deserializeToolCall } from '@service-cognition/generated/tools/tool';
-import type {
-  CreateCalendarEvent,
-  SendEmail,
-} from '@service-cognition/generated/tools/types';
 import { Button, Layer } from '@ui';
 import {
   type Component,
@@ -69,35 +64,29 @@ export type MagicChipAnswer = {
   respond: (answer: ElicitationAnswer) => Promise<boolean>;
 };
 
-/** A Macro user tool the agent drafted, for the tool's own composer. */
-type ReviewedTool = { name: string; data: unknown };
-
 /**
  * The chip's side of a question: the shared live state for a form, URL, or
- * unknown mode, or a recognized Macro user tool's draft. A draft the tool's
- * schema rejects falls back to the flat form the agent also sent, as the
- * session does.
+ * unknown mode, or a Macro user tool's draft for the tool's own composer. A
+ * draft the tool's schema rejects falls back to the flat form the agent also
+ * sent, as the session does.
  */
-type ChipQuestion = LiveQuestion | { kind: 'user_tool'; tool: ReviewedTool };
+type ChipQuestion =
+  | LiveQuestion
+  | { kind: 'user_tool'; tool: DraftedTool; toolCall: string };
 
 function createChipQuestion(asking: MagicChipQuestion): ChipQuestion {
   const request = asking.question.request;
   if (request.kind !== 'user_tool') return createLiveQuestion(request);
-  const call = deserializeToolCall({
-    id: asking.question.toolCall ?? String(asking.question.requestId),
-    name: request.tool,
-    json: request.draft,
-  });
-  return call.isOk()
-    ? {
-        kind: 'user_tool',
-        tool: { name: call.value.name, data: call.value.data },
-      }
+  const toolCall =
+    asking.question.toolCall ?? String(asking.question.requestId);
+  const tool = parseDraftedTool(request, toolCall);
+  return tool
+    ? { kind: 'user_tool', tool, toolCall }
     : createLiveQuestion({ kind: 'form', schema: request.schema });
 }
 
 function reviewedTool(question: ChipQuestion) {
-  return question.kind === 'user_tool' ? question.tool : undefined;
+  return question.kind === 'user_tool' ? question : undefined;
 }
 
 function liveQuestion(question: ChipQuestion): LiveQuestion | undefined {
@@ -280,55 +269,43 @@ const Passage: Component<{ markdown: string }> = (props) => (
 
 /**
  * The question in the passage's place: the prompt and what is asked - a
- * Macro user tool's draft in the tool's own composer (the calendar event
- * form, the email compose), editable in place and sent from there; a form's
- * fields; a URL and its host. Cropped at the chip's height until expanded.
+ * Macro user tool's draft in the tool's own composer, editable in place and
+ * sent from there; a form's fields; a URL and its host. Cropped at the
+ * chip's height until expanded.
  */
-const Question: Component<ChipAsking> = (props) => {
-  const reviewKey = () =>
-    props.asking.question.toolCall ?? String(props.asking.question.requestId);
-  const sink = <T,>() =>
-    createElicitationReviewSink<T>({
-      canAnswer: () => props.asking.canAnswer,
-      ownerName: () => props.asking.ownerName,
-      answering: () => props.locked && props.asking.canAnswer,
-      respond: props.respond,
-    });
-  return (
-    <div class="flex min-w-0 flex-col gap-2" data-magic-chip-asking>
-      <span class="text-sm leading-5 text-ink wrap-break-word">
-        {props.asking.question.message}
-      </span>
-      <Switch>
-        <Match when={reviewedTool(props.question)}>
-          {(tool) => (
-            <Switch>
-              <Match when={tool().name === 'CreateCalendarEvent'}>
-                <CalendarDraftComposer
-                  initialData={tool().data as CreateCalendarEvent}
-                  sink={sink<CreateCalendarEvent>()}
-                  previewKey={reviewKey()}
-                />
-              </Match>
-              <Match when={tool().name === 'SendEmail'}>
-                <EmailDraftComposer
-                  initialData={tool().data as SendEmail}
-                  sink={sink<SendEmail>()}
-                  debugName={`magic-chip-review:${reviewKey()}`}
-                />
-              </Match>
-            </Switch>
-          )}
-        </Match>
-        <Match when={liveQuestion(props.question)}>
-          {(question) => (
-            <QuestionFields question={question()} locked={props.locked} />
-          )}
-        </Match>
-      </Switch>
-    </div>
-  );
-};
+const Question: Component<ChipAsking> = (props) => (
+  <div class="flex min-w-0 flex-col gap-2" data-magic-chip-asking>
+    <span class="text-sm leading-5 text-ink wrap-break-word">
+      {props.asking.question.message}
+    </span>
+    <Switch>
+      <Match when={reviewedTool(props.question)}>
+        {(review) => (
+          // A press anywhere in the composer is the composer's: its widgets
+          // are not all controls the area could recognize, and none may
+          // collapse it mid-edit.
+          <div onClick={(event) => event.stopPropagation()}>
+            <UserToolComposer
+              tool={review().tool}
+              toolCall={review().toolCall}
+              review={{
+                canAnswer: () => props.asking.canAnswer,
+                ownerName: () => props.asking.ownerName,
+                answering: () => props.locked && props.asking.canAnswer,
+                respond: props.respond,
+              }}
+            />
+          </div>
+        )}
+      </Match>
+      <Match when={liveQuestion(props.question)}>
+        {(question) => (
+          <QuestionFields question={question()} locked={props.locked} />
+        )}
+      </Match>
+    </Switch>
+  </div>
+);
 
 /**
  * One card for the whole turn, at one height: a header naming the persona,
@@ -348,12 +325,12 @@ export const MagicChipView: Component<{
   answer?: MagicChipAnswer;
   onOpen?: () => void;
 }> = (props) => {
-  const asking = () =>
-    props.presentation.kind === 'asking'
-      ? props.presentation.asking
-      : undefined;
-  const markdown = () => answerMarkdown(props.presentation);
-  const status = () => presentationStatus(props.presentation);
+  // Memoized: read from many places per flush, once per streamed chunk.
+  const asking = createMemo(() =>
+    props.presentation.kind === 'asking' ? props.presentation.asking : undefined
+  );
+  const markdown = createMemo(() => answerMarkdown(props.presentation));
+  const status = createMemo(() => presentationStatus(props.presentation));
   const [expanded, setExpanded] = createSignal(false);
 
   // One draft per question: keyed on the request id so metadata refreshes of

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -47,6 +47,14 @@ function answerMarkdown(presentation: MagicChipPresentation) {
   return presentation.kind === 'working' ? undefined : presentation.markdown;
 }
 
+/** A press on one of the area's own controls is that control's, not a toggle. */
+function isControl(target: EventTarget | null) {
+  return (
+    target instanceof Element &&
+    target.closest('button, input, textarea, a, label') !== null
+  );
+}
+
 function isTextEntry(target: EventTarget | null) {
   return (
     target instanceof Element && target.closest('input, textarea') !== null
@@ -139,12 +147,15 @@ const ActivityText: Component<{ activity: MagicChipActivity }> = (props) => (
 );
 
 /**
- * The decisions for a live question, at the bottom right of the body: Submit
- * or Open with Decline for a question; a Macro user tool's single go-ahead
- * (Create event, Send email), the rest of the review being the session's.
- * The chip sends a tool draft as the agent wrote it.
+ * The decisions for a live question, on the row under the area: the refusal
+ * first (`Dismiss` for a tool draft, `Decline` for a question), then the
+ * go-ahead (`Send email`, `Create event`, `Submit`, `Open`), then the way
+ * into the session. The chip sends a tool draft as the agent wrote it;
+ * editing it is the session's.
  */
-const AskingActions: Component<ChipAsking> = (props) => {
+const AskingActions: Component<ChipAsking & { onOpen?: () => void }> = (
+  props
+) => {
   const confirmLabel = (tool: ReviewedTool) =>
     match(tool.name)
       .with('CreateCalendarEvent', () => 'Create event')
@@ -156,35 +167,56 @@ const AskingActions: Component<ChipAsking> = (props) => {
       content: { [DRAFT_FIELD]: JSON.stringify(tool.draft ?? {}) },
     });
   return (
-    <Switch>
-      <Match when={reviewedTool(props.question)}>
-        {(tool) => (
-          <Button
-            variant="cta"
-            size="xs"
-            disabled={props.locked}
-            onClick={() => accept(tool())}
-          >
-            {confirmLabel(tool())}
-          </Button>
-        )}
-      </Match>
-      <Match when={liveQuestion(props.question)}>
-        {(question) => (
-          <QuestionActions
-            question={question()}
-            locked={props.locked}
-            onRespond={props.respond}
-            cancel={false}
-          />
-        )}
-      </Match>
-    </Switch>
+    <>
+      <Switch>
+        <Match when={reviewedTool(props.question)}>
+          {(tool) => (
+            <>
+              <Button
+                variant="outline"
+                size="xs"
+                disabled={props.locked}
+                onClick={() => void props.respond({ action: 'decline' })}
+              >
+                Dismiss
+              </Button>
+              <Button
+                variant="cta"
+                size="xs"
+                disabled={props.locked}
+                onClick={() => accept(tool())}
+              >
+                {confirmLabel(tool())}
+              </Button>
+            </>
+          )}
+        </Match>
+        <Match when={liveQuestion(props.question)}>
+          {(question) => (
+            <QuestionActions
+              question={question()}
+              locked={props.locked}
+              onRespond={props.respond}
+              cancel={false}
+              declineFirst
+            />
+          )}
+        </Match>
+      </Switch>
+      <Button
+        variant="ghost"
+        size="xs"
+        disabled={!props.onOpen}
+        onClick={props.onOpen}
+      >
+        Open in session
+      </Button>
+    </>
   );
 };
 
 /**
- * The chip's top row: who is answering (`@bot · model`), what the turn is
+ * The chip's top row: who is answering (`Macro Agent · model`), what the turn is
  * doing, and the way into the session. The whole label opens the session,
  * as does the arrow.
  */
@@ -209,7 +241,7 @@ const ChipHeader: Component<{
     >
       <Show when={props.header?.agent}>
         {(agent) => (
-          <span class="shrink-0 font-semibold text-ink">@{agent()}</span>
+          <span class="shrink-0 font-semibold text-ink">{agent()}</span>
         )}
       </Show>
       <Show when={props.header?.model}>
@@ -262,40 +294,46 @@ const AnswerPending: Component<{ busy: boolean }> = (props) => (
   </Show>
 );
 
-/**
- * The answer: clipped to the fixed answer area with a fade while collapsed,
- * whole once expanded.
- */
-const AnswerBody: Component<{ markdown: string; expanded: boolean }> = (
-  props
-) => (
+/** The agent's passage, inert so the area's click is the disclosure. */
+const Passage: Component<{ markdown: string }> = (props) => (
   <div
-    class="relative"
-    classList={{ 'h-full overflow-hidden': !props.expanded }}
-    data-magic-chip-clip
+    class="pointer-events-none min-w-0 max-w-full wrap-break-word"
+    data-message-reply-preview
   >
-    <div
-      class="pointer-events-none min-w-0 max-w-full wrap-break-word"
-      data-message-reply-preview
-    >
-      <StaticMarkdownContext theme={channelTheme}>
-        <StaticMarkdown markdown={props.markdown} target="external" />
-      </StaticMarkdownContext>
-    </div>
-    <Show
-      when={props.expanded}
-      fallback={
-        <>
-          <div
-            class="pointer-events-none absolute inset-x-0 top-1/2 bottom-0 bg-linear-to-b from-transparent via-surface/80 to-surface group-hover/answer:via-hover/80 group-hover/answer:to-hover"
-            data-magic-chip-fade
-          />
-          <ExpandHint expanded={false} />
-        </>
-      }
-    >
-      <ExpandHint expanded />
-    </Show>
+    <StaticMarkdownContext theme={channelTheme}>
+      <StaticMarkdown markdown={props.markdown} target="external" />
+    </StaticMarkdownContext>
+  </div>
+);
+
+/**
+ * The question in the passage's place: the prompt and what is asked - a
+ * tool draft summarized read-only, a form's fields, a URL and its host.
+ */
+const Question: Component<ChipAsking> = (props) => (
+  <div class="flex min-w-0 flex-col gap-2" data-magic-chip-asking>
+    <span class="text-sm leading-5 text-ink wrap-break-word">
+      {props.asking.question.message}
+    </span>
+    <Switch>
+      <Match when={reviewedTool(props.question)}>
+        {(tool) => (
+          <Switch>
+            <Match when={tool().name === 'CreateCalendarEvent'}>
+              <EventDraft event={tool().data as CreateCalendarEvent} />
+            </Match>
+            <Match when={tool().name === 'SendEmail'}>
+              <EmailDraft email={tool().data as SendEmail} inFlight={false} />
+            </Match>
+          </Switch>
+        )}
+      </Match>
+      <Match when={liveQuestion(props.question)}>
+        {(question) => (
+          <QuestionFields question={question()} locked={props.locked} />
+        )}
+      </Match>
+    </Switch>
   </div>
 );
 
@@ -323,66 +361,13 @@ const ExpandHint: Component<{ expanded: boolean }> = (props) => (
 );
 
 /**
- * The question in the answer area's place: the prompt and what is asked - a
- * form's fields, a URL and its host, a tool draft summarized read-only -
- * scrolling inside the chip's height, with the decisions at the bottom
- * right. Anyone but the owner sees it read-only.
- */
-const AskingBody: Component<ChipAsking> = (props) => (
-  <div class="flex h-41 min-w-0 flex-col" data-magic-chip-asking>
-    <div class="relative min-h-0 flex-1">
-      <div class="absolute inset-0 flex flex-col gap-2 overflow-y-auto px-3 pt-2 pb-3">
-        <span class="text-sm leading-5 text-ink wrap-break-word">
-          {props.asking.question.message}
-        </span>
-        <Switch>
-          <Match when={reviewedTool(props.question)}>
-            {(tool) => (
-              <Switch>
-                <Match when={tool().name === 'CreateCalendarEvent'}>
-                  <EventDraft event={tool().data as CreateCalendarEvent} />
-                </Match>
-                <Match when={tool().name === 'SendEmail'}>
-                  <EmailDraft
-                    email={tool().data as SendEmail}
-                    inFlight={false}
-                  />
-                </Match>
-              </Switch>
-            )}
-          </Match>
-          <Match when={liveQuestion(props.question)}>
-            {(question) => (
-              <QuestionFields question={question()} locked={props.locked} />
-            )}
-          </Match>
-        </Switch>
-      </div>
-      {/* The area clips; the fade says there is more below. */}
-      <div
-        aria-hidden="true"
-        class="pointer-events-none absolute inset-x-0 bottom-0 h-4 bg-linear-to-t from-surface to-transparent"
-      />
-    </div>
-    <Show when={props.asking.canAnswer}>
-      <div
-        class="flex shrink-0 items-center justify-end gap-2 px-3 pb-2"
-        data-magic-chip-decisions
-      >
-        <AskingActions {...props} />
-      </div>
-    </Show>
-  </div>
-);
-
-/**
- * One card for the whole turn, at one height: a header naming the bot, its
- * model, and what the turn is doing (with the way into the session), over
- * an area that holds the agent's latest passage - a pulsing star while the
- * agent is busy before it writes, the passage as it streams, and the final
- * passage once the turn ends. Clicking the passage expands it in place. A
- * question the agent stops to ask takes the area instead, its decisions at
- * the bottom right, until it is answered.
+ * One card for the whole turn, at one height: a header naming the persona,
+ * its model, and what the turn is doing (clicking it opens the session),
+ * over an area that holds the agent's latest passage - a pulsing star while
+ * the agent is busy before it writes, the passage as it streams, the final
+ * passage once the turn ends - or, while the agent waits on a question, the
+ * question itself with its decisions on the row beneath. The area is clipped
+ * with a fade; clicking it expands it in place.
  */
 export const MagicChipView: Component<{
   agentSessionId: string;
@@ -427,6 +412,8 @@ export const MagicChipView: Component<{
         locked ? false : ((await props.answer?.respond(answer)) ?? false),
     };
   };
+  // There is something to expand once the agent has written, or asked.
+  const expandable = () => Boolean(markdown()) || Boolean(chipAsking());
   // While the answer area has no prose, a reply to the message previews the
   // header's line instead.
   const preview = () => {
@@ -437,10 +424,10 @@ export const MagicChipView: Component<{
     return live ? `${line} · ${live.question.message}` : line;
   };
 
-  // Before there is an answer there is nothing to expand, so the whole card
-  // leads to the session.
-  const onAnswerClick = () => {
-    if (markdown()) setExpanded((open) => !open);
+  // Before there is anything to expand, the whole card leads to the session.
+  const onAreaClick = (event: MouseEvent) => {
+    if (isControl(event.target)) return;
+    if (expandable()) setExpanded((open) => !open);
     else props.onOpen?.();
   };
 
@@ -462,34 +449,68 @@ export const MagicChipView: Component<{
           preview={preview()}
           onOpen={props.onOpen}
         />
-        {/* The passage stays mounted under a question so its expanded state
-            survives the question being answered. */}
         <div
           role="button"
           tabIndex={0}
-          aria-expanded={markdown() ? expanded() : undefined}
-          class="group/answer min-w-0 px-3 py-1 text-left hover:bg-hover"
-          classList={{ 'h-41': !expanded(), hidden: Boolean(chipAsking()) }}
+          aria-expanded={expandable() ? expanded() : undefined}
+          class="group/answer flex min-w-0 flex-col text-left hover:bg-hover"
+          classList={{ 'h-41': !expanded() }}
           data-magic-chip-answer
-          onClick={onAnswerClick}
+          onClick={onAreaClick}
           onKeyDown={(event) => {
+            if (event.target !== event.currentTarget) return;
             if (event.key !== 'Enter' && event.key !== ' ') return;
             event.preventDefault();
-            onAnswerClick();
+            if (expandable()) setExpanded((open) => !open);
+            else props.onOpen?.();
           }}
         >
-          <Show
-            when={markdown()}
-            fallback={<AnswerPending busy={status().busy} />}
+          <div
+            class="relative mx-3 mt-1 mb-1 min-h-0 flex-1"
+            classList={{ 'overflow-hidden': !expanded() }}
+            data-magic-chip-clip
           >
-            {(answer) => (
-              <AnswerBody markdown={answer()} expanded={expanded()} />
+            <Show
+              when={chipAsking()}
+              fallback={
+                <Show
+                  when={markdown()}
+                  fallback={<AnswerPending busy={status().busy} />}
+                >
+                  {(answer) => <Passage markdown={answer()} />}
+                </Show>
+              }
+            >
+              {(current) => <Question {...current()} />}
+            </Show>
+            <Show when={expandable()}>
+              <Show
+                when={expanded()}
+                fallback={
+                  <>
+                    <div
+                      class="pointer-events-none absolute inset-x-0 top-1/2 bottom-0 bg-linear-to-b from-transparent via-surface/80 to-surface group-hover/answer:via-hover/80 group-hover/answer:to-hover"
+                      data-magic-chip-fade
+                    />
+                    <ExpandHint expanded={false} />
+                  </>
+                }
+              >
+                <ExpandHint expanded />
+              </Show>
+            </Show>
+          </div>
+          <Show when={chipAsking()?.asking.canAnswer && chipAsking()}>
+            {(current) => (
+              <div
+                class="flex shrink-0 items-center justify-end gap-2 px-3 pb-2"
+                data-magic-chip-decisions
+              >
+                <AskingActions {...current()} onOpen={props.onOpen} />
+              </div>
             )}
           </Show>
         </div>
-        <Show when={chipAsking()}>
-          {(current) => <AskingBody {...current()} />}
-        </Show>
       </div>
     </Layer>
   );

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -117,52 +117,75 @@ type ChipAsking = {
 };
 
 /**
- * The question, beside the answer: who is being waited on, the prompt, and
- * the fields - a form's choices, a URL and its host, a tool draft summarized
- * read-only. The pane takes the chip's height and scrolls inside it, so a
- * long form never grows the card; it contributes no height of its own.
+ * The question: who is being waited on with the way into the session at the
+ * top, then the prompt and the fields - a form's choices, a URL and its
+ * host, a tool draft summarized read-only - scrolling inside the chip's
+ * height. The pane contributes no height of its own, so a long form never
+ * grows the card. Beside an answer it takes the right side; when the agent
+ * wrote nothing it is the whole card.
  */
-const AskingPane: Component<ChipAsking> = (props) => {
+const AskingPane: Component<
+  ChipAsking & { beside: boolean; onOpen?: () => void }
+> = (props) => {
   const waitingFor = () =>
     props.asking.canAnswer
       ? 'Waiting for you'
       : `Waiting for ${props.asking.ownerName}`;
   return (
     <div
-      class="relative w-[45%] min-w-40 max-w-72 shrink-0 border-l border-edge-muted"
+      class="relative"
+      classList={{
+        'w-[45%] min-w-40 max-w-72 shrink-0 border-l border-edge-muted':
+          props.beside,
+        'min-w-0 flex-1': !props.beside,
+      }}
       data-magic-chip-pane
     >
-      <div class="absolute inset-0 flex flex-col gap-2 overflow-y-auto px-3 py-2">
-        <div class="flex flex-col gap-0.5">
-          <span class="text-xs font-semibold text-ink-muted" aria-live="polite">
+      <div class="absolute inset-0 flex flex-col">
+        <div class="flex shrink-0 items-center justify-between gap-2 pr-1.5 pl-3 pt-1">
+          <span
+            class="min-w-0 truncate text-xs font-semibold text-ink-muted"
+            aria-live="polite"
+          >
             {waitingFor()}
           </span>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Open in session"
+            disabled={!props.onOpen}
+            onClick={props.onOpen}
+          >
+            <ArrowUpRight />
+          </Button>
+        </div>
+        <div class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-3 pb-3">
           <span class="text-sm leading-5 text-ink wrap-break-word">
             {props.asking.question.message}
           </span>
+          <Switch>
+            <Match when={reviewedTool(props.question)}>
+              {(tool) => (
+                <Switch>
+                  <Match when={tool().name === 'CreateCalendarEvent'}>
+                    <EventDraft event={tool().data as CreateCalendarEvent} />
+                  </Match>
+                  <Match when={tool().name === 'SendEmail'}>
+                    <EmailDraft
+                      email={tool().data as SendEmail}
+                      inFlight={false}
+                    />
+                  </Match>
+                </Switch>
+              )}
+            </Match>
+            <Match when={liveQuestion(props.question)}>
+              {(question) => (
+                <QuestionFields question={question()} locked={props.locked} />
+              )}
+            </Match>
+          </Switch>
         </div>
-        <Switch>
-          <Match when={reviewedTool(props.question)}>
-            {(tool) => (
-              <Switch>
-                <Match when={tool().name === 'CreateCalendarEvent'}>
-                  <EventDraft event={tool().data as CreateCalendarEvent} />
-                </Match>
-                <Match when={tool().name === 'SendEmail'}>
-                  <EmailDraft
-                    email={tool().data as SendEmail}
-                    inFlight={false}
-                  />
-                </Match>
-              </Switch>
-            )}
-          </Match>
-          <Match when={liveQuestion(props.question)}>
-            {(question) => (
-              <QuestionFields question={question()} locked={props.locked} />
-            )}
-          </Match>
-        </Switch>
       </div>
       {/* The pane clips; the fade says there is more below. */}
       <div
@@ -176,13 +199,11 @@ const AskingPane: Component<ChipAsking> = (props) => {
 /**
  * The decisions on the chip's bottom row, in the footer's place: Submit or
  * Open with Decline for a question, Create/Send with Cancel for a tool
- * draft, then the way into the session. Anyone but the owner gets only that
- * last one. The chip sends a tool draft as the agent wrote it; editing it
- * needs the session's composer.
+ * draft. Anyone but the owner reads who is being waited on instead. The
+ * chip sends a tool draft as the agent wrote it; editing it needs the
+ * session's composer, which the pane's arrow opens.
  */
-const AskingActions: Component<ChipAsking & { onOpen?: () => void }> = (
-  props
-) => {
+const AskingActions: Component<ChipAsking> = (props) => {
   const confirmLabel = (tool: ReviewedTool) =>
     match(tool.name)
       .with('CreateCalendarEvent', () => 'Create event')
@@ -199,7 +220,7 @@ const AskingActions: Component<ChipAsking & { onOpen?: () => void }> = (
       : `Waiting for ${props.asking.ownerName}`;
   return (
     <div
-      class="flex min-h-9 items-center gap-2 border-t border-edge-muted px-3 py-1.5 text-xs leading-5"
+      class="flex min-h-9 w-full items-center gap-2 border-t border-edge-muted px-3 py-1.5 text-xs leading-5"
       data-magic-chip-asking
       data-message-reply-preview={`${waitingFor()} · ${props.asking.question.message}`}
     >
@@ -244,20 +265,6 @@ const AskingActions: Component<ChipAsking & { onOpen?: () => void }> = (
           </Match>
         </Switch>
       </Show>
-      <Button
-        variant="ghost"
-        size="icon-xs"
-        class="ml-auto"
-        aria-label={
-          props.asking.canAnswer && reviewedTool(props.question)
-            ? 'Edit in session'
-            : 'Open session'
-        }
-        disabled={!props.onOpen}
-        onClick={props.onOpen}
-      >
-        <ArrowUpRight />
-      </Button>
     </div>
   );
 };
@@ -294,18 +301,20 @@ const ActivityText: Component<{ activity: MagicChipActivity }> = (props) => (
 );
 
 /**
- * Holds the answer's space until the agent writes: the chat's own waiting
- * glyph, pulsing while the agent is busy and still while it is not (a
- * disconnected session, a turn that ended without prose).
+ * Holds the answer's space while the agent is busy writing nothing yet: the
+ * chat's own waiting glyph. Once the agent is done (or waiting on the user)
+ * with nothing said, the space stays empty rather than showing a still star.
  */
 const AnswerPending: Component<{ busy: boolean }> = (props) => (
-  <div
-    class="flex h-full items-center justify-center"
-    data-magic-chip-pending
-    aria-hidden="true"
-  >
-    <PulsingStar kind="streamIndicator" animate={props.busy} />
-  </div>
+  <Show when={props.busy}>
+    <div
+      class="flex h-full items-center justify-center"
+      data-magic-chip-pending
+      aria-hidden="true"
+    >
+      <PulsingStar kind="streamIndicator" animate />
+    </div>
+  </Show>
 );
 
 /**
@@ -418,6 +427,11 @@ export const MagicChipView: Component<{
     };
   };
 
+  // The agent's side is shown while it has said something, or while there is
+  // no question to give the room to; a question with nothing said beside it
+  // takes the whole card.
+  const showAnswer = () => Boolean(markdown()) || !chipAsking();
+
   // Before there is an answer there is nothing to expand, so the whole card
   // leads to the session.
   const onAnswerClick = () => {
@@ -428,7 +442,7 @@ export const MagicChipView: Component<{
   return (
     <Layer depth={2}>
       <div
-        class="my-2 flex w-full min-w-0 max-w-full overflow-hidden rounded-lg border border-edge-muted bg-surface"
+        class="my-2 flex w-full min-w-0 max-w-full flex-col overflow-hidden rounded-lg border border-edge-muted bg-surface"
         data-magic-chip={props.agentSessionId}
         data-magic-chip-preview
         onMouseDown={(event) => {
@@ -437,13 +451,13 @@ export const MagicChipView: Component<{
           if (!isTextEntry(event.target)) event.preventDefault();
         }}
       >
-        <div class="flex min-w-0 flex-1 flex-col">
+        <div class="flex min-h-22">
           <div
             role="button"
             tabIndex={0}
             aria-expanded={markdown() ? expanded() : undefined}
-            class="group/answer px-3 py-1 text-left hover:bg-hover"
-            classList={{ 'h-22': !expanded() }}
+            class="group/answer min-w-0 flex-1 px-3 py-1 text-left hover:bg-hover"
+            classList={{ 'h-22': !expanded(), hidden: !showAnswer() }}
             data-magic-chip-answer
             onClick={onAnswerClick}
             onKeyDown={(event) => {
@@ -461,37 +475,41 @@ export const MagicChipView: Component<{
               )}
             </Show>
           </div>
-          <Show
-            when={chipAsking()}
-            fallback={
-              <button
-                type="button"
-                class="flex min-h-9 w-full items-center gap-1.5 border-t border-edge-muted px-3 py-2 text-left text-xs leading-5 text-ink-extra-muted hover:bg-hover"
-                data-message-reply-preview={
-                  markdown() ? undefined : replyPreview(activity())
-                }
-                disabled={!props.onOpen}
-                onClick={props.onOpen}
-              >
-                <span class="flex min-w-0 flex-1 items-center gap-1.5">
-                  <Show
-                    when={activity()}
-                    fallback={<span class="text-ink-muted">Open session</span>}
-                  >
-                    {(current) => <ActivityText activity={current()} />}
-                  </Show>
-                </span>
-                <ArrowUpRight aria-hidden="true" class="size-3 shrink-0" />
-              </button>
-            }
-          >
+          <Show when={chipAsking()}>
             {(current) => (
-              <AskingActions {...current()} onOpen={props.onOpen} />
+              <AskingPane
+                {...current()}
+                beside={showAnswer()}
+                onOpen={props.onOpen}
+              />
             )}
           </Show>
         </div>
-        <Show when={chipAsking()}>
-          {(current) => <AskingPane {...current()} />}
+        <Show
+          when={chipAsking()}
+          fallback={
+            <button
+              type="button"
+              class="flex min-h-9 w-full items-center gap-1.5 border-t border-edge-muted px-3 py-2 text-left text-xs leading-5 text-ink-extra-muted hover:bg-hover"
+              data-message-reply-preview={
+                markdown() ? undefined : replyPreview(activity())
+              }
+              disabled={!props.onOpen}
+              onClick={props.onOpen}
+            >
+              <span class="flex min-w-0 flex-1 items-center gap-1.5">
+                <Show
+                  when={activity()}
+                  fallback={<span class="text-ink-muted">Open session</span>}
+                >
+                  {(current) => <ActivityText activity={current()} />}
+                </Show>
+              </span>
+              <ArrowUpRight aria-hidden="true" class="size-3 shrink-0" />
+            </button>
+          }
+        >
+          {(current) => <AskingActions {...current()} />}
         </Show>
       </div>
     </Layer>

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/MagicChipView.tsx
@@ -5,10 +5,6 @@ import {
   QuestionFields,
   type RespondToElicitation,
 } from '@app/features/block-agent/component/parts/LiveElicitation';
-import {
-  EmailDraft,
-  EventDraft,
-} from '@app/features/block-agent/component/parts/UserToolCall';
 import { DRAFT_FIELD } from '@app/features/block-agent/state/elicitation-review-sink';
 import {
   StaticMarkdown,
@@ -20,46 +16,34 @@ import ArrowUpRight from '@phosphor/arrow-up-right.svg';
 import CaretRight from '@phosphor/caret-right.svg';
 import type { ElicitationAnswer } from '@service-agent-harness/generated/schemas';
 import { deserializeToolCall } from '@service-cognition/generated/tools/tool';
-import type {
-  CreateCalendarEvent,
-  SendEmail,
-} from '@service-cognition/generated/tools/types';
 import { Button, Layer } from '@ui';
 import {
   type Component,
   createMemo,
   createSignal,
+  type JSX,
   Match,
   Show,
   Switch,
   untrack,
 } from 'solid-js';
 import { match } from 'ts-pattern';
-import type {
-  MagicChipActivity,
-  MagicChipPresentation,
-  MagicChipQuestion,
+import {
+  type MagicChipActivity,
+  type MagicChipHeader,
+  type MagicChipPresentation,
+  type MagicChipQuestion,
+  presentationStatus,
 } from './presentation';
 
 function answerMarkdown(presentation: MagicChipPresentation) {
   return presentation.kind === 'working' ? undefined : presentation.markdown;
 }
 
-function currentActivity(presentation: MagicChipPresentation) {
-  return presentation.kind === 'working' || presentation.kind === 'answering'
-    ? presentation.activity
-    : undefined;
-}
-
 function isTextEntry(target: EventTarget | null) {
   return (
     target instanceof Element && target.closest('input, textarea') !== null
   );
-}
-
-function replyPreview(activity: MagicChipActivity | undefined) {
-  if (!activity) return 'Open session';
-  return `${activity.label}${activity.detail ? ` ${activity.detail}` : ''}`;
 }
 
 /** What the chip's answer to a question does. */
@@ -69,14 +53,14 @@ export type MagicChipAnswer = {
   respond: (answer: ElicitationAnswer) => Promise<boolean>;
 };
 
-/** A Macro user tool the agent drafted, read back for review. */
-type ReviewedTool = { name: string; data: unknown; draft: unknown };
+/** A Macro user tool the agent drafted, awaiting the user's go-ahead. */
+type ReviewedTool = { name: string; draft: unknown };
 
 /**
  * The chip's side of a question: the shared live state for a form, URL, or
- * unknown mode, or the draft of a recognized Macro user tool. A draft the
- * tool's schema rejects falls back to the flat form the agent also sent, as
- * the session does.
+ * unknown mode, or a recognized Macro user tool's draft. A draft the tool's
+ * schema rejects falls back to the flat form the agent also sent, as the
+ * session does.
  */
 type ChipQuestion = LiveQuestion | { kind: 'user_tool'; tool: ReviewedTool };
 
@@ -91,11 +75,7 @@ function createChipQuestion(asking: MagicChipQuestion): ChipQuestion {
   return call.isOk()
     ? {
         kind: 'user_tool',
-        tool: {
-          name: call.value.name,
-          data: call.value.data,
-          draft: request.draft,
-        },
+        tool: { name: call.value.name, draft: request.draft },
       }
     : createLiveQuestion({ kind: 'form', schema: request.schema });
 }
@@ -114,159 +94,6 @@ type ChipAsking = {
   question: ChipQuestion;
   locked: boolean;
   respond: RespondToElicitation;
-};
-
-/**
- * The question: who is being waited on with the way into the session at the
- * top, then the prompt and the fields - a form's choices, a URL and its
- * host, a tool draft summarized read-only - scrolling inside the chip's
- * height. The pane contributes no height of its own, so a long form never
- * grows the card. Beside an answer it takes the right side; when the agent
- * wrote nothing it is the whole card.
- */
-const AskingPane: Component<
-  ChipAsking & { beside: boolean; onOpen?: () => void }
-> = (props) => {
-  const waitingFor = () =>
-    props.asking.canAnswer
-      ? 'Waiting for you'
-      : `Waiting for ${props.asking.ownerName}`;
-  return (
-    <div
-      class="relative"
-      classList={{
-        'w-[45%] min-w-40 max-w-72 shrink-0 border-l border-edge-muted':
-          props.beside,
-        'min-w-0 flex-1': !props.beside,
-      }}
-      data-magic-chip-pane
-    >
-      <div class="absolute inset-0 flex flex-col">
-        <div class="flex shrink-0 items-center justify-between gap-2 pr-1.5 pl-3 pt-1">
-          <span
-            class="min-w-0 truncate text-xs font-semibold text-ink-muted"
-            aria-live="polite"
-          >
-            {waitingFor()}
-          </span>
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            aria-label="Open in session"
-            disabled={!props.onOpen}
-            onClick={props.onOpen}
-          >
-            <ArrowUpRight />
-          </Button>
-        </div>
-        <div class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-3 pb-3">
-          <span class="text-sm leading-5 text-ink wrap-break-word">
-            {props.asking.question.message}
-          </span>
-          <Switch>
-            <Match when={reviewedTool(props.question)}>
-              {(tool) => (
-                <Switch>
-                  <Match when={tool().name === 'CreateCalendarEvent'}>
-                    <EventDraft event={tool().data as CreateCalendarEvent} />
-                  </Match>
-                  <Match when={tool().name === 'SendEmail'}>
-                    <EmailDraft
-                      email={tool().data as SendEmail}
-                      inFlight={false}
-                    />
-                  </Match>
-                </Switch>
-              )}
-            </Match>
-            <Match when={liveQuestion(props.question)}>
-              {(question) => (
-                <QuestionFields question={question()} locked={props.locked} />
-              )}
-            </Match>
-          </Switch>
-        </div>
-      </div>
-      {/* The pane clips; the fade says there is more below. */}
-      <div
-        aria-hidden="true"
-        class="pointer-events-none absolute inset-x-0 bottom-0 h-4 bg-linear-to-t from-surface to-transparent"
-      />
-    </div>
-  );
-};
-
-/**
- * The decisions on the chip's bottom row, in the footer's place: Submit or
- * Open with Decline for a question, Create/Send with Cancel for a tool
- * draft. Anyone but the owner reads who is being waited on instead. The
- * chip sends a tool draft as the agent wrote it; editing it needs the
- * session's composer, which the pane's arrow opens.
- */
-const AskingActions: Component<ChipAsking> = (props) => {
-  const confirmLabel = (tool: ReviewedTool) =>
-    match(tool.name)
-      .with('CreateCalendarEvent', () => 'Create event')
-      .with('SendEmail', () => 'Send email')
-      .otherwise(() => 'Confirm');
-  const accept = (tool: ReviewedTool) =>
-    void props.respond({
-      action: 'accept',
-      content: { [DRAFT_FIELD]: JSON.stringify(tool.draft ?? {}) },
-    });
-  const waitingFor = () =>
-    props.asking.canAnswer
-      ? 'Waiting for you'
-      : `Waiting for ${props.asking.ownerName}`;
-  return (
-    <div
-      class="flex min-h-9 w-full items-center gap-2 border-t border-edge-muted px-3 py-1.5 text-xs leading-5"
-      data-magic-chip-asking
-      data-message-reply-preview={`${waitingFor()} · ${props.asking.question.message}`}
-    >
-      <Show
-        when={props.asking.canAnswer}
-        fallback={
-          <span class="min-w-0 truncate text-ink-muted">{waitingFor()}</span>
-        }
-      >
-        <Switch>
-          <Match when={reviewedTool(props.question)}>
-            {(tool) => (
-              <>
-                <Button
-                  variant="cta"
-                  size="xs"
-                  disabled={props.locked}
-                  onClick={() => accept(tool())}
-                >
-                  {confirmLabel(tool())}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="xs"
-                  disabled={props.locked}
-                  onClick={() => void props.respond({ action: 'decline' })}
-                >
-                  Cancel
-                </Button>
-              </>
-            )}
-          </Match>
-          <Match when={liveQuestion(props.question)}>
-            {(question) => (
-              <QuestionActions
-                question={question()}
-                locked={props.locked}
-                onRespond={props.respond}
-                cancel={false}
-              />
-            )}
-          </Match>
-        </Switch>
-      </Show>
-    </div>
-  );
 };
 
 /** The shimmering label plus its muted detail. */
@@ -298,6 +125,116 @@ const ActivityText: Component<{ activity: MagicChipActivity }> = (props) => (
       )}
     </Show>
   </>
+);
+
+/**
+ * The decisions for a live question, as buttons for the header: Submit or
+ * Open with Decline for a question; a Macro user tool's single go-ahead
+ * (Create event, Send email), the rest of the review being the session's.
+ * The chip sends a tool draft as the agent wrote it.
+ */
+const AskingActions: Component<ChipAsking> = (props) => {
+  const confirmLabel = (tool: ReviewedTool) =>
+    match(tool.name)
+      .with('CreateCalendarEvent', () => 'Create event')
+      .with('SendEmail', () => 'Send email')
+      .otherwise(() => 'Confirm');
+  const accept = (tool: ReviewedTool) =>
+    void props.respond({
+      action: 'accept',
+      content: { [DRAFT_FIELD]: JSON.stringify(tool.draft ?? {}) },
+    });
+  return (
+    <Switch>
+      <Match when={reviewedTool(props.question)}>
+        {(tool) => (
+          <Button
+            variant="cta"
+            size="xs"
+            disabled={props.locked}
+            onClick={() => accept(tool())}
+          >
+            {confirmLabel(tool())}
+          </Button>
+        )}
+      </Match>
+      <Match when={liveQuestion(props.question)}>
+        {(question) => (
+          <QuestionActions
+            question={question()}
+            locked={props.locked}
+            onRespond={props.respond}
+            cancel={false}
+          />
+        )}
+      </Match>
+    </Switch>
+  );
+};
+
+/**
+ * The chip's top row: who is answering (`@bot · model`), what the turn is
+ * doing, and the way into the session. The whole label opens the session,
+ * as does the arrow; while a question is live its decisions sit before the
+ * arrow.
+ */
+const ChipHeader: Component<{
+  header?: MagicChipHeader;
+  status: MagicChipActivity;
+  /** The reply preview, while the answer area has nothing to offer. */
+  preview?: string;
+  decisions?: JSX.Element;
+  onOpen?: () => void;
+}> = (props) => (
+  <div
+    class="flex min-h-9 items-center gap-1.5 border-b border-edge-muted py-1 pr-1.5 pl-3 text-xs leading-5"
+    data-magic-chip-header
+  >
+    <button
+      type="button"
+      class="flex min-w-0 flex-1 items-center gap-1.5 rounded-md text-left text-ink-extra-muted"
+      classList={{ 'hover:text-ink': Boolean(props.onOpen) }}
+      data-message-reply-preview={props.preview}
+      disabled={!props.onOpen}
+      onClick={props.onOpen}
+    >
+      <Show when={props.header?.agent}>
+        {(agent) => (
+          <span class="shrink-0 font-semibold text-ink">@{agent()}</span>
+        )}
+      </Show>
+      <Show when={props.header?.model}>
+        {(model) => (
+          <>
+            <Show when={props.header?.agent}>
+              <span aria-hidden="true" class="shrink-0 text-ink-placeholder">
+                ·
+              </span>
+            </Show>
+            <span class="min-w-0 truncate text-ink-muted" title={model()}>
+              {model()}
+            </span>
+          </>
+        )}
+      </Show>
+      <Show when={props.header?.agent || props.header?.model}>
+        <span aria-hidden="true" class="shrink-0 text-ink-placeholder">
+          ·
+        </span>
+      </Show>
+      <ActivityText activity={props.status} />
+    </button>
+    {props.decisions}
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      aria-label="Open in session"
+      disabled={!props.onOpen}
+      onClick={props.onOpen}
+    >
+      <ArrowUpRight />
+    </Button>
+  </div>
 );
 
 /**
@@ -378,15 +315,51 @@ const ExpandHint: Component<{ expanded: boolean }> = (props) => (
 );
 
 /**
- * One card for the whole turn: the answer area is reserved from the first
- * moment (a pulsing star while the agent works, the opening of the answer
- * once it writes) so the thread never jumps, and the bottom row reads the
- * current activity or `Open session`. Clicking the answer expands it in
- * place; clicking the row opens the session.
+ * A form or URL question's prompt and fields, scrolling inside the chip's
+ * height. The pane contributes no height of its own, so a long form never
+ * grows the card. Beside an answer it takes the right side; when the agent
+ * wrote nothing it is the whole card. Its decisions are in the header.
+ */
+const AskingPane: Component<
+  ChipAsking & { question: LiveQuestion; beside: boolean }
+> = (props) => (
+  <div
+    class="relative"
+    classList={{
+      'w-[45%] min-w-40 max-w-72 shrink-0 border-l border-edge-muted':
+        props.beside,
+      'min-w-0 flex-1': !props.beside,
+    }}
+    data-magic-chip-pane
+  >
+    <div class="absolute inset-0 flex flex-col gap-2 overflow-y-auto px-3 py-2">
+      <span class="text-sm leading-5 text-ink wrap-break-word">
+        {props.asking.question.message}
+      </span>
+      <QuestionFields question={props.question} locked={props.locked} />
+    </div>
+    {/* The pane clips; the fade says there is more below. */}
+    <div
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-x-0 bottom-0 h-4 bg-linear-to-t from-surface to-transparent"
+    />
+  </div>
+);
+
+/**
+ * One card for the whole turn, at one height: a header naming the bot, its
+ * model, and what the turn is doing (with the way into the session), over
+ * an area that holds the agent's latest passage - a pulsing star while the
+ * agent is busy before it writes, the passage as it streams, and the final
+ * passage once the turn ends. Clicking the passage expands it in place. A
+ * question the agent stops to ask puts its fields in a pane beside the
+ * passage (or in its place, when nothing was said) and its decisions in the
+ * header.
  */
 export const MagicChipView: Component<{
   agentSessionId: string;
   presentation: MagicChipPresentation;
+  header?: MagicChipHeader;
   /** How the chip answers a question; absent renders it read-only. */
   answer?: MagicChipAnswer;
   onOpen?: () => void;
@@ -396,7 +369,7 @@ export const MagicChipView: Component<{
       ? props.presentation.asking
       : undefined;
   const markdown = () => answerMarkdown(props.presentation);
-  const activity = () => currentActivity(props.presentation);
+  const status = () => presentationStatus(props.presentation);
   const [expanded, setExpanded] = createSignal(false);
 
   // One draft per question: keyed on the request id so metadata refreshes of
@@ -426,11 +399,24 @@ export const MagicChipView: Component<{
         locked ? false : ((await props.answer?.respond(answer)) ?? false),
     };
   };
-
+  // A form or URL has fields to show; a tool review is its one button.
+  const pane = () => {
+    const current = chipAsking();
+    const live = current && liveQuestion(current.question);
+    return current && live ? { ...current, question: live } : undefined;
+  };
   // The agent's side is shown while it has said something, or while there is
-  // no question to give the room to; a question with nothing said beside it
-  // takes the whole card.
-  const showAnswer = () => Boolean(markdown()) || !chipAsking();
+  // no question to give the room to.
+  const showAnswer = () => Boolean(markdown()) || !pane();
+  // While the answer area has no prose, a reply to the message previews the
+  // header's line instead.
+  const preview = () => {
+    if (markdown()) return undefined;
+    const current = status();
+    const line = `${current.label}${current.detail ? ` ${current.detail}` : ''}`;
+    const live = asking();
+    return live ? `${line} · ${live.question.message}` : line;
+  };
 
   // Before there is an answer there is nothing to expand, so the whole card
   // leads to the session.
@@ -451,6 +437,21 @@ export const MagicChipView: Component<{
           if (!isTextEntry(event.target)) event.preventDefault();
         }}
       >
+        <ChipHeader
+          header={props.header}
+          status={status()}
+          preview={preview()}
+          decisions={
+            <Show when={chipAsking()}>
+              {(current) => (
+                <Show when={current().asking.canAnswer}>
+                  <AskingActions {...current()} />
+                </Show>
+              )}
+            </Show>
+          }
+          onOpen={props.onOpen}
+        />
         <div class="flex min-h-22">
           <div
             role="button"
@@ -468,49 +469,17 @@ export const MagicChipView: Component<{
           >
             <Show
               when={markdown()}
-              fallback={<AnswerPending busy={activity()?.busy ?? false} />}
+              fallback={<AnswerPending busy={status().busy} />}
             >
               {(answer) => (
                 <AnswerBody markdown={answer()} expanded={expanded()} />
               )}
             </Show>
           </div>
-          <Show when={chipAsking()}>
-            {(current) => (
-              <AskingPane
-                {...current()}
-                beside={showAnswer()}
-                onOpen={props.onOpen}
-              />
-            )}
+          <Show when={pane()}>
+            {(current) => <AskingPane {...current()} beside={showAnswer()} />}
           </Show>
         </div>
-        <Show
-          when={chipAsking()}
-          fallback={
-            <button
-              type="button"
-              class="flex min-h-9 w-full items-center gap-1.5 border-t border-edge-muted px-3 py-2 text-left text-xs leading-5 text-ink-extra-muted hover:bg-hover"
-              data-message-reply-preview={
-                markdown() ? undefined : replyPreview(activity())
-              }
-              disabled={!props.onOpen}
-              onClick={props.onOpen}
-            >
-              <span class="flex min-w-0 flex-1 items-center gap-1.5">
-                <Show
-                  when={activity()}
-                  fallback={<span class="text-ink-muted">Open session</span>}
-                >
-                  {(current) => <ActivityText activity={current()} />}
-                </Show>
-              </span>
-              <ArrowUpRight aria-hidden="true" class="size-3 shrink-0" />
-            </button>
-          }
-        >
-          {(current) => <AskingActions {...current()} />}
-        </Show>
       </div>
     </Layer>
   );

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/create-magic-chip-model.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/create-magic-chip-model.ts
@@ -14,16 +14,18 @@ import {
 } from '@queries/agent-session/session-fold';
 import type {
   FoldedMessage,
-  PendingElicitation,
+  SessionMetadata,
 } from '@service-agent-fold/generated/types';
 import { agentHarnessServiceClient } from '@service-agent-harness/client';
 import type {
   AgentSessionLogEntryDto,
+  SessionBot,
   SessionStatusDto,
 } from '@service-agent-harness/generated/schemas';
 import { type Accessor, createSignal, onCleanup } from 'solid-js';
 import {
   deriveMagicChipPresentation,
+  type MagicChipHeader,
   type MagicChipPresentation,
   type MagicChipQuestion,
 } from './presentation';
@@ -45,23 +47,36 @@ function magicChipStatus(
   return MAGIC_CHIP_STATUSES.find((candidate) => candidate === value);
 }
 
+/** The model's display name, or its id when the runtime lists no name. */
+function modelName(metadata: SessionMetadata | undefined): string | undefined {
+  const model = metadata?.model;
+  if (!model) return undefined;
+  return (
+    metadata.supportedModels.find((option) => option.id === model)?.name ??
+    model
+  );
+}
+
 /**
  * Observe the session lifecycle and the chip's anchored folded turn.
  *
  * Also the chip's half of answering a question the agent stops to ask in
  * that turn: the session's metadata names the live question, the session
  * row names its owner, and {@link ElicitationController} sends the answer.
+ * The header reads the bot and model off the same fold.
  */
 export function createMagicChipModel(props: MagicChipDecoratorProps): {
   presentation: Accessor<MagicChipPresentation>;
+  header: Accessor<MagicChipHeader | undefined>;
   elicitation: ElicitationController;
 } {
   const [latestEvent, setLatestEvent] = createSignal<string>();
   const [messages, setMessages] = createSignal<FoldedMessage[]>([]);
   const [persistedStatus, setPersistedStatus] = createSignal(props.status);
   const [ownerId, setOwnerId] = createSignal<string>();
-  const [pendingElicitation, setPendingElicitation] =
-    createSignal<PendingElicitation>();
+  const [bot, setBot] = createSignal<SessionBot>();
+  const [metadata, setMetadata] = createSignal<SessionMetadata>();
+  const pendingElicitation = () => metadata()?.pendingElicitation ?? undefined;
   const viewerId = useUserId();
   let active = true;
   let release: (() => void) | undefined;
@@ -112,9 +127,7 @@ export function createMagicChipModel(props: MagicChipDecoratorProps): {
         )
       );
     },
-    onMetadata: (metadata) => {
-      setPendingElicitation(metadata.pendingElicitation ?? undefined);
-    },
+    onMetadata: setMetadata,
   })
     .then((acquired) => {
       if (!active) {
@@ -123,7 +136,8 @@ export function createMagicChipModel(props: MagicChipDecoratorProps): {
       }
       release = acquired.release;
       setMessages(acquired.messages);
-      setPendingElicitation(acquired.metadata.pendingElicitation ?? undefined);
+      setBot(acquired.bot);
+      setMetadata(acquired.metadata);
     })
     .catch((error: unknown) => {
       console.error('[magic-chip] session log could not be folded', error);
@@ -174,5 +188,11 @@ export function createMagicChipModel(props: MagicChipDecoratorProps): {
     });
   };
 
-  return { presentation, elicitation };
+  const header = (): MagicChipHeader | undefined => {
+    const agent = bot()?.name;
+    const model = modelName(metadata());
+    return agent || model ? { agent, model } : undefined;
+  };
+
+  return { presentation, header, elicitation };
 }

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/create-magic-chip-model.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/create-magic-chip-model.ts
@@ -1,3 +1,4 @@
+import { harnessDisplayName } from '@app/features/block-agent/component/compose-agent-session-options';
 import {
   createElicitationController,
   type ElicitationController,
@@ -19,7 +20,6 @@ import type {
 import { agentHarnessServiceClient } from '@service-agent-harness/client';
 import type {
   AgentSessionLogEntryDto,
-  SessionBot,
   SessionStatusDto,
 } from '@service-agent-harness/generated/schemas';
 import { type Accessor, createSignal, onCleanup } from 'solid-js';
@@ -47,10 +47,38 @@ function magicChipStatus(
   return MAGIC_CHIP_STATUSES.find((candidate) => candidate === value);
 }
 
-/** The model's display name, or its id when the runtime lists no name. */
-function modelName(metadata: SessionMetadata | undefined): string | undefined {
+/** What the session row says about who runs it, until the fold says more. */
+type SessionIdentity = { harness: string; model: string };
+
+/**
+ * The persona as the header names it: the runtime's product name followed
+ * by "Agent" (`Macro Agent`, `Cursor Agent`), a titled slug for a runtime
+ * the composer does not name.
+ */
+function agentName(harness: string | undefined): string | undefined {
+  if (!harness) return undefined;
+  const known = harnessDisplayName(harness);
+  const name =
+    known === harness
+      ? harness
+          .split(/[-_]/)
+          .filter(Boolean)
+          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+          .join(' ')
+      : known;
+  return `${name} Agent`;
+}
+
+/**
+ * The model's display name from the fold, its id when the runtime lists no
+ * name, or the slug the session was created with before the fold reports.
+ */
+function modelName(
+  metadata: SessionMetadata | undefined,
+  session: SessionIdentity | undefined
+): string | undefined {
   const model = metadata?.model;
-  if (!model) return undefined;
+  if (!model) return session?.model || undefined;
   return (
     metadata.supportedModels.find((option) => option.id === model)?.name ??
     model
@@ -63,7 +91,7 @@ function modelName(metadata: SessionMetadata | undefined): string | undefined {
  * Also the chip's half of answering a question the agent stops to ask in
  * that turn: the session's metadata names the live question, the session
  * row names its owner, and {@link ElicitationController} sends the answer.
- * The header reads the bot and model off the same fold.
+ * The header names the persona and model from the session row and the fold.
  */
 export function createMagicChipModel(props: MagicChipDecoratorProps): {
   presentation: Accessor<MagicChipPresentation>;
@@ -74,7 +102,7 @@ export function createMagicChipModel(props: MagicChipDecoratorProps): {
   const [messages, setMessages] = createSignal<FoldedMessage[]>([]);
   const [persistedStatus, setPersistedStatus] = createSignal(props.status);
   const [ownerId, setOwnerId] = createSignal<string>();
-  const [bot, setBot] = createSignal<SessionBot>();
+  const [session, setSession] = createSignal<SessionIdentity>();
   const [metadata, setMetadata] = createSignal<SessionMetadata>();
   const pendingElicitation = () => metadata()?.pendingElicitation ?? undefined;
   const viewerId = useUserId();
@@ -96,7 +124,13 @@ export function createMagicChipModel(props: MagicChipDecoratorProps): {
       .get(props.agentSessionId)
       .catch(() => undefined);
     if (!active) return;
-    if (result?.isOk()) setOwnerId(result.value.ownerId);
+    if (result?.isOk()) {
+      setOwnerId(result.value.ownerId);
+      setSession({
+        harness: result.value.harness,
+        model: result.value.model,
+      });
+    }
     const status = result?.isOk()
       ? magicChipStatus(result.value.status)
       : undefined;
@@ -136,7 +170,6 @@ export function createMagicChipModel(props: MagicChipDecoratorProps): {
       }
       release = acquired.release;
       setMessages(acquired.messages);
-      setBot(acquired.bot);
       setMetadata(acquired.metadata);
     })
     .catch((error: unknown) => {
@@ -189,8 +222,8 @@ export function createMagicChipModel(props: MagicChipDecoratorProps): {
   };
 
   const header = (): MagicChipHeader | undefined => {
-    const agent = bot()?.name;
-    const model = modelName(metadata());
+    const agent = agentName(session()?.harness);
+    const model = modelName(metadata(), session());
     return agent || model ? { agent, model } : undefined;
   };
 

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/create-magic-chip-model.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/create-magic-chip-model.ts
@@ -1,4 +1,8 @@
-import { harnessDisplayName } from '@app/features/block-agent/component/compose-agent-session-options';
+import {
+  harnessDisplayName,
+  harnessTitle,
+  modelDisplayName,
+} from '@app/features/block-agent/component/compose-agent-session-options';
 import {
   createElicitationController,
   type ElicitationController,
@@ -22,7 +26,7 @@ import type {
   AgentSessionLogEntryDto,
   SessionStatusDto,
 } from '@service-agent-harness/generated/schemas';
-import { type Accessor, createSignal, onCleanup } from 'solid-js';
+import { type Accessor, createMemo, createSignal, onCleanup } from 'solid-js';
 import {
   deriveMagicChipPresentation,
   type MagicChipHeader,
@@ -58,15 +62,7 @@ type SessionIdentity = { harness: string; model: string };
 function agentName(harness: string | undefined): string | undefined {
   if (!harness) return undefined;
   const known = harnessDisplayName(harness);
-  const name =
-    known === harness
-      ? harness
-          .split(/[-_]/)
-          .filter(Boolean)
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-          .join(' ')
-      : known;
-  return `${name} Agent`;
+  return `${known === harness ? harnessTitle(harness) : known} Agent`;
 }
 
 /**
@@ -79,10 +75,7 @@ function modelName(
 ): string | undefined {
   const model = metadata?.model;
   if (!model) return session?.model || undefined;
-  return (
-    metadata.supportedModels.find((option) => option.id === model)?.name ??
-    model
-  );
+  return modelDisplayName(model, metadata.supportedModels);
 }
 
 /**
@@ -205,7 +198,9 @@ export function createMagicChipModel(props: MagicChipDecoratorProps): {
     };
   };
 
-  const presentation = () => {
+  // Memoized: the view reads these from many places per flush, and a fold
+  // pushes a frame per streamed chunk.
+  const presentation = createMemo(() => {
     const turn = props.promptedMessage.turn;
     const messagesForTurn = messages().filter(
       (message) => message.turn === turn
@@ -219,13 +214,13 @@ export function createMagicChipModel(props: MagicChipDecoratorProps): {
         (message) => message.author.kind === 'agent'
       ),
     });
-  };
+  });
 
-  const header = (): MagicChipHeader | undefined => {
+  const header = createMemo((): MagicChipHeader | undefined => {
     const agent = agentName(session()?.harness);
     const model = modelName(metadata(), session());
     return agent || model ? { agent, model } : undefined;
-  };
+  });
 
   return { presentation, header, elicitation };
 }

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.test.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.test.ts
@@ -1,6 +1,9 @@
 import type { FoldedMessage } from '@service-agent-fold/generated/types';
 import { describe, expect, it } from 'vitest';
-import { deriveMagicChipPresentation } from './presentation';
+import {
+  deriveMagicChipPresentation,
+  presentationStatus,
+} from './presentation';
 
 const response = (overrides: Partial<FoldedMessage> = {}): FoldedMessage => ({
   agentSessionId: 'session',
@@ -397,5 +400,97 @@ describe('deriveMagicChipPresentation', () => {
         })
       ).toEqual({ kind: 'settled', markdown: 'Done.' });
     });
+  });
+});
+
+describe('the latest passage', () => {
+  const twoPassages = [
+    { kind: 'text' as const, text: 'Let me check the tests.' },
+    {
+      kind: 'tool_use' as const,
+      id: 'ran',
+      name: { kind: 'native' as const, name: 'Terminal' },
+      status: 'completed' as const,
+      detail: {
+        kind: 'terminal' as const,
+        command: 'cargo test',
+        output: 'ok',
+        exitCode: 0,
+      },
+    },
+    { kind: 'text' as const, text: 'They pass.' },
+  ];
+
+  it('shows only what the agent says now, not what it said before a tool ran', () => {
+    expect(
+      deriveMagicChipPresentation({
+        persistedStatus: 'acp_ready',
+        response: response({ parts: twoPassages }),
+      })
+    ).toEqual({
+      kind: 'answering',
+      markdown: 'They pass.',
+      activity: { label: 'Writing response', busy: false },
+    });
+  });
+
+  it('settles on the final passage', () => {
+    expect(
+      deriveMagicChipPresentation({
+        persistedStatus: 'acp_ready',
+        response: response({
+          parts: twoPassages,
+          stop: { kind: 'end_turn' },
+        }),
+      })
+    ).toEqual({ kind: 'settled', markdown: 'They pass.' });
+  });
+});
+
+describe('presentationStatus', () => {
+  const activity = {
+    label: 'Running command',
+    detail: 'cargo test',
+    busy: true,
+  };
+  const question = {
+    question: {
+      requestId: 1,
+      turn: 0,
+      toolCall: null,
+      message: 'Which?',
+      request: { kind: 'unrecognized' as const, mode: 'x', raw: {} },
+    },
+    ownerName: 'Alice Owner',
+  };
+
+  it('reads the activity while the agent works or writes', () => {
+    expect(presentationStatus({ kind: 'working', activity })).toBe(activity);
+    expect(
+      presentationStatus({ kind: 'answering', markdown: 'Hi', activity })
+    ).toBe(activity);
+  });
+
+  it('names who a question waits on', () => {
+    expect(
+      presentationStatus({
+        kind: 'asking',
+        markdown: '',
+        asking: { ...question, canAnswer: true },
+      })
+    ).toEqual({ label: 'Waiting for you', busy: false });
+    expect(
+      presentationStatus({
+        kind: 'asking',
+        markdown: '',
+        asking: { ...question, canAnswer: false },
+      })
+    ).toEqual({ label: 'Waiting for Alice Owner', busy: false });
+  });
+
+  it('reads Done once settled', () => {
+    expect(presentationStatus({ kind: 'settled', markdown: 'Fixed.' })).toEqual(
+      { label: 'Done', busy: false }
+    );
   });
 });

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.ts
@@ -18,11 +18,6 @@ export type MagicChipActivity = {
   busy: boolean;
 };
 
-/**
- * A question the agent is waiting on, as the chip offers it: the live slot
- * from the session's metadata, and whether this viewer is the one who may
- * answer (the session's owner) or is watching someone else be asked.
- */
 /** Who is answering, for the chip's header: the persona and its model. */
 export type MagicChipHeader = {
   /** The persona's name, e.g. `Macro Agent`. */
@@ -31,6 +26,11 @@ export type MagicChipHeader = {
   model?: string;
 };
 
+/**
+ * A question the agent is waiting on, as the chip offers it: the live slot
+ * from the session's metadata, and whether this viewer is the one who may
+ * answer (the session's owner) or is watching someone else be asked.
+ */
 export type MagicChipQuestion = {
   question: PendingElicitation;
   canAnswer: boolean;

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.ts
@@ -23,6 +23,14 @@ export type MagicChipActivity = {
  * from the session's metadata, and whether this viewer is the one who may
  * answer (the session's owner) or is watching someone else be asked.
  */
+/** Who is answering, for the chip's header: the bot and its model. */
+export type MagicChipHeader = {
+  /** The bot's display name, shown as an `@` mention. */
+  agent?: string;
+  /** The model's display name, when the runtime has reported one. */
+  model?: string;
+};
+
 export type MagicChipQuestion = {
   question: PendingElicitation;
   canAnswer: boolean;
@@ -34,9 +42,10 @@ export type MagicChipQuestion = {
  * The one state the chip renders.
  *
  * Four: an activity line while the agent works with nothing to show, the
- * answer as it is written with the activity line still under it, a question
- * the agent has stopped to ask (with whatever answer it had written so far
- * above it), and the answer alone once the turn ends.
+ * agent's latest passage as it is written with the activity alongside, a
+ * question the agent has stopped to ask (with that passage beside it), and
+ * the final passage alone once the turn ends. `markdown` is always the
+ * turn's latest text chunk, never the whole turn.
  */
 export type MagicChipPresentation =
   | { kind: 'working'; activity: MagicChipActivity }
@@ -321,16 +330,35 @@ function liveEventActivity(
   return statusActivity(name);
 }
 
-function answerMarkdown(response: FoldedMessage | undefined): string {
+/**
+ * The agent's latest prose: the last text part of the turn, which the fold
+ * appends into as chunks land. A passage written before a tool ran gives way
+ * to what the agent says after it, and when the turn ends cleanly the final
+ * passage is what stays.
+ */
+function latestChunk(response: FoldedMessage | undefined): string {
   return (
-    response?.parts
-      .filter(
-        (part): part is Extract<MessagePart, { kind: 'text' }> =>
-          part.kind === 'text' && Boolean(part.text.trim())
-      )
-      .map((part) => part.text)
-      .join('\n\n') ?? ''
+    response?.parts.findLast(
+      (part): part is Extract<MessagePart, { kind: 'text' }> =>
+        part.kind === 'text' && Boolean(part.text.trim())
+    )?.text ?? ''
   );
+}
+
+/** The one line the chip's header reads for the turn. */
+export function presentationStatus(
+  presentation: MagicChipPresentation
+): MagicChipActivity {
+  return match(presentation)
+    .with({ kind: 'working' }, { kind: 'answering' }, (p) => p.activity)
+    .with({ kind: 'asking' }, ({ asking }) => ({
+      label: asking.canAnswer
+        ? 'Waiting for you'
+        : `Waiting for ${asking.ownerName}`,
+      busy: false,
+    }))
+    .with({ kind: 'settled' }, () => ({ label: 'Done', busy: false }))
+    .exhaustive();
 }
 
 /** Project fold and lifecycle facts into the one state the view renders. */
@@ -339,7 +367,7 @@ export function deriveMagicChipPresentation(
 ): MagicChipPresentation {
   const { response, prompt, latestEvent, persistedStatus, asking } = input;
 
-  const markdown = answerMarkdown(response);
+  const markdown = latestChunk(response);
   if (response?.stop?.kind === 'end_turn' && markdown) {
     return { kind: 'settled', markdown };
   }

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/decorator/MagicChip/presentation.ts
@@ -23,9 +23,9 @@ export type MagicChipActivity = {
  * from the session's metadata, and whether this viewer is the one who may
  * answer (the session's owner) or is watching someone else be asked.
  */
-/** Who is answering, for the chip's header: the bot and its model. */
+/** Who is answering, for the chip's header: the persona and its model. */
 export type MagicChipHeader = {
-  /** The bot's display name, shown as an `@` mention. */
+  /** The persona's name, e.g. `Macro Agent`. */
   agent?: string;
   /** The model's display name, when the runtime has reported one. */
   model?: string;

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -51,21 +51,21 @@ command · cargo test`, `Waiting for you`, `Done`); clicking the header or its a
 latest passage: a pulsing star while the agent is busy before it writes, the passage as it
 streams, and the final passage once the turn ends - the last text the agent wrote, not the
 whole turn, and a finished turn with nothing said leaves the area empty. The area is
-clipped with a fade over its lower half and a `Show more` cue; hovering tints it, and
-clicking it expands it in place (`Show less` collapses it). Before anything is there to
-expand, clicking the area also opens the session.
+cropped at the chip's height with a fade at its foot; clicking it expands it in place, and
+clicking again collapses it. Before anything is there to expand, clicking the area also
+opens the session.
 
 When the agent stops to ask a question the question takes the area in the passage's
-place, clipped and expandable the same way: the prompt, then what is asked - a form's
+place, cropped and expandable the same way: the prompt, then what is asked - a form's
 fields (choice rows with an accent box, an `Other` row when the agent allows a free-text
 answer, text and number inputs, a yes/no), a URL request's host and address, or a Macro
-user tool's draft (`SendEmail`, `CreateCalendarEvent`) summarized read-only. A row at the
-bottom of the area carries the decisions, refusal first: `Dismiss · Send email · Open in
-session` (or `Create event`) for a tool draft, `Decline · Submit · Open in session` (or
-`Open` for a URL) for a question. Editing or cancelling a draft belongs to the session.
-Only the session's owner gets the decisions; other viewers see the question read-only and
-the header names who is being waited on. Once answered, the area shows the agent's
-passage again.
+user tool's draft (`SendEmail`, `CreateCalendarEvent`) in the tool's own composer - the
+same email compose or calendar event form the session shows, editable in place; expand
+the area to reach its `Send`/`Create`, which answers with the edited draft. A row at the
+bottom of the area carries the other decisions, refusal first: `Dismiss · Open in session`
+for a tool draft, `Decline · Submit · Open in session` (or `Open` for a URL) for a question.
+Only the session's owner can act; other viewers see the question read-only and the header
+names who is being waited on. Once answered, the area shows the agent's passage again.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention. With GraphQL enabled, document mentions and preview cards load
 in bounded batches, including task status/priority/assignees and the viewer's edit

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -51,16 +51,18 @@ bottom row reads the current activity (`Booting agent`, `Writing response`, ...)
 answer text to expand it in place (`Show less` collapses it again); click the
 bottom row to open the agent session. Before an
 answer exists, clicking the answer area also opens the session.
-When the agent stops to ask a question the chip keeps its height and gains a pane on its
-right: `Waiting for you` (or `Waiting for <owner>`), the prompt, and the question's fields -
-a form's choices (rows with an accent box, an `Other` row when the agent allows a free-text
+When the agent stops to ask a question the chip keeps its height and shows the question in
+a pane: beside the answer on the chip's right when the agent said something first, or as the
+whole card when it did not. The pane reads `Waiting for you` (or `Waiting for <owner>`) with
+an `Open in session` arrow at its top-right, then the prompt and the question's fields - a
+form's choices (rows with an accent box, an `Other` row when the agent allows a free-text
 answer), text and number inputs, a yes/no; a URL request's host and address; a Macro user
-tool's draft summarized read-only. The pane scrolls inside the chip when the question is
-long. The decisions sit on the chip's bottom row in the footer's place: `Submit` (or `Open`
-for a URL) and `Decline` for a question, `Create event`/`Send email` and `Cancel` for a
-tool draft, then an arrow that opens the session (`Edit in session` for a draft). Only the
+tool's draft summarized read-only - scrolling inside the chip when long. The decisions sit
+on the chip's bottom row in the footer's place: `Submit` (or `Open` for a URL) and `Decline`
+for a question, `Create event`/`Send email` and `Cancel` for a tool draft. Only the
 session's owner gets the decisions; other viewers see the fields disabled and the bottom
-row reads who is being waited on.
+row reads who is being waited on. The answer area shows the pulsing star only while the
+agent is busy; a finished or waiting turn with nothing said shows nothing there.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention. With GraphQL enabled, document mentions and preview cards load
 in bounded batches, including task status/priority/assignees and the viewer's edit

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -54,17 +54,17 @@ text the agent wrote, not the whole turn, and a finished turn with nothing said 
 the area empty. The passage is clipped to four lines with a fade and a `Show more`
 cue: click it to expand in place (`Show less` collapses it). Before an answer exists,
 clicking the area also opens the session.
-When the agent stops to ask a question the chip keeps its height. A form or URL question
-puts its prompt and fields in a pane - beside the passage on the chip's right when the
-agent said something first, or as the whole card when it did not - scrolling inside the
-chip when long: a form's choices (rows with an accent box, an `Other` row when the agent
-allows a free-text answer), text and number inputs, a yes/no; a URL request's host and
-address. Its decisions sit in the header before the arrow: `Submit` (or `Open` for a URL)
-and `Decline`. A Macro user tool the agent drafted (`SendEmail`, `CreateCalendarEvent`)
-is kept simple: the header offers only its go-ahead (`Send email`, `Create event`) and the
-arrow into the session, where the draft can be read, edited, or cancelled. Only the
-session's owner gets the decisions; other viewers see a form's fields disabled and the
-header reads who is being waited on.
+When the agent stops to ask a question the chip keeps its height and the question takes
+the area under the header in the passage's place: the prompt, then what is asked - a
+form's fields (choice rows with an accent box, an `Other` row when the agent allows a
+free-text answer, text and number inputs, a yes/no), a URL request's host and address, or
+a Macro user tool's draft (`SendEmail`, `CreateCalendarEvent`) summarized read-only -
+scrolling inside the chip when long. The decisions sit at the bottom right of that area:
+`Submit` (or `Open` for a URL) and `Decline` for a question; only the go-ahead (`Send
+email`, `Create event`) for a tool draft, whose editing and cancelling belong to the
+session behind the header's arrow. Only the session's owner gets the decisions; other
+viewers see the question read-only and the header names who is being waited on. Once
+answered, the area shows the agent's passage again.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention. With GraphQL enabled, document mentions and preview cards load
 in bounded batches, including task status/priority/assignees and the viewer's edit

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -51,7 +51,7 @@ or its arrow (`Open in session`) opens the agent session. The area under the hea
 holds the agent's latest passage: a pulsing star while the agent is busy before it
 writes, the passage as it streams, and the final passage once the turn ends - the last
 text the agent wrote, not the whole turn, and a finished turn with nothing said leaves
-the area empty. The passage is clipped to four lines with a fade and a `Show more`
+the area empty. The passage is clipped to about seven lines with a fade and a `Show more`
 cue: click it to expand in place (`Show less` collapses it). Before an answer exists,
 clicking the area also opens the session.
 When the agent stops to ask a question the chip keeps its height and the question takes

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -51,6 +51,14 @@ bottom row reads the current activity (`Booting agent`, `Writing response`, ...)
 answer text to expand it in place (`Show less` collapses it again); click the
 bottom row to open the agent session. Before an
 answer exists, clicking the answer area also opens the session.
+When the agent stops to ask a question, the chip's bottom section becomes the question
+itself: `Waiting for you` (or `Waiting for <owner>`) over the prompt, then the same
+controls the session shows - a form's fields (choice rows, text and number inputs, a
+yes/no, an `Other` row when the agent allows a free-text answer) with `Submit`,
+`Decline`, and `Cancel`; a URL request's host and `Open`; a Macro user tool's draft
+summarized read-only with `Create event`/`Send email` and `Cancel`. `Open session`
+(or `Edit in session` for a tool draft) sits at the right of that row. Only the
+session's owner can answer; other viewers see the controls disabled.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention. With GraphQL enabled, document mentions and preview cards load
 in bounded batches, including task status/priority/assignees and the viewer's edit

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -51,14 +51,16 @@ bottom row reads the current activity (`Booting agent`, `Writing response`, ...)
 answer text to expand it in place (`Show less` collapses it again); click the
 bottom row to open the agent session. Before an
 answer exists, clicking the answer area also opens the session.
-When the agent stops to ask a question, the chip's bottom section becomes the question
-itself: `Waiting for you` (or `Waiting for <owner>`) over the prompt, then the same
-controls the session shows - a form's fields (choice rows, text and number inputs, a
-yes/no, an `Other` row when the agent allows a free-text answer) with `Submit`,
-`Decline`, and `Cancel`; a URL request's host and `Open`; a Macro user tool's draft
-summarized read-only with `Create event`/`Send email` and `Cancel`. `Open session`
-(or `Edit in session` for a tool draft) sits at the right of that row. Only the
-session's owner can answer; other viewers see the controls disabled.
+When the agent stops to ask a question the chip keeps its height and gains a pane on its
+right: `Waiting for you` (or `Waiting for <owner>`), the prompt, and the question's fields -
+a form's choices (rows with an accent box, an `Other` row when the agent allows a free-text
+answer), text and number inputs, a yes/no; a URL request's host and address; a Macro user
+tool's draft summarized read-only. The pane scrolls inside the chip when the question is
+long. The decisions sit on the chip's bottom row in the footer's place: `Submit` (or `Open`
+for a URL) and `Decline` for a question, `Create event`/`Send email` and `Cancel` for a
+tool draft, then an arrow that opens the session (`Edit in session` for a draft). Only the
+session's owner gets the decisions; other viewers see the fields disabled and the bottom
+row reads who is being waited on.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention. With GraphQL enabled, document mentions and preview cards load
 in bounded batches, including task status/priority/assignees and the viewer's edit

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -44,25 +44,27 @@ bot asks before scheduling a specific clock time. `@macro-new` / `@coder` / `@cu
 an agent session; follow-up
 `@` mentions of that bot in the same thread route to it.
 The reply renders a Magic Chip: a rounded card of constant height that is present
-from the moment the session boots. Its answer area shows a pulsing star while the
-agent works, then the opening of the answer clipped to four lines and faded out; its
-bottom row reads the current activity (`Booting agent`, `Writing response`, ...) and
-`Open session` once the turn ends. A `Show more` cue sits over the fade: click the
-answer text to expand it in place (`Show less` collapses it again); click the
-bottom row to open the agent session. Before an
-answer exists, clicking the answer area also opens the session.
-When the agent stops to ask a question the chip keeps its height and shows the question in
-a pane: beside the answer on the chip's right when the agent said something first, or as the
-whole card when it did not. The pane reads `Waiting for you` (or `Waiting for <owner>`) with
-an `Open in session` arrow at its top-right, then the prompt and the question's fields - a
-form's choices (rows with an accent box, an `Other` row when the agent allows a free-text
-answer), text and number inputs, a yes/no; a URL request's host and address; a Macro user
-tool's draft summarized read-only - scrolling inside the chip when long. The decisions sit
-on the chip's bottom row in the footer's place: `Submit` (or `Open` for a URL) and `Decline`
-for a question, `Create event`/`Send email` and `Cancel` for a tool draft. Only the
-session's owner gets the decisions; other viewers see the fields disabled and the bottom
-row reads who is being waited on. The answer area shows the pulsing star only while the
-agent is busy; a finished or waiting turn with nothing said shows nothing there.
+from the moment the session boots. Its header names the bot as a mention (`@cursor`),
+the model when the runtime has reported one, and what the turn is doing (`Booting
+agent`, `Running command · cargo test`, `Waiting for you`, `Done`); clicking the header
+or its arrow (`Open in session`) opens the agent session. The area under the header
+holds the agent's latest passage: a pulsing star while the agent is busy before it
+writes, the passage as it streams, and the final passage once the turn ends - the last
+text the agent wrote, not the whole turn, and a finished turn with nothing said leaves
+the area empty. The passage is clipped to four lines with a fade and a `Show more`
+cue: click it to expand in place (`Show less` collapses it). Before an answer exists,
+clicking the area also opens the session.
+When the agent stops to ask a question the chip keeps its height. A form or URL question
+puts its prompt and fields in a pane - beside the passage on the chip's right when the
+agent said something first, or as the whole card when it did not - scrolling inside the
+chip when long: a form's choices (rows with an accent box, an `Other` row when the agent
+allows a free-text answer), text and number inputs, a yes/no; a URL request's host and
+address. Its decisions sit in the header before the arrow: `Submit` (or `Open` for a URL)
+and `Decline`. A Macro user tool the agent drafted (`SendEmail`, `CreateCalendarEvent`)
+is kept simple: the header offers only its go-ahead (`Send email`, `Create event`) and the
+arrow into the session, where the draft can be read, edited, or cancelled. Only the
+session's owner gets the decisions; other viewers see a form's fields disabled and the
+header reads who is being waited on.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention. With GraphQL enabled, document mentions and preview cards load
 in bounded batches, including task status/priority/assignees and the viewer's edit

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -44,27 +44,28 @@ bot asks before scheduling a specific clock time. `@macro-new` / `@coder` / `@cu
 an agent session; follow-up
 `@` mentions of that bot in the same thread route to it.
 The reply renders a Magic Chip: a rounded card of constant height that is present
-from the moment the session boots. Its header names the bot as a mention (`@cursor`),
-the model when the runtime has reported one, and what the turn is doing (`Booting
-agent`, `Running command · cargo test`, `Waiting for you`, `Done`); clicking the header
-or its arrow (`Open in session`) opens the agent session. The area under the header
-holds the agent's latest passage: a pulsing star while the agent is busy before it
-writes, the passage as it streams, and the final passage once the turn ends - the last
-text the agent wrote, not the whole turn, and a finished turn with nothing said leaves
-the area empty. The passage is clipped to about seven lines with a fade and a `Show more`
-cue: click it to expand in place (`Show less` collapses it). Before an answer exists,
-clicking the area also opens the session.
-When the agent stops to ask a question the chip keeps its height and the question takes
-the area under the header in the passage's place: the prompt, then what is asked - a
-form's fields (choice rows with an accent box, an `Other` row when the agent allows a
-free-text answer, text and number inputs, a yes/no), a URL request's host and address, or
-a Macro user tool's draft (`SendEmail`, `CreateCalendarEvent`) summarized read-only -
-scrolling inside the chip when long. The decisions sit at the bottom right of that area:
-`Submit` (or `Open` for a URL) and `Decline` for a question; only the go-ahead (`Send
-email`, `Create event`) for a tool draft, whose editing and cancelling belong to the
-session behind the header's arrow. Only the session's owner gets the decisions; other
-viewers see the question read-only and the header names who is being waited on. Once
-answered, the area shows the agent's passage again.
+from the moment the session boots. Its header names the persona (`Macro Agent`,
+`Cursor Agent`), the model, and what the turn is doing (`Booting agent`, `Running
+command · cargo test`, `Waiting for you`, `Done`); clicking the header or its arrow
+(`Open in session`) opens the agent session. The area under the header holds the agent's
+latest passage: a pulsing star while the agent is busy before it writes, the passage as it
+streams, and the final passage once the turn ends - the last text the agent wrote, not the
+whole turn, and a finished turn with nothing said leaves the area empty. The area is
+clipped with a fade over its lower half and a `Show more` cue; hovering tints it, and
+clicking it expands it in place (`Show less` collapses it). Before anything is there to
+expand, clicking the area also opens the session.
+
+When the agent stops to ask a question the question takes the area in the passage's
+place, clipped and expandable the same way: the prompt, then what is asked - a form's
+fields (choice rows with an accent box, an `Other` row when the agent allows a free-text
+answer, text and number inputs, a yes/no), a URL request's host and address, or a Macro
+user tool's draft (`SendEmail`, `CreateCalendarEvent`) summarized read-only. A row at the
+bottom of the area carries the decisions, refusal first: `Dismiss · Send email · Open in
+session` (or `Create event`) for a tool draft, `Decline · Submit · Open in session` (or
+`Open` for a URL) for a question. Editing or cancelling a draft belongs to the session.
+Only the session's owner gets the decisions; other viewers see the question read-only and
+the header names who is being waited on. Once answered, the area shows the agent's
+passage again.
 Agent replies may contain mention chips (`<m-document-mention>`) that render like any
 other channel mention. With GraphQL enabled, document mentions and preview cards load
 in bounded batches, including task status/priority/assignees and the viewer's edit


### PR DESCRIPTION
## Why

Asking `@macro(new)` to ask a question rendered a chip that said `Waiting for you · What's the best color?` with only **Decline** and **Answer in session** — the options never showed. The chip's `AskingCard` only knew how to review a Macro user tool; a `form`, `url`, or `unrecognized` request fell through to nothing. Along the way the chip's shape got a rethink: it must keep its height whatever the agent does, say who is answering, and show what the agent is saying *now*.

## The chip

```
┌────────────────────────────────────────────────────────────────┐
│ Cursor Agent · Claude Opus 5 High · Running command · cargo test ↗ │  header
├────────────────────────────────────────────────────────────────┤
│ The failing test is in `agent_fold`: the batch fold re-derives │  latest passage
│ every message per frame, so the…                    Show more ›│  (h-41, expands)
└────────────────────────────────────────────────────────────────┘
```

- **Header** — `<Persona> Agent · model · status`, then the `Open in session` arrow; the label is a button too. Persona is the session's harness through `harnessDisplayName` (`Macro Agent`, `Cursor Agent`). Model is the fold's display name via `supportedModels`, falling back to the slug the session was created with until the fold reports one. Status is the existing activity vocabulary, `Waiting for you` / `Waiting for <owner>` while a question is live, `Done` once settled.
- **Body** — the turn's **latest text chunk**, streaming: `markdown` is now the last non-empty text part, so a passage written before a tool ran gives way to what the agent says after it, and the final passage is what the chip settles on forever. The pulsing star shows only while the agent is busy before writing; a finished or waiting turn with nothing said leaves the area empty.
- **Height** — header (`min-h-9`) + body (`h-41`), ~202px, in every state. Verified on all six gallery chips.

## Questions

While a question is live it takes the area in the passage's place and gets the same treatment: cropped at the chip's height with a fade at its foot, expanded in place on click (a press on one of the question's own controls — a choice, an input, a button, the composer's editor — is that control's, never a toggle). No hover tint, no `Show more` cue. The passage's expanded state survives underneath and comes back once answered.

- **Macro user tool** (`SendEmail`, `CreateCalendarEvent`) — the tool's **own composer** (`EmailDraftComposer` / `CalendarDraftComposer`, the same ones the session mounts), cropped; expand to edit the draft in place and send/create from the composer, which answers with the edited draft through `createElicitationReviewSink`. The row beneath: `Dismiss · Open in session`. A draft the tool's schema rejects falls back to the flat form.
- **Form / URL / unrecognized** — prompt + fields; row: `Decline · Submit · Open in session` (`Open` for a URL). Cancel stays in the session for room. Draft state is keyed on the request id so metadata refreshes keep what was typed.
- Non-owners see the question read-only (the composer cannot act), no row, and the header naming who is being waited on.

## Shared code

- **`component/parts/LiveElicitation.tsx`** (new): `createLiveQuestion(request)` makes the per-request state (`FormDraft` with values / shown-errors / `content()`); `QuestionFields` and `QuestionActions` render over it so a surface can place them apart; `LiveQuestionCard` stacks them for the session. `ElicitationPart` uses it for `form | url | unrecognized` and as the user-tool fallback.
- **`ui/ElicitationForm.tsx`** restyled to the app's idiom: menu-style choice rows with an accent-filled box (round single / square multi), `Other` as a row, bordered inputs, `Yes` row for booleans; ARIA roles kept.
- **`presentation.ts`**: `latestChunk`, `presentationStatus`, `MagicChipHeader`. **`create-magic-chip-model.ts`**: follows bot + metadata, exposes `header`.
- **Gallery** (`/app/component/agent-ui`): chip in booting / writing / done, and asking as form / quiet form / url / tool draft.
- `docs/AGENT_GUIDE/channels.md` describes the header, the latest-passage body, and the question surfaces.

## Tests

69 across `presentation.test.ts` (latest chunk, settle on final chunk, header status), `MagicChipView.test.tsx` (header label/model/status, reply preview placement, expand/collapse, tool review from the header alone, quiet answer area, non-owner, on-the-wire lock, review transition keeps the expanded answer, form pane + header decisions, whole-card vs beside, draft survives refresh / resets on new request, custom text, url consent, unrecognized), `ElicitationForm.test.tsx` (rows, multi-select), `ElicitationPart.test.tsx` (unchanged), `create-magic-chip-model.test.ts` (unchanged). `bun type-check` and `biome check` clean.

Not verified: a live agent question in a real thread — `@macro(new)` "ask me the best color" is the test to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches channel agent UX and elicitation answer flows (forms, URL open-after-consent, tool drafts) shared between Magic Chip and session; behavior is heavily tested but live-thread verification is noted as pending.
> 
> **Overview**
> The channel **Magic Chip** is reworked so agent turns stay a fixed height: a new **header** shows persona, model, and status (`Waiting for you`, `Done`, etc.), and the body shows the turn's **latest text passage** (not all text concatenated). While the agent asks a question, the passage area is replaced by **in-place elicitation**—forms, URL consent, unrecognized modes, and Macro user-tool composers—instead of routing owners to the session with no options.
> 
> **`LiveElicitation`** centralizes shared question UI (`QuestionFields`, `QuestionActions`, `UserToolComposer`) for both the session **`ElicitationPart`** and **`MagicChipView`**, with decisions on a row under the chip's cropped area. **`ElicitationForm`** is restyled to app choice rows (with keyboard-friendly radio groups and multi-select) and gains tests. Small helpers move to **`compose-agent-session-options`** (`harnessTitle`, `modelDisplayName`); presentation/model code adds **`latestChunk`**, **`presentationStatus`**, and header wiring. Gallery fixtures and docs for channels are updated; test coverage expands for the chip and forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc8e3f9e7ac237f3d056dc03d7c354ce7047e76f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

