### PR TITLE
fix(crm): take the stage definition name from system_properties

### DIFF
--- a/crates/crm/Cargo.toml
+++ b/crates/crm/Cargo.toml
@@ -12,7 +12,6 @@ ai_tools = [
   "dep:models_properties",
   "dep:properties",
   "dep:schemars",
-  "dep:system_properties",
   "entity_access/ports",
   "ports",
 ]
@@ -63,7 +62,7 @@ properties = { path = "../properties", default-features = false, features = [
   "ports",
 ], optional = true }
 schemars = { workspace = true, optional = true }
-system_properties = { path = "../system_properties", optional = true }
+system_properties = { path = "../system_properties" }
 
 # Axum / inbound dependencies
 axum = { workspace = true, optional = true }

--- a/crates/crm/src/domain/stages.rs
+++ b/crates/crm/src/domain/stages.rs
@@ -14,7 +14,7 @@ use crate::domain::{
 mod test;
 
 /// Name of the team-scoped stage definition; `Stage` is reserved by a trigger.
-pub use properties::CRM_TEAM_STAGE_DEFINITION_NAME;
+pub use system_properties::CRM_TEAM_STAGE_DEFINITION_NAME;
 
 /// Maximum stages in one pipeline.
 pub const MAX_STAGES: usize = 50;

--- a/crates/properties/src/domain/model.rs
+++ b/crates/properties/src/domain/model.rs
@@ -15,8 +15,7 @@ use models_properties::service::property_value::PropertyValue;
 use models_properties::{DataType, EntityReference, EntityType, PropertyOwner};
 use uuid::Uuid;
 
-/// Name of a team's CRM stage definition. Written by the CRM crate, read by the loaders here.
-pub const CRM_TEAM_STAGE_DEFINITION_NAME: &str = "Deal Stage";
+pub use system_properties::CRM_TEAM_STAGE_DEFINITION_NAME;
 
 /// Map an internal properties storage type to its canonical entity type.
 pub fn canonical_entity_type(entity_type: EntityType) -> AccessEntityType {

--- a/crates/system_properties/src/lib.rs
+++ b/crates/system_properties/src/lib.rs
@@ -51,5 +51,8 @@ pub use domain::model::{
     StageOption, StatusOption, SystemPropertyError, SystemPropertyKey,
 };
 pub use domain::port::SystemPropertiesRepository;
+
+/// Name of a team's CRM stage definition. Written by the CRM crate, read by the property loaders.
+pub const CRM_TEAM_STAGE_DEFINITION_NAME: &str = "Deal Stage";
 pub use domain::service::{SystemPropertiesService, SystemPropertiesServiceImpl};
 pub use outbound::pgpool::PgSystemPropertiesRepository;


### PR DESCRIPTION
#6270 re-exported it from the properties crate, which crm only pulls in
behind optional features. Builds with only `ports` broke.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build and import-path refactor only; the constant value is unchanged and behavior should be identical at runtime.
> 
> **Overview**
> Fixes **CRM `ports`-only builds** that broke when the team stage definition name lived only behind optional `properties` wiring.
> 
> **`CRM_TEAM_STAGE_DEFINITION_NAME`** (`"Deal Stage"`) is now defined once in **`system_properties`** and re-exported from **`properties`** for existing callers. **CRM** imports it directly from **`system_properties`** and takes **`system_properties` as a non-optional dependency**, so domain code like **`stages.rs`** no longer needs the optional **`properties`** feature just to compile the constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b518edc1eb78463641b8b988647e489797127c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->