### PR TITLE
draft: partial migration to lexical extensions 

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,6 +58,7 @@
     "@inkibra/tauri-plugins": "git+https://github.com/macro-inc/tauri-plugins.git#6ddd6600e20436388f169e936b610fe93944b7b0",
     "@kobalte/core": "^0.13.11",
     "@leeoniya/ufuzzy": "^1.0.19",
+    "@lexical/extension": "0.45.0",
     "@lexical/history": "0.45.0",
     "@lexical/html": "0.45.0",
     "@lexical/link": "0.45.0",

--- a/apps/web/src/features/block-canvas/component/nodes/TextBox.tsx
+++ b/apps/web/src/features/block-canvas/component/nodes/TextBox.tsx
@@ -93,7 +93,7 @@ function TextBoxEditor(props: {
     );
 
   const handle = config.buildHandle();
-  const { lexical: editor, plugins } = handle;
+  const { lexical: editor } = handle;
   const state = handle._internal;
   props.setter(editor);
 
@@ -140,19 +140,17 @@ function TextBoxEditor(props: {
     };
   };
 
-  plugins.useReactive(
-    () => props.focusOnMount,
-    () => {
-      if (props.focusOnMount) {
-        return (editor) => {
-          return editor.registerRootListener((root) => {
-            if (root === null) return;
-            Object.assign(root.style, textwrapStyles());
-          });
-        };
-      }
-    }
-  );
+  let cleanupTextWrap = () => {};
+  createEffect(() => {
+    cleanupTextWrap();
+    cleanupTextWrap = props.focusOnMount
+      ? editor.registerRootListener((root) => {
+          if (root === null) return;
+          Object.assign(root.style, textwrapStyles());
+        })
+      : () => {};
+  });
+  onCleanup(() => cleanupTextWrap());
 
   createEffect(() => {
     const val = state.markdownState();

--- a/apps/web/src/features/block-code/component/CodeMarkdown.tsx
+++ b/apps/web/src/features/block-code/component/CodeMarkdown.tsx
@@ -1,7 +1,7 @@
 import { DecoratorRenderer } from '@core/component/LexicalMarkdown/component/core/DecoratorRenderer';
 import { NodeAccessoryRenderer } from '@core/component/LexicalMarkdown/component/core/NodeAccessoryRenderer';
 import {
-  createLexicalWrapper,
+  createLegacyLexicalWrapper,
   LexicalWrapperContext,
 } from '@core/component/LexicalMarkdown/context/LexicalWrapperContext';
 import {
@@ -19,7 +19,7 @@ export function CodeMarkdown() {
   const blockText = blockTextSignal.get;
   const blockMetadata = blockMetadataSignal.get;
 
-  const lexicalWrapper = createLexicalWrapper({
+  const lexicalWrapper = createLegacyLexicalWrapper({
     type: 'markdown',
     namespace: 'code-markdown',
     isInteractable: () => false,

--- a/apps/web/src/features/block-md/comments/CommentsProvider.tsx
+++ b/apps/web/src/features/block-md/comments/CommentsProvider.tsx
@@ -89,7 +89,7 @@ export const CommentsProvider: VoidComponent<{
     console.error('Cannot use comment plugin without node ids.');
     return null;
   }
-  const { plugins, editor } = wrapper;
+  const { editor } = wrapper;
 
   const currentPeerId = () => props.loroManager.peerIdStr;
 
@@ -378,7 +378,7 @@ export const CommentsProvider: VoidComponent<{
     )
   );
 
-  plugins.use(
+  autoRegister(
     commentPlugin({
       ops: {
         add: addCommentMark,
@@ -387,7 +387,7 @@ export const CommentsProvider: VoidComponent<{
         init: initComments,
       },
       peerId: currentPeerId,
-    })
+    })(editor)
   );
 
   return null;

--- a/apps/web/src/features/block-md/component/ComposeSkill.tsx
+++ b/apps/web/src/features/block-md/component/ComposeSkill.tsx
@@ -2,7 +2,7 @@ import { useSplitLayout } from '@components/app/split-layout/layout';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { buildConfig } from '@core/component/LexicalMarkdown/builder/MarkdownConfigBuilder';
 import { MarkdownShell } from '@core/component/LexicalMarkdown/builder/MarkdownShell';
-import { createLexicalWrapper } from '@core/component/LexicalMarkdown/context/LexicalWrapperContext';
+import { createLegacyLexicalWrapper } from '@core/component/LexicalMarkdown/context/LexicalWrapperContext';
 import {
   autoRegister,
   singleLinePlugin,
@@ -98,7 +98,7 @@ function ComposeSkillTitleEditor(props: {
   );
   const [rootConnected, setRootConnected] = createSignal(false);
 
-  const { editor, plugins, cleanup } = createLexicalWrapper({
+  const { editor, plugins, cleanup } = createLegacyLexicalWrapper({
     namespace: 'skill-composer-title',
     type: 'title',
     isInteractable: () => !props.disabled(),

--- a/apps/web/src/features/block-md/component/ComposeTask.tsx
+++ b/apps/web/src/features/block-md/component/ComposeTask.tsx
@@ -4,7 +4,7 @@ import { buildConfig } from '@core/component/LexicalMarkdown/builder/MarkdownCon
 import { MarkdownShell } from '@core/component/LexicalMarkdown/builder/MarkdownShell';
 import { EmojiMenu } from '@core/component/LexicalMarkdown/component/menu/EmojiMenu';
 import { TagsMenu } from '@core/component/LexicalMarkdown/component/menu/TagsMenu';
-import { createLexicalWrapper } from '@core/component/LexicalMarkdown/context/LexicalWrapperContext';
+import { createLegacyLexicalWrapper } from '@core/component/LexicalMarkdown/context/LexicalWrapperContext';
 import {
   autoRegister,
   emojisPlugin,
@@ -194,7 +194,7 @@ export function ComposeTaskTitleEditor(props: {
   );
   const [rootConnected, setRootConnected] = createSignal(false);
 
-  const { editor, plugins, cleanup } = createLexicalWrapper({
+  const { editor, plugins, cleanup } = createLegacyLexicalWrapper({
     namespace: 'task-composer-title',
     type: 'title',
     isInteractable: () => !props.disabled(),

--- a/apps/web/src/features/block-md/component/InstructionsEditor.tsx
+++ b/apps/web/src/features/block-md/component/InstructionsEditor.tsx
@@ -13,7 +13,7 @@ import {
   MarkdownEditorErrors,
 } from '@core/component/LexicalMarkdown/constants';
 import {
-  createLexicalWrapper,
+  createLegacyLexicalWrapper,
   LexicalWrapperContext,
 } from '@core/component/LexicalMarkdown/context/LexicalWrapperContext';
 import {
@@ -136,7 +136,7 @@ export function InstructionsEditor(props: {
     return (canEdit() ?? false) && !editorError();
   });
 
-  const lexicalWrapper = createLexicalWrapper({
+  const lexicalWrapper = createLegacyLexicalWrapper({
     type: 'markdown-sync',
     namespace: 'block-md-instructions',
     isInteractable: isContentEditable,

--- a/apps/web/src/features/block-md/component/InstructionsEditor.tsx
+++ b/apps/web/src/features/block-md/component/InstructionsEditor.tsx
@@ -396,7 +396,6 @@ export function InstructionsEditor(props: {
         <Show when={IS_SYNC()}>
           <MarkdownCollabProvider
             editor={editor}
-            pluginManager={plugins}
             editorContainerRef={editorContainerRef}
             highlighLayerRef={editorContainerRef}
             mappings={lexicalWrapper.mapping!}

--- a/apps/web/src/features/block-md/component/MarkdownCollabProvider.tsx
+++ b/apps/web/src/features/block-md/component/MarkdownCollabProvider.tsx
@@ -1,7 +1,6 @@
 import { markdownBlockErrorSignal } from '@block-md/signal/error';
 import { CollabProvider } from '@core/component/LexicalMarkdown/collaboration/CollabProvider';
 import type { MarkdownEditorErrors } from '@core/component/LexicalMarkdown/constants';
-import type { PluginManager } from '@core/component/LexicalMarkdown/plugins';
 import { blockSourceSignal, blockSyncSourceSignal } from '@core/signal/load';
 import { useCanComment, useCanEdit } from '@core/signal/permissions';
 import { isSourceSyncService } from '@core/util/source';
@@ -22,7 +21,6 @@ export {
 
 export type MarkdownCollabProviderProps = {
   editor: LexicalEditor;
-  pluginManager: PluginManager;
   editorContainerRef: HTMLDivElement;
   highlighLayerRef: HTMLDivElement;
   mappings: NodeIdMappings;
@@ -47,7 +45,6 @@ export function MarkdownCollabProvider(props: MarkdownCollabProviderProps) {
   return (
     <CollabProvider
       editor={props.editor}
-      pluginManager={props.pluginManager}
       editorContainerRef={props.editorContainerRef}
       highlightLayerRef={props.highlighLayerRef}
       mappings={props.mappings}

--- a/apps/web/src/features/block-md/component/MarkdownEditor.tsx
+++ b/apps/web/src/features/block-md/component/MarkdownEditor.tsx
@@ -11,6 +11,7 @@ import {
   useBlockId,
   useMaybeBlockAliasedName,
 } from '@core/block';
+import { registerLoroHistory } from '@core/component/LexicalMarkdown/collaboration/undo';
 import { DecoratorRenderer } from '@core/component/LexicalMarkdown/component/core/DecoratorRenderer';
 import { FocusClickTarget } from '@core/component/LexicalMarkdown/component/core/FocusClickTarget';
 import {
@@ -45,6 +46,7 @@ import {
   LexicalWrapperContext,
   type LexicalWrapperWithMapping,
 } from '@core/component/LexicalMarkdown/context/LexicalWrapperContext';
+import { pluginExtension } from '@core/component/LexicalMarkdown/extensions/pluginExtension';
 import {
   awaitPlugin,
   CLOSE_INLINE_SEARCH_COMMAND,
@@ -52,6 +54,7 @@ import {
   createDragInsertStore,
   createProgressStatsStore,
   createWordcountStatsStore,
+  customDeletePlugin,
   DefaultShortcuts,
   diffPlugin,
   documentMetadataPlugin,
@@ -103,6 +106,7 @@ import {
   type PersistentLocation,
   parsePersistentLocation,
 } from '@core/component/LexicalMarkdown/plugins/location';
+import { markdownShortcutsPlugin } from '@core/component/LexicalMarkdown/plugins/markdown-shortcuts';
 import {
   INSERT_MEDIA_COMMAND,
   mediaPlugin,
@@ -118,6 +122,7 @@ import {
 import { snippetsPlugin } from '@core/component/LexicalMarkdown/plugins/snippets';
 import { createMenuOperations } from '@core/component/LexicalMarkdown/shared/inlineMenu';
 import {
+  bindStateAs,
   editorFocusSignal,
   editorIsEmpty,
   getSaveState,
@@ -163,9 +168,13 @@ import { isSourceDSS, isSourceSyncService } from '@core/util/source';
 import { bufToString } from '@core/util/string';
 import { handleFileFolderDrop } from '@core/util/upload';
 import { type EntityDragEvent, isEntityDragEvent } from '@entity';
+import { CheckListExtension } from '@lexical/list';
+import { CODE } from '@lexical/markdown';
+import { RichTextExtension } from '@lexical/rich-text';
 import type { LoroManager } from '@macro-inc/collaboration/collab/manager';
 import {
   $isInlineSearchNode,
+  ALL_TRANSFORMERS,
   AwaitNode,
   CommentNode,
   createPeerIdValidator,
@@ -173,6 +182,7 @@ import {
   type PeerIdValidator,
   peerIdPlugin,
 } from '@macro-inc/lexical-core';
+import { HR } from '@macro-inc/lexical-core/transformers/transformers';
 import { useDocTags } from '@property/tags';
 import { EntityType } from '@service-properties/generated/schemas/entityType';
 import { onElementConnect } from '@solid-primitives/lifecycle';
@@ -180,7 +190,12 @@ import { isIOS } from '@solid-primitives/platform';
 import { createCallback } from '@solid-primitives/rootless';
 import { debounce, throttle } from '@solid-primitives/scheduled';
 import { createDroppable, useDragDropContext } from '@thisbeyond/solid-dnd';
-import { $getRoot, $isElementNode, type EditorState } from 'lexical';
+import {
+  $getRoot,
+  $isElementNode,
+  type AnyLexicalExtensionArgument,
+  type EditorState,
+} from 'lexical';
 import {
   type Accessor,
   createEffect,
@@ -347,11 +362,24 @@ export function MarkdownEditor(props: {
     return createPeerIdValidator(peerId, true);
   };
 
-  const configureEditor = (wrapper: LexicalWrapperWithMapping) => {
-    const { editor, plugins } = wrapper;
-    [state, setState] = createSignal(editor.getEditorState());
+  const editorExtensions = (wrapper: LexicalWrapperWithMapping) => {
+    const result: AnyLexicalExtensionArgument[] = [
+      RichTextExtension,
+      CheckListExtension,
+    ];
+    const use = (
+      name: string,
+      plugin: (editor: typeof wrapper.editor) => () => void
+    ) => {
+      result.push(pluginExtension(`markdown-editor/${name}`, plugin));
+    };
 
-    plugins.use(
+    use('state', (editor) => {
+      [state, setState] = createSignal(editor.getEditorState());
+      return bindStateAs(editor, setState, 'json');
+    });
+    use(
+      'location',
       locationPlugin({
         mapping: wrapper.mapping,
         revokeOptions: {
@@ -363,124 +391,139 @@ export function MarkdownEditor(props: {
         },
       })
     );
-
-    plugins
-      .richText()
-      .list()
-      .markdownShortcuts()
-      .delete()
-      .state<EditorState>(setState, 'json')
-      .history(400, props.loroManager)
-      .use(tabIndentationPlugin())
-      .use(selectionDataPlugin(wrapper))
-      .use(horizontalRulePlugin())
-      .use(
-        emojisPlugin({
-          menu: emojiMenuOperations,
-          peerIdValidator: peerIdValidator(),
-        })
-      )
-      .use(
-        mentionsPlugin({
-          menu: mentionsMenuOperations,
-          peerIdValidator: peerIdValidator(),
-          sourceDocumentId: blockId,
-        })
-      )
-      .use(
-        tagsPlugin({
-          menu: tagsMenuOperations,
-          peerIdValidator: peerIdValidator(),
-        })
-      )
-      .use(
-        snippetsPlugin({
-          menu: snippetsMenuOperations,
-          peerIdValidator: peerIdValidator(),
-          sourceDocumentId: blockId,
-        })
-      )
-      .use(
-        actionsPlugin({
-          menu: actionsMenuOperations,
-          peerIdValidator: peerIdValidator(),
-        })
-      )
-      .use(mediaPlugin())
-      .use(
-        tablePlugin({
-          hasCellMerge: true,
-          hasCellBackgroundColor: true,
-          hasTabHandler: true,
-          hasHorizontalScroll: true,
-        })
-      )
-      .use(tableCellResizerPlugin())
-      .use(tableTouchSelectionPlugin())
-      .use(
-        filePastePlugin({
-          onPasteFilesAndDirs: (fileEntries, directories) =>
-            handleFileFolderDrop(
-              fileEntries,
-              directories,
-              createFilesReadyHandler(editor, blockId)
-            ),
-        })
-      )
-      .use(
-        findAndReplacePlugin({
-          getListOffset: () => findAndReplaceStore.listOffset,
-          setListOffset: onSetListOffset,
-        })
-      )
-      .use(textPastePlugin())
-      .use(restoreFocusPlugin())
-      .use(markdownPastePlugin())
-      .use(normalizeEnterPlugin())
-      .use(trailingParagraphPlugin())
-      .use(
-        checkboxToTaskPlugin({
-          currentUserId: userId(),
-          parentTaskId: blockName === 'task' ? blockId : undefined,
-        })
-      )
-      .use(
-        keyboardShortcutsPlugin({
-          shortcuts: [
-            ...DefaultShortcuts,
-            {
-              label: `${IS_MAC ? 'meta' : 'ctrl'}+shift+o`,
-              test: (e) =>
-                e.code === 'KeyO' &&
-                e.shiftKey &&
-                (IS_MAC ? e.metaKey : e.ctrlKey),
-              handler: (editor) => {
-                const userId = useUserId()();
-                if (!userId) return;
-                editor.dispatchCommand(CONVERT_CHECKBOXES_TO_TASKS, {});
-              },
-              priority: 0,
+    use(
+      'markdown-shortcuts',
+      markdownShortcutsPlugin({
+        transformers: ALL_TRANSFORMERS,
+        triggerOnEnterTransformers: [HR, CODE],
+      })
+    );
+    use('delete', customDeletePlugin());
+    use('history', (editor) =>
+      registerLoroHistory(editor, props.loroManager.doc, 400)
+    );
+    use('tab-indentation', tabIndentationPlugin());
+    use('selection-data', selectionDataPlugin(wrapper));
+    use('horizontal-rule', horizontalRulePlugin());
+    use(
+      'emojis',
+      emojisPlugin({
+        menu: emojiMenuOperations,
+        peerIdValidator: peerIdValidator(),
+      })
+    );
+    use(
+      'mentions',
+      mentionsPlugin({
+        menu: mentionsMenuOperations,
+        peerIdValidator: peerIdValidator(),
+        sourceDocumentId: blockId,
+      })
+    );
+    use(
+      'tags',
+      tagsPlugin({
+        menu: tagsMenuOperations,
+        peerIdValidator: peerIdValidator(),
+      })
+    );
+    use(
+      'snippets',
+      snippetsPlugin({
+        menu: snippetsMenuOperations,
+        peerIdValidator: peerIdValidator(),
+        sourceDocumentId: blockId,
+      })
+    );
+    use(
+      'actions',
+      actionsPlugin({
+        menu: actionsMenuOperations,
+        peerIdValidator: peerIdValidator(),
+      })
+    );
+    use('media', mediaPlugin());
+    use(
+      'tables',
+      tablePlugin({
+        hasCellMerge: true,
+        hasCellBackgroundColor: true,
+        hasTabHandler: true,
+        hasHorizontalScroll: true,
+      })
+    );
+    use('table-cell-resizer', tableCellResizerPlugin());
+    use('table-touch-selection', tableTouchSelectionPlugin());
+    use('file-paste', (editor) =>
+      filePastePlugin({
+        onPasteFilesAndDirs: (fileEntries, directories) =>
+          handleFileFolderDrop(
+            fileEntries,
+            directories,
+            createFilesReadyHandler(editor, blockId)
+          ),
+      })(editor)
+    );
+    use(
+      'find-and-replace',
+      findAndReplacePlugin({
+        getListOffset: () => findAndReplaceStore.listOffset,
+        setListOffset: onSetListOffset,
+      })
+    );
+    use('text-paste', textPastePlugin());
+    use('restore-focus', restoreFocusPlugin());
+    use('markdown-paste', markdownPastePlugin());
+    use('normalize-enter', normalizeEnterPlugin());
+    use('trailing-paragraph', trailingParagraphPlugin());
+    use(
+      'checkbox-to-task',
+      checkboxToTaskPlugin({
+        currentUserId: userId(),
+        parentTaskId: blockName === 'task' ? blockId : undefined,
+      })
+    );
+    use(
+      'keyboard-shortcuts',
+      keyboardShortcutsPlugin({
+        shortcuts: [
+          ...DefaultShortcuts,
+          {
+            label: `${IS_MAC ? 'meta' : 'ctrl'}+shift+o`,
+            test: (e) =>
+              e.code === 'KeyO' &&
+              e.shiftKey &&
+              (IS_MAC ? e.metaKey : e.ctrlKey),
+            handler: (editor) => {
+              const userId = useUserId()();
+              if (!userId) return;
+              editor.dispatchCommand(CONVERT_CHECKBOXES_TO_TASKS, {});
             },
-          ],
-        })
-      )
-      .use(
-        documentMetadataPlugin({
-          onVersionError: (error) => setEditorError(error),
-        })
-      )
-      .use(pinnedPropertiesPlugin())
-      .use(awaitPlugin());
+            priority: 0,
+          },
+        ],
+      })
+    );
+    use(
+      'document-metadata',
+      documentMetadataPlugin({
+        onVersionError: (error) => setEditorError(error),
+      })
+    );
+    use('pinned-properties', pinnedPropertiesPlugin());
+    use('await', awaitPlugin());
 
     if (isIOS || isNativeMobilePlatform()) {
-      plugins.use(
+      use(
+        'ios-cursor-scroll',
         iosCursorScrollPlugin({ scrollContainer: () => md.scrollContainer })
       );
     }
 
     if (ENABLE_MARKDOWN_LIVE_COLLABORATION) {
       const peerId = () => props.loroManager.peerIdStr;
-      plugins.use(
+      use(
+        'peer-id',
         peerIdPlugin({
           peerId,
           nodes: [InlineSearchNode, CommentNode, AwaitNode],
@@ -489,7 +532,8 @@ export function MarkdownEditor(props: {
     }
 
     if (ENABLE_MARKDOWN_DIFF) {
-      plugins.use(
+      use(
+        'diff',
         diffPlugin({
           revisionsSignal: revisionsSignal,
           nodeIdMap: wrapper.mapping,
@@ -498,7 +542,8 @@ export function MarkdownEditor(props: {
     }
 
     if (ENABLE_MARKDOWN_AI_GENERATE) {
-      plugins.use(
+      use(
+        'generate',
         generatePlugin({
           completionSignal: completionSignal,
           isGeneratingSignal,
@@ -511,23 +556,28 @@ export function MarkdownEditor(props: {
       );
     }
 
-    plugins.use(
+    use(
+      'code',
       codePlugin({
         accessories: accessoryStore,
         setAccessories: setAccessoryStore,
       })
     );
-    plugins.use(listToTablePlugin());
+    use('list-to-table', listToTablePlugin());
 
     if (isFeatureEnabled(enableGitBlame)) {
-      plugins.use(
+      use(
+        'blame-tooltip',
         blameTooltipPlugin({ setState: (state) => setBlameTooltipStore(state) })
       );
     }
-    plugins.use(
+    use(
+      'wordcount',
       wordcountPlugin({ setStore: setWordcountStats, debounceTime: 200 })
     );
-    plugins.use(progressPlugin({ setStore: setProgressStats }));
+    use('progress', progressPlugin({ setStore: setProgressStats }));
+
+    return result;
   };
 
   const lexicalWrapper = createLexicalWrapper({
@@ -535,11 +585,11 @@ export function MarkdownEditor(props: {
     namespace: 'block-md-main',
     isInteractable: isContentEditable,
     withIds: true,
-    configure: (wrapper) =>
-      configureEditor(wrapper as LexicalWrapperWithMapping),
+    extensions: (wrapper) =>
+      editorExtensions(wrapper as LexicalWrapperWithMapping),
   });
 
-  const { editor, cleanup: cleanupPlugins } = lexicalWrapper;
+  const { editor, cleanup: cleanupEditor } = lexicalWrapper;
 
   setMdStore('editor', editor);
   setMdStore('mapping', lexicalWrapper.mapping);
@@ -755,7 +805,7 @@ export function MarkdownEditor(props: {
 
   onCleanup(() => {
     additionalCleanups.forEach((cleanup) => cleanup());
-    cleanupPlugins();
+    cleanupEditor();
   });
 
   const [titleEditorMenuOpen, setTitleEditorMenuOpen] = createSignal(false);

--- a/apps/web/src/features/block-md/component/MarkdownEditor.tsx
+++ b/apps/web/src/features/block-md/component/MarkdownEditor.tsx
@@ -43,6 +43,7 @@ import { FloatingMenuGroup } from '@core/component/LexicalMarkdown/context/Float
 import {
   createLexicalWrapper,
   LexicalWrapperContext,
+  type LexicalWrapperWithMapping,
 } from '@core/component/LexicalMarkdown/context/LexicalWrapperContext';
 import {
   awaitPlugin,
@@ -187,6 +188,7 @@ import {
   createSignal,
   on,
   onCleanup,
+  type Setter,
   Show,
   Suspense,
   untrack,
@@ -305,36 +307,247 @@ export function MarkdownEditor(props: {
     );
   });
 
-  const lexicalWrapper = createLexicalWrapper({
-    type: 'markdown-sync',
-    namespace: 'block-md-main',
-    isInteractable: isContentEditable,
-    withIds: true,
-  });
-
-  const { editor, plugins, cleanup: cleanupPlugins } = lexicalWrapper;
-
-  const [state, setState] = createSignal<EditorState>(editor.getEditorState());
-
-  setMdStore('editor', editor);
-  setMdStore('mapping', lexicalWrapper.mapping);
-  setMdStore('plugins', plugins);
-
-  const [editorFocus, setEditorFocus] = createSignal(false);
-  autoRegister(editorFocusSignal(editor, setEditorFocus));
-
+  let state!: Accessor<EditorState>;
+  let setState!: Setter<EditorState>;
   const mentionsMenuOperations = createMenuOperations();
   const tagsMenuOperations = createMenuOperations();
   const emojiMenuOperations = createMenuOperations();
   const actionsMenuOperations = createMenuOperations();
   const snippetsMenuOperations = createMenuOperations();
 
-  // store for the drag insert pluign.
+  // Stores shared by editor plugins and their Solid UI.
   const [dragInsertStore, setDragInsertStore] = createDragInsertStore();
-
-  // store for the draggable block (drag-to-rearrange) plugin.
   const [draggableBlockStore, setDraggableBlockStore] =
     createDraggableBlockStore();
+  const [accessoryStore, setAccessoryStore] = createAccessoryStore();
+  const [blameTooltipStore, setBlameTooltipStore] = createBlameTooltipStore();
+  const [wordcountStats, setWordcountStats] = createWordcountStatsStore();
+  const [progressStats, setProgressStats] = createProgressStatsStore();
+
+  const onSetListOffset = (listOffset: NodekeyOffset[]) => {
+    setFindAndReplaceStore('listOffset', listOffset);
+    if (findAndReplaceStore.currentMatch >= listOffset.length) {
+      setFindAndReplaceStore('currentMatch', 0);
+    }
+  };
+
+  const [highlightNodeId, setHighlightNodeId] = createSignal<string>();
+  const [activeCommentIdParam, setActiveCommentIdParam] = createSignal<
+    string | undefined
+  >(undefined, { equals: false });
+  const [activeLocation, setActiveLocation] =
+    createSignal<PersistentLocation>();
+  const [locationReady, setLocationReady] = createSignal(false);
+
+  const peerIdValidator: Accessor<PeerIdValidator> = () => {
+    if (!IS_SYNC()) {
+      return createPeerIdValidator(() => undefined, false);
+    }
+    const peerId = () => props.loroManager.peerIdStr;
+    return createPeerIdValidator(peerId, true);
+  };
+
+  const configureEditor = (wrapper: LexicalWrapperWithMapping) => {
+    const { editor, plugins } = wrapper;
+    [state, setState] = createSignal(editor.getEditorState());
+
+    plugins.use(
+      locationPlugin({
+        mapping: wrapper.mapping,
+        revokeOptions: {
+          onRevokeLocation: () => {
+            setActiveLocation();
+          },
+          selectionChange: () => locationReady(),
+          mutation: () => locationReady(),
+        },
+      })
+    );
+
+    plugins
+      .richText()
+      .list()
+      .markdownShortcuts()
+      .delete()
+      .state<EditorState>(setState, 'json')
+      .history(400, props.loroManager)
+      .use(tabIndentationPlugin())
+      .use(selectionDataPlugin(wrapper))
+      .use(horizontalRulePlugin())
+      .use(
+        emojisPlugin({
+          menu: emojiMenuOperations,
+          peerIdValidator: peerIdValidator(),
+        })
+      )
+      .use(
+        mentionsPlugin({
+          menu: mentionsMenuOperations,
+          peerIdValidator: peerIdValidator(),
+          sourceDocumentId: blockId,
+        })
+      )
+      .use(
+        tagsPlugin({
+          menu: tagsMenuOperations,
+          peerIdValidator: peerIdValidator(),
+        })
+      )
+      .use(
+        snippetsPlugin({
+          menu: snippetsMenuOperations,
+          peerIdValidator: peerIdValidator(),
+          sourceDocumentId: blockId,
+        })
+      )
+      .use(
+        actionsPlugin({
+          menu: actionsMenuOperations,
+          peerIdValidator: peerIdValidator(),
+        })
+      )
+      .use(mediaPlugin())
+      .use(
+        tablePlugin({
+          hasCellMerge: true,
+          hasCellBackgroundColor: true,
+          hasTabHandler: true,
+          hasHorizontalScroll: true,
+        })
+      )
+      .use(tableCellResizerPlugin())
+      .use(tableTouchSelectionPlugin())
+      .use(
+        filePastePlugin({
+          onPasteFilesAndDirs: (fileEntries, directories) =>
+            handleFileFolderDrop(
+              fileEntries,
+              directories,
+              createFilesReadyHandler(editor, blockId)
+            ),
+        })
+      )
+      .use(
+        findAndReplacePlugin({
+          getListOffset: () => findAndReplaceStore.listOffset,
+          setListOffset: onSetListOffset,
+        })
+      )
+      .use(textPastePlugin())
+      .use(restoreFocusPlugin())
+      .use(markdownPastePlugin())
+      .use(normalizeEnterPlugin())
+      .use(trailingParagraphPlugin())
+      .use(
+        checkboxToTaskPlugin({
+          currentUserId: userId(),
+          parentTaskId: blockName === 'task' ? blockId : undefined,
+        })
+      )
+      .use(
+        keyboardShortcutsPlugin({
+          shortcuts: [
+            ...DefaultShortcuts,
+            {
+              label: `${IS_MAC ? 'meta' : 'ctrl'}+shift+o`,
+              test: (e) =>
+                e.code === 'KeyO' &&
+                e.shiftKey &&
+                (IS_MAC ? e.metaKey : e.ctrlKey),
+              handler: (editor) => {
+                const userId = useUserId()();
+                if (!userId) return;
+                editor.dispatchCommand(CONVERT_CHECKBOXES_TO_TASKS, {});
+              },
+              priority: 0,
+            },
+          ],
+        })
+      )
+      .use(
+        documentMetadataPlugin({
+          onVersionError: (error) => setEditorError(error),
+        })
+      )
+      .use(pinnedPropertiesPlugin())
+      .use(awaitPlugin());
+
+    if (isIOS || isNativeMobilePlatform()) {
+      plugins.use(
+        iosCursorScrollPlugin({ scrollContainer: () => md.scrollContainer })
+      );
+    }
+
+    if (ENABLE_MARKDOWN_LIVE_COLLABORATION) {
+      const peerId = () => props.loroManager.peerIdStr;
+      plugins.use(
+        peerIdPlugin({
+          peerId,
+          nodes: [InlineSearchNode, CommentNode, AwaitNode],
+        })
+      );
+    }
+
+    if (ENABLE_MARKDOWN_DIFF) {
+      plugins.use(
+        diffPlugin({
+          revisionsSignal: revisionsSignal,
+          nodeIdMap: wrapper.mapping,
+        })
+      );
+    }
+
+    if (ENABLE_MARKDOWN_AI_GENERATE) {
+      plugins.use(
+        generatePlugin({
+          completionSignal: completionSignal,
+          isGeneratingSignal,
+          generatedAndWaitingSignal,
+          menuSignal: generateMenuSignal,
+          setContext: generateContextSignal[1],
+          accessories: accessoryStore,
+          setAccessories: setAccessoryStore,
+        })
+      );
+    }
+
+    plugins.use(
+      codePlugin({
+        accessories: accessoryStore,
+        setAccessories: setAccessoryStore,
+      })
+    );
+    plugins.use(listToTablePlugin());
+
+    if (isFeatureEnabled(enableGitBlame)) {
+      plugins.use(
+        blameTooltipPlugin({ setState: (state) => setBlameTooltipStore(state) })
+      );
+    }
+    plugins.use(
+      wordcountPlugin({ setStore: setWordcountStats, debounceTime: 200 })
+    );
+    plugins.use(progressPlugin({ setStore: setProgressStats }));
+  };
+
+  const lexicalWrapper = createLexicalWrapper({
+    type: 'markdown-sync',
+    namespace: 'block-md-main',
+    isInteractable: isContentEditable,
+    withIds: true,
+    configure: (wrapper) =>
+      configureEditor(wrapper as LexicalWrapperWithMapping),
+  });
+
+  const { editor, cleanup: cleanupPlugins } = lexicalWrapper;
+
+  setMdStore('editor', editor);
+  setMdStore('mapping', lexicalWrapper.mapping);
+  setMdStore('wordcountStats', wordcountStats);
+  setMdStore('progressStats', progressStats);
+
+  const [editorFocus, setEditorFocus] = createSignal(false);
+  autoRegister(editorFocusSignal(editor, setEditorFocus));
 
   // set up the solid-dnd stuff
   const droppable = createDroppable(editor._config.namespace, {
@@ -446,22 +659,6 @@ export function MarkdownEditor(props: {
     dndDragMove(event);
   });
 
-  const onSetListOffset = (listOffset: NodekeyOffset[]) => {
-    setFindAndReplaceStore('listOffset', listOffset);
-    if (findAndReplaceStore.currentMatch >= listOffset.length) {
-      setFindAndReplaceStore('currentMatch', 0);
-    }
-  };
-
-  const [highlightNodeId, setHighlightNodeId] = createSignal<string>();
-  const [activeCommentIdParam, setActiveCommentIdParam] = createSignal<
-    string | undefined
-  >(undefined, { equals: false });
-
-  const [activeLocation, setActiveLocation] =
-    createSignal<PersistentLocation>();
-  const [locationReady, setLocationReady] = createSignal(false);
-
   createEffect(() => {
     setMdStore({ locationReady: locationReady() });
   });
@@ -484,19 +681,6 @@ export function MarkdownEditor(props: {
           setActiveLocation(locationObj);
         }
       }
-    })
-  );
-
-  plugins.use(
-    locationPlugin({
-      mapping: lexicalWrapper.mapping,
-      revokeOptions: {
-        onRevokeLocation: () => {
-          setActiveLocation();
-        },
-        selectionChange: () => locationReady(),
-        mutation: () => locationReady(),
-      },
     })
   );
 
@@ -528,176 +712,6 @@ export function MarkdownEditor(props: {
     }
   });
 
-  const peerIdValidator: Accessor<PeerIdValidator> = () => {
-    if (!IS_SYNC()) {
-      return createPeerIdValidator(() => undefined, false);
-    }
-    const peerId = () => props.loroManager.peerIdStr;
-    return createPeerIdValidator(peerId, true);
-  };
-
-  // plugins
-  plugins
-    .richText()
-    .list()
-    .markdownShortcuts()
-    .delete()
-    .state<EditorState>(setState, 'json')
-    .history(400, props.loroManager)
-    .use(tabIndentationPlugin())
-    .use(selectionDataPlugin(lexicalWrapper))
-    .use(horizontalRulePlugin())
-    .use(
-      emojisPlugin({
-        menu: emojiMenuOperations,
-        peerIdValidator: peerIdValidator(),
-      })
-    )
-    .use(
-      mentionsPlugin({
-        menu: mentionsMenuOperations,
-        peerIdValidator: peerIdValidator(),
-        sourceDocumentId: blockId,
-      })
-    )
-    .use(
-      tagsPlugin({
-        menu: tagsMenuOperations,
-        peerIdValidator: peerIdValidator(),
-      })
-    )
-    .use(
-      snippetsPlugin({
-        menu: snippetsMenuOperations,
-        peerIdValidator: peerIdValidator(),
-        sourceDocumentId: blockId,
-      })
-    )
-    .use(
-      actionsPlugin({
-        menu: actionsMenuOperations,
-        peerIdValidator: peerIdValidator(),
-      })
-    )
-    .use(mediaPlugin())
-    .use(
-      tablePlugin({
-        hasCellMerge: true,
-        hasCellBackgroundColor: true,
-        hasTabHandler: true,
-        hasHorizontalScroll: true,
-      })
-    )
-    .use(tableCellResizerPlugin())
-    .use(tableTouchSelectionPlugin())
-    .use(
-      filePastePlugin({
-        onPasteFilesAndDirs: (fileEntries, directories) =>
-          handleFileFolderDrop(
-            fileEntries,
-            directories,
-            createFilesReadyHandler(editor, blockId)
-          ),
-      })
-    )
-    .use(
-      findAndReplacePlugin({
-        getListOffset: () => findAndReplaceStore.listOffset,
-        setListOffset: onSetListOffset,
-      })
-    )
-    .use(
-      dragInsertPlugin({
-        setState: setDragInsertStore,
-        dragListenerRef: editorContainerRef,
-      })
-    )
-    .use(textPastePlugin())
-    .use(restoreFocusPlugin())
-    .use(markdownPastePlugin())
-    .use(normalizeEnterPlugin())
-    .use(trailingParagraphPlugin())
-    .use(
-      checkboxToTaskPlugin({
-        currentUserId: userId(),
-        parentTaskId: blockName === 'task' ? blockId : undefined,
-      })
-    )
-    .use(
-      keyboardShortcutsPlugin({
-        shortcuts: [
-          ...DefaultShortcuts,
-          {
-            label: `${IS_MAC ? 'meta' : 'ctrl'}+shift+o`,
-            test: (e) =>
-              e.code === 'KeyO' &&
-              e.shiftKey &&
-              (IS_MAC ? e.metaKey : e.ctrlKey),
-            handler: (editor) => {
-              const userId = useUserId()();
-              if (!userId) return;
-              editor.dispatchCommand(CONVERT_CHECKBOXES_TO_TASKS, {});
-            },
-            priority: 0,
-          },
-        ],
-      })
-    )
-    .use(
-      documentMetadataPlugin({
-        onVersionError: (error) => setEditorError(error),
-      })
-    )
-    .use(pinnedPropertiesPlugin())
-    .use(awaitPlugin());
-
-  if (isIOS || isNativeMobilePlatform()) {
-    plugins.use(
-      iosCursorScrollPlugin({ scrollContainer: () => md.scrollContainer })
-    );
-  }
-
-  if (ENABLE_MARKDOWN_LIVE_COLLABORATION) {
-    const peerId = () => props.loroManager.peerIdStr;
-    plugins.use(
-      peerIdPlugin({
-        peerId,
-        nodes: [InlineSearchNode, CommentNode, AwaitNode],
-      })
-    );
-  }
-
-  if (ENABLE_MARKDOWN_DIFF) {
-    plugins.use(
-      diffPlugin({
-        revisionsSignal: revisionsSignal,
-        nodeIdMap: lexicalWrapper.mapping!,
-      })
-    );
-  }
-
-  const [accessoryStore, setAccessoryStore] = createAccessoryStore();
-  if (ENABLE_MARKDOWN_AI_GENERATE) {
-    plugins.use(
-      generatePlugin({
-        completionSignal: completionSignal,
-        isGeneratingSignal,
-        generatedAndWaitingSignal,
-        menuSignal: generateMenuSignal,
-        setContext: generateContextSignal[1],
-        accessories: accessoryStore,
-        setAccessories: setAccessoryStore,
-      })
-    );
-  }
-  plugins.use(
-    codePlugin({
-      accessories: accessoryStore,
-      setAccessories: setAccessoryStore,
-    })
-  );
-  plugins.use(listToTablePlugin());
-
   const [editorHasNoContent, setEditorHasNoContent] = createSignal(false);
 
   const observeClickTargetHeight = () => {
@@ -716,24 +730,23 @@ export function MarkdownEditor(props: {
     setMdStore('selection', lexicalWrapper.selection);
     editor.setRootElement(el);
 
-    // Register plugins that require the container ref.
-    plugins.use(
-      dragInsertPlugin({
-        setState: setDragInsertStore,
-        dragListenerRef: editorContainerRef,
-      })
-    );
-    plugins.use(
-      draggableBlockPlugin({
-        setState: setDraggableBlockStore,
-        anchorElem: editorContainerRef,
-      })
-    );
+    // These registrations depend on the connected container and are owned by
+    // the Solid root lifecycle rather than being added to the extension graph late.
+    const cleanupDragInsert = dragInsertPlugin({
+      setState: setDragInsertStore,
+      dragListenerRef: editorContainerRef,
+    })(editor);
+    const cleanupDraggableBlocks = draggableBlockPlugin({
+      setState: setDraggableBlockStore,
+      anchorElem: editorContainerRef,
+    })(editor);
 
     const editorRefObserver = new ResizeObserver(observeClickTargetHeight);
 
     editorRefObserver.observe(el);
     onCleanup(() => {
+      cleanupDragInsert();
+      cleanupDraggableBlocks();
       editorRefObserver.disconnect();
     });
   };
@@ -780,12 +793,9 @@ export function MarkdownEditor(props: {
     editor.setEditable(editorReady() && (canEdit() ?? false));
   });
 
-  plugins.useReactive(
+  lazyRegister(
     () => md.titleEditor,
-    () => {
-      if (md.titleEditor)
-        return keyNavigationPlugin(md.titleEditor, isInlineMenuOpen);
-    }
+    (titleEditor) => keyNavigationPlugin(titleEditor, isInlineMenuOpen)(editor)
   );
 
   const isBlankMarkdown = createMemo(() => {
@@ -957,23 +967,6 @@ export function MarkdownEditor(props: {
     },
   });
 
-  const [blameTooltipStore, setBlameTooltipStore] = createBlameTooltipStore();
-  if (isFeatureEnabled(enableGitBlame)) {
-    plugins.use(
-      blameTooltipPlugin({ setState: (s) => setBlameTooltipStore(s) })
-    );
-  }
-
-  const [wordcountStats, setWordcountStats] = createWordcountStatsStore();
-  plugins.use(
-    wordcountPlugin({ setStore: setWordcountStats, debounceTime: 200 })
-  );
-  setMdStore('wordcountStats', wordcountStats);
-
-  const [progressStats, setProgressStats] = createProgressStatsStore();
-  plugins.use(progressPlugin({ setStore: setProgressStats }));
-  setMdStore('progressStats', progressStats);
-
   return (
     <LexicalWrapperContext.Provider value={lexicalWrapper}>
       <Show when={editorError()}>
@@ -1018,7 +1011,6 @@ export function MarkdownEditor(props: {
         <Show when={IS_SYNC()}>
           <MarkdownCollabProvider
             editor={editor}
-            pluginManager={plugins}
             editorContainerRef={editorContainerRef}
             highlighLayerRef={highlightLayerRef() ?? editorContainerRef}
             mappings={lexicalWrapper.mapping!}

--- a/apps/web/src/features/block-md/component/MarkdownPopup.tsx
+++ b/apps/web/src/features/block-md/component/MarkdownPopup.tsx
@@ -113,8 +113,8 @@ export function MarkdownPopup(props: {
 }) {
   const blockId = useBlockId();
 
-  const { editor, plugins } = useContext(LexicalWrapperContext) ?? {};
-  if (!editor || !plugins) {
+  const { editor } = useContext(LexicalWrapperContext) ?? {};
+  if (!editor) {
     console.error('MarkdownPopup mounted outside of LexicalWrapperContext!');
     return '';
   }
@@ -166,7 +166,7 @@ export function MarkdownPopup(props: {
     setAiEditLocation(editor.read(() => $getSelectionLocation()));
   };
 
-  plugins.use(
+  autoRegister(
     popupPlugin({
       setIsPopupVisible: setPopupVisible,
       setSelection: setSelectionAndHighlight,
@@ -182,7 +182,7 @@ export function MarkdownPopup(props: {
           ) != null
         );
       },
-    })
+    })(editor)
   );
 
   // The actual control value for showPopup lags.

--- a/apps/web/src/features/block-md/component/TitleEditor.tsx
+++ b/apps/web/src/features/block-md/component/TitleEditor.tsx
@@ -5,7 +5,7 @@ import {
 } from '@core/block';
 import { EmojiMenu } from '@core/component/LexicalMarkdown/component/menu/EmojiMenu';
 import { TagsMenu } from '@core/component/LexicalMarkdown/component/menu/TagsMenu';
-import { createLexicalWrapper } from '@core/component/LexicalMarkdown/context/LexicalWrapperContext';
+import { createLegacyLexicalWrapper } from '@core/component/LexicalMarkdown/context/LexicalWrapperContext';
 import {
   autoRegister,
   emojisPlugin,
@@ -192,7 +192,7 @@ export function TitleEditor(props: { autoFocusOnMount?: boolean } = {}) {
   const [state, setState] = createSignal('');
   const [initialized, setInitialized] = createSignal(false);
 
-  const { editor, plugins, cleanup } = createLexicalWrapper({
+  const { editor, plugins, cleanup } = createLegacyLexicalWrapper({
     namespace: 'block-md-title',
     type: 'title',
     isInteractable: createMemo(() => {

--- a/apps/web/src/features/block-md/signal/markdownBlockData.ts
+++ b/apps/web/src/features/block-md/signal/markdownBlockData.ts
@@ -17,7 +17,7 @@ export const blockDataSignal = blockDataSignalAs<MarkdownData>('md');
  * Store for the data and helpful ui refs for the Notebook/MD block
  * @property editor The Editor instance
  * @property titleEditor The Editor instance for the title
- * @property plugins The plugin manager for the main editor
+ * @property plugins The plugin manager for legacy editor surfaces
  * @property selection A store with the processed selection data
  * @property notebook The notbook ref which is the direct containing parent of the two editors and is
  *     clamped to a max width.

--- a/apps/web/src/lib/core/collab-surface/CollabMdSurface.tsx
+++ b/apps/web/src/lib/core/collab-surface/CollabMdSurface.tsx
@@ -8,7 +8,7 @@ import {
   type MarkdownEditorErrors,
 } from '@core/component/LexicalMarkdown/constants';
 import {
-  createLexicalWrapper,
+  createLegacyLexicalWrapper,
   LexicalWrapperContext,
 } from '@core/component/LexicalMarkdown/context/LexicalWrapperContext';
 import {
@@ -138,7 +138,7 @@ export function CollabMdSurface(props: CollabMdSurfaceProps) {
 
   const isContentEditable = () => canEdit() && !editorError();
 
-  const lexicalWrapper = createLexicalWrapper({
+  const lexicalWrapper = createLegacyLexicalWrapper({
     type: 'markdown-sync',
     namespace: props.namespace ?? 'collab-surface',
     isInteractable: isContentEditable,

--- a/apps/web/src/lib/core/collab-surface/CollabMdSurface.tsx
+++ b/apps/web/src/lib/core/collab-surface/CollabMdSurface.tsx
@@ -290,7 +290,6 @@ export function CollabMdSurface(props: CollabMdSurfaceProps) {
           <Show when={session.syncSource()}>
             <CollabProvider
               editor={editor}
-              pluginManager={plugins}
               editorContainerRef={editorContainerRef}
               highlightLayerRef={editorContainerRef}
               mappings={lexicalWrapper.mapping!}

--- a/apps/web/src/lib/core/component/LexicalMarkdown/builder/MarkdownConfigBuilder.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/builder/MarkdownConfigBuilder.ts
@@ -1,7 +1,7 @@
 import type { EditorType } from '@macro-inc/lexical-core';
 import type { LexicalEditor } from 'lexical';
 import type { Store } from 'solid-js/store';
-import type { PluginManager, SelectionData } from '../plugins';
+import type { SelectionData } from '../plugins';
 import type { Action } from '../plugins/actions/types';
 import { buildHandleFromConfig } from './buildHandleFromConfig';
 import type {
@@ -225,8 +225,8 @@ export class EditorConfigBuilder implements EditorBuilder {
 
   /**
    * Register a custom Lexical plugin as part of the builder chain.
-   * Plugins are queued here and applied during `buildHandle()` after all
-   * built-in plugins have been registered.
+   * Plugins are queued here, adapted into named extensions, and composed into
+   * the editor graph after the built-in extensions.
    */
   use(pluginFn: (editor: LexicalEditor) => () => void): this {
     this._queuedPlugins.push(pluginFn);
@@ -262,13 +262,6 @@ export class EditorConfigBuilder implements EditorBuilder {
     return this._handle.lexical;
   }
 
-  /** The plugin manager. Available after `<MarkdownShell>` mounts. */
-  get plugins(): PluginManager {
-    if (!this._handle)
-      throw new Error('editor.plugins accessed before <MarkdownShell> mounted');
-    return this._handle.plugins;
-  }
-
   /** Reactive selection state, if `.withSelectionData()` was enabled. Available after `<MarkdownShell>` mounts. */
   get selection(): Store<SelectionData> | undefined {
     return this._handle?.selection;
@@ -281,8 +274,8 @@ export class EditorConfigBuilder implements EditorBuilder {
  * Chain feature methods to opt into capabilities, then pass the builder to
  * directly to `<MarkdownShell editor={...} />`.
  *
- * Use the builder variable to access `controls`, `lexical`, `plugins`, and
- * `selection` after the component has mounted.
+ * Use the builder variable to access `controls`, `lexical`, and `selection`
+ * after the component has mounted.
  *
  * @param type - Lexical editor mode. Defaults to `'markdown'` (full rich-text).
  *   Use `'chat'` for a mode that supports mention nodes without media nodes.

--- a/apps/web/src/lib/core/component/LexicalMarkdown/builder/MarkdownConfigBuilder.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/builder/MarkdownConfigBuilder.ts
@@ -242,10 +242,7 @@ export class EditorConfigBuilder implements EditorBuilder {
    */
   buildHandle(): EditorHandle {
     if (this._handle) return this._handle;
-    this._handle = buildHandleFromConfig(this.state);
-    for (const plugin of this._queuedPlugins) {
-      this._handle.plugins.use(plugin);
-    }
+    this._handle = buildHandleFromConfig(this.state, this._queuedPlugins);
     return this._handle;
   }
 

--- a/apps/web/src/lib/core/component/LexicalMarkdown/builder/buildHandleFromConfig.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/builder/buildHandleFromConfig.ts
@@ -2,7 +2,10 @@ import { handleFileFolderDrop } from '@core/util/upload';
 import type { EditorType } from '@macro-inc/lexical-core';
 import type { SerializedEditorState } from 'lexical';
 import { createSignal } from 'solid-js';
-import { createLexicalWrapper } from '../context/LexicalWrapperContext';
+import {
+  createLexicalWrapper,
+  type LexicalWrapper,
+} from '../context/LexicalWrapperContext';
 import {
   actionsPlugin,
   agentCommandsPlugin,
@@ -20,6 +23,7 @@ import {
   markdownPastePlugin,
   mediaPlugin,
   mentionsPlugin,
+  type PluginFunction,
   selectionDataPlugin,
   singleLinePlugin,
   skillsPlugin,
@@ -48,28 +52,11 @@ import type {
   MediaOptions,
 } from './types';
 
-export function buildHandleFromConfig(config: EditorConfig): EditorHandle {
+export function buildHandleFromConfig(
+  config: EditorConfig,
+  additionalPlugins: PluginFunction[] = []
+): EditorHandle {
   const [isInteractable, setIsInteractable] = createSignal(true);
-
-  const lexicalWrapper = config.withIds
-    ? createLexicalWrapper({
-        type: config.type as EditorType,
-        namespace: config.namespace,
-        isInteractable,
-        withIds: true,
-      })
-    : createLexicalWrapper({
-        type: config.type as EditorType,
-        namespace: config.namespace,
-        isInteractable,
-      });
-
-  if (config.skipPreviewFetch) {
-    lexicalWrapper.skipPreviewFetch = true;
-  }
-
-  const { editor, plugins, cleanup: cleanupLexical } = lexicalWrapper;
-
   const [markdownState, setMarkdownState] = createSignal<string>('');
 
   const actionsMenuOps =
@@ -114,127 +101,6 @@ export function buildHandleFromConfig(config: EditorConfig): EditorHandle {
   const accessoryStore = accessoryStoreResult?.[0];
   const setAccessoryStore = accessoryStoreResult?.[1];
 
-  if (config.type === 'plain-text') {
-    plugins.plainText().state<string>(setMarkdownState, 'plain');
-  } else if (config.singleLine) {
-    plugins.richText().state<string>(setMarkdownState, 'markdown');
-  } else {
-    // Full markdown: everything
-    plugins
-      .richText()
-      .list()
-      .markdownShortcuts()
-      .delete()
-      .state<string>(setMarkdownState, 'markdown');
-  }
-
-  if (config.type !== 'plain-text' && !config.singleLine) {
-    plugins.use(trailingParagraphPlugin());
-  }
-
-  // History
-  if (config.history) {
-    plugins.history(config.history.timeGap);
-  }
-
-  // Single line mode
-  if (config.singleLine) {
-    plugins.use(singleLinePlugin());
-  }
-
-  // Restore focus (registered early, before other plugins)
-  if (config.restoreFocus) {
-    plugins.use(restoreFocusPlugin());
-  }
-
-  // Text paste handling
-  plugins.use(textPastePlugin());
-
-  // Markdown paste handling (rich & full editors only)
-  if (config.type !== 'plain-text') {
-    plugins.use(markdownPastePlugin());
-  }
-
-  // Tab indentation (unless custom handler)
-  if (!config.handlers.onTab) {
-    plugins.use(tabIndentationPlugin());
-  }
-
-  // Horizontal rules & normalize-enter (full multi-line markdown only)
-  if (config.type !== 'plain-text' && !config.singleLine) {
-    plugins.use(horizontalRulePlugin());
-    plugins.use(normalizeEnterPlugin());
-  }
-
-  // Await placeholders for in-flight async operations (any non-plain-text editor).
-  if (config.type !== 'plain-text') {
-    plugins.use(awaitPlugin());
-  }
-
-  // Selection / formatting state
-  if (config.selectionData) {
-    plugins.use(selectionDataPlugin(lexicalWrapper));
-  }
-
-  // Actions / slash-command menu (not available for plain-text)
-  if (actionsMenuOps) {
-    plugins.use(actionsPlugin({ menu: actionsMenuOps }));
-  }
-
-  // Mentions & Emojis (not available for plain-text — nodes not registered)
-  if (config.type !== 'plain-text') {
-    if (config.mentions && mentionsMenuOps) {
-      plugins.use(
-        mentionsPlugin({
-          menu: mentionsMenuOps,
-          onCreateMention: config.mentions.onCreate,
-          onRemoveMention: config.mentions.onRemove,
-          sourceDocumentId: config.mentions.sourceDocumentId,
-        })
-      );
-    }
-
-    if (config.tags && tagsMenuOps) {
-      plugins.use(
-        tagsPlugin({
-          menu: tagsMenuOps,
-          insertTags: config.tags.insertTags,
-          onCreateTag: config.tags.applyTargetLabel
-            ? undefined
-            : config.tags.onCreate,
-          onRemoveTag: config.tags.onRemove,
-          setTags: config.tags.setTags,
-        })
-      );
-    }
-
-    if (emojisMenuOps) {
-      plugins.use(emojisPlugin({ menu: emojisMenuOps }));
-    }
-
-    if (snippetsMenuOps) {
-      plugins.use(
-        snippetsPlugin({
-          menu: snippetsMenuOps,
-          sourceDocumentId: config.mentions?.sourceDocumentId,
-        })
-      );
-    }
-
-    if (skillsMenuOps) {
-      plugins.use(skillsPlugin({ menu: skillsMenuOps }));
-    }
-
-    if (agentCommandsMenuOps && config.agentCommands) {
-      plugins.use(
-        agentCommandsPlugin({
-          menu: agentCommandsMenuOps,
-          commands: config.agentCommands.commands,
-        })
-      );
-    }
-  }
-
   // Media (images, videos)
   const mediaEnabled = !!config.media;
   const mediaConfig: MediaOptions | undefined =
@@ -249,15 +115,6 @@ export function buildHandleFromConfig(config: EditorConfig): EditorHandle {
   const dragInsertStore = dragInsertStoreResult?.[0];
   const setDragInsertStore = dragInsertStoreResult?.[1];
 
-  if (mediaEnabled) {
-    plugins.use(mediaPlugin());
-  }
-
-  // File drag-and-drop from desktop
-  if (fileDropConfig && setDragInsertStore) {
-    plugins.use(dragInsertPlugin({ setState: setDragInsertStore }));
-  }
-
   // Drag-to-rearrange blocks (uses root element fallback since no anchor ref
   // is available during builder-time configuration).
   const draggableBlockStoreResult = config.draggableBlocks
@@ -266,76 +123,235 @@ export function buildHandleFromConfig(config: EditorConfig): EditorHandle {
   const draggableBlockStore = draggableBlockStoreResult?.[0];
   const setDraggableBlockStore = draggableBlockStoreResult?.[1];
 
-  if (config.draggableBlocks && setDraggableBlockStore) {
-    plugins.use(draggableBlockPlugin({ setState: setDraggableBlockStore }));
-  }
+  const configure = (lexicalWrapper: LexicalWrapper) => {
+    if (config.skipPreviewFetch) {
+      lexicalWrapper.skipPreviewFetch = true;
+    }
 
-  // File clipboard paste — auto-register when fileDrop is enabled, since
-  // dragInsertPlugin blocks DRAG_DROP_PASTE (Lexical's built-in paste-files
-  // path) without processing the files. A custom filePaste config from
-  // withFilePaste() takes precedence.
-  if (fileDropConfig && !config.filePaste) {
-    plugins.use(
-      filePastePlugin({
-        onPasteFilesAndDirs: (fileEntries, directories) => {
-          handleFileFolderDrop(
-            fileEntries,
-            directories,
-            createFilesReadyHandler(
-              editor,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              fileDropConfig.constrainedMediaDimensions
-            )
-          );
-        },
+    const { editor, plugins } = lexicalWrapper;
+
+    if (config.type === 'plain-text') {
+      plugins.plainText().state<string>(setMarkdownState, 'plain');
+    } else if (config.singleLine) {
+      plugins.richText().state<string>(setMarkdownState, 'markdown');
+    } else {
+      // Full markdown: everything
+      plugins
+        .richText()
+        .list()
+        .markdownShortcuts()
+        .delete()
+        .state<string>(setMarkdownState, 'markdown');
+    }
+
+    if (config.type !== 'plain-text' && !config.singleLine) {
+      plugins.use(trailingParagraphPlugin());
+    }
+
+    // History
+    if (config.history) {
+      plugins.history(config.history.timeGap);
+    }
+
+    // Single line mode
+    if (config.singleLine) {
+      plugins.use(singleLinePlugin());
+    }
+
+    // Restore focus (registered early, before other plugins)
+    if (config.restoreFocus) {
+      plugins.use(restoreFocusPlugin());
+    }
+
+    // Text paste handling
+    plugins.use(textPastePlugin());
+
+    // Markdown paste handling (rich & full editors only)
+    if (config.type !== 'plain-text') {
+      plugins.use(markdownPastePlugin());
+    }
+
+    // Tab indentation (unless custom handler)
+    if (!config.handlers.onTab) {
+      plugins.use(tabIndentationPlugin());
+    }
+
+    // Horizontal rules & normalize-enter (full multi-line markdown only)
+    if (config.type !== 'plain-text' && !config.singleLine) {
+      plugins.use(horizontalRulePlugin());
+      plugins.use(normalizeEnterPlugin());
+    }
+
+    // Await placeholders for in-flight async operations (any non-plain-text editor).
+    if (config.type !== 'plain-text') {
+      plugins.use(awaitPlugin());
+    }
+
+    // Selection / formatting state
+    if (config.selectionData) {
+      plugins.use(selectionDataPlugin(lexicalWrapper));
+    }
+
+    // Actions / slash-command menu (not available for plain-text)
+    if (actionsMenuOps) {
+      plugins.use(actionsPlugin({ menu: actionsMenuOps }));
+    }
+
+    // Mentions & Emojis (not available for plain-text — nodes not registered)
+    if (config.type !== 'plain-text') {
+      if (config.mentions && mentionsMenuOps) {
+        plugins.use(
+          mentionsPlugin({
+            menu: mentionsMenuOps,
+            onCreateMention: config.mentions.onCreate,
+            onRemoveMention: config.mentions.onRemove,
+            sourceDocumentId: config.mentions.sourceDocumentId,
+          })
+        );
+      }
+
+      if (config.tags && tagsMenuOps) {
+        plugins.use(
+          tagsPlugin({
+            menu: tagsMenuOps,
+            insertTags: config.tags.insertTags,
+            onCreateTag: config.tags.applyTargetLabel
+              ? undefined
+              : config.tags.onCreate,
+            onRemoveTag: config.tags.onRemove,
+            setTags: config.tags.setTags,
+          })
+        );
+      }
+
+      if (emojisMenuOps) {
+        plugins.use(emojisPlugin({ menu: emojisMenuOps }));
+      }
+
+      if (snippetsMenuOps) {
+        plugins.use(
+          snippetsPlugin({
+            menu: snippetsMenuOps,
+            sourceDocumentId: config.mentions?.sourceDocumentId,
+          })
+        );
+      }
+
+      if (skillsMenuOps) {
+        plugins.use(skillsPlugin({ menu: skillsMenuOps }));
+      }
+
+      if (agentCommandsMenuOps && config.agentCommands) {
+        plugins.use(
+          agentCommandsPlugin({
+            menu: agentCommandsMenuOps,
+            commands: config.agentCommands.commands,
+          })
+        );
+      }
+    }
+
+    if (mediaEnabled) {
+      plugins.use(mediaPlugin());
+    }
+
+    // File drag-and-drop from desktop
+    if (fileDropConfig && setDragInsertStore) {
+      plugins.use(dragInsertPlugin({ setState: setDragInsertStore }));
+    }
+
+    if (config.draggableBlocks && setDraggableBlockStore) {
+      plugins.use(draggableBlockPlugin({ setState: setDraggableBlockStore }));
+    }
+
+    // File clipboard paste — auto-register when fileDrop is enabled, since
+    // dragInsertPlugin blocks DRAG_DROP_PASTE (Lexical's built-in paste-files
+    // path) without processing the files. A custom filePaste config from
+    // withFilePaste() takes precedence.
+    if (fileDropConfig && !config.filePaste) {
+      plugins.use(
+        filePastePlugin({
+          onPasteFilesAndDirs: (fileEntries, directories) => {
+            handleFileFolderDrop(
+              fileEntries,
+              directories,
+              createFilesReadyHandler(
+                editor,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                fileDropConfig.constrainedMediaDimensions
+              )
+            );
+          },
+        })
+      );
+    }
+
+    // Code blocks with syntax highlighting
+    if (config.code && accessoryStore && setAccessoryStore) {
+      plugins.use(
+        codePlugin({
+          accessories: accessoryStore,
+          setAccessories: setAccessoryStore,
+        })
+      );
+    }
+
+    // Checkbox to task conversion
+    if (config.checkboxToTask) {
+      plugins.use(checkboxToTaskPlugin());
+    }
+
+    // File paste handling
+    if (config.filePaste) {
+      plugins.use(
+        filePastePlugin({
+          onPasteFilesAndDirs: config.filePaste.onPasteFilesAndDirs,
+        })
+      );
+    }
+
+    // Keyboard focus leave detection
+    if (config.focusLeave) {
+      plugins.use(
+        keyboardFocusPlugin({
+          onFocusLeaveStart: config.focusLeave.onStart,
+          onFocusLeaveEnd: config.focusLeave.onEnd,
+          ignoreKeys: () =>
+            (actionsMenuOps?.isOpen() ?? false) ||
+            (mentionsMenuOps?.isOpen() ?? false) ||
+            (tagsMenuOps?.isOpen() ?? false) ||
+            (emojisMenuOps?.isOpen() ?? false) ||
+            (snippetsMenuOps?.isOpen() ?? false) ||
+            (skillsMenuOps?.isOpen() ?? false) ||
+            (agentCommandsMenuOps?.isOpen() ?? false),
+        })
+      );
+    }
+
+    for (const plugin of additionalPlugins) {
+      plugins.use(plugin);
+    }
+  };
+
+  const lexicalWrapper = config.withIds
+    ? createLexicalWrapper({
+        type: config.type as EditorType,
+        namespace: config.namespace,
+        isInteractable,
+        withIds: true,
+        configure,
       })
-    );
-  }
+    : createLexicalWrapper({
+        type: config.type as EditorType,
+        namespace: config.namespace,
+        isInteractable,
+        configure,
+      });
 
-  // Code blocks with syntax highlighting
-  if (config.code && accessoryStore && setAccessoryStore) {
-    plugins.use(
-      codePlugin({
-        accessories: accessoryStore,
-        setAccessories: setAccessoryStore,
-      })
-    );
-  }
-
-  // Checkbox to task conversion
-  if (config.checkboxToTask) {
-    plugins.use(checkboxToTaskPlugin());
-  }
-
-  // File paste handling
-  if (config.filePaste) {
-    plugins.use(
-      filePastePlugin({
-        onPasteFilesAndDirs: config.filePaste.onPasteFilesAndDirs,
-      })
-    );
-  }
-
-  // Keyboard focus leave detection
-  if (config.focusLeave) {
-    plugins.use(
-      keyboardFocusPlugin({
-        onFocusLeaveStart: config.focusLeave.onStart,
-        onFocusLeaveEnd: config.focusLeave.onEnd,
-        ignoreKeys: () =>
-          (actionsMenuOps?.isOpen() ?? false) ||
-          (mentionsMenuOps?.isOpen() ?? false) ||
-          (tagsMenuOps?.isOpen() ?? false) ||
-          (emojisMenuOps?.isOpen() ?? false) ||
-          (snippetsMenuOps?.isOpen() ?? false) ||
-          (skillsMenuOps?.isOpen() ?? false) ||
-          (agentCommandsMenuOps?.isOpen() ?? false),
-      })
-    );
-  }
+  const { editor, plugins, cleanup: cleanupLexical } = lexicalWrapper;
 
   const controls: EditorControls = {
     focus: () => editor.focus(),

--- a/apps/web/src/lib/core/component/LexicalMarkdown/builder/buildHandleFromConfig.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/builder/buildHandleFromConfig.ts
@@ -1,11 +1,22 @@
 import { handleFileFolderDrop } from '@core/util/upload';
-import type { EditorType } from '@macro-inc/lexical-core';
-import type { SerializedEditorState } from 'lexical';
+import { HistoryExtension } from '@lexical/history';
+import { CheckListExtension } from '@lexical/list';
+import { CODE } from '@lexical/markdown';
+import { PlainTextExtension } from '@lexical/plain-text';
+import { RichTextExtension } from '@lexical/rich-text';
+import { ALL_TRANSFORMERS, type EditorType } from '@macro-inc/lexical-core';
+import { HR } from '@macro-inc/lexical-core/transformers/transformers';
+import {
+  type AnyLexicalExtensionArgument,
+  configExtension,
+  type SerializedEditorState,
+} from 'lexical';
 import { createSignal } from 'solid-js';
 import {
   createLexicalWrapper,
   type LexicalWrapper,
 } from '../context/LexicalWrapperContext';
+import { pluginExtension } from '../extensions/pluginExtension';
 import {
   actionsPlugin,
   agentCommandsPlugin,
@@ -14,6 +25,7 @@ import {
   createAccessoryStore,
   createDraggableBlockStore,
   createDragInsertStore,
+  customDeletePlugin,
   draggableBlockPlugin,
   dragInsertPlugin,
   emojisPlugin,
@@ -34,10 +46,12 @@ import {
   trailingParagraphPlugin,
 } from '../plugins';
 import { checkboxToTaskPlugin } from '../plugins/checkbox-to-task';
+import { markdownShortcutsPlugin } from '../plugins/markdown-shortcuts';
 import { normalizeEnterPlugin } from '../plugins/normalize-enter';
 import { restoreFocusPlugin } from '../plugins/restore-focus';
 import { createMenuOperations } from '../shared/inlineMenu';
 import {
+  bindStateAs,
   getSaveState,
   initializeEditorEmpty,
   initializeEditorWithState,
@@ -123,84 +137,98 @@ export function buildHandleFromConfig(
   const draggableBlockStore = draggableBlockStoreResult?.[0];
   const setDraggableBlockStore = draggableBlockStoreResult?.[1];
 
-  const configure = (lexicalWrapper: LexicalWrapper) => {
-    if (config.skipPreviewFetch) {
-      lexicalWrapper.skipPreviewFetch = true;
-    }
-
-    const { editor, plugins } = lexicalWrapper;
+  const extensions = (lexicalWrapper: LexicalWrapper) => {
+    const result: AnyLexicalExtensionArgument[] = [];
+    const use = (name: string, plugin: PluginFunction) => {
+      result.push(pluginExtension(`builder/${name}`, plugin));
+    };
 
     if (config.type === 'plain-text') {
-      plugins.plainText().state<string>(setMarkdownState, 'plain');
+      result.push(PlainTextExtension);
+      use('state', (editor) => bindStateAs(editor, setMarkdownState, 'plain'));
     } else if (config.singleLine) {
-      plugins.richText().state<string>(setMarkdownState, 'markdown');
+      result.push(RichTextExtension);
+      use('state', (editor) =>
+        bindStateAs(editor, setMarkdownState, 'markdown')
+      );
     } else {
       // Full markdown: everything
-      plugins
-        .richText()
-        .list()
-        .markdownShortcuts()
-        .delete()
-        .state<string>(setMarkdownState, 'markdown');
+      result.push(RichTextExtension, CheckListExtension);
+      use(
+        'markdown-shortcuts',
+        markdownShortcutsPlugin({
+          transformers: ALL_TRANSFORMERS,
+          triggerOnEnterTransformers: [HR, CODE],
+        })
+      );
+      use('delete', customDeletePlugin());
+      use('state', (editor) =>
+        bindStateAs(editor, setMarkdownState, 'markdown')
+      );
     }
 
     if (config.type !== 'plain-text' && !config.singleLine) {
-      plugins.use(trailingParagraphPlugin());
+      use('trailing-paragraph', trailingParagraphPlugin());
     }
 
     // History
     if (config.history) {
-      plugins.history(config.history.timeGap);
+      result.push(
+        configExtension(HistoryExtension, {
+          delay: config.history.timeGap ?? 400,
+        })
+      );
     }
 
     // Single line mode
     if (config.singleLine) {
-      plugins.use(singleLinePlugin());
+      use('single-line', singleLinePlugin());
     }
 
     // Restore focus (registered early, before other plugins)
     if (config.restoreFocus) {
-      plugins.use(restoreFocusPlugin());
+      use('restore-focus', restoreFocusPlugin());
     }
 
     // Text paste handling
-    plugins.use(textPastePlugin());
+    use('text-paste', textPastePlugin());
 
     // Markdown paste handling (rich & full editors only)
     if (config.type !== 'plain-text') {
-      plugins.use(markdownPastePlugin());
+      use('markdown-paste', markdownPastePlugin());
     }
 
     // Tab indentation (unless custom handler)
     if (!config.handlers.onTab) {
-      plugins.use(tabIndentationPlugin());
+      use('tab-indentation', tabIndentationPlugin());
     }
 
     // Horizontal rules & normalize-enter (full multi-line markdown only)
     if (config.type !== 'plain-text' && !config.singleLine) {
-      plugins.use(horizontalRulePlugin());
-      plugins.use(normalizeEnterPlugin());
+      use('horizontal-rule', horizontalRulePlugin());
+      use('normalize-enter', normalizeEnterPlugin());
     }
 
     // Await placeholders for in-flight async operations (any non-plain-text editor).
     if (config.type !== 'plain-text') {
-      plugins.use(awaitPlugin());
+      use('await', awaitPlugin());
     }
 
     // Selection / formatting state
     if (config.selectionData) {
-      plugins.use(selectionDataPlugin(lexicalWrapper));
+      use('selection-data', selectionDataPlugin(lexicalWrapper));
     }
 
     // Actions / slash-command menu (not available for plain-text)
     if (actionsMenuOps) {
-      plugins.use(actionsPlugin({ menu: actionsMenuOps }));
+      use('actions', actionsPlugin({ menu: actionsMenuOps }));
     }
 
     // Mentions & Emojis (not available for plain-text — nodes not registered)
     if (config.type !== 'plain-text') {
       if (config.mentions && mentionsMenuOps) {
-        plugins.use(
+        use(
+          'mentions',
           mentionsPlugin({
             menu: mentionsMenuOps,
             onCreateMention: config.mentions.onCreate,
@@ -211,7 +239,8 @@ export function buildHandleFromConfig(
       }
 
       if (config.tags && tagsMenuOps) {
-        plugins.use(
+        use(
+          'tags',
           tagsPlugin({
             menu: tagsMenuOps,
             insertTags: config.tags.insertTags,
@@ -225,11 +254,12 @@ export function buildHandleFromConfig(
       }
 
       if (emojisMenuOps) {
-        plugins.use(emojisPlugin({ menu: emojisMenuOps }));
+        use('emojis', emojisPlugin({ menu: emojisMenuOps }));
       }
 
       if (snippetsMenuOps) {
-        plugins.use(
+        use(
+          'snippets',
           snippetsPlugin({
             menu: snippetsMenuOps,
             sourceDocumentId: config.mentions?.sourceDocumentId,
@@ -238,11 +268,12 @@ export function buildHandleFromConfig(
       }
 
       if (skillsMenuOps) {
-        plugins.use(skillsPlugin({ menu: skillsMenuOps }));
+        use('skills', skillsPlugin({ menu: skillsMenuOps }));
       }
 
       if (agentCommandsMenuOps && config.agentCommands) {
-        plugins.use(
+        use(
+          'agent-commands',
           agentCommandsPlugin({
             menu: agentCommandsMenuOps,
             commands: config.agentCommands.commands,
@@ -252,16 +283,19 @@ export function buildHandleFromConfig(
     }
 
     if (mediaEnabled) {
-      plugins.use(mediaPlugin());
+      use('media', mediaPlugin());
     }
 
     // File drag-and-drop from desktop
     if (fileDropConfig && setDragInsertStore) {
-      plugins.use(dragInsertPlugin({ setState: setDragInsertStore }));
+      use('drag-insert', dragInsertPlugin({ setState: setDragInsertStore }));
     }
 
     if (config.draggableBlocks && setDraggableBlockStore) {
-      plugins.use(draggableBlockPlugin({ setState: setDraggableBlockStore }));
+      use(
+        'draggable-block',
+        draggableBlockPlugin({ setState: setDraggableBlockStore })
+      );
     }
 
     // File clipboard paste — auto-register when fileDrop is enabled, since
@@ -269,7 +303,8 @@ export function buildHandleFromConfig(
     // path) without processing the files. A custom filePaste config from
     // withFilePaste() takes precedence.
     if (fileDropConfig && !config.filePaste) {
-      plugins.use(
+      use(
+        'file-drop-paste',
         filePastePlugin({
           onPasteFilesAndDirs: (fileEntries, directories) => {
             handleFileFolderDrop(
@@ -291,7 +326,8 @@ export function buildHandleFromConfig(
 
     // Code blocks with syntax highlighting
     if (config.code && accessoryStore && setAccessoryStore) {
-      plugins.use(
+      use(
+        'code',
         codePlugin({
           accessories: accessoryStore,
           setAccessories: setAccessoryStore,
@@ -301,12 +337,13 @@ export function buildHandleFromConfig(
 
     // Checkbox to task conversion
     if (config.checkboxToTask) {
-      plugins.use(checkboxToTaskPlugin());
+      use('checkbox-to-task', checkboxToTaskPlugin());
     }
 
     // File paste handling
     if (config.filePaste) {
-      plugins.use(
+      use(
+        'file-paste',
         filePastePlugin({
           onPasteFilesAndDirs: config.filePaste.onPasteFilesAndDirs,
         })
@@ -315,7 +352,8 @@ export function buildHandleFromConfig(
 
     // Keyboard focus leave detection
     if (config.focusLeave) {
-      plugins.use(
+      use(
+        'keyboard-focus',
         keyboardFocusPlugin({
           onFocusLeaveStart: config.focusLeave.onStart,
           onFocusLeaveEnd: config.focusLeave.onEnd,
@@ -331,9 +369,11 @@ export function buildHandleFromConfig(
       );
     }
 
-    for (const plugin of additionalPlugins) {
-      plugins.use(plugin);
+    for (const [index, plugin] of additionalPlugins.entries()) {
+      use(`custom-${index}`, plugin);
     }
+
+    return result;
   };
 
   const lexicalWrapper = config.withIds
@@ -342,16 +382,18 @@ export function buildHandleFromConfig(
         namespace: config.namespace,
         isInteractable,
         withIds: true,
-        configure,
+        skipPreviewFetch: config.skipPreviewFetch,
+        extensions,
       })
     : createLexicalWrapper({
         type: config.type as EditorType,
         namespace: config.namespace,
         isInteractable,
-        configure,
+        skipPreviewFetch: config.skipPreviewFetch,
+        extensions,
       });
 
-  const { editor, plugins, cleanup: cleanupLexical } = lexicalWrapper;
+  const { editor, cleanup: cleanupLexical } = lexicalWrapper;
 
   const controls: EditorControls = {
     focus: () => editor.focus(),
@@ -390,7 +432,6 @@ export function buildHandleFromConfig(
   return {
     controls,
     lexical: editor,
-    plugins,
     selection: lexicalWrapper.selection,
     _internal: {
       builderConfig: config,

--- a/apps/web/src/lib/core/component/LexicalMarkdown/builder/extensionLifecycle.test.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/builder/extensionLifecycle.test.ts
@@ -1,0 +1,49 @@
+import { LexicalBuilder } from '@lexical/extension';
+import { createRoot } from 'solid-js';
+import { describe, expect, test, vi } from 'vitest';
+import { buildConfig } from './MarkdownConfigBuilder';
+
+vi.hoisted(() => {
+  class FakeWebSocket extends EventTarget {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+    readonly readyState = FakeWebSocket.OPEN;
+    close() {}
+    send() {}
+  }
+  Object.defineProperty(globalThis, 'WebSocket', {
+    configurable: true,
+    value: FakeWebSocket,
+  });
+});
+
+describe('MarkdownConfigBuilder extension lifecycle', () => {
+  test('builds an extension graph and disposes custom registrations', () => {
+    createRoot((dispose) => {
+      const cleanup = vi.fn();
+      const register = vi.fn(() => cleanup);
+      const handle = buildConfig('plain-text')
+        .namespace('extension-lifecycle-test')
+        .use(register)
+        .buildHandle();
+
+      const builder = LexicalBuilder.maybeFromEditor(handle.lexical);
+      expect(builder).toBeDefined();
+      expect([...builder!.extensionNameMap.keys()]).toEqual(
+        expect.arrayContaining([
+          '@lexical/plain-text',
+          '@macro-inc/lexical/builder/state',
+          '@macro-inc/lexical/builder/custom-0',
+        ])
+      );
+      expect(register).toHaveBeenCalledWith(handle.lexical);
+      expect('plugins' in handle).toBe(false);
+
+      handle._internal.cleanupLexical();
+      expect(cleanup).toHaveBeenCalledOnce();
+      dispose();
+    });
+  });
+});

--- a/apps/web/src/lib/core/component/LexicalMarkdown/builder/types.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/builder/types.ts
@@ -14,7 +14,6 @@ import type {
   createDraggableBlockStore,
   createDragInsertStore,
   ItemMention,
-  PluginManager,
   SelectionData,
 } from '../plugins';
 import type { Action } from '../plugins/actions/types';
@@ -211,7 +210,6 @@ export interface EditorInternals {
 export interface EditorHandle {
   controls: EditorControls;
   lexical: LexicalEditor;
-  plugins: PluginManager;
   selection?: Store<SelectionData>;
   /** @internal consumed by MarkdownShell component; do not access directly */
   _internal: EditorInternals;

--- a/apps/web/src/lib/core/component/LexicalMarkdown/collaboration/CollabProvider.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/collaboration/CollabProvider.tsx
@@ -9,7 +9,6 @@ import {
 import { $reconcileLexicalState } from '@core/component/LexicalMarkdown/collaboration/reconcile';
 import { useRemoteCursors } from '@core/component/LexicalMarkdown/collaboration/remote-cursor';
 import type { MarkdownEditorErrors } from '@core/component/LexicalMarkdown/constants';
-import type { PluginManager } from '@core/component/LexicalMarkdown/plugins';
 import {
   initializeEditorEmpty,
   initializeEditorWithVersionedState,
@@ -80,7 +79,6 @@ export type CollabObservability = {
 
 export type CollabProviderProps = {
   editor: LexicalEditor;
-  pluginManager: PluginManager;
   editorContainerRef: HTMLDivElement;
   highlightLayerRef: HTMLDivElement;
   mappings: NodeIdMappings;
@@ -450,9 +448,12 @@ export function CollabProvider(props: CollabProviderProps) {
     );
   }
 
+  let cleanupLexicalStateSync = () => {};
+
   function startSync() {
+    cleanupLexicalStateSync();
     syncEngine.start();
-    props.pluginManager.use(lexicalStateSyncPlugin);
+    cleanupLexicalStateSync = lexicalStateSyncPlugin();
   }
 
   const [managerInitialized, setManagerInitialized] = createSignal(
@@ -576,6 +577,7 @@ export function CollabProvider(props: CollabProviderProps) {
   );
 
   onCleanup(() => {
+    cleanupLexicalStateSync();
     syncEngine.stop();
     walSyncer.destroy();
     const documentId = syncSource()?.documentId;

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/core/MarkdownTextarea.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/core/MarkdownTextarea.tsx
@@ -26,7 +26,7 @@ import {
 import type { SetStoreFunction } from 'solid-js/store';
 import { FloatingMenuGroup } from '../../context/FloatingMenuContext';
 import {
-  createLexicalWrapper,
+  createLegacyLexicalWrapper,
   LexicalWrapperContext,
 } from '../../context/LexicalWrapperContext';
 import {
@@ -138,7 +138,7 @@ interface MarkdownTextareaProps {
 export function MarkdownTextarea(props: MarkdownTextareaProps) {
   let mountRef!: HTMLDivElement;
   let scrollContainerRef: HTMLDivElement | undefined;
-  const lexicalWrapper = createLexicalWrapper({
+  const lexicalWrapper = createLegacyLexicalWrapper({
     type: props.type ?? 'markdown',
     namespace: 'markdown-textarea',
     isInteractable: props.editable,

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/debug/MarkdownParseTestPage.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/debug/MarkdownParseTestPage.tsx
@@ -11,7 +11,7 @@ import {
   Show,
 } from 'solid-js';
 import {
-  createLexicalWrapper,
+  createLegacyLexicalWrapper,
   LexicalWrapperContext,
 } from '../../context/LexicalWrapperContext';
 import {
@@ -147,7 +147,7 @@ export function TestEditor(props: {
   let mountRef!: HTMLDivElement;
 
   const lexicalWrapper = createMemo(() =>
-    createLexicalWrapper({
+    createLegacyLexicalWrapper({
       type: 'markdown',
       namespace: 'markdown-textarea',
       isInteractable: () => true,

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/menu/FloatingEquationMenu.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/menu/FloatingEquationMenu.tsx
@@ -35,7 +35,6 @@ false && clickOutside;
 export function FloatingEquationMenu() {
   const canEdit = useCanEdit();
   const lexicalWrapper = useContext(LexicalWrapperContext);
-  const plugins = () => lexicalWrapper?.plugins;
   const editor = () => lexicalWrapper?.editor;
 
   const [menuOpen, setMenuOpen] = createMenuOpenSignal(
@@ -167,19 +166,19 @@ export function FloatingEquationMenu() {
     resetMenu();
   });
 
+  let cleanupKatex = () => {};
   createEffect(() => {
-    const currentPlugins = plugins();
-    if (!currentPlugins) return;
-
-    if (!canEdit()) return;
-
-    currentPlugins.use(
-      katexPlugin({
-        onClickEquation: handleClickEquation,
-        onCreateEquation: handleCreateEquation,
-      })
-    );
+    cleanupKatex();
+    const currentEditor = editor();
+    cleanupKatex =
+      currentEditor && canEdit()
+        ? katexPlugin({
+            onClickEquation: handleClickEquation,
+            onCreateEquation: handleCreateEquation,
+          })(currentEditor)
+        : () => {};
   });
+  onCleanup(() => cleanupKatex());
 
   const keydown = (e: KeyboardEvent) => {
     if (!menuOpen()) {

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/menu/FloatingFormatMenu.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/menu/FloatingFormatMenu.tsx
@@ -138,7 +138,7 @@ export function FloatingFormatMenu(props: {
   // On mobile the native selection toolbar takes this menu's place.
   if (isMobile()) return '';
 
-  const { editor, plugins } = lexicalWrapper;
+  const { editor } = lexicalWrapper;
   const selection = (): SelectionData | undefined => lexicalWrapper.selection;
 
   const [menuOpen, setMenuOpen] = createMenuOpenSignal(
@@ -148,11 +148,11 @@ export function FloatingFormatMenu(props: {
   const [selectionInfo, setSelectionInfo] =
     createSignal<EnhancedSelection | null>(null, { equals: () => false });
 
-  plugins.use(
+  autoRegister(
     popupPlugin({
       setIsPopupVisible: setMenuOpen,
       setSelection: setSelectionInfo,
-    })
+    })(editor)
   );
 
   // Lag the open state so the menu doesn't flash while a selection is being

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/menu/FloatingLinkMenu.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/menu/FloatingLinkMenu.tsx
@@ -61,11 +61,9 @@ export function FloatingLinkMenu(props: {
   closePopup?: () => void;
   autoLinkMatchMode?: AutoLinkMatchMode;
 }) {
-  const { plugins, editor } = useContext(LexicalWrapperContext) ?? {};
-  if (!plugins || !editor) {
-    console.error(
-      'FloatingLinkMenu requires plugins and editor from LexicalWrapperContext!'
-    );
+  const { editor } = useContext(LexicalWrapperContext) ?? {};
+  if (!editor) {
+    console.error('FloatingLinkMenu requires LexicalWrapperContext!');
     return '';
   }
 
@@ -239,13 +237,13 @@ export function FloatingLinkMenu(props: {
     editor.focus();
   };
 
-  plugins.use(
+  autoRegister(
     linksPlugin({
       onHoverLink,
       onClickLink,
       onCreateLink,
       autoLinkMatchMode: props.autoLinkMatchMode,
-    })
+    })(editor)
   );
 
   const keydown = (e: KeyboardEvent) => {

--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/menu/FloatingTableMenu.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/menu/FloatingTableMenu.tsx
@@ -8,6 +8,7 @@ import {
   createEffect,
   createSignal,
   Index,
+  onCleanup,
   Show,
   untrack,
   useContext,
@@ -39,7 +40,6 @@ const MAX_GRID_SIZE = 12;
 export function FloatingTableMenu() {
   const canEdit = useCanEdit();
   const lexicalWrapper = useContext(LexicalWrapperContext);
-  const plugins = () => lexicalWrapper?.plugins;
   const editor = () => lexicalWrapper?.editor;
 
   const [menuOpen, setMenuOpen] = createMenuOpenSignal(
@@ -79,15 +79,16 @@ export function FloatingTableMenu() {
     resetMenu();
   };
 
+  let cleanupTablePicker = () => {};
   createEffect(() => {
-    const currentPlugins = plugins();
-    if (!currentPlugins) return;
-
-    currentPlugins.useReactive(canEdit, () => {
-      if (!canEdit()) return;
-      return tablePickerPlugin({ onCreateTable: handleCreateTable });
-    });
+    cleanupTablePicker();
+    const currentEditor = editor();
+    cleanupTablePicker =
+      currentEditor && canEdit()
+        ? tablePickerPlugin({ onCreateTable: handleCreateTable })(currentEditor)
+        : () => {};
   });
+  onCleanup(() => cleanupTablePicker());
 
   const visibleRows = () =>
     Math.max(MIN_GRID_SIZE, Math.min(MAX_GRID_SIZE, rows() + 1));

--- a/apps/web/src/lib/core/component/LexicalMarkdown/context/LexicalWrapperContext.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/context/LexicalWrapperContext.tsx
@@ -10,7 +10,7 @@ import {
   RegisteredNodesByType,
   SupportedNodeTypes,
 } from '@macro-inc/lexical-core';
-import type { NodeKey } from 'lexical';
+import type { AnyLexicalExtensionArgument, NodeKey } from 'lexical';
 import {
   defineExtension,
   type EditorThemeClasses,
@@ -18,6 +18,7 @@ import {
 } from 'lexical';
 import { createContext } from 'solid-js';
 import type { Store } from 'solid-js/store';
+import { pluginExtension } from '../extensions/pluginExtension';
 import { insertTextPlugin } from '../plugins/insert-text';
 import { nodeTransformPlugin } from '../plugins/node-transform';
 import {
@@ -33,13 +34,15 @@ type LexicalWrapperProps = {
   isInteractable: () => boolean;
   withIds?: boolean;
   theme?: EditorThemeClasses;
-  /** Register editor behavior as part of the extension lifecycle. */
-  configure?: (wrapper: LexicalWrapper) => void;
+  skipPreviewFetch?: boolean;
+  /** Additional behavior composed into the editor's extension graph. */
+  extensions?:
+    | AnyLexicalExtensionArgument[]
+    | ((wrapper: LexicalWrapper) => AnyLexicalExtensionArgument[]);
 };
 
 export type LexicalWrapperBase = {
   type: EditorType;
-  plugins: PluginManager;
   editor: LexicalEditor;
   cleanup: () => void;
   isInteractable: () => boolean;
@@ -53,6 +56,11 @@ export type LexicalWrapperWithMapping = LexicalWrapperBase & {
 };
 
 export type LexicalWrapper = LexicalWrapperBase | LexicalWrapperWithMapping;
+
+/** Wrapper retained for editor surfaces that have not migrated to extensions. */
+export type LegacyLexicalWrapper = LexicalWrapper & {
+  plugins: PluginManager;
+};
 
 export const LexicalWrapperContext = createContext<LexicalWrapper>();
 
@@ -85,7 +93,8 @@ export function createLexicalWrapper({
   isInteractable,
   withIds,
   theme,
-  configure,
+  skipPreviewFetch,
+  extensions,
 }: LexicalWrapperProps): LexicalWrapper {
   _id++;
 
@@ -99,48 +108,83 @@ export function createLexicalWrapper({
   });
 
   const mapping = withIds ? createMapping() : undefined;
-  let wrapper!: LexicalWrapper;
   let disposeEditor = () => {};
+  const wrapper: LexicalWrapper = {
+    editor: undefined as unknown as LexicalEditor,
+    cleanup: () => disposeEditor(),
+    type,
+    isInteractable,
+    mapping,
+    skipPreviewFetch,
+  };
+  const configuredExtensions =
+    typeof extensions === 'function' ? extensions(wrapper) : (extensions ?? []);
   const editorWithDispose = buildEditorFromExtensions(
     defineExtension({
-      name: 'macro/editor',
+      name: '@macro-inc/lexical/editor-config',
       theme: theme ?? baseTheme,
       namespace: namespace + '_' + _id,
       nodes: () => [...nodes, ...replacements],
       onError: console.error,
       register: (editor) => {
-        const plugins = createPluginManager(editor, type);
-        wrapper = {
-          plugins,
-          editor,
-          cleanup: () => disposeEditor(),
-          type,
-          isInteractable,
-          mapping,
-        };
-
-        // Default plugins here.
-        plugins.use(insertTextPlugin());
-        plugins.use(nodeTransformPlugin());
-
-        if (mapping) {
-          plugins.use(
+        wrapper.editor = editor;
+        return () => {};
+      },
+    }),
+    pluginExtension('insert-text', insertTextPlugin()),
+    pluginExtension('node-transform', nodeTransformPlugin()),
+    ...(mapping
+      ? [
+          pluginExtension(
+            'node-id',
             nodeIdPlugin({
               nodes: SupportedNodeTypes,
               idLength: 8,
               mappings: mapping,
             })
-          );
-        }
-
-        configure?.(wrapper);
-        return plugins.cleanup;
-      },
-    })
+          ),
+        ]
+      : []),
+    ...configuredExtensions
   );
   disposeEditor = editorWithDispose.dispose;
+  wrapper.editor = editorWithDispose;
 
   return wrapper;
+}
+
+/**
+ * Compatibility constructor for editor surfaces that still register through
+ * PluginManager. New editor configurations should use `extensions` instead.
+ */
+export function createLegacyLexicalWrapper(
+  props: LexicalWrapperProps & { withIds: true }
+): LexicalWrapperWithMapping & { plugins: PluginManager };
+export function createLegacyLexicalWrapper(
+  props: LexicalWrapperProps & { withIds?: false | undefined }
+): LexicalWrapperBase & { plugins: PluginManager };
+export function createLegacyLexicalWrapper(
+  props: LexicalWrapperProps
+): LegacyLexicalWrapper {
+  let plugins!: PluginManager;
+  const legacyManagerExtension = pluginExtension(
+    'legacy-plugin-manager',
+    (editor) => {
+      plugins = createPluginManager(editor, props.type);
+      return plugins.cleanup;
+    }
+  );
+  const configuredExtensions = props.extensions;
+  const extensions = (wrapper: LexicalWrapper) => [
+    legacyManagerExtension,
+    ...(typeof configuredExtensions === 'function'
+      ? configuredExtensions(wrapper)
+      : (configuredExtensions ?? [])),
+  ];
+  const wrapper = props.withIds
+    ? createLexicalWrapper({ ...props, withIds: true, extensions })
+    : createLexicalWrapper({ ...props, withIds: false, extensions });
+  return Object.assign(wrapper, { plugins });
 }
 
 export function isWrapperWithIds(

--- a/apps/web/src/lib/core/component/LexicalMarkdown/context/LexicalWrapperContext.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/context/LexicalWrapperContext.tsx
@@ -1,6 +1,7 @@
 /**
  * @file Wrap the Lexical Editor in some helpful utilities.
  */
+import { buildEditorFromExtensions } from '@lexical/extension';
 import {
   type EditorType,
   type NodeIdMappings,
@@ -11,19 +12,19 @@ import {
 } from '@macro-inc/lexical-core';
 import type { NodeKey } from 'lexical';
 import {
-  createEditor,
+  defineExtension,
   type EditorThemeClasses,
   type LexicalEditor,
 } from 'lexical';
 import { createContext } from 'solid-js';
 import type { Store } from 'solid-js/store';
+import { insertTextPlugin } from '../plugins/insert-text';
+import { nodeTransformPlugin } from '../plugins/node-transform';
 import {
   createPluginManager,
-  insertTextPlugin,
-  nodeTransformPlugin,
   type PluginManager,
-  type SelectionData,
-} from '../plugins';
+} from '../plugins/pluginManager';
+import type { SelectionData } from '../plugins/selection-data';
 import { theme as baseTheme } from '../theme';
 
 type LexicalWrapperProps = {
@@ -32,6 +33,8 @@ type LexicalWrapperProps = {
   isInteractable: () => boolean;
   withIds?: boolean;
   theme?: EditorThemeClasses;
+  /** Register editor behavior as part of the extension lifecycle. */
+  configure?: (wrapper: LexicalWrapper) => void;
 };
 
 export type LexicalWrapperBase = {
@@ -82,6 +85,7 @@ export function createLexicalWrapper({
   isInteractable,
   withIds,
   theme,
+  configure,
 }: LexicalWrapperProps): LexicalWrapper {
   _id++;
 
@@ -94,44 +98,49 @@ export function createLexicalWrapper({
     return true;
   });
 
-  const editor = createEditor({
-    theme: theme ?? baseTheme,
-    namespace: namespace + '_' + _id,
-    nodes: [...nodes, ...replacements],
-    onError: console.error,
-  });
+  const mapping = withIds ? createMapping() : undefined;
+  let wrapper!: LexicalWrapper;
+  let disposeEditor = () => {};
+  const editorWithDispose = buildEditorFromExtensions(
+    defineExtension({
+      name: 'macro/editor',
+      theme: theme ?? baseTheme,
+      namespace: namespace + '_' + _id,
+      nodes: () => [...nodes, ...replacements],
+      onError: console.error,
+      register: (editor) => {
+        const plugins = createPluginManager(editor, type);
+        wrapper = {
+          plugins,
+          editor,
+          cleanup: () => disposeEditor(),
+          type,
+          isInteractable,
+          mapping,
+        };
 
-  const plugins = createPluginManager(editor, type);
+        // Default plugins here.
+        plugins.use(insertTextPlugin());
+        plugins.use(nodeTransformPlugin());
 
-  let mapping: NodeIdMappings | undefined;
+        if (mapping) {
+          plugins.use(
+            nodeIdPlugin({
+              nodes: SupportedNodeTypes,
+              idLength: 8,
+              mappings: mapping,
+            })
+          );
+        }
 
-  // Default plugins here.
-  plugins.use(insertTextPlugin());
-  plugins.use(nodeTransformPlugin());
+        configure?.(wrapper);
+        return plugins.cleanup;
+      },
+    })
+  );
+  disposeEditor = editorWithDispose.dispose;
 
-  if (withIds) {
-    mapping = createMapping();
-    plugins.use(
-      nodeIdPlugin({
-        nodes: SupportedNodeTypes,
-        idLength: 8,
-        mappings: mapping,
-      })
-    );
-  }
-
-  const cleanup = () => {
-    plugins.cleanup();
-  };
-
-  return {
-    plugins,
-    editor,
-    cleanup,
-    type,
-    isInteractable,
-    mapping,
-  };
+  return wrapper;
 }
 
 export function isWrapperWithIds(

--- a/apps/web/src/lib/core/component/LexicalMarkdown/extensions/pluginExtension.test.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/extensions/pluginExtension.test.ts
@@ -1,0 +1,20 @@
+import { buildEditorFromExtensions } from '@lexical/extension';
+import { describe, expect, test, vi } from 'vitest';
+import { pluginExtension } from './pluginExtension';
+
+describe('pluginExtension', () => {
+  test('lets the Lexical extension lifecycle own registration and cleanup', () => {
+    const register = vi.fn(() => vi.fn());
+    const extension = pluginExtension('test/lifecycle', register);
+
+    const editor = buildEditorFromExtensions(extension);
+
+    expect(extension.name).toBe('@macro-inc/lexical/test/lifecycle');
+    expect(register).toHaveBeenCalledOnce();
+    expect(register).toHaveBeenCalledWith(editor);
+
+    const cleanup = register.mock.results[0].value;
+    editor.dispose();
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/lib/core/component/LexicalMarkdown/extensions/pluginExtension.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/extensions/pluginExtension.ts
@@ -1,0 +1,18 @@
+import type { AnyLexicalExtension } from 'lexical';
+import { defineExtension } from 'lexical';
+import type { PluginFunction } from '../plugins/pluginManager';
+
+/**
+ * Adapt an existing Lexical registration callback into an independently named
+ * extension. This keeps the callback implementation while giving Lexical's
+ * extension graph ownership of registration and disposal.
+ */
+export function pluginExtension(
+  name: string,
+  register: PluginFunction
+): AnyLexicalExtension {
+  return defineExtension({
+    name: `@macro-inc/lexical/${name}`,
+    register: (editor) => register(editor),
+  });
+}

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "@inkibra/tauri-plugins": "git+https://github.com/macro-inc/tauri-plugins.git#6ddd6600e20436388f169e936b610fe93944b7b0",
         "@kobalte/core": "^0.13.11",
         "@leeoniya/ufuzzy": "^1.0.19",
+        "@lexical/extension": "0.45.0",
         "@lexical/history": "0.45.0",
         "@lexical/html": "0.45.0",
         "@lexical/link": "0.45.0",


### PR DESCRIPTION
- **[wip]**
- **[wip]**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core markdown editor initialization, collaboration sync wiring, and plugin registration across many surfaces; behavior should be equivalent but lifecycle/order changes can affect editing, undo, and sync edge cases.
> 
> **Overview**
> This PR begins migrating Lexical editor setup from the fluent **PluginManager** API to Lexical’s **extension graph** (`@lexical/extension`), with a `pluginExtension` helper that wraps existing register/cleanup callbacks as named extensions.
> 
> **`createLexicalWrapper`** now builds editors via `buildEditorFromExtensions` and accepts an `extensions` callback; **`createLegacyLexicalWrapper`** keeps `PluginManager` for surfaces not yet migrated (title editors, instructions, collab surface, code markdown, etc.). The markdown **builder** (`buildHandleFromConfig`) composes the same features as extensions instead of `plugins.richText().list()…`, drops **`plugins` from `EditorHandle`**, and queues custom `.use()` plugins as extension entries.
> 
> The main **`MarkdownEditor`** registers its large plugin set through `editorExtensions()` (rich text, shortcuts, collab history, menus, tables, AI/diff flags, etc.); container-dependent **drag-insert** / **draggable-block** plugins stay on Solid lifecycle at root connect. **`CollabProvider`** no longer takes `pluginManager`—Loro lexical sync is started/stopped with explicit cleanup.
> 
> Call sites that hung behavior off `plugins.use` / `useReactive` now **`autoRegister(plugin()(editor))`** or Solid `createEffect` cleanup (comments, popups, floating menus, canvas text wrap). Tests cover extension lifecycle and custom plugin disposal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0cc741877e61dd04a30d9873d2ce4452089ccfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->