### PR TITLE
chore: delete all selected table rows from the hover trash control

### DIFF
--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/misc/TableDeleteButtons.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/misc/TableDeleteButtons.tsx
@@ -1,17 +1,24 @@
 import { mdStore } from '@block-md/signal/markdownBlockData';
 import { ScopedPortal } from '@core/component/ScopedPortal';
 import {
-  $deleteTableColumnAtSelection,
-  $deleteTableRowAtSelection,
-  $getTableNodeFromLexicalNodeOrThrow,
+  $computeTableMap,
   $isTableCellNode,
+  $isTableRowNode,
   getDOMCellFromTarget,
 } from '@lexical/table';
 import TrashIcon from '@phosphor/trash-simple.svg';
 import { createCallback } from '@solid-primitives/rootless';
 import { Layer } from '@ui';
-import { $getNearestNodeFromDOMNode, isHTMLElement } from 'lexical';
+import {
+  $getNearestNodeFromDOMNode,
+  isHTMLElement,
+  type LexicalEditor,
+} from 'lexical';
 import { createEffect, createSignal, onCleanup, Show } from 'solid-js';
+import {
+  $deleteTableAtHover,
+  $selectionDeleteExtent,
+} from '../../plugins/tables/tableDelete';
 import { tableColumnResizeEdge } from './TableCellResizer';
 
 type DeleteTarget = {
@@ -28,6 +35,13 @@ type DeleteTarget = {
   // Pointer proximity to the border each button sits on.
   nearTop: boolean;
   nearLeft: boolean;
+  // Expanded to the table selection when it covers the hovered row/column.
+  deleteRowTop: number;
+  deleteRowBottom: number;
+  deleteColLeft: number;
+  deleteColRight: number;
+  selectedRowCount: number;
+  selectedColumnCount: number;
 };
 
 // How far (px) inside the table's top/left border the pointer still counts
@@ -36,6 +50,71 @@ const EDGE_PROXIMITY_PX = 20;
 
 const BUTTON_CLASS =
   'fixed z-20 flex size-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-edge bg-surface text-ink-muted shadow-sm hover:border-failure hover:bg-failure hover:text-surface';
+
+function readSelectionDeletePixels(
+  editor: LexicalEditor,
+  cellElem: HTMLElement,
+  cellRect: DOMRect
+): Pick<
+  DeleteTarget,
+  | 'deleteRowTop'
+  | 'deleteRowBottom'
+  | 'deleteColLeft'
+  | 'deleteColRight'
+  | 'selectedRowCount'
+  | 'selectedColumnCount'
+> {
+  const fallback = {
+    deleteRowTop: cellRect.top,
+    deleteRowBottom: cellRect.bottom,
+    deleteColLeft: cellRect.left,
+    deleteColRight: cellRect.right,
+    selectedRowCount: 1,
+    selectedColumnCount: 1,
+  };
+  return editor.read(() => {
+    const cellNode = $getNearestNodeFromDOMNode(cellElem);
+    if (!$isTableCellNode(cellNode) || !cellNode.isAttached()) return fallback;
+    const extent = $selectionDeleteExtent(cellNode);
+    if (!extent) return fallback;
+
+    const next = { ...fallback };
+    if (extent.expandRows) {
+      const minRowNode = extent.table.getChildAtIndex(extent.minRow);
+      const maxRowNode = extent.table.getChildAtIndex(extent.maxRow);
+      const minEl =
+        minRowNode && $isTableRowNode(minRowNode)
+          ? editor.getElementByKey(minRowNode.getKey())
+          : null;
+      const maxEl =
+        maxRowNode && $isTableRowNode(maxRowNode)
+          ? editor.getElementByKey(maxRowNode.getKey())
+          : null;
+      if (minEl && maxEl) {
+        const minR = minEl.getBoundingClientRect();
+        const maxR = maxEl.getBoundingClientRect();
+        next.deleteRowTop = Math.min(minR.top, maxR.top);
+        next.deleteRowBottom = Math.max(minR.bottom, maxR.bottom);
+        next.selectedRowCount = extent.maxRow - extent.minRow + 1;
+      }
+    }
+    if (extent.expandColumns) {
+      const [map, pos] = $computeTableMap(extent.table, cellNode, cellNode);
+      const minCell = map[pos.startRow]?.[extent.minColumn]?.cell;
+      const maxCell = map[pos.startRow]?.[extent.maxColumn]?.cell;
+      const minEl = minCell ? editor.getElementByKey(minCell.getKey()) : null;
+      const maxEl = maxCell ? editor.getElementByKey(maxCell.getKey()) : null;
+      if (minEl && maxEl) {
+        const minR = minEl.getBoundingClientRect();
+        const maxR = maxEl.getBoundingClientRect();
+        next.deleteColLeft = Math.min(minR.left, maxR.left);
+        next.deleteColRight = Math.max(minR.right, maxR.right);
+        next.selectedColumnCount = extent.maxColumn - extent.minColumn + 1;
+      }
+    }
+    return next;
+  });
+}
 
 export function TableDeleteButtons() {
   const mdData = mdStore.get;
@@ -79,6 +158,18 @@ export function TableDeleteButtons() {
     const nearLeft = event.clientX - tableLeft <= EDGE_PROXIMITY_PX;
     if (!nearTop && !nearLeft) return clear();
 
+    const currentEditor = editor();
+    const selectionPixels = currentEditor
+      ? readSelectionDeletePixels(currentEditor, domCell.elem, rect)
+      : {
+          deleteRowTop: rect.top,
+          deleteRowBottom: rect.bottom,
+          deleteColLeft: rect.left,
+          deleteColRight: rect.right,
+          selectedRowCount: 1,
+          selectedColumnCount: 1,
+        };
+
     setTarget({
       cellElem: domCell.elem,
       cellLeft: rect.left,
@@ -91,6 +182,7 @@ export function TableDeleteButtons() {
       tableRight: Math.min(tableRect.right, wrapperRect?.right ?? Infinity),
       nearTop,
       nearLeft,
+      ...selectionPixels,
     });
   });
 
@@ -102,18 +194,7 @@ export function TableDeleteButtons() {
     currentEditor.update(() => {
       const cellNode = $getNearestNodeFromDOMNode(currentTarget.cellElem);
       if (!$isTableCellNode(cellNode) || !cellNode.isAttached()) return;
-
-      if (type === 'table') {
-        const tableNode = $getTableNodeFromLexicalNodeOrThrow(cellNode);
-        tableNode.remove();
-        return;
-      }
-
-      // The delete helpers operate on the selection, so anchor it in the
-      // hovered cell.
-      cellNode.selectStart();
-      if (type === 'row') $deleteTableRowAtSelection();
-      else $deleteTableColumnAtSelection();
+      $deleteTableAtHover(cellNode, type);
     });
 
     setHovered(undefined);
@@ -161,17 +242,19 @@ export function TableDeleteButtons() {
                   style={{
                     left:
                       h() === 'column'
-                        ? `${t().cellLeft}px`
+                        ? `${t().deleteColLeft}px`
                         : `${t().tableLeft}px`,
                     width:
                       h() === 'column'
-                        ? `${t().cellRight - t().cellLeft}px`
+                        ? `${t().deleteColRight - t().deleteColLeft}px`
                         : `${t().tableRight - t().tableLeft}px`,
                     top:
-                      h() === 'row' ? `${t().cellTop}px` : `${t().tableTop}px`,
+                      h() === 'row'
+                        ? `${t().deleteRowTop}px`
+                        : `${t().tableTop}px`,
                     height:
                       h() === 'row'
-                        ? `${t().cellBottom - t().cellTop}px`
+                        ? `${t().deleteRowBottom - t().deleteRowTop}px`
                         : `${t().tableBottom - t().tableTop}px`,
                   }}
                 />
@@ -180,7 +263,11 @@ export function TableDeleteButtons() {
             <Show when={t().nearTop}>
               <button
                 type="button"
-                aria-label="Delete column"
+                aria-label={
+                  t().selectedColumnCount > 1
+                    ? 'Delete selected columns'
+                    : 'Delete column'
+                }
                 class={BUTTON_CLASS}
                 style={{
                   left: `${(t().cellLeft + t().cellRight) / 2}px`,
@@ -197,7 +284,11 @@ export function TableDeleteButtons() {
             <Show when={t().nearLeft}>
               <button
                 type="button"
-                aria-label="Delete row"
+                aria-label={
+                  t().selectedRowCount > 1
+                    ? 'Delete selected rows'
+                    : 'Delete row'
+                }
                 class={BUTTON_CLASS}
                 style={{
                   left: `${t().tableLeft}px`,

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/tables/tableDelete.test.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/tables/tableDelete.test.ts
@@ -1,0 +1,125 @@
+import { $createTableSelection } from '@lexical/table';
+import { $setSelection, type LexicalEditor } from 'lexical';
+import { describe, expect, it } from 'vitest';
+import { $deleteTableAtHover } from './tableDelete';
+import {
+  $getCell,
+  $getTable,
+  buildTable,
+  createTableTestEditor,
+  placeCaret,
+  readCellTexts,
+  textGrid,
+} from './tableTestUtils';
+
+function createTableEditor(): LexicalEditor {
+  return createTableTestEditor();
+}
+
+const GRID = [
+  ['01', '02', '03'],
+  ['04', '05', '06'],
+  ['07', '08', '09'],
+];
+
+async function selectCells(
+  editor: LexicalEditor,
+  from: [number, number],
+  to: [number, number]
+) {
+  await new Promise<void>((resolve) => {
+    editor.update(
+      () => {
+        const selection = $createTableSelection();
+        selection.set(
+          $getTable().getKey(),
+          $getCell(...from).getKey(),
+          $getCell(...to).getKey()
+        );
+        $setSelection(selection);
+      },
+      { onUpdate: () => resolve() }
+    );
+  });
+}
+
+async function deleteAtHover(
+  editor: LexicalEditor,
+  cell: [number, number],
+  type: 'row' | 'column' | 'table'
+) {
+  await new Promise<void>((resolve) => {
+    editor.update(
+      () => {
+        $deleteTableAtHover($getCell(...cell), type);
+      },
+      { onUpdate: () => resolve() }
+    );
+  });
+}
+
+describe('$deleteTableAtHover', () => {
+  it('deletes every selected row when the hovered cell is in that row range', async () => {
+    const editor = createTableEditor();
+    await buildTable(editor, textGrid(GRID));
+    await selectCells(editor, [0, 0], [1, 1]);
+    await deleteAtHover(editor, [1, 0], 'row');
+
+    expect(readCellTexts(editor)).toEqual([['07', '08', '09']]);
+  });
+
+  it('deletes selected rows when hovering a cell in those rows outside the selected columns', async () => {
+    const editor = createTableEditor();
+    await buildTable(editor, textGrid(GRID));
+    await selectCells(editor, [0, 0], [1, 0]);
+    await deleteAtHover(editor, [0, 2], 'row');
+
+    expect(readCellTexts(editor)).toEqual([['07', '08', '09']]);
+  });
+
+  it('deletes only the hovered row when it is outside the selection', async () => {
+    const editor = createTableEditor();
+    await buildTable(editor, textGrid(GRID));
+    await selectCells(editor, [0, 0], [0, 1]);
+    await deleteAtHover(editor, [2, 0], 'row');
+
+    expect(readCellTexts(editor)).toEqual([
+      ['01', '02', '03'],
+      ['04', '05', '06'],
+    ]);
+  });
+
+  it('deletes a single row from a caret in the hovered cell', async () => {
+    const editor = createTableEditor();
+    await buildTable(editor, textGrid(GRID));
+    await placeCaret(editor, '04');
+    await deleteAtHover(editor, [1, 0], 'row');
+
+    expect(readCellTexts(editor)).toEqual([
+      ['01', '02', '03'],
+      ['07', '08', '09'],
+    ]);
+  });
+
+  it('deletes every selected column when the hovered cell is in that column range', async () => {
+    const editor = createTableEditor();
+    await buildTable(editor, textGrid(GRID));
+    await selectCells(editor, [0, 0], [1, 1]);
+    await deleteAtHover(editor, [0, 1], 'column');
+
+    expect(readCellTexts(editor)).toEqual([['03'], ['06'], ['09']]);
+  });
+
+  it('deletes only the hovered column when it is outside the selection', async () => {
+    const editor = createTableEditor();
+    await buildTable(editor, textGrid(GRID));
+    await selectCells(editor, [0, 0], [1, 0]);
+    await deleteAtHover(editor, [0, 2], 'column');
+
+    expect(readCellTexts(editor)).toEqual([
+      ['01', '02'],
+      ['04', '05'],
+      ['07', '08'],
+    ]);
+  });
+});

--- a/apps/web/src/lib/core/component/LexicalMarkdown/plugins/tables/tableDelete.ts
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/plugins/tables/tableDelete.ts
@@ -1,0 +1,121 @@
+import {
+  $computeTableMap,
+  $deleteTableColumnAtSelection,
+  $deleteTableRowAtSelection,
+  $getTableCellNodeFromLexicalNode,
+  $getTableNodeFromLexicalNodeOrThrow,
+  $isTableSelection,
+  type TableCellNode,
+  type TableNode,
+} from '@lexical/table';
+import { $getSelection } from 'lexical';
+
+type TableSelectionRange = {
+  table: TableNode;
+  minRow: number;
+  maxRow: number;
+  minColumn: number;
+  maxColumn: number;
+};
+
+/**
+ * Grid span of the current table selection, or null when the selection is
+ * not a table selection.
+ */
+function $getTableSelectionRange(): TableSelectionRange | null {
+  const selection = $getSelection();
+  if (!$isTableSelection(selection)) return null;
+  const anchorCell = $getTableCellNodeFromLexicalNode(
+    selection.anchor.getNode()
+  );
+  const focusCell = $getTableCellNodeFromLexicalNode(selection.focus.getNode());
+  if (!anchorCell || !focusCell) return null;
+  const table = $getTableNodeFromLexicalNodeOrThrow(anchorCell);
+  const [, aPos, fPos] = $computeTableMap(table, anchorCell, focusCell);
+  return {
+    table,
+    minRow: Math.min(aPos.startRow, fPos.startRow),
+    maxRow: Math.max(
+      aPos.startRow + anchorCell.getRowSpan() - 1,
+      fPos.startRow + focusCell.getRowSpan() - 1
+    ),
+    minColumn: Math.min(aPos.startColumn, fPos.startColumn),
+    maxColumn: Math.max(
+      aPos.startColumn + anchorCell.getColSpan() - 1,
+      fPos.startColumn + focusCell.getColSpan() - 1
+    ),
+  };
+}
+
+/**
+ * The current table selection, if it lives in the same table as `cell`.
+ */
+function $tableSelectionRangeForCell(
+  cell: TableCellNode
+): TableSelectionRange | null {
+  const range = $getTableSelectionRange();
+  if (!range) return null;
+  const table = $getTableNodeFromLexicalNodeOrThrow(cell);
+  if (table.getKey() !== range.table.getKey()) return null;
+  return range;
+}
+
+export type TableDeleteHoverExtent = TableSelectionRange & {
+  expandRows: boolean;
+  expandColumns: boolean;
+};
+
+/**
+ * How far a table selection should expand the hover-delete highlight, if
+ * the hovered cell shares a table with that selection.
+ */
+export function $selectionDeleteExtent(
+  hoveredCell: TableCellNode
+): TableDeleteHoverExtent | null {
+  const range = $tableSelectionRangeForCell(hoveredCell);
+  if (!range) return null;
+  const [, pos] = $computeTableMap(range.table, hoveredCell, hoveredCell);
+  return {
+    ...range,
+    expandRows: pos.startRow >= range.minRow && pos.startRow <= range.maxRow,
+    expandColumns:
+      pos.startColumn >= range.minColumn && pos.startColumn <= range.maxColumn,
+  };
+}
+
+/**
+ * Whether a table selection already covers the hovered cell's row (or
+ * column). When it does, the hover delete control should act on that whole
+ * selection rather than collapsing to a single cell.
+ */
+function $selectionCoversHoveredAxis(
+  hoveredCell: TableCellNode,
+  axis: 'row' | 'column'
+): boolean {
+  const extent = $selectionDeleteExtent(hoveredCell);
+  if (!extent) return false;
+  return axis === 'row' ? extent.expandRows : extent.expandColumns;
+}
+
+/**
+ * Delete the hovered row, column, or whole table. If a table selection
+ * already covers the hovered axis, the selection is left intact so Lexical
+ * removes every selected row or column; otherwise the caret is moved into
+ * `hoveredCell` first (single row/column).
+ *
+ * Must run inside an editor update.
+ */
+export function $deleteTableAtHover(
+  hoveredCell: TableCellNode,
+  type: 'row' | 'column' | 'table'
+): void {
+  if (type === 'table') {
+    $getTableNodeFromLexicalNodeOrThrow(hoveredCell).remove();
+    return;
+  }
+  if (!$selectionCoversHoveredAxis(hoveredCell, type)) {
+    hoveredCell.selectStart();
+  }
+  if (type === 'row') $deleteTableRowAtSelection();
+  else $deleteTableColumnAtSelection();
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When a rectangular table cell selection is active, hovering the left-edge delete icon now deletes **every selected row** (and the top-edge icon deletes every selected column), instead of collapsing to a single hovered cell first.

## Behavior
- Select a region of cells, hover the left trash icon: the red highlight covers the selected rows and click removes those entire rows.
- Same for the top trash icon and selected columns.
- Hovering a row/column **outside** the selection still deletes only that one row/column.
- A caret in a cell still deletes a single row/column, as before.

## Why
`$deleteTableRowAtSelection` already removes the full selected row range. The hover control was calling `selectStart()` on the hovered cell first, which discarded the table selection.

## Test plan
- Unit tests in `tableDelete.test.ts` cover multi-row/column delete, hovering outside the selection, and caret/single-row delete.
- Manual: select a 2-row region, hover the left trash icon (highlight spans both rows), click, confirm both rows are gone.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1a77a7e-deed-47e4-967b-ad142141b593?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1a77a7e-deed-47e4-967b-ad142141b593&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

