### PR TITLE
Seanaye/fix/loading while local evaluation

### DIFF
--- a/apps/web/src/lib/queries/soup/graphql/items.test.ts
+++ b/apps/web/src/lib/queries/soup/graphql/items.test.ts
@@ -557,6 +557,23 @@ describe('createGraphqlSoupAstItemsQuery', () => {
       );
       expect(query.hasNextPage()).toBe(false);
       expect(fake.executions).toHaveLength(2);
+      // Once a projection covers page two, resetting the chain must not keep
+      // those unloaded rows alive through that projection if reevaluation fails.
+      entityFilterMock.mockRejectedValue(new Error('reconciliation failed'));
+      const callsBeforeReset = entityFilterMock.mock.calls.length;
+      query.resetToInitialPage();
+      expect(
+        query.data()?.entities.some((item) => item.name === 'Second page')
+      ).toBe(false);
+      await vi.waitFor(() =>
+        expect(entityFilterMock.mock.calls.length).toBeGreaterThan(
+          callsBeforeReset
+        )
+      );
+      expect(
+        query.data()?.entities.some((item) => item.name === 'Second page')
+      ).toBe(false);
+      expect(query.hasNextPage()).toBe(true);
     } finally {
       dispose();
     }

--- a/apps/web/src/lib/queries/soup/graphql/items.test.ts
+++ b/apps/web/src/lib/queries/soup/graphql/items.test.ts
@@ -562,6 +562,154 @@ describe('createGraphqlSoupAstItemsQuery', () => {
     }
   });
 
