### PR TITLE
fix(calls): leave call

### DIFF
--- a/crates/call/src/domain/ports.rs
+++ b/crates/call/src/domain/ports.rs
@@ -493,7 +493,7 @@ pub trait CallRtcClient: Send + Sync + 'static {
         request: VoipPushPayloadRequest<'a>,
     ) -> impl Future<Output = Vec<(MacroUserIdStr<'static>, VoipPushPayload)>> + Send;
 
-    /// Remove a participant from a room.
+    /// Remove a participant from a room. Already-absent identities succeed.
     fn remove_participant<'a>(
         &self,
         room_name: &str,

--- a/crates/call/src/domain/ports.rs
+++ b/crates/call/src/domain/ports.rs
@@ -493,7 +493,7 @@ pub trait CallRtcClient: Send + Sync + 'static {
         request: VoipPushPayloadRequest<'a>,
     ) -> impl Future<Output = Vec<(MacroUserIdStr<'static>, VoipPushPayload)>> + Send;
 
-    /// Remove a participant from a room. Already-absent identities succeed.
+    /// Remove a participant from a room.
     fn remove_participant<'a>(
         &self,
         room_name: &str,

--- a/crates/call/src/outbound/livekit_rtc_client.rs
+++ b/crates/call/src/outbound/livekit_rtc_client.rs
@@ -8,6 +8,7 @@ mod test;
 
 use futures::future;
 use livekit_api::access_token::{AccessToken, TokenVerifier, VideoGrants};
+use livekit_api::services::ServiceError;
 use livekit_api::services::agent_dispatch::AgentDispatchClient;
 use livekit_api::services::egress::{EgressClient, EgressOutput, RoomCompositeOptions, encoding};
 use livekit_api::services::room::{CreateRoomOptions, RoomClient};
@@ -227,10 +228,11 @@ impl CallRtcClient for LivekitRtcClient {
         room_name: &str,
         participant_identity: MacroUserIdStr<'_>,
     ) -> anyhow::Result<()> {
-        self.room_client
-            .remove_participant(room_name, participant_identity.as_ref())
-            .await?;
-        Ok(())
+        interpret_remove_participant_result(
+            self.room_client
+                .remove_participant(room_name, participant_identity.as_ref())
+                .await,
+        )
     }
 
     #[tracing::instrument(err, skip(self, s3_config))]
@@ -331,4 +333,8 @@ impl CallRtcClient for LivekitRtcClient {
             created_at: event.created_at,
         })
     }
+}
+
+fn interpret_remove_participant_result(result: Result<(), ServiceError>) -> anyhow::Result<()> {
+    result.map_err(Into::into)
 }

--- a/crates/call/src/outbound/livekit_rtc_client.rs
+++ b/crates/call/src/outbound/livekit_rtc_client.rs
@@ -8,10 +8,10 @@ mod test;
 
 use futures::future;
 use livekit_api::access_token::{AccessToken, TokenVerifier, VideoGrants};
-use livekit_api::services::ServiceError;
 use livekit_api::services::agent_dispatch::AgentDispatchClient;
 use livekit_api::services::egress::{EgressClient, EgressOutput, RoomCompositeOptions, encoding};
 use livekit_api::services::room::{CreateRoomOptions, RoomClient};
+use livekit_api::services::{ServiceError, TwirpError, TwirpErrorCode};
 use livekit_api::webhooks::WebhookReceiver;
 use livekit_protocol::{
     AudioCodec, CreateAgentDispatchRequest, EncodedFileOutput, EncodedFileType, S3Upload,
@@ -336,5 +336,16 @@ impl CallRtcClient for LivekitRtcClient {
 }
 
 fn interpret_remove_participant_result(result: Result<(), ServiceError>) -> anyhow::Result<()> {
-    result.map_err(Into::into)
+    match result {
+        Ok(()) => Ok(()),
+        Err(error) if is_participant_already_absent(&error) => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn is_participant_already_absent(error: &ServiceError) -> bool {
+    matches!(
+        error,
+        ServiceError::Twirp(TwirpError::Twirp(code)) if code.code == TwirpErrorCode::NOT_FOUND
+    )
 }

--- a/crates/call/src/outbound/livekit_rtc_client/test.rs
+++ b/crates/call/src/outbound/livekit_rtc_client/test.rs
@@ -1,7 +1,15 @@
+use livekit_api::services::{ServiceError, TwirpError, TwirpErrorCode};
 use macro_user_id::user_id::MacroUserIdStr;
 
 use super::*;
 use crate::domain::ports::CallRtcClient as _;
+
+fn twirp(code: &str, msg: &str) -> ServiceError {
+    ServiceError::Twirp(TwirpError::Twirp(TwirpErrorCode {
+        code: code.to_string(),
+        msg: msg.to_string(),
+    }))
+}
 
 fn client() -> LivekitRtcClient {
     LivekitRtcClient::new(
@@ -47,4 +55,27 @@ async fn verify_access_token_rejects_token_signed_with_a_different_secret() {
 #[test]
 fn verify_access_token_rejects_garbage() {
     assert!(client().verify_access_token("not-a-jwt").is_err());
+}
+
+#[test]
+fn remove_participant_not_found_is_already_gone() {
+    let error = twirp(TwirpErrorCode::NOT_FOUND, "participant does not exist");
+    interpret_remove_participant_result(Err(error))
+        .expect("leave must succeed when LiveKit already dropped the participant");
+}
+
+#[test]
+fn remove_participant_room_not_found_is_already_gone() {
+    let error = twirp(TwirpErrorCode::NOT_FOUND, "requested room does not exist");
+    interpret_remove_participant_result(Err(error))
+        .expect("leave must succeed when the LiveKit room is already gone");
+}
+
+#[test]
+fn remove_participant_unavailable_still_fails() {
+    let error = twirp(TwirpErrorCode::UNAVAILABLE, "overloaded");
+    let message = interpret_remove_participant_result(Err(error))
+        .expect_err("transient LiveKit failures must still surface")
+        .to_string();
+    assert_eq!(message, "twirp error: twirp error: unavailable: overloaded");
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow LiveKit adapter change with idempotent error handling; only NOT_FOUND is swallowed and other Twirp errors still fail.
> 
> **Overview**
> **Leave call** no longer treats a missing LiveKit participant or room as a hard failure when kicking someone from the RTC room.
> 
> `remove_participant` now runs LiveKit’s response through `interpret_remove_participant_result`, which maps Twirp **`NOT_FOUND`** to success so “already left / room gone” is idempotent. Transient errors (e.g. **`UNAVAILABLE`**) still propagate. Unit tests cover both NOT_FOUND cases and a non-NOT_FOUND failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e69befb2b22511870ffdd779971256622605f568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->