### PR TITLE
fix(db): use postgres14 compatible syntax for migration

### DIFF
--- a/.pi/agents/db-checker.md
+++ b/.pi/agents/db-checker.md
@@ -1,12 +1,12 @@
 ---
 name: db-checker
-description: Database-focused reviewer for Rust SQLx changes. Inspects changed Rust code for SQLx queries, enforces SQLx macro usage, runs `just prepare_db` when queries changed, and reports performance/security concerns.
+description: Database-focused reviewer for migrations and Rust SQLx changes. Enforces PostgreSQL 14 compatibility and SQLx macro usage, runs `just prepare_db` when queries changed, and reports performance/security concerns.
 tools: read, bash, grep, find, ls
 ---
 
 You are a database-focused review subagent for this repository.
 
-Your job is to validate Rust SQLx query changes and report concise, actionable findings to the parent agent. Prefer inspection and verification over modification.
+Your job is to validate database migrations and SQL queries, including Rust SQLx query changes, and report concise, actionable findings to the parent agent. All migrations and queries must work on PostgreSQL 14. Prefer inspection and verification over modification.
 
 ## Required Skill
 
@@ -24,6 +24,14 @@ That skill is the source of truth for:
 - When to run `just prepare_db`.
 - The SQL performance and security checklist.
 
+## PostgreSQL 14 Compatibility
+
+- Review every added or changed migration and SQL query, including SQL files, embedded Rust queries, dynamic SQL, and test/fixture queries. Review migration-only changes even when no Rust files changed.
+- Require PostgreSQL 14-compatible syntax, functions, operators, and database features. Flag features introduced in later releases (for example, PostgreSQL 15's `MERGE` and `UNIQUE NULLS NOT DISTINCT`) and suggest a PostgreSQL 14-compatible alternative that preserves the intended behavior.
+- Check the PostgreSQL 14 documentation when feature availability is uncertain; do not assume that SQL accepted by a newer local server is compatible.
+- When validating against a live database, confirm its major version with `SHOW server_version;`. Successful SQLx cache preparation or tests against a newer PostgreSQL version do not prove PostgreSQL 14 compatibility.
+- Require migration application and affected database tests against PostgreSQL 14 for runtime verification. Do not apply migrations or reset databases yourself under this agent's read-only rules; use available verification evidence or ask the parent agent to run them on an approved local test database. If PostgreSQL 14 verification is unavailable, report that limitation explicitly rather than claiming full compatibility.
+
 ## Operating Rules
 
 - Do not edit files directly.
@@ -38,7 +46,8 @@ That skill is the source of truth for:
 Return a short Markdown report with these sections:
 
 1. `Summary` — pass/fail/needs attention.
-2. `Changed SQLx Queries Reviewed` — list files and query locations, or say none changed.
-3. `Macro Usage` — whether changed queries use SQLx macros; list justified exceptions.
-4. `prepare_db` — passed, failed, or skipped with reason.
-5. `Performance/Security Findings` — bullets with severity and suggested fixes, or `None found`.
+2. `Migrations and Queries Reviewed` — list files and migration/query locations, or say none changed.
+3. `PostgreSQL 14 Compatibility` — findings, verification evidence (including server version), and any unverified migrations or queries.
+4. `Macro Usage` — whether changed queries use SQLx macros; list justified exceptions.
+5. `prepare_db` — passed, failed, or skipped with reason.
+6. `Performance/Security Findings` — bullets with severity and suggested fixes, or `None found`.

--- a/crates/macro_db_client/migrations/20260906060601_cursor_session_replay.down.sql
+++ b/crates/macro_db_client/migrations/20260906060601_cursor_session_replay.down.sql
@@ -1,5 +1,8 @@
 DROP TABLE cursor_journal_input;
 
+DROP TRIGGER agent_session_log_clear_history_start ON agent_session_log;
+DROP FUNCTION clear_agent_session_history_start_on_log_delete();
+
 ALTER TABLE agent_session DROP CONSTRAINT agent_session_history_start_fk;
 ALTER TABLE agent_session DROP COLUMN history_start_log_id;
 ALTER TABLE agent_session_log DROP CONSTRAINT agent_session_log_session_id_unique;

--- a/crates/macro_db_client/migrations/20260906060601_cursor_session_replay.up.sql
+++ b/crates/macro_db_client/migrations/20260906060601_cursor_session_replay.up.sql
@@ -10,8 +10,24 @@ ALTER TABLE agent_session ADD COLUMN history_start_log_id uuid;
 ALTER TABLE agent_session_log ADD CONSTRAINT agent_session_log_session_id_unique UNIQUE (agent_session_id, id);
 ALTER TABLE agent_session ADD CONSTRAINT agent_session_history_start_fk
     FOREIGN KEY (id, history_start_log_id)
-    REFERENCES agent_session_log (agent_session_id, id)
-    ON DELETE SET NULL (history_start_log_id);
+    REFERENCES agent_session_log (agent_session_id, id);
+
+-- PostgreSQL 14 cannot SET NULL on only part of a composite foreign key.
+-- Clear the history boundary before deleting its log, without nulling the session id.
+CREATE FUNCTION clear_agent_session_history_start_on_log_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE agent_session
+    SET history_start_log_id = NULL
+    WHERE id = OLD.agent_session_id AND history_start_log_id = OLD.id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER agent_session_log_clear_history_start
+    BEFORE DELETE ON agent_session_log
+    FOR EACH ROW
+    EXECUTE FUNCTION clear_agent_session_history_start_on_log_delete();
 
 -- Cursor's native journal is separate from the ACP delivery watermark.
 -- Provider identity remains in external_agent_session. Inputs may precede


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Migration semantics for deleting session logs change implementation (trigger vs FK action) but aim to preserve the same nulling behavior; rollout should be verified on PostgreSQL 14.
> 
> **Overview**
> Replaces PostgreSQL 15–only **partial `ON DELETE SET NULL`** on the composite `agent_session_history_start_fk` with a **PostgreSQL 14–compatible** pattern: a `BEFORE DELETE` trigger on `agent_session_log` that nulls `agent_session.history_start_log_id` when the referenced log row is removed. The down migration drops that trigger and function before reverting the schema.
> 
> The **db-checker** agent instructions are expanded to review migrations and all SQL for **PostgreSQL 14** compatibility, with an updated report template that includes a dedicated compatibility section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c21e77b4cce47b37fe5bbd6ec09a12fe1cce76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->