### PR TITLE
fix(md): include task chip titles in document find

### DIFF
--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/find-and-replace/findAndReplacePlugin.test.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/find-and-replace/findAndReplacePlugin.test.ts
@@ -1,0 +1,132 @@
+import {
+  $createDocumentMentionNode,
+  $createUserMentionNode,
+} from '@macro-inc/lexical-core';
+import { SupportedNodeTypes } from '@macro-inc/lexical-core/node-list';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  createEditor,
+  type LexicalEditor,
+} from 'lexical';
+import { describe, expect, it } from 'vitest';
+import {
+  DO_SEARCH_COMMAND,
+  findAndReplacePlugin,
+  type NodekeyOffset,
+} from './findAndReplacePlugin';
+
+function createSearchEditor(): {
+  editor: LexicalEditor;
+  getListOffset: () => NodekeyOffset[];
+} {
+  const editor = createEditor({
+    namespace: 'find-and-replace-plugin-test',
+    nodes: SupportedNodeTypes,
+    onError: (error) => {
+      throw error;
+    },
+  });
+
+  let listOffset: NodekeyOffset[] = [];
+  findAndReplacePlugin({
+    getListOffset: () => listOffset,
+    setListOffset: (next) => {
+      listOffset = next;
+    },
+  })(editor);
+
+  return {
+    editor,
+    getListOffset: () => listOffset,
+  };
+}
+
+describe('findAndReplacePlugin document mentions', () => {
+  it('finds a substring in an inline task chip title', () => {
+    const { editor, getListOffset } = createSearchEditor();
+    let mentionKey = '';
+
+    editor.update(
+      () => {
+        const mention = $createDocumentMentionNode({
+          documentId: 'task-1',
+          documentName: 'Fix login bug',
+          blockName: 'task',
+        });
+        mentionKey = mention.getKey();
+        const paragraph = $createParagraphNode();
+        paragraph.append(
+          $createTextNode('Please '),
+          mention,
+          $createTextNode(' today')
+        );
+        $getRoot().clear().append(paragraph);
+      },
+      { discrete: true }
+    );
+
+    editor.getEditorState().read(() => {
+      editor.dispatchCommand(DO_SEARCH_COMMAND, 'login');
+    });
+
+    const offsets = getListOffset();
+    expect(offsets.some((offset) => offset.key === mentionKey)).toBe(true);
+    expect(offsets[0]?.offset.start).toBe(4);
+    expect(offsets[0]?.offset.end).toBe(9);
+  });
+
+  it('still finds regular paragraph text next to a task chip', () => {
+    const { editor, getListOffset } = createSearchEditor();
+    let textKey = '';
+
+    editor.update(
+      () => {
+        const mention = $createDocumentMentionNode({
+          documentId: 'task-1',
+          documentName: 'Fix login bug',
+          blockName: 'task',
+        });
+        const text = $createTextNode('Please review today');
+        textKey = text.getKey();
+        const paragraph = $createParagraphNode();
+        paragraph.append(text, mention);
+        $getRoot().clear().append(paragraph);
+      },
+      { discrete: true }
+    );
+
+    editor.getEditorState().read(() => {
+      editor.dispatchCommand(DO_SEARCH_COMMAND, 'review');
+    });
+
+    const offsets = getListOffset();
+    expect(offsets.some((offset) => offset.key === textKey)).toBe(true);
+    expect(offsets.every((offset) => offset.key === textKey)).toBe(true);
+  });
+
+  it('does not match ignored user-mention display names', () => {
+    const { editor, getListOffset } = createSearchEditor();
+
+    editor.update(
+      () => {
+        const mention = $createUserMentionNode({
+          userId: 'user-1',
+          email: 'wolf@macro.com',
+          displayName: 'Wolf UniqueHandle',
+        });
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTextNode('Hello '), mention);
+        $getRoot().clear().append(paragraph);
+      },
+      { discrete: true }
+    );
+
+    editor.getEditorState().read(() => {
+      editor.dispatchCommand(DO_SEARCH_COMMAND, 'UniqueHandle');
+    });
+
+    expect(getListOffset()).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/find-and-replace/findAndReplacePlugin.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/find-and-replace/findAndReplacePlugin.ts
@@ -71,12 +71,10 @@ function isBetween(target: number, a: number, b: number) {
 }
 
 function shouldIgnoreNodeType(type: string) {
-  const ignoredTypes = [
-    'document-mention',
-    'user-mention',
-    'horizontalrule',
-    'equation',
-  ];
+  // Document mentions (task chips, doc/channel refs, …) stay searchable via
+  // getTextContent() so Ctrl+F matches their visible titles. Replace still
+  // no-ops on them because they are not TextNodes.
+  const ignoredTypes = ['user-mention', 'horizontalrule', 'equation'];
   return ignoredTypes.includes(type);
 }
 

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/find-and-replace/searchHighlight.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/find-and-replace/searchHighlight.tsx
@@ -16,13 +16,7 @@ import {
   type FloatingStyle,
   getFloatingSearchHighlightPosition,
 } from './getFloatingSearchHighlightStyle';
-
-function getFirstChild(htmlEl: ChildNode | null | undefined) {
-  if (htmlEl?.firstChild) {
-    return getFirstChild(htmlEl.firstChild);
-  }
-  return htmlEl;
-}
+import { getSearchHighlightClientRects } from './searchHighlightTarget';
 
 function registerEventListener<K extends keyof HTMLElementEventMap>(
   target: HTMLElement | null,
@@ -52,19 +46,17 @@ export function SearchHighlight({
   const updateTextFormatFloatingToolbar = createCallback(
     (listOffset: NodekeyOffset[]) => {
       const newStyles: { style: FloatingStyle; idx: number | undefined }[] = [];
-      let matches = 0;
+      const matches = listOffset.reduce(
+        (max, offset) => Math.max(max, offset.pairKey ?? 0),
+        0
+      );
       listOffset.map((offset: NodekeyOffset) => {
         const editorInstance = editor();
         if (!editorInstance) return;
-        const htmlEl = getFirstChild(
-          editorInstance.getElementByKey(offset.key)?.firstChild
-        );
-        if (!htmlEl) return;
-        const range = document.createRange();
+        const element = editorInstance.getElementByKey(offset.key);
+        if (!element) return;
         try {
-          range.setStart(htmlEl, offset.offset.start);
-          range.setEnd(htmlEl, offset.offset.end);
-          const rects = range.getClientRects();
+          const rects = getSearchHighlightClientRects(element, offset.offset);
           [...rects].map((rect) => {
             const newStyle = getFloatingSearchHighlightPosition(
               rect,
@@ -77,7 +69,6 @@ export function SearchHighlight({
               ) !== 4
             ) {
               newStyles.push({ style: newStyle, idx: offset.pairKey });
-              matches = Math.max(matches, offset.pairKey ?? 0);
             }
           });
         } catch (error) {

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/find-and-replace/searchHighlightTarget.test.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/find-and-replace/searchHighlightTarget.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'vitest';
+import { resolveSearchHighlightRanges } from './searchHighlightTarget';
+
+if (typeof globalThis.document === 'undefined') {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  globalThis.document = dom.window.document;
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  globalThis.Node = dom.window.Node;
+  globalThis.NodeFilter = dom.window.NodeFilter;
+}
+
+function mentionChip(title: string, collapsed = false): HTMLElement {
+  const root = document.createElement('span');
+  root.setAttribute('data-document-mention', 'true');
+  const icon = document.createElement('span');
+  icon.appendChild(document.createElement('svg'));
+  root.appendChild(icon);
+  if (!collapsed) {
+    const name = document.createElement('span');
+    name.setAttribute('data-document-name', title);
+    name.appendChild(document.createTextNode(title));
+    root.appendChild(name);
+  }
+  document.body.appendChild(root);
+  return root;
+}
+
+describe('resolveSearchHighlightRanges', () => {
+  it('highlights the matching substring inside a task chip title', () => {
+    const chip = mentionChip('Fix login bug');
+    const ranges = resolveSearchHighlightRanges(chip, {
+      start: 4,
+      end: 9,
+      isReplace: true,
+    });
+
+    expect(ranges).toHaveLength(1);
+    expect(ranges[0]?.startContainer.textContent).toBe('Fix login bug');
+    expect(ranges[0]?.startOffset).toBe(4);
+    expect(ranges[0]?.endOffset).toBe(9);
+  });
+
+  it('falls back to the whole chip when the title is collapsed', () => {
+    const chip = mentionChip('Fix login bug', true);
+    const ranges = resolveSearchHighlightRanges(chip, {
+      start: 0,
+      end: 13,
+      isReplace: true,
+    });
+
+    expect(ranges).toHaveLength(1);
+    expect(ranges[0]?.startContainer).toBe(chip.parentNode);
+    expect(ranges[0]?.endContainer).toBe(chip.parentNode);
+  });
+
+  it('uses text-node offsets for ordinary editor text', () => {
+    const wrapper = document.createElement('span');
+    const text = document.createTextNode('Please review today');
+    wrapper.appendChild(text);
+    document.body.appendChild(wrapper);
+
+    const ranges = resolveSearchHighlightRanges(wrapper, {
+      start: 8,
+      end: 14,
+      isReplace: true,
+    });
+
+    expect(ranges).toHaveLength(1);
+    expect(ranges[0]?.startContainer).toBe(text);
+    expect(ranges[0]?.startOffset).toBe(8);
+    expect(ranges[0]?.endOffset).toBe(14);
+  });
+});

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/find-and-replace/searchHighlightTarget.test.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/find-and-replace/searchHighlightTarget.test.ts
@@ -1,15 +1,6 @@
 // @vitest-environment jsdom
-import { JSDOM } from 'jsdom';
 import { describe, expect, it } from 'vitest';
 import { resolveSearchHighlightRanges } from './searchHighlightTarget';
-
-if (typeof globalThis.document === 'undefined') {
-  const dom = new JSDOM('<!doctype html><html><body></body></html>');
-  globalThis.document = dom.window.document;
-  globalThis.HTMLElement = dom.window.HTMLElement;
-  globalThis.Node = dom.window.Node;
-  globalThis.NodeFilter = dom.window.NodeFilter;
-}
 
 function mentionChip(title: string, collapsed = false): HTMLElement {
   const root = document.createElement('span');

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/find-and-replace/searchHighlightTarget.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/find-and-replace/searchHighlightTarget.ts
@@ -1,0 +1,95 @@
+import type { SplitOffset } from './findAndReplacePlugin';
+
+function getDeepestFirstChild(
+  htmlEl: ChildNode | null | undefined
+): ChildNode | null | undefined {
+  if (htmlEl?.firstChild) {
+    return getDeepestFirstChild(htmlEl.firstChild);
+  }
+  return htmlEl;
+}
+
+export function isDocumentMentionElement(element: HTMLElement): boolean {
+  return (
+    element.hasAttribute('data-document-mention') ||
+    element.querySelector('[data-document-mention]') !== null
+  );
+}
+
+function rangesFromTextOffsets(
+  root: Node,
+  start: number,
+  end: number
+): Range[] {
+  const ranges: Range[] = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let cursor = 0;
+  let node = walker.nextNode();
+  while (node) {
+    const text = node.textContent ?? '';
+    const nodeStart = cursor;
+    const nodeEnd = cursor + text.length;
+    const overlapStart = Math.max(start, nodeStart);
+    const overlapEnd = Math.min(end, nodeEnd);
+    if (overlapStart < overlapEnd) {
+      const range = document.createRange();
+      range.setStart(node, overlapStart - nodeStart);
+      range.setEnd(node, overlapEnd - nodeStart);
+      ranges.push(range);
+    }
+    cursor = nodeEnd;
+    if (cursor >= end) break;
+    node = walker.nextNode();
+  }
+  return ranges;
+}
+
+/**
+ * Map a find-match offset onto DOM ranges. Mention chips are decorator nodes,
+ * so character offsets must be applied to the title text inside the pill
+ * rather than the first descendant (often an icon).
+ */
+export function resolveSearchHighlightRanges(
+  element: HTMLElement,
+  offset: SplitOffset
+): Range[] {
+  if (isDocumentMentionElement(element)) {
+    const nameEl =
+      (element.hasAttribute('data-document-name')
+        ? element
+        : element.querySelector('[data-document-name]')) ?? element;
+    const ranges = rangesFromTextOffsets(nameEl, offset.start, offset.end);
+    if (ranges.length > 0) {
+      return ranges;
+    }
+    const range = document.createRange();
+    range.selectNode(element);
+    return [range];
+  }
+
+  const htmlEl = getDeepestFirstChild(element.firstChild);
+  if (!htmlEl) return [];
+  const range = document.createRange();
+  try {
+    range.setStart(htmlEl, offset.start);
+    range.setEnd(htmlEl, offset.end);
+    return [range];
+  } catch {
+    return [];
+  }
+}
+
+export function getSearchHighlightClientRects(
+  element: HTMLElement,
+  offset: SplitOffset
+): DOMRect[] {
+  const ranges = resolveSearchHighlightRanges(element, offset);
+  const rects = ranges.flatMap((range) => [...range.getClientRects()]);
+  if (rects.length === 0 && isDocumentMentionElement(element)) {
+    const box = element.getBoundingClientRect();
+    if (box.width > 0 || box.height > 0) {
+      return [box];
+    }
+  }
+  return rects;
+}

--- a/docs/AGENT_GUIDE/documents.md
+++ b/docs/AGENT_GUIDE/documents.md
@@ -17,6 +17,10 @@ nodes — use the snapshot itself to verify content. For formatting checks, run
 Body placeholder advertises: `/` for block commands, `@` to reference files, `;` for snippets.
 Markdown auto-format works while typing (`#` heading, `[]` checklist, `>` quote).
 
+`Ctrl+F` / `Cmd+F` opens the in-document find bar. Matches include paragraph
+text and inline mention chips (tasks, docs, channels, skills, …) by the title
+shown on the chip.
+
 ## Reference hover previews
 
 Hover a document reference chip to open its preview without navigating. With


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ctrl+F in a markdown document skipped `document-mention` nodes, so a string that only appeared on an inline task chip never showed as a find hit.

## What changed
- Include document mentions (task chips, doc/channel refs, skills, …) in the in-document find index via their stored title
- Highlight the matching substring inside the chip pill (fallback: the whole chip when the title is collapsed)
- Count matches from search results, not from successful highlight geometry, so a hit still appears even if overlay math fails
- Replace is unchanged: mention nodes are not `TextNode`s, so find/replace still no-ops on chips

## Testing
- Unit: find matches a substring in a task mention title; regular paragraph text still matches; user mentions stay ignored
- Unit: highlight ranges land on the chip title text, and collapsed chips fall back to the whole element
- Browser: created a doc with an inline task chip `ZebraWidgetFindHit`, Ctrl+F `ZebraWidget` → **1 of 1 match** with the title highlighted; regular text search still works

[Find bar showing 1 of 1 match on a task chip](https://cursor.com/agents/bc-ead8b094-2f83-4886-9e47-9c9940285184/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffind_bar_task_chip_one_match.webp)
[ctrl_f_finds_task_chip_title.mp4](https://cursor.com/agents/bc-ead8b094-2f83-4886-9e47-9c9940285184/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fctrl_f_finds_task_chip_title.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ead8b094-2f83-4886-9e47-9c9940285184?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ead8b094-2f83-4886-9e47-9c9940285184&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

