### PR TITLE
fix(calendar): transparent event background

### DIFF
--- a/apps/web/src/features/calendar/calendar.css
+++ b/apps/web/src/features/calendar/calendar.css
@@ -8,7 +8,7 @@
 	--fc-event-bg-color: color-mix(
 		in oklch,
 		var(--color-calendar) 5%,
-		var(--color-surface)
+		var(--color-panel)
 	);
 	--fc-event-border-color: var(--color-calendar);
 	--fc-event-text-color: var(--color-calendar);
@@ -488,7 +488,7 @@
 	.fc-event:not(.fc-daygrid-dot-event):not(
 		:has(.calendar-event-content-selected)
 	):has([data-response-status="accepted"]) {
-	--fc-event-bg-color: var(--color-surface);
+	--fc-event-bg-color: var(--color-panel);
 	--fc-event-border-color: var(--event-calendar-color, var(--color-calendar));
 	background-image: linear-gradient(
 		color-mix(
@@ -528,7 +528,7 @@
 .calendar-view
 	.fc
 	.fc-event:has(.calendar-event-content[data-response-status="needs_action"]) {
-	--fc-event-bg-color: transparent;
+	--fc-event-bg-color: var(--color-panel);
 	--fc-event-text-color: var(--color-ink-muted);
 }
 
@@ -596,7 +596,7 @@
 		--fc-event-bg-color: color-mix(
 			in oklch,
 			var(--event-calendar-color, var(--color-calendar)) 18%,
-			var(--color-surface)
+			var(--color-panel)
 		);
 		--fc-event-text-color: var(--color-ink);
 		box-shadow:
@@ -667,7 +667,7 @@
 		--fc-event-bg-color: color-mix(
 			in oklch,
 			var(--event-calendar-color, var(--color-calendar)) 16%,
-			var(--color-surface)
+			var(--color-panel)
 		);
 		background-color: var(--fc-event-bg-color);
 		background-image: none;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CSS-only calendar styling with no logic or data changes; risk is limited to visual appearance across themes.
> 
> **Overview**
> Fixes calendar events that looked **transparent or washed out** by switching event fill tokens from `--color-surface` to **`--color-panel`** across default, accepted, tentative, and hover/`color-mix` backgrounds in `calendar.css`.
> 
> **Needs-action** events no longer use a fully transparent `--fc-event-bg-color`; they get the same panel fill as other non-selected chips so RSVP-pending items stay readable on the grid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca3dec31ab051334e1fc6919452b033f9e22bb6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->