+  it.each(['error', 'unsupported', 'incomplete'] as const)(
+    'shows later server pages while reconciliation is pending and after %s',
+    async (outcome) => {
+      const fake = makeFakeClient();
+      getGraphqlSoupClientMock.mockReturnValue(fake.client);
+      let revision = REVISION_1;
+      let notify: (revision: string) => void = () => {};
+      let release!: () => void;
+      const pending = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      let retries = 0;
+      getGraphqlSoupCacheHostMock.mockReturnValue({
+        currentRevision: async () => revision,
+        entityFilter: entityFilterMock,
+        onCacheChanged: (callback: typeof notify) => {
+          notify = callback;
+          return () => {};
+        },
+        onCacheGenerationChanged: () => () => {},
+      });
+      makeGraphqlSoupInputMock.mockImplementation(({ cursor }) =>
+        cursor
+          ? { continuation: { cursor } }
+          : { initial: { sortMethod: 'UPDATED_AT', limit: 2 } }
+      );
+      entityFilterMock.mockImplementation(async () => {
+        if (revision !== REVISION_2) {
+          retries += 1;
+          await pending;
+          if (outcome === 'error') throw new Error('reconciliation failed');
+          return { kind: outcome, revision };
+        }
+        return {
+          kind: 'reconciled',
+          revision,
+          keys: ['GraphqlSoupDocument:new', 'GraphqlSoupDocument:kept'],
+          retainedKeys: [],
+          optimistic: false,
+        };
+      });
+      readRecordsByKeysMock.mockImplementation(async () => ({
+        revision,
+        records: [
+          {
+            recordKey: 'GraphqlSoupDocument:new',
+            record: {
+              __typename: 'GraphqlSoupDocument',
+              id: 'new',
+              name: 'New candidate',
+            },
+          },
+        ],
+      }));
+      let dispose!: () => void;
+      let query!: ReturnType<typeof createGraphqlSoupAstItemsQuery>;
+      createRoot((stop) => {
+        dispose = stop;
+        query = createGraphqlSoupAstItemsQuery(
+          () => ({ params: {}, body: {} }),
+          () => ({ enabled: true })
+        );
+      });
+      const names = () => query.data()?.entities.map((item) => item.name);
+      try {
+        fake.executions[0].next(
+          graphqlSoupPage({
+            items: [
+              { id: 'kept', name: 'Baseline survivor' },
+              { id: 'removed', name: 'Confirmed non-match' },
+            ],
+            next_cursor: 'server-cursor-2',
+          })
+        );
+        revision = REVISION_2;
+        notify(revision);
+        await vi.waitFor(() =>
+          expect(names()).toEqual(['New candidate', 'Baseline survivor'])
+        );
+        const secondPage = query.fetchNextPage();
+        await vi.waitFor(() => expect(fake.executions).toHaveLength(2));
+        revision = '3';
+        notify(revision);
+        fake.executions[1].next(
+          graphqlSoupPage({
+            // The candidate is also returned by pagination: render it only once.
+            items: [
+              { id: 'new', name: 'New candidate' },
+              { id: 'second', name: 'Second page' },
+            ],
+            next_cursor: 'server-cursor-3',
+          }),
+          { source: 'live-network', revision }
+        );
+        await secondPage;
+        await vi.waitFor(() => expect(retries).toBeGreaterThan(0));
+        expect(names()).toEqual([
+          'New candidate',
+          'Baseline survivor',
+          'Second page',
+        ]);
+        expect(query.isLoading()).toBe(false);
+        expect(query.isPlaceholderData()).toBe(false);
+        release();
+        await vi.waitFor(() =>
+          expect(entityFilterMock).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              baseline: expect.arrayContaining([
+                expect.objectContaining({ key: 'GraphqlSoupDocument:second' }),
+              ]),
+            })
+          )
+        );
+        expect(names()).toEqual([
+          'New candidate',
+          'Baseline survivor',
+          'Second page',
+        ]);
+        // A second load-more must not rely on local evaluation recovering.
+        const thirdPage = query.fetchNextPage();
+        await vi.waitFor(() => expect(fake.executions).toHaveLength(3));
+        expect(fake.executions[2].variables).toEqual({
+          input: { continuation: { cursor: 'server-cursor-3' } },
+        });
+        revision = '4';
+        notify(revision);
+        fake.executions[2].next(
+          graphqlSoupPage({
+            items: [{ id: 'third', name: 'Third page' }],
+            next_cursor: null,
+          }),
+          { source: 'live-network', revision }
+        );
+        await thirdPage;
+        expect(names()).toEqual([
+          'New candidate',
+          'Baseline survivor',
+          'Second page',
+          'Third page',
+        ]);
+        expect(query.hasNextPage()).toBe(false);
+      } finally {
+        release();
+        dispose();
+      }
+    }
+  );
+
   it('never supplies another filter or cache generation as baseline evidence', async () => {
     const fake = makeFakeClient();
     getGraphqlSoupClientMock.mockReturnValue(fake.client);

--- a/apps/web/src/lib/queries/soup/graphql/items.test.ts
+++ b/apps/web/src/lib/queries/soup/graphql/items.test.ts
@@ -5,7 +5,7 @@ import type {
   OperationContext,
   OperationResult,
 } from '@urql/core';
-import { createRoot, createSignal } from 'solid-js';
+import { createComputed, createRoot, createSignal } from 'solid-js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { makeSubject } from 'wonka';
 
@@ -171,7 +171,7 @@ describe('createGraphqlSoupAstItemsQuery', () => {
     });
   });
 
