### PR TITLE
Revert "feat(calls): promote screen share in room-composite recordings"

### DIFF
--- a/crates/call/src/domain/ports.rs
+++ b/crates/call/src/domain/ports.rs
@@ -500,13 +500,7 @@ pub trait CallRtcClient: Send + Sync + 'static {
         participant_identity: MacroUserIdStr<'a>,
     ) -> impl Future<Output = anyhow::Result<()>> + Send;
 
-    /// Start recording a room into the configured destination. Returns the
-    /// provider's egress ID.
-    ///
-    /// While nobody shares a screen, cameras fill the frame as equal tiles.
-    /// While someone shares, the shared screen fills the stage and cameras
-    /// move to a strip. The recording follows share start and stop for its
-    /// whole duration without further calls from the domain.
+    /// Start a room composite egress (recording). Returns the egress ID.
     fn start_room_composite_egress(
         &self,
         room_name: &str,
@@ -514,9 +508,6 @@ pub trait CallRtcClient: Send + Sync + 'static {
     ) -> impl Future<Output = anyhow::Result<String>> + Send;
 
     /// Stop an active egress by ID.
-    ///
-    /// Stopping does not change layout. The composition is chosen when
-    /// recording starts.
     fn stop_egress(&self, egress_id: &str) -> impl Future<Output = anyhow::Result<()>> + Send;
 
     /// Validate a webhook signature and parse the event from the raw body.

--- a/crates/call/src/outbound/livekit_rtc_client.rs
+++ b/crates/call/src/outbound/livekit_rtc_client.rs
@@ -27,9 +27,6 @@ use crate::domain::ports::CallRtcClient;
 
 const VOIP_TOKEN_MINT_CONCURRENCY: usize = 16;
 
-/// Empty layout is not default grid. The stock template only promotes layouts that start with `grid`.
-const STOCK_TEMPLATE_LAYOUT: &str = "grid";
-
 /// LiveKit implementation of [`CallRtcClient`].
 pub struct LivekitRtcClient {
     room_client: RoomClient,
@@ -108,7 +105,6 @@ fn build_room_composite_egress_request(
     });
 
     let options = RoomCompositeOptions {
-        layout: STOCK_TEMPLATE_LAYOUT.to_owned(),
         encoding: encoding::EncodingOptions {
             audio_codec: AudioCodec::Aac,
             video_codec: VideoCodec::H264Main,

--- a/crates/call/src/outbound/livekit_rtc_client/test.rs
+++ b/crates/call/src/outbound/livekit_rtc_client/test.rs
@@ -1,18 +1,7 @@
-use livekit_protocol::VideoCodec;
 use macro_user_id::user_id::MacroUserIdStr;
 
 use super::*;
-use crate::domain::models::EgressS3Config;
 use crate::domain::ports::CallRtcClient as _;
-
-fn s3_config() -> EgressS3Config {
-    EgressS3Config {
-        bucket: "recordings-bucket".to_string(),
-        region: "us-east-1".to_string(),
-        access_key: "test-access-key".to_string(),
-        secret: "test-secret".to_string(),
-    }
-}
 
 fn client() -> LivekitRtcClient {
     LivekitRtcClient::new(
@@ -58,47 +47,4 @@ async fn verify_access_token_rejects_token_signed_with_a_different_secret() {
 #[test]
 fn verify_access_token_rejects_garbage() {
     assert!(client().verify_access_token("not-a-jwt").is_err());
-}
-
-#[test]
-fn room_composite_request_asks_the_stock_template_to_stage_a_shared_screen() {
-    let request = build_room_composite_egress_request("room-1", &s3_config());
-    assert_eq!(request.options.layout, "grid");
-    assert!(request.options.custom_base_url.is_empty());
-}
-
-#[test]
-fn room_composite_request_writes_one_mp4_under_the_room_prefix() {
-    let request = build_room_composite_egress_request("room-1", &s3_config());
-    assert_eq!(request.outputs.len(), 1);
-    let EgressOutput::File(file) = &request.outputs[0] else {
-        panic!("expected one file output");
-    };
-    assert_eq!(file.filepath, "calls/room-1/{time}");
-    assert_eq!(file.file_type, EncodedFileType::Mp4 as i32);
-}
-
-#[test]
-fn room_composite_request_uploads_to_the_configured_bucket() {
-    let request = build_room_composite_egress_request("room-1", &s3_config());
-    let EgressOutput::File(file) = &request.outputs[0] else {
-        panic!("expected one file output");
-    };
-    let Some(encoded_file_output::Output::S3(s3)) = &file.output else {
-        panic!("expected S3 upload");
-    };
-    assert_eq!(s3.bucket, "recordings-bucket");
-    assert_eq!(s3.region, "us-east-1");
-}
-
-#[test]
-fn room_composite_request_encodes_for_browser_playback() {
-    let request = build_room_composite_egress_request("room-1", &s3_config());
-    let encoding = &request.options.encoding;
-    assert_eq!(encoding.width, 1920);
-    assert_eq!(encoding.height, 1080);
-    assert_eq!(encoding.framerate, 30);
-    assert_eq!(encoding.video_bitrate, 4500);
-    assert_eq!(encoding.video_codec, VideoCodec::H264Main);
-    assert_eq!(encoding.audio_codec, AudioCodec::Aac);
 }

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -95,8 +95,6 @@ Google's out-of-office event type.
 
 Tabs `All` / `Missed` / `Unattended`; `Call` button to start one. Recordings, transcriptions
 and summaries appear here; empty state notes "Calls are available to agents."
-New recordings stage a shared screen with cameras in a side strip. Older
-recordings stay an equal-tile grid.
 
 ## Customers (CRM) — `/app/component/companies`
 


### PR DESCRIPTION
Reverts macro-inc/macro#6266

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Recording composition reverts to provider defaults; no auth, data, or API contract changes beyond egress visual layout.
> 
> **Overview**
> Reverts the room-composite recording change that forced LiveKit’s **`grid`** layout so screen shares could be staged with cameras in a strip.
> 
> **`LivekitRtcClient`** no longer sets `RoomCompositeOptions.layout` when starting egress; recordings use LiveKit’s default composition again. Port doc comments and the agent guide no longer describe share-aware layout, and the unit tests that pinned layout, S3 path, and encoding on the egress request builder were removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94e0e11309e9a0bdd5ab003d4dc82b2b74d0ebcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->