### PR TITLE
feat(block-agent): show a working row while a turn has nothing to read

### DIFF
--- a/apps/web/src/features/block-agent/component/AgentMessage.tsx
+++ b/apps/web/src/features/block-agent/component/AgentMessage.tsx
@@ -12,7 +12,7 @@ import type {
 import { For, type JSX, Show } from 'solid-js';
 import { match } from 'ts-pattern';
 import { isControlMessage } from '../state/control-message';
-import { ActionLine, Thought } from '../ui';
+import { ActionLine, Thought, WorkingLine } from '../ui';
 import { ControlPart } from './parts/ControlPart';
 import { ElicitationPart } from './parts/ElicitationPart';
 import { PermissionPart } from './parts/PermissionPart';
@@ -53,6 +53,27 @@ function AgentMessagePart(props: {
     .with({ kind: 'control' }, (part) => <ControlPart part={part} />)
     .with({ kind: 'elicitation' }, (part) => <ElicitationPart part={part} />)
     .exhaustive();
+}
+
+/**
+ * Whether an open turn should show the working row at its tail.
+ *
+ * Skipped wherever the transcript already shows the turn is alive — prose
+ * streaming in, a thought shimmering — and wherever it is not: a permission
+ * or elicitation prompt is waiting on the reader, not working.
+ */
+function showsWorkingLine(message: FoldedMessage): boolean {
+  const last = message.parts[message.parts.length - 1];
+  if (last === undefined) return true;
+  return match(last)
+    .with(
+      { kind: 'text' },
+      { kind: 'thought' },
+      { kind: 'permission' },
+      { kind: 'elicitation' },
+      () => false
+    )
+    .otherwise(() => true);
 }
 
 /**
@@ -105,6 +126,11 @@ export function Message(props: { message: FoldedMessage }) {
               />
             )}
           </For>
+          {/* The turn is open with nothing to read yet — a dot and a rotating
+              verb, so the wait reads as work rather than as a stall. */}
+          <Show when={inFlight() && showsWorkingLine(props.message)}>
+            <WorkingLine />
+          </Show>
           {/* A turn the runtime errored is something that happened to the
               session, like a model change or a stop — so it reads as one,
               at the foot of whatever the agent managed to say first. */}

--- a/apps/web/src/features/block-agent/ui/TextShimmer.tsx
+++ b/apps/web/src/features/block-agent/ui/TextShimmer.tsx
@@ -17,6 +17,11 @@ const SWAP_MS = 200;
 export interface TextShimmerProps {
   text: string;
   active: boolean;
+  /**
+   * What assistive technology hears, when that should stay put while the
+   * visible text changes. Defaults to the visible text.
+   */
+  label?: string;
   class?: string;
 }
 
@@ -49,7 +54,7 @@ export function TextShimmer(props: TextShimmerProps) {
   return (
     <span
       class={`inline-grid whitespace-pre align-baseline ${props.class ?? ''}`}
-      aria-label={props.text}
+      aria-label={props.label ?? props.text}
     >
       <span
         aria-hidden="true"

--- a/apps/web/src/features/block-agent/ui/WorkingLine.test.tsx
+++ b/apps/web/src/features/block-agent/ui/WorkingLine.test.tsx
@@ -1,0 +1,28 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { WorkingLine } from './WorkingLine';
+import { WORKING_LABEL } from './working-verbs';
+
+afterEach(cleanup);
+
+describe('WorkingLine', () => {
+  it('opens on the base word, so short turns never show a verb', () => {
+    const { container } = render(() => <WorkingLine />);
+
+    expect(container.textContent).toContain(WORKING_LABEL);
+  });
+
+  it('offers one stable label rather than a rotating one', () => {
+    const { getAllByLabelText } = render(() => <WorkingLine />);
+
+    expect(getAllByLabelText(WORKING_LABEL)).toHaveLength(1);
+  });
+
+  it('has nothing to expand, so it is not a control', () => {
+    const { queryByRole } = render(() => <WorkingLine />);
+
+    expect(queryByRole('button')).toBeNull();
+  });
+});

--- a/apps/web/src/features/block-agent/ui/WorkingLine.tsx
+++ b/apps/web/src/features/block-agent/ui/WorkingLine.tsx
@@ -1,0 +1,67 @@
+/**
+ * The tail of an open turn that has produced nothing to read yet.
+ *
+ * A sibling of `Thought`, deliberately shaped differently. A thought row leads
+ * with a caret because there is text behind it; this row has nothing to
+ * expand, so the caret gives way to a dot that breathes on the shimmer's own
+ * period, and the row is not a control at all. The leading slot keeps the
+ * caret's width so the label does not shift sideways once reasoning arrives
+ * and the row becomes a `Thought`.
+ */
+
+import { createSignal, onCleanup } from 'solid-js';
+import { TextShimmer } from './TextShimmer';
+import { createVerbDraw, WORKING_LABEL } from './working-verbs';
+
+/**
+ * How long a word holds. Faster reads as thrashing rather than work. The first
+ * word holds for a full interval too, so the short turns that make up most of
+ * a session never show a verb at all.
+ */
+const HOLD_MS = 4000;
+
+/** How long the crossfade between words runs. */
+const SWAP_MS = 180;
+
+export function WorkingLine() {
+  const [verb, setVerb] = createSignal(WORKING_LABEL);
+  const [swapping, setSwapping] = createSignal(false);
+
+  const drawVerb = createVerbDraw();
+  let swapTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const rotation = setInterval(() => {
+    setSwapping(true);
+    swapTimer = setTimeout(() => {
+      setVerb(drawVerb());
+      setSwapping(false);
+    }, SWAP_MS);
+  }, HOLD_MS);
+
+  onCleanup(() => {
+    clearInterval(rotation);
+    if (swapTimer !== undefined) clearTimeout(swapTimer);
+  });
+
+  return (
+    <div class="flex min-h-7 items-center gap-1 py-1 text-xs leading-5 text-ink-extra-muted">
+      <span
+        aria-hidden="true"
+        class="flex size-4 shrink-0 items-center justify-center"
+      >
+        <span class="agent-working-dot size-[5px] rounded-full bg-current" />
+      </span>
+      {/* The visible word rotates; the label a screen reader hears does not.
+          Narrating a synonym every few seconds is noise, and the one fact
+          worth announcing is that the turn is still open. */}
+      <TextShimmer
+        text={verb()}
+        label={WORKING_LABEL}
+        active
+        class={`transition-opacity duration-200 motion-reduce:transition-none ${
+          swapping() ? 'opacity-0' : ''
+        }`}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/block-agent/ui/index.ts
+++ b/apps/web/src/features/block-agent/ui/index.ts
@@ -56,3 +56,5 @@ export {
   type TodoItem,
   type ToolStatus,
 } from './types';
+export { WorkingLine } from './WorkingLine';
+export { createVerbDraw, WORKING_LABEL } from './working-verbs';

--- a/apps/web/src/features/block-agent/ui/working-verbs.test.ts
+++ b/apps/web/src/features/block-agent/ui/working-verbs.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { createVerbDraw, VERBS } from './working-verbs';
+
+describe('createVerbDraw', () => {
+  it('spends the whole list before repeating a verb', () => {
+    const draw = createVerbDraw();
+    const drawn = Array.from({ length: VERBS.length }, draw);
+
+    expect(new Set(drawn).size).toBe(VERBS.length);
+  });
+
+  it('reshuffles rather than running dry', () => {
+    const draw = createVerbDraw();
+    const drawn = Array.from({ length: VERBS.length * 3 }, draw);
+
+    expect(drawn.every((verb) => VERBS.includes(verb))).toBe(true);
+  });
+
+  it('offers gerunds only, so any two read as the same kind of word', () => {
+    expect(VERBS.every((verb) => verb.endsWith('ing'))).toBe(true);
+  });
+});

--- a/apps/web/src/features/block-agent/ui/working-verbs.ts
+++ b/apps/web/src/features/block-agent/ui/working-verbs.ts
@@ -1,0 +1,64 @@
+/**
+ * The words an open turn shows while the agent has produced nothing to read.
+ *
+ * Modelled on Claude Code's spinner corpus, but off paper rather than out of a
+ * kitchen, because that is the work this agent does.
+ */
+
+export const VERBS: readonly string[] = [
+  'Skimming',
+  'Poring',
+  'Leafing',
+  'Combing',
+  'Sifting',
+  'Thumbing',
+  'Excerpting',
+  'Pondering',
+  'Puzzling',
+  'Mulling',
+  'Percolating',
+  'Weighing',
+  'Reconsidering',
+  'Drafting',
+  'Wordsmithing',
+  'Redlining',
+  'Tightening',
+  'Annotating',
+  'Collating',
+  'Threading',
+  'Indexing',
+  'Cross-referencing',
+];
+
+/**
+ * The word an open turn shows before its first rotation, and the label a
+ * screen reader hears for the whole turn. Deliberately not "Thinking": a bare
+ * row has no reasoning behind it and the turn may well be running a tool.
+ */
+export const WORKING_LABEL = 'Working';
+
+/**
+ * A draw that does not repeat until every verb has been used.
+ *
+ * Repetition is the one thing that makes a rotation look cheap, so the list is
+ * drawn down and reshuffled rather than sampled.
+ */
+export function createVerbDraw(
+  random: () => number = Math.random
+): () => string {
+  let remaining: string[] = [];
+
+  return () => {
+    if (remaining.length === 0) remaining = shuffled(VERBS, random);
+    return remaining.pop() ?? WORKING_LABEL;
+  };
+}
+
+function shuffled(pool: readonly string[], random: () => number): string[] {
+  const out = [...pool];
+  for (let index = out.length - 1; index > 0; index--) {
+    const swap = Math.floor(random() * (index + 1));
+    [out[index], out[swap]] = [out[swap] as string, out[index] as string];
+  }
+  return out;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -586,6 +586,31 @@ html[data-theme-light='false'] {
   }
 }
 
+/* The dot leading an open agent turn that has nothing to expand yet. Shares
+   the shimmer's period so the row reads as one motion, not two. */
+@keyframes agent-working-dot {
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: scale(0.65);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.agent-working-dot {
+  animation: agent-working-dot 1.8s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-working-dot {
+    animation: none;
+    opacity: 0.55;
+  }
+}
+
 @keyframes skeleton-shimmer {
   100% {
     transform: translateX(100%);


### PR DESCRIPTION
An open agent turn that hasn't produced any text yet renders nothing at all, so a long wait looks exactly like a stall. This adds the row that fills that gap: a breathing dot and a verb that changes every four seconds.

```
● Collating
```

Live mock of the row, and of the thought row it hands off to: https://claude.ai/code/artifact/4a3f14d7-d58b-46f6-9a25-55347489bdc4

## Why it isn't just a `Thought`

`Thought` leads with a caret because there's reasoning behind it. This row has nothing to expand, so the caret gives way to a dot that pulses on the shimmer's own 1.8s period, and the row is a plain `div` — not a button, nothing to tab to. The 16px leading slot is kept anyway, so the label doesn't shift sideways when reasoning arrives and a real `Thought` takes over.

## Why "Working" and not "Thinking"

A bare row has no reasoning behind it, and the turn may well be off running a tool — "Thinking" claims something we can't see. "Working" covers the whole open turn. It's also the stable `aria-label` for the turn's lifetime (new optional `label` prop on `TextShimmer`): the visible word changes, but a screen reader hears one fact rather than a stream of synonyms.

## The verbs

One flat list of 22 gerunds, off paper rather than out of a kitchen because that's the work this agent does — *Poring, Leafing, Collating, Redlining*. Drawn down and reshuffled rather than sampled, so nothing repeats until the list is spent. The base word holds for a full interval, so the short turns that make up most of a session never show a verb at all.

## Where it shows

At the tail of an in-flight agent message, skipped wherever the transcript already shows the turn is alive (streaming prose, a shimmering thought) or where it isn't working at all (a permission or elicitation prompt waiting on the reader).

## Not included

**An elapsed-seconds counter.** `FoldedMessage` carries no turn start time and the transcript is virtualised, so a client-side counter would reset on scroll remount and quietly lie. Worth a follow-up that puts `startedAt` on the wire.

## Testing

- `bunx vitest run` in `apps/web` — full suite green (494 files, 4491 tests).
- `just check` clean.
- Unit tests cover the draw (spends the list before repeating, reshuffles, gerunds only) and the row (opens on the base word, one stable label, exposes no button).
- Not yet exercised against a live session in a browser — the states are reproduced in the linked mock, but a reviewer running the stack should confirm the row appears between tool calls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Agent transcript UI and accessibility only; no backend, auth, or data-path changes.
> 
> **Overview**
> In-flight agent turns that have not yet surfaced readable content no longer look like a dead stall. **`AgentMessage`** appends a new **`WorkingLine`** when the turn is open and **`showsWorkingLine`** says the transcript is not already “alive” (streaming **text**/**thought**) or blocked on the user (**permission**/**elicitation**).
> 
> **`WorkingLine`** is a non-interactive row (pulsing dot + shimmering label) that opens on **“Working”** and, after ~4s, rotates through shuffled gerunds from **`working-verbs`** without repeating until the pool is exhausted. **`TextShimmer`** gains an optional **`label`** so screen readers keep a stable **“Working”** announcement while the visible word changes. Global CSS adds **`agent-working-dot`** animation (aligned to the shimmer period, with reduced-motion fallback). Unit tests cover the verb draw and row behavior; **`WorkingLine`** is exported from the block-agent UI barrel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe9ced8fe38bae5866014135f1a60998c087963b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->