-  it('uses a complete local page as placeholder while authoritative network continues', async () => {
+  it('shows current-query local data without a tab placeholder while the network continues', async () => {
     const fake = makeFakeClient();
     getGraphqlSoupClientMock.mockReturnValue(fake.client);
     getGraphqlSoupCacheHostMock.mockReturnValue({
@@ -207,7 +207,8 @@ describe('createGraphqlSoupAstItemsQuery', () => {
         expect(fake.executions).toHaveLength(1);
         void vi
           .waitFor(() => {
-            expect(query.isPlaceholderData()).toBe(true);
+            expect(query.isPlaceholderData()).toBe(false);
+            expect(query.isLoading()).toBe(false);
             expect(query.data()?.entities[0]?.name).toBe('Local task');
           })
           .then(() => {
@@ -288,7 +289,7 @@ describe('createGraphqlSoupAstItemsQuery', () => {
         void vi
           .waitFor(() => {
             expect(query.data()?.entities[0]?.name).toBe('Optimistic task');
-            expect(query.isPlaceholderData()).toBe(true);
+            expect(query.isPlaceholderData()).toBe(false);
           })
           .then(async () => {
             fake.executions[0]?.next(
@@ -729,6 +730,207 @@ describe('createGraphqlSoupAstItemsQuery', () => {
       dispose();
     }
   });
+
+  it.each(['pending', 'empty', 'older rows'] as const)(
+    'keeps the last local display while recomputing against a %s server page',
+    async (serverPage) => {
+      const fake = makeFakeClient();
+      getGraphqlSoupClientMock.mockReturnValue(fake.client);
+      let revision = REVISION_1;
+      let notify: (revision: string) => void = () => {};
+      let release!: (result: unknown) => void;
+      const pending = new Promise((resolve) => {
+        release = resolve;
+      });
+      let recomputing = false;
+      getGraphqlSoupCacheHostMock.mockReturnValue({
+        currentRevision: async () => revision,
+        entityFilter: entityFilterMock,
+        onCacheChanged: (callback: typeof notify) => {
+          notify = callback;
+          return () => {};
+        },
+        onCacheGenerationChanged: () => () => {},
+      });
+      const result = () => ({
+        kind: 'reconciled',
+        revision,
+        keys: ['GraphqlSoupDocument:local'],
+        retainedKeys: [],
+        optimistic: false,
+      });
+      entityFilterMock.mockImplementation(async () => {
+        if (revision === '3') {
+          recomputing = true;
+          return pending;
+        }
+        return result();
+      });
+      readRecordsByKeysMock.mockImplementation(async () => ({
+        revision,
+        records: [
+          {
+            recordKey: 'GraphqlSoupDocument:local',
+            record: {
+              id: 'local',
+              name: revision === '3' ? 'Updated local row' : 'Local row',
+            },
+          },
+        ],
+      }));
+      let dispose!: () => void;
+      let query!: ReturnType<typeof createGraphqlSoupAstItemsQuery>;
+      const displays: Array<{
+        names: string[] | undefined;
+        loading: boolean;
+        placeholder: boolean;
+      }> = [];
+      createRoot((stop) => {
+        dispose = stop;
+        query = createGraphqlSoupAstItemsQuery(
+          () => ({ params: {}, body: {} }),
+          () => ({ enabled: true })
+        );
+        createComputed(() =>
+          displays.push({
+            names: query.data()?.entities.map((item) => item.name),
+            loading: query.isLoading(),
+            placeholder: query.isPlaceholderData(),
+          })
+        );
+      });
+      try {
+        if (serverPage !== 'pending') {
+          fake.executions[0].next(
+            graphqlSoupPage({
+              items:
+                serverPage === 'empty'
+                  ? []
+                  : [{ id: 'server', name: 'Old server row' }],
+              next_cursor: null,
+            })
+          );
+        }
+        revision = REVISION_2;
+        notify(revision);
+        await vi.waitFor(() =>
+          expect(query.data()?.entities[0]?.name).toBe('Local row')
+        );
+        const previousDisplay = query.data();
+        displays.length = 0;
+        revision = '3';
+        notify(revision);
+        await vi.waitFor(() => expect(recomputing).toBe(true));
+        expect(query.data()).toBe(previousDisplay);
+        expect(query.isLoading()).toBe(false);
+        expect(query.isPlaceholderData()).toBe(false);
+        // The outstanding initial network request still has normal fetching
+        // semantics; recomputation does not turn retained rows into loading.
+        expect(query.isFetching()).toBe(serverPage === 'pending');
+        release(result());
+        await vi.waitFor(() =>
+          expect(query.data()?.entities[0]?.name).toBe('Updated local row')
+        );
+        expect(
+          displays.every(
+            (display) =>
+              !display.loading &&
+              !display.placeholder &&
+              (display.names?.[0] === 'Local row' ||
+                display.names?.[0] === 'Updated local row')
+          )
+        ).toBe(true);
+        // A failed local retry also keeps the display, not an older baseline.
+        entityFilterMock.mockRejectedValue(
+          new Error('temporary cache failure')
+        );
+        const calls = entityFilterMock.mock.calls.length;
+        revision = '4';
+        notify(revision);
+        await vi.waitFor(() =>
+          expect(entityFilterMock.mock.calls.length).toBeGreaterThan(calls)
+        );
+        expect(query.data()?.entities[0]?.name).toBe('Updated local row');
+        expect(query.isLoading()).toBe(false);
+        fake.executions[0].next(
+          graphqlSoupPage({
+            items: [{ id: 'fresh', name: 'Fresh server row' }],
+            next_cursor: null,
+          }),
+          { source: 'live-network', revision: '4' }
+        );
+        expect(query.data()?.entities[0]?.name).toBe('Fresh server row');
+      } finally {
+        dispose();
+      }
+    }
+  );
+
+  it.each(['query', 'generation'] as const)(
+    'never retains the local display across a %s change',
+    async (change) => {
+      const fake = makeFakeClient();
+      getGraphqlSoupClientMock.mockReturnValue(fake.client);
+      let revision = REVISION_1;
+      let notifyGeneration: () => void = () => {};
+      getGraphqlSoupCacheHostMock.mockReturnValue({
+        currentRevision: async () => revision,
+        entityFilter: entityFilterMock,
+        onCacheChanged: () => () => {},
+        onCacheGenerationChanged: (callback: () => void) => {
+          notifyGeneration = callback;
+          return () => {};
+        },
+      });
+      const [scope, setScope] = createSignal('one');
+      makeGraphqlSoupInputMock.mockImplementation(({ body }) => ({
+        initial: { sortMethod: 'UPDATED_AT', filters: body, limit: 100 },
+      }));
+      entityFilterMock.mockResolvedValue({
+        kind: 'reconciled',
+        revision,
+        keys: ['GraphqlSoupDocument:old'],
+        retainedKeys: [],
+        optimistic: false,
+      });
+      readRecordsByKeysMock.mockResolvedValue({
+        revision,
+        records: [
+          {
+            recordKey: 'GraphqlSoupDocument:old',
+            record: { id: 'old', name: 'Previous local result' },
+          },
+        ],
+      });
+      let dispose!: () => void;
+      let query!: ReturnType<typeof createGraphqlSoupAstItemsQuery>;
+      createRoot((stop) => {
+        dispose = stop;
+        query = createGraphqlSoupAstItemsQuery(
+          () => ({ params: {}, body: { scope: scope() } }) as never,
+          () => ({ enabled: true })
+        );
+      });
+      try {
+        await vi.waitFor(() =>
+          expect(query.data()?.entities[0]?.name).toBe('Previous local result')
+        );
+        entityFilterMock.mockImplementation(() => new Promise(() => {}));
+        if (change === 'query') setScope('two');
+        else {
+          revision = REVISION_0;
+          notifyGeneration();
+        }
+        expect(
+          query.data()?.entities.some((item) => item.id === 'old')
+        ).not.toBe(true);
+        expect(query.isLoading()).toBe(true);
+        expect(query.isPlaceholderData()).toBe(false);
+      } finally {
+        dispose();
+      }
+    }
+  );
 
   it('retains identical page projections across cache re-executions', () => {
     const firstPage = {

--- a/apps/web/src/lib/queries/soup/graphql/items.ts
+++ b/apps/web/src/lib/queries/soup/graphql/items.ts
@@ -47,7 +47,9 @@ import { mapSoupPageToEntityList } from '../transform-utils';
 import { makeGraphqlSoupInput } from './ast';
 import {
   materializeReconciledSoup,
+  soupItemKey,
   soupReconciliationBaseline,
+  unreconciledServerRecords,
 } from './reconciliation';
 
 export type GraphqlSoupAstItemsQueryArgs = {
@@ -107,6 +109,8 @@ export function createGraphqlSoupAstItemsQuery(
   type LocalProjection = {
     input: GraphqlSoupInput;
     generation: number;
+    baselineKeys: ReadonlySet<string>;
+    displayedKeys: ReadonlySet<string>;
     data: SoupAstItemsData;
   };
   const [currentCacheRevision, setCurrentCacheRevision] = createSignal<
@@ -298,17 +302,20 @@ export function createGraphqlSoupAstItemsQuery(
             setCurrentCacheRevision(latestRevision);
             continue;
           }
-          const items = materializeReconciledSoup(
+          const reconciledRecords = materializeReconciledSoup(
             result.keys,
             chunks.flatMap((chunk) => chunk.records),
             records
-          ).flatMap((record) => {
+          );
+          const items = reconciledRecords.flatMap((record) => {
             const item = mapGraphqlSoupItem(record);
             return item ? [item] : [];
           });
           setLocalProjection({
             input,
             generation: requestGeneration,
+            baselineKeys: new Set(records.map(soupItemKey)),
+            displayedKeys: new Set(reconciledRecords.map(soupItemKey)),
             data: {
               entities: mapSoupPageToEntityList(
                 { items, next_cursor: undefined },
@@ -410,21 +417,63 @@ export function createGraphqlSoupAstItemsQuery(
       : []
   );
 
-  // A revision change invalidates local authority, not the rows already on
-  // screen. Retain that display until its replacement is ready, but never
-  // across a different query or cache generation. Publishing a replacement
-  // still requires all the revision checks above.
+  const serverRecordKeys = createMemo(
+    () => new Set(serverRecords().map(soupItemKey))
+  );
+
+  // Retain same-query rows across revisions and page additions, not across a
+  // query/generation change or removal of the baseline they were built from.
+  // Publishing a replacement still requires all the revision checks above.
   const displayLocalProjection = (): LocalProjection | undefined => {
     const local = localProjection();
-    return local?.input === firstPageInput() &&
-      local?.generation === cacheGeneration
-      ? local
-      : undefined;
+    if (
+      !local ||
+      local.input !== firstPageInput() ||
+      local.generation !== cacheGeneration
+    )
+      return undefined;
+    const keys = serverRecordKeys();
+    for (const key of local.baselineKeys) {
+      if (!keys.has(key)) return undefined;
+    }
+    return local;
   };
   const networkIsAuthoritative = (): boolean =>
     networkAuthorityInput === firstPageInput() &&
     networkAuthorityRevision() !== undefined &&
     networkAuthorityRevision() === currentCacheRevision();
+
+  // An overlay covers only the server rows that existed when it was evaluated.
+  // New server pages must render immediately, even if the next evaluation stalls
+  // or fails. Preserve covered decisions and local additions, then append new
+  // rows in server-page order until a successful reconciliation orders the union.
+  const displayData = createMemo((): SoupAstItemsData | undefined => {
+    if (networkIsAuthoritative()) return query.data?.data;
+    const local = displayLocalProjection();
+    if (!local) return query.data?.data;
+    const additions = unreconciledServerRecords(
+      serverRecords(),
+      local.baselineKeys,
+      local.displayedKeys
+    ).flatMap((record) => {
+      const item = mapGraphqlSoupItem(record);
+      return item ? [item] : [];
+    });
+    if (additions.length === 0) return local.data;
+    const entities = mapSoupPageToEntityList(
+      { items: additions, next_cursor: undefined },
+      {
+        instructionsIdQuery,
+        showSupportedForeignEntities: options().showSupportedForeignEntities,
+      }
+    );
+    return entities.length === 0
+      ? local.data
+      : {
+          ...local.data,
+          entities: [...local.data.entities, ...entities],
+        };
+  });
 
   const error = (): CombinedError | undefined => query.error ?? undefined;
   createComputed(
@@ -436,10 +485,7 @@ export function createGraphqlSoupAstItemsQuery(
   );
 
   return {
-    data: () => {
-      if (networkIsAuthoritative()) return query.data?.data;
-      return displayLocalProjection()?.data ?? query.data?.data;
-    },
+    data: displayData,
     error,
     isSupported,
     isEnabled: () => query.isEnabled,

--- a/apps/web/src/lib/queries/soup/graphql/items.ts
+++ b/apps/web/src/lib/queries/soup/graphql/items.ts
@@ -105,9 +105,9 @@ export function createGraphqlSoupAstItemsQuery(
     records: GraphqlSoupItem[];
   };
   type LocalProjection = {
-    revision: CacheRevision;
+    input: GraphqlSoupInput;
+    generation: number;
     data: SoupAstItemsData;
-    baseline: readonly GraphqlSoupItem[];
   };
   const [currentCacheRevision, setCurrentCacheRevision] = createSignal<
     CacheRevision | undefined
@@ -201,6 +201,7 @@ export function createGraphqlSoupAstItemsQuery(
     const host = getGraphqlSoupCacheHost();
     const records = serverRecords();
     const requestId = ++localRequest;
+    const requestGeneration = cacheGeneration;
     if (input !== previousInitialInput) {
       previousInitialInput = input;
       setLocalProjection(undefined);
@@ -306,8 +307,8 @@ export function createGraphqlSoupAstItemsQuery(
             return item ? [item] : [];
           });
           setLocalProjection({
-            revision: latestRevision,
-            baseline: records,
+            input,
+            generation: requestGeneration,
             data: {
               entities: mapSoupPageToEntityList(
                 { items, next_cursor: undefined },
@@ -409,12 +410,14 @@ export function createGraphqlSoupAstItemsQuery(
       : []
   );
 
-  const authoritativeLocalProjection = (): LocalProjection | undefined => {
+  // A revision change invalidates local authority, not the rows already on
+  // screen. Retain that display until its replacement is ready, but never
+  // across a different query or cache generation. Publishing a replacement
+  // still requires all the revision checks above.
+  const displayLocalProjection = (): LocalProjection | undefined => {
     const local = localProjection();
-    const revision = currentCacheRevision();
-    return local &&
-      local.revision === revision &&
-      local.baseline === serverRecords()
+    return local?.input === firstPageInput() &&
+      local?.generation === cacheGeneration
       ? local
       : undefined;
   };
@@ -435,18 +438,18 @@ export function createGraphqlSoupAstItemsQuery(
   return {
     data: () => {
       if (networkIsAuthoritative()) return query.data?.data;
-      const local = authoritativeLocalProjection();
-      return local?.data ?? query.data?.data ?? localProjection()?.data;
+      return displayLocalProjection()?.data ?? query.data?.data;
     },
     error,
     isSupported,
     isEnabled: () => query.isEnabled,
-    isLoading: () =>
-      query.isLoading && authoritativeLocalProjection() === undefined,
+    isLoading: () => query.isLoading && displayLocalProjection() === undefined,
     isFetching: () => query.isFetching,
     isFetchingNextPage: () => query.isFetchingNextPage,
-    isPlaceholderData: () =>
-      !networkIsAuthoritative() && authoritativeLocalProjection() !== undefined,
+    // Current-query cache results are usable data, not previous-tab
+    // placeholders. In particular, local recomputation must not animate the
+    // mobile tab-loading bar or make the view report that it has no data.
+    isPlaceholderData: () => false,
     hasNextPage: () => query.hasNextPage,
     fetchNextPage: async () => {
       // The display overlay never owns or resets the server cursor chain.

--- a/apps/web/src/lib/queries/soup/graphql/reconciliation.test.ts
+++ b/apps/web/src/lib/queries/soup/graphql/reconciliation.test.ts
@@ -4,6 +4,7 @@ import {
   materializeReconciledSoup,
   soupItemKey,
   soupReconciliationBaseline,
+  unreconciledServerRecords,
 } from './reconciliation';
 
 const item = (id: string, typename = 'GraphqlSoupDocument') =>
@@ -49,6 +50,25 @@ describe('flat Soup baseline reconciliation', () => {
         'UPDATED_AT'
       )
     ).toBeUndefined();
+  });
+
+  it('merges new server rows without duplicates or resurrecting covered removals', () => {
+    const kept = item('kept');
+    const removed = item('removed');
+    const candidate = item('candidate');
+    const nextPage = item('next-page');
+    const sameIdProject = item('candidate', 'GraphqlSoupProject');
+    const baselineKeys = new Set([soupItemKey(kept), soupItemKey(removed)]);
+    const displayedKeys = new Set([soupItemKey(kept), soupItemKey(candidate)]);
+    expect(
+      unreconciledServerRecords(
+        [kept, removed, candidate, nextPage, nextPage, sameIdProject],
+        baselineKeys,
+        displayedKeys
+      )
+    ).toEqual([nextPage, sameIdProject]);
+    expect(baselineKeys.size).toBe(2);
+    expect(displayedKeys.size).toBe(2);
   });
 
   it('retains unknown baseline display data, omits unrenderable new items and never resurrects removals', () => {

--- a/apps/web/src/lib/queries/soup/graphql/reconciliation.ts
+++ b/apps/web/src/lib/queries/soup/graphql/reconciliation.ts
@@ -26,6 +26,23 @@ export function soupReconciliationBaseline(
     : undefined;
 }
 
+/** Rows discovered by server pagination after an overlay was computed. Do not
+ * re-add covered baseline rows (including confirmed non-matches), or duplicate
+ * local candidates that pagination now also returns. */
+export function unreconciledServerRecords(
+  records: readonly GraphqlSoupItem[],
+  baselineKeys: ReadonlySet<string>,
+  displayedKeys: ReadonlySet<string>
+): GraphqlSoupItem[] {
+  const seen = new Set([...baselineKeys, ...displayedKeys]);
+  return records.filter((record) => {
+    const key = soupItemKey(record);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 /** Materialize only reconciled survivors, preserving baseline display data if
  * a selected record is incomplete. Unrenderable new candidates are omitted. */
 export function materializeReconciledSoup(

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -7,7 +7,11 @@ loaded server pages with matching cached entities. Complete matching updates can
 appear without a list refetch; confirmed non-matches and explicit deletions disappear.
 Rows whose current predicate facts are unknown retain their previous server membership
 and sort evidence until hydration or a network refresh resolves them. Unrelated
-notification-only cache records do not block other rows' updates.
+notification-only cache records do not block other rows' updates. While recomputation
+is pending, the last rendered result for the same query and cache generation stays
+visible; local results do not trigger the tab-loading bar. A fresh server response
+still replaces that result, and initial loads without usable data retain normal loading
+indicators.
 
 This is a best-effort display, not proof that every matching entity is cached. Loading
 more still follows the original server cursors and preserves already loaded pages.

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -15,6 +15,9 @@ indicators.
 
 This is a best-effort display, not proof that every matching entity is cached. Loading
 more still follows the original server cursors and preserves already loaded pages.
+Newly loaded server rows join the retained display immediately, without duplicates or
+waiting for local recomputation to succeed. Removing pages from the server baseline
+invalidates overlays built from those pages.
 Changing filters or resetting the cache discards prior reconciliation evidence. Grouped
 lists, unsupported filters/sorts, and native/non-cache transports keep their existing
 network behavior.


### PR DESCRIPTION
PR removes the loading indicator state from soup when a local filter is being evaluated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-side list merging and loading semantics for GraphQL-cached Soup queries; behavior is heavily tested but affects visible list state during pagination and cache updates.
> 
> **Overview**
> Fixes flat Soup list UX when the browser GraphQL cache reconciles filters locally: **current-query cache rows are treated as real data**, not placeholder state, so **`isPlaceholderData` is always false** and **`isLoading` stays false** while a prior local result is retained during recomputation (avoiding the mobile tab-loading bar and empty-list flashes).
> 
> **Display logic** now keeps the last local overlay for the same filter input and cache generation, invalidates it when the server baseline shrinks (e.g. `resetToInitialPage`) or filters/generation change, and **merges newly paginated server rows immediately** via `unreconciledServerRecords`—without duplicating reconciled candidates or resurrecting removed baseline rows—until a successful reconciliation reorders the union.
> 
> Tests and `surfaces.md` document pagination during pending/failed reconciliation, stable display across recomputation, and query/generation boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2cc76413f58e96857dd2ac1a009c92d42c52269. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->