### PR TITLE
feat: outer sidebar unread badges

### DIFF
--- a/apps/web/src/components/app/sidebar-next/list-nav.tsx
+++ b/apps/web/src/components/app/sidebar-next/list-nav.tsx
@@ -16,7 +16,7 @@ import type { SidebarNextNavItem } from './nav-items';
 
 export type ListNavProps = {
   item: SidebarNextNavItem;
-  unreadCount?: number;
+  unreadCount?: number | '99+';
   hasActiveCall?: boolean;
   onContextMenuOpenChange?: (open: boolean) => void;
 };
@@ -39,7 +39,8 @@ export const ListNav = (props: ListNavProps) => {
   const location = useLocation();
 
   const content = () => sidebarContent(props.item.id, props.item.params);
-  const hasUnread = () => (props.unreadCount ?? 0) > 0;
+  const hasUnread = () =>
+    props.unreadCount === '99+' || (props.unreadCount ?? 0) > 0;
   const label = () =>
     [
       props.item.label,
@@ -103,7 +104,7 @@ export const ListNav = (props: ListNavProps) => {
         size="icon-md"
         class="cursor-default rounded-xl"
         label={label()}
-        tooltip={`Go to ${label()}`}
+        tooltip={`Go to ${props.item.label}`}
         tooltipPlacement="right"
         hotkey={[TOKENS.sidebar.goToLeader, props.item.hotkeyToken]}
         draggable={false}
@@ -145,7 +146,9 @@ export const ListNav = (props: ListNavProps) => {
             data-sidebar-unread-count
             class="pointer-events-none absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold tabular-nums text-panel ring-2 ring-surface"
           >
-            {(props.unreadCount ?? 0) > 99 ? '99+' : props.unreadCount}
+            {props.unreadCount === '99+' || (props.unreadCount ?? 0) > 99
+              ? '99+'
+              : props.unreadCount}
           </span>
         </Show>
         <Show when={props.hasActiveCall}>

--- a/apps/web/src/components/app/sidebar-next/list-nav.tsx
+++ b/apps/web/src/components/app/sidebar-next/list-nav.tsx
@@ -7,13 +7,17 @@ import {
 } from '@components/app/app-sidebar/sidebar';
 import { useSplitLayout } from '@components/app/split-layout/layout';
 import { TOKENS } from '@core/hotkey/tokens';
+import PhoneIcon from '@phosphor-fill/phone-fill.svg';
 import { useLocation } from '@solidjs/router';
 import { Button, cn } from '@ui';
+import { Show } from 'solid-js';
 import { NavGlyph } from './nav-glyph';
 import type { SidebarNextNavItem } from './nav-items';
 
 export type ListNavProps = {
   item: SidebarNextNavItem;
+  unreadCount?: number;
+  hasActiveCall?: boolean;
   onContextMenuOpenChange?: (open: boolean) => void;
 };
 
@@ -35,6 +39,13 @@ export const ListNav = (props: ListNavProps) => {
   const location = useLocation();
 
   const content = () => sidebarContent(props.item.id, props.item.params);
+  const hasUnread = () => (props.unreadCount ?? 0) > 0;
+  const label = () =>
+    [
+      props.item.label,
+      ...(hasUnread() ? [`${props.unreadCount} unread`] : []),
+      ...(props.hasActiveCall ? ['active call'] : []),
+    ].join(', ');
 
   // Read the manager signal live: it is undefined until the split layout
   // mounts, which happens after the sidebar.
@@ -91,8 +102,8 @@ export const ListNav = (props: ListNavProps) => {
         variant="ghost"
         size="icon-md"
         class="cursor-default rounded-xl"
-        label={props.item.label}
-        tooltip={`Go to ${props.item.label}`}
+        label={label()}
+        tooltip={`Go to ${label()}`}
         tooltipPlacement="right"
         hotkey={[TOKENS.sidebar.goToLeader, props.item.hotkeyToken]}
         draggable={false}
@@ -128,6 +139,24 @@ export const ListNav = (props: ListNavProps) => {
           filled={isActive()}
           class={cn('size-5.5', isActive() && 'text-accent')}
         />
+        <Show when={hasUnread()}>
+          <span
+            aria-hidden="true"
+            data-sidebar-unread-count
+            class="pointer-events-none absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold tabular-nums text-panel ring-2 ring-surface"
+          >
+            {(props.unreadCount ?? 0) > 99 ? '99+' : props.unreadCount}
+          </span>
+        </Show>
+        <Show when={props.hasActiveCall}>
+          <span
+            aria-hidden="true"
+            data-sidebar-active-call
+            class="pointer-events-none absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full bg-accent text-panel ring-2 ring-surface"
+          >
+            <PhoneIcon class="size-2.5" />
+          </span>
+        </Show>
       </Button>
     </SidebarOpenInSplitMenu>
   );

--- a/apps/web/src/components/app/sidebar-next/nav-items.ts
+++ b/apps/web/src/components/app/sidebar-next/nav-items.ts
@@ -54,15 +54,6 @@ const SIDEBAR_NEXT_NAV_ITEMS = [
     hotkeyToken: TOKENS.sidebar.goTo.inbox,
   },
   {
-    id: 'documents',
-    label: 'Drive',
-    href: LIST_VIEW_PATHS.documents,
-    icon: FolderSimpleIcon,
-    iconActive: FolderSimpleFillIcon,
-    hotkey: 'f',
-    hotkeyToken: TOKENS.sidebar.goTo.documents,
-  },
-  {
     id: 'mail',
     label: 'Email',
     href: LIST_VIEW_PATHS.mail,
@@ -79,6 +70,15 @@ const SIDEBAR_NEXT_NAV_ITEMS = [
     iconActive: ChatsCircleFillIcon,
     hotkey: 'c',
     hotkeyToken: TOKENS.sidebar.goTo.channels,
+  },
+  {
+    id: 'documents',
+    label: 'Drive',
+    href: LIST_VIEW_PATHS.documents,
+    icon: FolderSimpleIcon,
+    iconActive: FolderSimpleFillIcon,
+    hotkey: 'f',
+    hotkeyToken: TOKENS.sidebar.goTo.documents,
   },
   {
     id: 'tasks',

--- a/apps/web/src/components/app/sidebar-next/sidebar-rail.tsx
+++ b/apps/web/src/components/app/sidebar-next/sidebar-rail.tsx
@@ -1,4 +1,6 @@
+import { useChannelsUnreadCount } from '@app/features/channels-view/use-channels-unread-count';
 import { useEmailUnreadCount } from '@app/features/email-view/queries/use-email-unread-count';
+import { useInboxUnreadCount } from '@app/features/inbox-view/queries/use-inbox-unread-count';
 import { useAnalytics } from '@app/lib/analytics/analytics-context';
 import { globalSplitManager } from '@app/signal/splitLayout';
 import {
@@ -42,6 +44,13 @@ export const SidebarRail = (props: SidebarRailProps) => {
   const layout = useSplitLayout();
   const activeCalls = useActiveCallsQuery();
   const emailUnreadCount = useEmailUnreadCount();
+  const inboxUnreadCount = useInboxUnreadCount();
+  const channelsUnreadCount = useChannelsUnreadCount();
+  const unreadCounts = {
+    inbox: inboxUnreadCount,
+    mail: emailUnreadCount,
+    channels: channelsUnreadCount,
+  };
   // The outer rail must not suspend while call state is loading.
   const hasActiveCall = () =>
     activeCalls.isSuccess && (activeCalls.data?.length ?? 0) > 0;
@@ -86,7 +95,9 @@ export const SidebarRail = (props: SidebarRailProps) => {
                 <ListNav
                   item={item}
                   unreadCount={
-                    item.id === 'mail' ? emailUnreadCount() : undefined
+                    item.id in unreadCounts
+                      ? unreadCounts[item.id as keyof typeof unreadCounts]()
+                      : undefined
                   }
                   hasActiveCall={item.id === 'channels' && hasActiveCall()}
                 />

--- a/apps/web/src/components/app/sidebar-next/sidebar-rail.tsx
+++ b/apps/web/src/components/app/sidebar-next/sidebar-rail.tsx
@@ -1,3 +1,4 @@
+import { useEmailUnreadCount } from '@app/features/email-view/queries/use-email-unread-count';
 import { useAnalytics } from '@app/lib/analytics/analytics-context';
 import { globalSplitManager } from '@app/signal/splitLayout';
 import {
@@ -7,6 +8,7 @@ import {
 } from '@components/app/app-sidebar/sidebar';
 import { useSplitLayout } from '@components/app/split-layout/layout';
 import { hotkeyScopeNeutralAttribute } from '@core/dom-selectors';
+import { useActiveCallsQuery } from '@queries/call/call';
 import { For } from 'solid-js';
 import { SidebarRailCreateButton } from './create-button';
 import { FooterActions } from './footer-actions';
@@ -38,6 +40,11 @@ export const SidebarRail = (props: SidebarRailProps) => {
   const gates = useNavItemGates();
   const analytics = useAnalytics();
   const layout = useSplitLayout();
+  const activeCalls = useActiveCallsQuery();
+  const emailUnreadCount = useEmailUnreadCount();
+  // The outer rail must not suspend while call state is loading.
+  const hasActiveCall = () =>
+    activeCalls.isSuccess && (activeCalls.data?.length ?? 0) > 0;
 
   const isExpanded = () => (props.sidebarState ?? 'expanded') === 'expanded';
 
@@ -76,7 +83,13 @@ export const SidebarRail = (props: SidebarRailProps) => {
           <For each={visibleNavItems(gates())}>
             {(item) => (
               <li class="flex">
-                <ListNav item={item} />
+                <ListNav
+                  item={item}
+                  unreadCount={
+                    item.id === 'mail' ? emailUnreadCount() : undefined
+                  }
+                  hasActiveCall={item.id === 'channels' && hasActiveCall()}
+                />
               </li>
             )}
           </For>

--- a/apps/web/src/features/channels-view/use-channels-unread-count.ts
+++ b/apps/web/src/features/channels-view/use-channels-unread-count.ts
@@ -1,0 +1,43 @@
+import { clause, compileClause, confine } from '@app/features/soup';
+import { withEntityNotifications } from '@app/features/soup/entity-notifications';
+import { hasNotificationCoverage } from '@app/features/soup/notification-coverage';
+import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
+import { notificationIsRead } from '@entity/utils/notification';
+import { boundedCount } from '@queries/soup/bounded-count';
+import { createBoundedCountPagination } from '@queries/soup/bounded-count-pagination';
+import { useSoupAstItemsQuery } from '@queries/soup/items';
+
+/** Counts channels, not messages or Inbox thread rows. Includes direct messages. */
+export function useChannelsUnreadCount() {
+  const source = useGlobalNotificationSource();
+  const query = useSoupAstItemsQuery(() => ({
+    params: { expand: true, limit: 100, sort_method: 'updated_at' },
+    body: compileClause(
+      confine({
+        chanf: clause.and(
+          clause.eq('channelIsParticipant', true),
+          clause.eq('channelSeen', false)
+        ),
+      })
+    ),
+  }));
+  const count = () => {
+    if (query.isLoading || query.error || query.isPlaceholderData) return;
+    const entities = query.data?.entities;
+    if (!entities) return;
+    const unread = entities.filter(
+      (entity) =>
+        entity.type === 'channel' &&
+        // Deliberately unscoped: unread thread activity also makes a channel unread.
+        withEntityNotifications(entity, source)
+          .notifications?.()
+          .some((notification) => !notificationIsRead(notification))
+    );
+    return boundedCount(
+      unread.map((entity) => entity.id),
+      !query.hasNextPage && hasNotificationCoverage(entities, source)
+    );
+  };
+  createBoundedCountPagination(query, count);
+  return count;
+}

--- a/apps/web/src/features/email-view/queries/use-email-unread-count.test.ts
+++ b/apps/web/src/features/email-view/queries/use-email-unread-count.test.ts
@@ -1,14 +1,29 @@
 import type { SoupAstItemsQueryArgs } from '@queries/soup/items';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useEmailUnreadCount } from './use-email-unread-count';
+import { createRoot } from 'solid-js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEmailUnreadCount as createCount } from './use-email-unread-count';
+
+const disposers: (() => void)[] = [];
+afterEach(() => {
+  for (const dispose of disposers.splice(0)) dispose();
+});
+
+function useEmailUnreadCount() {
+  return createRoot((dispose) => {
+    disposers.push(dispose);
+    return createCount();
+  });
+}
 
 const mocks = vi.hoisted(() => ({
   query: {
     isLoading: false,
     error: null as Error | null,
     isPlaceholderData: false,
+    isEnabled: false,
+    hasNextPage: false,
     data: {
-      groups: [{ totalCount: 120, itemIds: ['one-loaded-row'] }],
+      entities: [{ id: 'email-1', type: 'email', isRead: false }],
     },
   },
   buildEmailQuery: vi.fn(() => ({
@@ -35,8 +50,9 @@ describe('useEmailUnreadCount', () => {
     mocks.query.isLoading = false;
     mocks.query.error = null;
     mocks.query.isPlaceholderData = false;
+    mocks.query.hasNextPage = false;
     mocks.query.data = {
-      groups: [{ totalCount: 120, itemIds: ['one-loaded-row'] }],
+      entities: [{ id: 'email-1', type: 'email', isRead: false }],
     };
   });
 
@@ -48,20 +64,47 @@ describe('useEmailUnreadCount', () => {
       facets: { read: ['unread'] },
     });
     expect(mocks.args).toEqual({
-      params: { limit: 1, sort_method: 'updated_at' },
+      params: { limit: 100, sort_method: 'updated_at' },
       body: { emailView: 'inbox' },
-      groupBy: { type: 'entity_type' },
     });
     expect(mocks.args?.transport).toBeUndefined();
   });
 
-  it('counts all server rows, not just hydrated rows, and reads updated totals', () => {
+  it('counts a complete result and responds to cached read changes', () => {
     const count = useEmailUnreadCount();
-    expect(count()).toBe(120);
-    mocks.query.data.groups[0].totalCount = 119;
-    expect(count()).toBe(119);
-    mocks.query.data.groups = [];
+    expect(count()).toBe(1);
+    mocks.query.data.entities[0].isRead = true;
     expect(count()).toBe(0);
+    mocks.query.data.entities = [];
+    expect(count()).toBe(0);
+  });
+
+  it('does not claim an exact count for an incomplete page', () => {
+    mocks.query.hasNextPage = true;
+    expect(useEmailUnreadCount()()).toBeUndefined();
+  });
+
+  it('displays 99+ only after confirming 100 distinct unread threads', () => {
+    mocks.query.hasNextPage = true;
+    mocks.query.data.entities = Array.from({ length: 100 }, (_, i) => ({
+      id: `email-${i}`,
+      type: 'email',
+      isRead: false,
+    }));
+    const count = useEmailUnreadCount();
+    expect(count()).toBe('99+');
+    mocks.query.data.entities[0].isRead = true;
+    expect(count()).toBeUndefined();
+    mocks.query.hasNextPage = false;
+    expect(count()).toBe(99);
+  });
+
+  it('excludes duplicate threads and non-email rows', () => {
+    mocks.query.data.entities.push(
+      { id: 'email-1', type: 'email', isRead: false },
+      { id: 'document-1', type: 'document', isRead: false }
+    );
+    expect(useEmailUnreadCount()()).toBe(1);
   });
 
   it('does not read data or suspend while pending', () => {

--- a/apps/web/src/features/email-view/queries/use-email-unread-count.test.ts
+++ b/apps/web/src/features/email-view/queries/use-email-unread-count.test.ts
@@ -1,0 +1,91 @@
+import type { SoupAstItemsQueryArgs } from '@queries/soup/items';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEmailUnreadCount } from './use-email-unread-count';
+
+const mocks = vi.hoisted(() => ({
+  query: {
+    isLoading: false,
+    error: null as Error | null,
+    isPlaceholderData: false,
+    data: {
+      groups: [{ totalCount: 120, itemIds: ['one-loaded-row'] }],
+    },
+  },
+  buildEmailQuery: vi.fn(() => ({
+    params: { limit: 100, sort_method: 'updated_at' },
+    body: { emailView: 'inbox' },
+  })),
+  args: undefined as SoupAstItemsQueryArgs | undefined,
+}));
+
+vi.mock('@queries/soup/items', () => ({
+  useSoupAstItemsQuery: (args: () => SoupAstItemsQueryArgs) => {
+    mocks.args = args();
+    return mocks.query;
+  },
+}));
+
+vi.mock('./email-query', () => ({
+  buildEmailQuery: mocks.buildEmailQuery,
+}));
+
+describe('useEmailUnreadCount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.query.isLoading = false;
+    mocks.query.error = null;
+    mocks.query.isPlaceholderData = false;
+    mocks.query.data = {
+      groups: [{ totalCount: 120, itemIds: ['one-loaded-row'] }],
+    };
+  });
+
+  it('reuses unread Signal eligibility across all inboxes and allows either transport', () => {
+    useEmailUnreadCount();
+    expect(mocks.buildEmailQuery).toHaveBeenCalledWith({
+      tab: 'important',
+      inboxIds: undefined,
+      facets: { read: ['unread'] },
+    });
+    expect(mocks.args).toEqual({
+      params: { limit: 1, sort_method: 'updated_at' },
+      body: { emailView: 'inbox' },
+      groupBy: { type: 'entity_type' },
+    });
+    expect(mocks.args?.transport).toBeUndefined();
+  });
+
+  it('counts all server rows, not just hydrated rows, and reads updated totals', () => {
+    const count = useEmailUnreadCount();
+    expect(count()).toBe(120);
+    mocks.query.data.groups[0].totalCount = 119;
+    expect(count()).toBe(119);
+    mocks.query.data.groups = [];
+    expect(count()).toBe(0);
+  });
+
+  it('does not read data or suspend while pending', () => {
+    mocks.query.isLoading = true;
+    const descriptor = Object.getOwnPropertyDescriptor(mocks.query, 'data')!;
+    Object.defineProperty(mocks.query, 'data', {
+      configurable: true,
+      get() {
+        throw new Error('pending resource read');
+      },
+    });
+    try {
+      expect(useEmailUnreadCount()()).toBeUndefined();
+    } finally {
+      Object.defineProperty(mocks.query, 'data', descriptor);
+    }
+  });
+
+  it('does not present errors or placeholder totals as an authoritative count', () => {
+    const count = useEmailUnreadCount();
+    mocks.query.error = new Error('unavailable');
+    expect(count()).toBeUndefined();
+    mocks.query.error = null;
+    mocks.query.isPlaceholderData = true;
+    expect(count()).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/email-view/queries/use-email-unread-count.ts
+++ b/apps/web/src/features/email-view/queries/use-email-unread-count.ts
@@ -1,13 +1,17 @@
+import { boundedCount } from '@queries/soup/bounded-count';
+import { createBoundedCountPagination } from '@queries/soup/bounded-count-pagination';
 import { useSoupAstItemsQuery } from '@queries/soup/items';
 import { buildEmailQuery } from './email-query';
 
 /**
- * Count unread Signal rows across every linked inbox, independently of the
- * open Email view's search, filters, and pagination. Group totals come from
- * the server; the single hydrated row is not the count.
+ * Read enough unread Signal rows to display the sidebar badge. A complete
+ * result gives an exact count; 100 confirmed unread rows establish `99+`.
+ * A shorter, incomplete result is unknown while subsequent pages load.
  *
  * The Soup facade selects REST/TanStack or GraphQL using the same rollout
- * controls as the Email view and participates in their cache updates.
+ * controls as the Email view. Do not use grouped totals: the grouped backend
+ * does not include email. Replace this bounded row query with the general
+ * count capability once that is available.
  */
 export function useEmailUnreadCount() {
   const query = useSoupAstItemsQuery(() => {
@@ -18,16 +22,24 @@ export function useEmailUnreadCount() {
     });
     return {
       ...args,
-      params: { ...args.params, limit: 1 },
-      groupBy: { type: 'entity_type' as const },
+      params: { ...args.params, limit: 100 },
     };
   });
 
-  return (): number | undefined => {
+  const count = (): number | '99+' | undefined => {
     // Do not suspend the outer sidebar, or turn an unavailable count into zero.
     if (query.isLoading || query.error || query.isPlaceholderData) return;
-    const groups = query.data?.groups;
-    if (!groups) return;
-    return groups.reduce((total, group) => total + group.totalCount, 0);
+    const entities = query.data?.entities;
+    if (!entities) return;
+    // Cached rows can remain after a read mutation. Count live unread state,
+    // not the query's page size, and count each thread only once.
+    const unreadIds = new Set(
+      entities
+        .filter((entity) => entity.type === 'email' && !entity.isRead)
+        .map((entity) => entity.id)
+    );
+    return boundedCount(unreadIds, !query.hasNextPage);
   };
+  createBoundedCountPagination(query, count);
+  return count;
 }

--- a/apps/web/src/features/email-view/queries/use-email-unread-count.ts
+++ b/apps/web/src/features/email-view/queries/use-email-unread-count.ts
@@ -1,0 +1,33 @@
+import { useSoupAstItemsQuery } from '@queries/soup/items';
+import { buildEmailQuery } from './email-query';
+
+/**
+ * Count unread Signal rows across every linked inbox, independently of the
+ * open Email view's search, filters, and pagination. Group totals come from
+ * the server; the single hydrated row is not the count.
+ *
+ * The Soup facade selects REST/TanStack or GraphQL using the same rollout
+ * controls as the Email view and participates in their cache updates.
+ */
+export function useEmailUnreadCount() {
+  const query = useSoupAstItemsQuery(() => {
+    const args = buildEmailQuery({
+      tab: 'important',
+      inboxIds: undefined,
+      facets: { read: ['unread'] },
+    });
+    return {
+      ...args,
+      params: { ...args.params, limit: 1 },
+      groupBy: { type: 'entity_type' as const },
+    };
+  });
+
+  return (): number | undefined => {
+    // Do not suspend the outer sidebar, or turn an unavailable count into zero.
+    if (query.isLoading || query.error || query.isPlaceholderData) return;
+    const groups = query.data?.groups;
+    if (!groups) return;
+    return groups.reduce((total, group) => total + group.totalCount, 0);
+  };
+}

--- a/apps/web/src/features/inbox-view/queries/inbox-eligibility.ts
+++ b/apps/web/src/features/inbox-view/queries/inbox-eligibility.ts
@@ -1,0 +1,85 @@
+import { withEntityNotifications } from '@app/features/soup/entity-notifications';
+import { useFeatureFlag } from '@app/lib/analytics/posthog';
+import {
+  enableCalendarUi,
+  enableInboxNotifiedSort,
+  enableReminders,
+  enableSnippets,
+  enableSupportedSoupForeignEntities,
+  isFeatureEnabled,
+} from '@core/constant/featureFlags';
+import { type EntityData, isSnippetEntity } from '@entity';
+import type { NotificationSource } from '@notifications';
+import { startOfDay, subWeeks } from 'date-fns';
+import { match } from 'ts-pattern';
+import {
+  noiseFilter,
+  signalFilter,
+} from '../../next-soup/filters/inbox-filters';
+import {
+  notDoneFilter,
+  scheduledRemindersFilter,
+} from '../../next-soup/filters/predicates';
+import type { InboxQueryCapabilities, InboxViewContext } from './inbox-query';
+import { inboxSortTimestamp } from './inbox-results';
+
+export function useInboxQueryCapabilities() {
+  const foreignEntities = useFeatureFlag(enableSupportedSoupForeignEntities);
+  const notifiedSort = useFeatureFlag(enableInboxNotifiedSort);
+  return (): InboxQueryCapabilities => ({
+    calendar: isFeatureEnabled(enableCalendarUi),
+    foreignEntities: foreignEntities().enabled,
+    notifiedSort: notifiedSort().enabled,
+    reminders: isFeatureEnabled(enableReminders),
+    snippets: isFeatureEnabled(enableSnippets),
+  });
+}
+
+function matchesCapabilities(
+  entity: EntityData,
+  capabilities: InboxQueryCapabilities
+): boolean {
+  if (entity.type === 'calendar_event') return capabilities.calendar;
+  if (entity.type === 'foreign') return capabilities.foreignEntities;
+  if (entity.type === 'reminder') return capabilities.reminders;
+  if (isSnippetEntity(entity)) return capabilities.snippets;
+  return true;
+}
+
+/** Shared row eligibility for the Inbox list and its badge, before admission. */
+export function selectInboxEntities(
+  entities: EntityData[],
+  context: Pick<InboxViewContext, 'tab' | 'capabilities'>,
+  source: NotificationSource
+) {
+  return entities
+    .filter((entity) => matchesCapabilities(entity, context.capabilities))
+    .map((entity) =>
+      withEntityNotifications(entity, source, { scopeChannelThreads: true })
+    )
+    .filter((entity) =>
+      match(context.tab)
+        .with('signal', () => {
+          if (!signalFilter(entity) || !notDoneFilter(source)(entity))
+            return false;
+          if (
+            entity.type !== 'document' &&
+            entity.type !== 'email' &&
+            entity.type !== 'chat' &&
+            entity.type !== 'project'
+          ) {
+            return true;
+          }
+          return (
+            new Date(inboxSortTimestamp(entity) ?? 0).getTime() >=
+            subWeeks(startOfDay(new Date()), 2).getTime()
+          );
+        })
+        .with(
+          'noise',
+          () => noiseFilter(entity) && notDoneFilter(source)(entity)
+        )
+        .with('reminders', () => scheduledRemindersFilter(entity))
+        .exhaustive()
+    );
+}

--- a/apps/web/src/features/inbox-view/queries/inbox-query.ts
+++ b/apps/web/src/features/inbox-view/queries/inbox-query.ts
@@ -182,3 +182,22 @@ export function buildInboxQuery(
     body,
   };
 }
+
+/**
+ * The badge counts matching rows; it does not display their notification order.
+ * `notified_at` forces a REST fallback today, whose rows have no notification
+ * edges. With the global source on GraphQL those rows may never gain coverage.
+ *
+ * Preserve the list's filters and let the shared client eligibility selector
+ * enforce notification membership/scoping, using a sort both transports support.
+ */
+export function buildInboxUnreadCountQuery(
+  context: InboxViewContext,
+  options: { now?: Date } = {}
+): SoupAstItemsQueryArgs {
+  const query = buildInboxQuery(context, options);
+  return {
+    ...query,
+    params: { ...query.params, sort_method: 'updated_at' },
+  };
+}

--- a/apps/web/src/features/inbox-view/queries/use-inbox-query.ts
+++ b/apps/web/src/features/inbox-view/queries/use-inbox-query.ts
@@ -7,45 +7,20 @@ import {
   testFacets,
   useSearchContext,
 } from '@app/features/soup';
-import { withEntityNotifications } from '@app/features/soup/entity-notifications';
-import { useFeatureFlag } from '@app/lib/analytics/posthog';
 import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
-import {
-  enableCalendarUi,
-  enableInboxNotifiedSort,
-  enableReminders,
-  enableSnippets,
-  enableSupportedSoupForeignEntities,
-  isFeatureEnabled,
-} from '@core/constant/featureFlags';
 import { useUserId } from '@core/context/user';
-import {
-  type EntityData,
-  isSnippetEntity,
-  type WithNotification,
-} from '@entity';
-import type { NotificationSource } from '@notifications';
+import type { EntityData, WithNotification } from '@entity';
 import { useSoupAstItemsQuery } from '@queries/soup/items';
-import { startOfDay, subWeeks } from 'date-fns';
 import { createMemo } from 'solid-js';
-import { match } from 'ts-pattern';
-import {
-  noiseFilter,
-  signalFilter,
-} from '../../next-soup/filters/inbox-filters';
-import {
-  notDoneFilter,
-  scheduledRemindersFilter,
-} from '../../next-soup/filters/predicates';
 import { INBOX_FACETS, type InboxFacetContext } from '../inbox-facets';
-import type { InboxTab, InboxViewState } from '../types';
-import { soupItemMatchesInboxTab } from './inbox-item-filter';
+import type { InboxViewState } from '../types';
 import {
-  buildInboxQuery,
-  type InboxQueryCapabilities,
-  type InboxViewContext,
-} from './inbox-query';
-import { groupInboxEntitiesByDate, inboxSortTimestamp } from './inbox-results';
+  selectInboxEntities,
+  useInboxQueryCapabilities,
+} from './inbox-eligibility';
+import { soupItemMatchesInboxTab } from './inbox-item-filter';
+import { buildInboxQuery, type InboxViewContext } from './inbox-query';
+import { groupInboxEntitiesByDate } from './inbox-results';
 import { buildInboxSearchRequest } from './inbox-search';
 
 export type InboxDataSourceItem = SoupRow<WithNotification<EntityData>>;
@@ -57,64 +32,15 @@ export type InboxDataSourceInput = Pick<
   'tab' | 'search' | 'groupBy' | 'facets'
 >;
 
-function matchesCapabilities(
-  entity: EntityData,
-  capabilities: InboxQueryCapabilities
-): boolean {
-  if (entity.type === 'calendar_event') return capabilities.calendar;
-  if (entity.type === 'foreign') return capabilities.foreignEntities;
-  if (entity.type === 'reminder') return capabilities.reminders;
-  if (isSnippetEntity(entity)) return capabilities.snippets;
-
-  return true;
-}
-
-function matchesTab(
-  entity: WithNotification<EntityData>,
-  tab: InboxTab,
-  source: NotificationSource
-): boolean {
-  return match(tab)
-    .with('signal', () => {
-      if (!signalFilter(entity) || !notDoneFilter(source)(entity)) return false;
-
-      if (
-        entity.type !== 'document' &&
-        entity.type !== 'email' &&
-        entity.type !== 'chat' &&
-        entity.type !== 'project'
-      ) {
-        return true;
-      }
-
-      return (
-        new Date(inboxSortTimestamp(entity) ?? 0).getTime() >=
-        subWeeks(startOfDay(new Date()), 2).getTime()
-      );
-    })
-    .with('noise', () => noiseFilter(entity) && notDoneFilter(source)(entity))
-    .with('reminders', () => scheduledRemindersFilter(entity))
-    .exhaustive();
-}
-
 export function useInboxDataSource(
   state: InboxDataSourceInput
 ): InboxDataSource {
   const notificationSource = useGlobalNotificationSource();
   const userId = useUserId();
 
-  const foreignEntities = useFeatureFlag(enableSupportedSoupForeignEntities);
-  const notifiedSort = useFeatureFlag(enableInboxNotifiedSort);
+  const capabilities = useInboxQueryCapabilities();
 
   const facetContext = (): InboxFacetContext => ({ notificationSource });
-
-  const capabilities = (): InboxQueryCapabilities => ({
-    calendar: isFeatureEnabled(enableCalendarUi),
-    foreignEntities: foreignEntities().enabled,
-    notifiedSort: notifiedSort().enabled,
-    reminders: isFeatureEnabled(enableReminders),
-    snippets: isFeatureEnabled(enableSnippets),
-  });
 
   const viewContext = createMemo(
     (): InboxViewContext => ({
@@ -135,24 +61,15 @@ export function useInboxDataSource(
     const tab = viewContext().tab;
     return {
       enabled: true,
-      showSupportedForeignEntities: foreignEntities().enabled,
+      showSupportedForeignEntities: capabilities().foreignEntities,
       meta: {
         insertFilter: (item) => soupItemMatchesInboxTab(item, tab),
       },
     };
   });
 
-  const transformEntities = (entities: EntityData[]) => {
-    const context = viewContext();
-    return entities
-      .filter((entity) => matchesCapabilities(entity, context.capabilities))
-      .map((entity) =>
-        withEntityNotifications(entity, notificationSource, {
-          scopeChannelThreads: true,
-        })
-      )
-      .filter((entity) => matchesTab(entity, context.tab, notificationSource));
-  };
+  const transformEntities = (entities: EntityData[]) =>
+    selectInboxEntities(entities, viewContext(), notificationSource);
 
   const { entityPool } = useSearchContext();
   const localPool = createMemo(() => {

--- a/apps/web/src/features/inbox-view/queries/use-inbox-unread-count.ts
+++ b/apps/web/src/features/inbox-view/queries/use-inbox-unread-count.ts
@@ -1,0 +1,58 @@
+import { testFacets } from '@app/features/soup';
+import { hasNotificationCoverage } from '@app/features/soup/notification-coverage';
+import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
+import { useUserId } from '@core/context/user';
+import { boundedCount } from '@queries/soup/bounded-count';
+import { createBoundedCountPagination } from '@queries/soup/bounded-count-pagination';
+import { useSoupAstItemsQuery } from '@queries/soup/items';
+import { createMemo } from 'solid-js';
+import { INBOX_FACETS } from '../inbox-facets';
+import {
+  selectInboxEntities,
+  useInboxQueryCapabilities,
+} from './inbox-eligibility';
+import { soupItemMatchesInboxTab } from './inbox-item-filter';
+import { buildInboxQuery, type InboxViewContext } from './inbox-query';
+
+export function useInboxUnreadCount() {
+  const notificationSource = useGlobalNotificationSource();
+  const userId = useUserId();
+  const capabilities = useInboxQueryCapabilities();
+  const context = createMemo(
+    (): InboxViewContext => ({
+      tab: 'signal',
+      facets: { read: ['unread'] },
+      facetContext: { notificationSource },
+      capabilities: capabilities(),
+      userId: userId(),
+    })
+  );
+  const args = createMemo(() => buildInboxQuery(context()));
+  const query = useSoupAstItemsQuery(args, () => ({
+    showSupportedForeignEntities: capabilities().foreignEntities,
+    meta: { insertFilter: (item) => soupItemMatchesInboxTab(item, 'signal') },
+  }));
+
+  const count = () => {
+    if (query.isLoading || query.error || query.isPlaceholderData) return;
+    const entities = query.data?.entities;
+    if (!entities) return;
+    const current = context();
+    const unread = selectInboxEntities(
+      entities,
+      current,
+      notificationSource
+    ).filter((entity) =>
+      testFacets(current.facets, INBOX_FACETS, entity, current.facetContext)
+    );
+    // Keep a channel and its thread rows distinct. Do not apply the list's
+    // admission retention: reading a retained row must decrement the badge.
+    return boundedCount(
+      unread.map((entity) => `${entity.type}:${entity.id}`),
+      !query.hasNextPage &&
+        hasNotificationCoverage(entities, notificationSource)
+    );
+  };
+  createBoundedCountPagination(query, count);
+  return count;
+}

--- a/apps/web/src/features/inbox-view/queries/use-inbox-unread-count.ts
+++ b/apps/web/src/features/inbox-view/queries/use-inbox-unread-count.ts
@@ -12,7 +12,10 @@ import {
   useInboxQueryCapabilities,
 } from './inbox-eligibility';
 import { soupItemMatchesInboxTab } from './inbox-item-filter';
-import { buildInboxQuery, type InboxViewContext } from './inbox-query';
+import {
+  buildInboxUnreadCountQuery,
+  type InboxViewContext,
+} from './inbox-query';
 
 export function useInboxUnreadCount() {
   const notificationSource = useGlobalNotificationSource();
@@ -27,7 +30,7 @@ export function useInboxUnreadCount() {
       userId: userId(),
     })
   );
-  const args = createMemo(() => buildInboxQuery(context()));
+  const args = createMemo(() => buildInboxUnreadCountQuery(context()));
   const query = useSoupAstItemsQuery(args, () => ({
     showSupportedForeignEntities: capabilities().foreignEntities,
     meta: { insertFilter: (item) => soupItemMatchesInboxTab(item, 'signal') },

--- a/apps/web/src/features/soup/badge-counts.test.ts
+++ b/apps/web/src/features/soup/badge-counts.test.ts
@@ -1,0 +1,170 @@
+import type { EntityData } from '@entity';
+import { notificationIsRead } from '@entity/utils/notification';
+import type { NotificationSource, UnifiedNotification } from '@notifications';
+import { compositeEntity } from '@notifications/types';
+import { boundedCount } from '@queries/soup/bounded-count';
+import { describe, expect, it, vi } from 'vitest';
+import { INBOX_FACETS } from '../inbox-view/inbox-facets';
+import { selectInboxEntities } from '../inbox-view/queries/inbox-eligibility';
+import { withEntityNotifications } from './entity-notifications';
+import { testFacets } from './filters/facets';
+import { hasNotificationCoverage } from './notification-coverage';
+
+vi.mock('@service-storage/websocket', () => ({
+  storageWS: { reconnectIfDisconnected: vi.fn() },
+  createWebSocketJob: vi.fn(),
+}));
+vi.mock('@service-connection/websocket', () => ({
+  ws: { addEventListener: vi.fn(), send: vi.fn() },
+  state: () => 'closed',
+  createConnectionBlockWebsocketEffect: vi.fn(),
+  createConnectionWebsocketEffect: vi.fn(),
+}));
+
+const context = {
+  tab: 'signal' as const,
+  capabilities: {
+    calendar: false,
+    foreignEntities: false,
+    notifiedSort: true,
+    reminders: false,
+    snippets: false,
+  },
+};
+
+function notification(id: string, threadId?: string): UnifiedNotification {
+  return {
+    id,
+    entity_type: 'channel',
+    entity_id: 'channel-1',
+    created_at: new Date().toISOString(),
+    done: false,
+    notification_metadata: threadId
+      ? {
+          tag: 'channel_message_reply',
+          content: { threadId, messageId: id, senderId: 'sender' },
+        }
+      : {
+          tag: 'channel_message_send',
+          content: { messageId: id, senderId: 'sender' },
+        },
+  } as unknown as UnifiedNotification;
+}
+
+function source(notifications: UnifiedNotification[], complete = true) {
+  return {
+    notificationsByEntity: () => ({
+      [compositeEntity({ type: 'channel', id: 'channel-1' })]: notifications,
+    }),
+    isLoading: () => false,
+    _notificationsQuery: { error: null, hasNextPage: !complete },
+  } as unknown as NotificationSource;
+}
+
+function rows(notifications: UnifiedNotification[]): EntityData[] {
+  return [
+    { id: 'channel-1', type: 'channel', notifications },
+    {
+      id: 'thread-1',
+      messageId: 'thread-1',
+      channelId: 'channel-1',
+      type: 'channel_thread',
+      notifications,
+    },
+  ] as unknown as EntityData[];
+}
+
+function inboxCount(entities: EntityData[], notifications: NotificationSource) {
+  const unread = selectInboxEntities(entities, context, notifications).filter(
+    (entity) =>
+      testFacets({ read: ['unread'] }, INBOX_FACETS, entity, {
+        notificationSource: notifications,
+      })
+  );
+  return boundedCount(
+    unread.map((entity) => `${entity.type}:${entity.id}`),
+    true
+  );
+}
+
+describe('sidebar count row identities', () => {
+  it('uses the same row identities with REST notification data', () => {
+    const entities = [
+      { id: 'channel-1', type: 'channel' },
+      {
+        id: 'thread-1',
+        messageId: 'thread-1',
+        channelId: 'channel-1',
+        type: 'channel_thread',
+      },
+    ] as EntityData[];
+    expect(
+      inboxCount(
+        entities,
+        source([notification('send'), notification('reply', 'thread-1')])
+      )
+    ).toBe(2);
+  });
+
+  it('counts channel and thread Inbox rows separately, but the channel once', () => {
+    const notifications = [
+      notification('send-1'),
+      notification('send-2'),
+      notification('reply-1', 'thread-1'),
+      notification('reply-2', 'thread-1'),
+    ];
+    const entities = rows(notifications);
+    const notificationsSource = source([]);
+    expect(inboxCount(entities, notificationsSource)).toBe(2);
+    const channel = withEntityNotifications(entities[0], notificationsSource);
+    expect(channel.notifications?.().some((n) => !notificationIsRead(n))).toBe(
+      true
+    );
+    expect(boundedCount([channel.id, channel.id], true)).toBe(1);
+  });
+
+  it('removes a read top-level row but keeps unread thread activity', () => {
+    const send = notification('send');
+    send.viewed_at = new Date().toISOString();
+    const notifications = [send, notification('reply', 'thread-1')];
+    const entities = rows(notifications);
+    const notificationsSource = source([]);
+    expect(inboxCount(entities, notificationsSource)).toBe(1);
+    expect(
+      withEntityNotifications(entities[0], notificationsSource)
+        .notifications?.()
+        .some((n) => !notificationIsRead(n))
+    ).toBe(true);
+  });
+
+  it('does not count done rows', () => {
+    const done = notification('send');
+    done.done = true;
+    expect(inboxCount(rows([done]), source([]))).toBe(0);
+  });
+});
+
+describe('count completeness', () => {
+  it('does not use the global GraphQL page size as a limit on attached edges', () => {
+    expect(hasNotificationCoverage(rows([]), source([], false))).toBe(true);
+  });
+
+  it('waits for REST notification coverage before claiming a total', () => {
+    const entities = [{ id: 'channel-1', type: 'channel' }] as EntityData[];
+    expect(hasNotificationCoverage(entities, source([], false))).toBe(false);
+    expect(hasNotificationCoverage(entities, source([]))).toBe(true);
+  });
+
+  it('distinguishes unknown, zero, exact, and capped counts', () => {
+    expect(boundedCount([], false)).toBeUndefined();
+    expect(boundedCount([], true)).toBe(0);
+    expect(boundedCount(['a', 'a', 'b'], true)).toBe(2);
+    expect(boundedCount(['a', 'b'], false)).toBeUndefined();
+    expect(
+      boundedCount(
+        Array.from({ length: 100 }, (_, i) => `${i}`),
+        false
+      )
+    ).toBe('99+');
+  });
+});

--- a/apps/web/src/features/soup/badge-counts.test.ts
+++ b/apps/web/src/features/soup/badge-counts.test.ts
@@ -3,9 +3,14 @@ import { notificationIsRead } from '@entity/utils/notification';
 import type { NotificationSource, UnifiedNotification } from '@notifications';
 import { compositeEntity } from '@notifications/types';
 import { boundedCount } from '@queries/soup/bounded-count';
+import { makeGraphqlSoupInput } from '@queries/soup/graphql/ast';
 import { describe, expect, it, vi } from 'vitest';
 import { INBOX_FACETS } from '../inbox-view/inbox-facets';
 import { selectInboxEntities } from '../inbox-view/queries/inbox-eligibility';
+import {
+  buildInboxQuery,
+  buildInboxUnreadCountQuery,
+} from '../inbox-view/queries/inbox-query';
 import { withEntityNotifications } from './entity-notifications';
 import { testFacets } from './filters/facets';
 import { hasNotificationCoverage } from './notification-coverage';
@@ -145,6 +150,16 @@ describe('sidebar count row identities', () => {
 });
 
 describe('count completeness', () => {
+  it('counts attached unread rows outside the global GraphQL source coverage', () => {
+    const entities = rows([
+      notification('send'),
+      notification('reply', 'thread-1'),
+    ]);
+    const partialSource = source([], false);
+    expect(hasNotificationCoverage(entities, partialSource)).toBe(true);
+    expect(inboxCount(entities, partialSource)).toBe(2);
+  });
+
   it('does not use the global GraphQL page size as a limit on attached edges', () => {
     expect(hasNotificationCoverage(rows([]), source([], false))).toBe(true);
   });
@@ -167,4 +182,39 @@ describe('count completeness', () => {
       )
     ).toBe('99+');
   });
+});
+
+describe('Inbox badge transport compatibility', () => {
+  it.each([false, true])(
+    'translates the real unread Signal filters with optional types enabled=%s',
+    (enabled) => {
+      const queryContext = {
+        ...context,
+        capabilities: {
+          ...context.capabilities,
+          calendar: enabled,
+          foreignEntities: enabled,
+          reminders: enabled,
+          snippets: enabled,
+        },
+        facets: { read: ['unread'] },
+        facetContext: {},
+        userId: 'macro|viewer@example.com',
+      };
+      const options = { now: new Date('2026-09-09T12:00:00Z') };
+      const list = buildInboxQuery(queryContext, options);
+      const badge = buildInboxUnreadCountQuery(queryContext, options);
+
+      // This was the mixed-transport failure: REST rows need global
+      // notifications, but that source no longer eagerly paginates in GQL mode.
+      expect(list.params.sort_method).toBe('notified_at');
+      expect(() => makeGraphqlSoupInput(list)).toThrow('notified_at');
+      expect(badge.body).toEqual(list.body);
+      expect(badge.transport).toBeUndefined();
+      const input = makeGraphqlSoupInput(badge);
+      expect(input.initial?.sortMethod).toBe('UPDATED_AT');
+      expect(input.initial?.emailView).toBe('INBOX');
+      expect(input.initial?.limit).toBe(100);
+    }
+  );
 });

--- a/apps/web/src/features/soup/notification-coverage.ts
+++ b/apps/web/src/features/soup/notification-coverage.ts
@@ -1,0 +1,27 @@
+import type { EntityData } from '@entity';
+import type { NotificationSource } from '@notifications';
+
+/**
+ * GraphQL list rows carry their own notification edges, independently of the
+ * global source's pagination. REST rows rely on that source finishing its load.
+ */
+export function hasNotificationCoverage(
+  entities: EntityData[],
+  source: NotificationSource
+): boolean {
+  if (
+    entities.every(
+      (entity) =>
+        entity.type === 'email' ||
+        ('notifications' in entity &&
+          (Array.isArray(entity.notifications) ||
+            typeof entity.notifications === 'function'))
+    )
+  )
+    return true;
+  return (
+    !source.isLoading() &&
+    !source._notificationsQuery.error &&
+    !source._notificationsQuery.hasNextPage
+  );
+}

--- a/apps/web/src/lib/queries/soup/bounded-count-pagination.test.ts
+++ b/apps/web/src/lib/queries/soup/bounded-count-pagination.test.ts
@@ -1,0 +1,112 @@
+import { batch, createRoot } from 'solid-js';
+import { createStore } from 'solid-js/store';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { boundedCount } from './bounded-count';
+import { createBoundedCountPagination } from './bounded-count-pagination';
+
+const disposers: (() => void)[] = [];
+afterEach(() => {
+  for (const dispose of disposers.splice(0)) dispose();
+  vi.restoreAllMocks();
+});
+
+function setup(
+  initial: string[],
+  pages: string[][],
+  options: { enabled?: boolean; fail?: boolean; loading?: boolean } = {}
+) {
+  return createRoot((dispose) => {
+    disposers.push(dispose);
+    let page = 0;
+    const fetchNextPage = vi.fn(async () => {
+      setState('isFetching', true);
+      await Promise.resolve();
+      if (options.fail) {
+        const error = new Error('page failed');
+        batch(() => {
+          setState('error', error);
+          setState('isFetching', false);
+        });
+        throw error;
+      }
+      const next = pages[page++];
+      batch(() => {
+        setState('keys', (previous) => [...previous, ...next]);
+        setState('hasNextPage', page < pages.length);
+        setState('isFetching', false);
+      });
+    });
+    const [query, setState] = createStore({
+      keys: initial,
+      isEnabled: options.enabled ?? true,
+      isLoading: options.loading ?? false,
+      isFetching: false,
+      isFetchingNextPage: false,
+      isPlaceholderData: false,
+      error: null as Error | null,
+      hasNextPage: pages.length > 0,
+      fetchNextPage,
+    });
+    const count = () => boundedCount(query.keys, !query.hasNextPage);
+    createBoundedCountPagination(query, count);
+    return { query, setState, count, fetchNextPage };
+  });
+}
+
+describe('bounded count pagination', () => {
+  it('resolves an incomplete first page instead of leaving its badge hidden', async () => {
+    const result = setup(['channel'], [['thread']]);
+    await vi.waitFor(() => expect(result.count()).toBe(2));
+    expect(result.fetchNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues through pages with no matching unread rows', async () => {
+    const result = setup([], [[], ['unread']]);
+    await vi.waitFor(() => expect(result.count()).toBe(1));
+    expect(result.fetchNextPage).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops at 99+ even when more pages exist', async () => {
+    const result = setup(
+      Array.from({ length: 99 }, (_, i) => `${i}`),
+      [['100'], ['101']]
+    );
+    await vi.waitFor(() => expect(result.count()).toBe('99+'));
+    expect(result.query.hasNextPage).toBe(true);
+    expect(result.fetchNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes when reading rows takes the count below the cap', async () => {
+    const result = setup(
+      Array.from({ length: 100 }, (_, i) => `${i}`),
+      [['next']]
+    );
+    expect(result.fetchNextPage).not.toHaveBeenCalled();
+    result.setState('keys', ['remaining']);
+    await vi.waitFor(() => expect(result.count()).toBe(2));
+    expect(result.fetchNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for initial loading and never overlaps requests', async () => {
+    const result = setup([], [['a'], ['b']], { loading: true });
+    expect(result.fetchNextPage).not.toHaveBeenCalled();
+    result.setState('isLoading', false);
+    await vi.waitFor(() => expect(result.count()).toBe(2));
+    expect(result.fetchNextPage).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not paginate a disabled query or a complete result', () => {
+    expect(
+      setup([], [['a']], { enabled: false }).fetchNextPage
+    ).not.toHaveBeenCalled();
+    expect(setup(['a'], []).fetchNextPage).not.toHaveBeenCalled();
+  });
+
+  it('does not retry a failed page in a loop', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = setup([], [['a']], { fail: true });
+    await vi.waitFor(() => expect(result.query.error).not.toBeNull());
+    expect(result.fetchNextPage).toHaveBeenCalledTimes(1);
+    expect(result.count()).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/queries/soup/bounded-count-pagination.ts
+++ b/apps/web/src/lib/queries/soup/bounded-count-pagination.ts
@@ -1,0 +1,53 @@
+import { type Accessor, createEffect, untrack } from 'solid-js';
+import type { boundedCount } from './bounded-count';
+import type { SoupAstItemsQuery } from './items';
+
+type CountPageSource = Pick<
+  SoupAstItemsQuery,
+  | 'isEnabled'
+  | 'isLoading'
+  | 'isFetching'
+  | 'isFetchingNextPage'
+  | 'isPlaceholderData'
+  | 'error'
+  | 'hasNextPage'
+  | 'fetchNextPage'
+>;
+
+/**
+ * Continue an incomplete badge query until its count is known or capped.
+ * Fetching is driven by the query's loading/error state, not by whether the
+ * corresponding list view is open. Read mutations can make a capped count
+ * unknown again; the same rule then resumes pagination.
+ */
+export function createBoundedCountPagination(
+  query: CountPageSource,
+  count: Accessor<ReturnType<typeof boundedCount>>
+) {
+  const fetchNextPage = async () => {
+    try {
+      await query.fetchNextPage();
+    } catch (error) {
+      // The query retains its error state; do not start a separate retry loop.
+      console.error('Failed to load the next unread-count page', error);
+    }
+  };
+
+  // This effect synchronizes the external query with the count's data needs;
+  // the count itself remains a pure derivation of the loaded rows.
+  createEffect(() => {
+    if (
+      !query.isEnabled ||
+      query.isLoading ||
+      query.isFetching ||
+      query.isFetchingNextPage ||
+      query.isPlaceholderData ||
+      query.error ||
+      !query.hasNextPage ||
+      count() !== undefined
+    ) {
+      return;
+    }
+    untrack(() => void fetchNextPage());
+  });
+}

--- a/apps/web/src/lib/queries/soup/bounded-count.ts
+++ b/apps/web/src/lib/queries/soup/bounded-count.ts
@@ -1,0 +1,9 @@
+/** Only complete results can establish a total below the badge's display cap. */
+export function boundedCount(
+  keys: Iterable<string>,
+  complete: boolean
+): number | '99+' | undefined {
+  const count = new Set(keys).size;
+  if (count >= 100) return '99+';
+  return complete ? count : undefined;
+}

--- a/docs/AGENT_GUIDE/navigation.md
+++ b/docs/AGENT_GUIDE/navigation.md
@@ -37,6 +37,22 @@ Splits: the app is a tiling window manager. A second pane appends its own segmen
 - Bottom: button named after the user's email — menu with `Command menu (Ctrl K)`,
   `Settings (Ctrl ;)`, `Log out`.
 
+### New outer sidebar badges
+
+The icon-only sidebar shows unread badges for Notifications, Email, and Chat
+(Channels). Notifications counts unread Signal rows: a channel-level row and a
+thread-reply row count separately. Email counts unread Signal threads across linked
+inboxes. Chat counts distinct unread channels, including DMs and unread thread
+activity. A separate phone badge indicates an active channel call.
+
+Counts display `99+` after 100 matching rows are confirmed. Zero and unavailable
+counts have no numeric badge. These are currently bounded list queries, not the
+planned general server-count API: they load additional pages until 100 matching
+rows are confirmed or the list is exhausted. An incomplete result is hidden while
+those pages load rather than shown as an exact total. A missing badge is not proof
+that there are no unread items. Accessible button names include visible unread
+counts and active-call state; match names by prefix when locating these buttons.
+
 ## Favorites
 
 Use an entity's command/context menu to add or remove it from Favorites; drag rows


### PR DESCRIPTION
Implements badges on Notifications, Email, and Chat for the outer sidebar, which show the number of unread rows. The Chat icon also gets an active call badge when there is an active call in one of the user's channels.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Badge totals depend on client-side Soup pagination, notification coverage, and shared inbox eligibility—incorrect counts or extra background fetches are possible if those paths diverge from the list views.
> 
> **Overview**
> Adds **unread badges** and an **active-call indicator** to the icon-only sidebar rail for Notifications, Email, and Chat, wired through new bounded Soup list queries that paginate until counts are exact or capped at **`99+`**.
> 
> `ListNav` now accepts `unreadCount` and `hasActiveCall`, renders accent pills (numeric unread + phone icon on Chat), and folds that state into accessible button names. `SidebarRail` pulls counts from `useInboxUnreadCount`, `useEmailUnreadCount`, and `useChannelsUnreadCount`, plus `useActiveCallsQuery` for Chat.
> 
> Shared counting logic lives in **`boundedCount`**, **`createBoundedCountPagination`**, and **`hasNotificationCoverage`**. Inbox list eligibility is extracted to **`selectInboxEntities`** so the Signal unread badge matches the inbox list; badge queries use **`updated_at`** sort via **`buildInboxUnreadCountQuery`** so GraphQL and REST both work (unlike list `notified_at`). Drive nav order is tweaked in **`nav-items`**. Agent navigation docs describe badge semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d804da7a12c94d636d8c3fb6756700b48c7c9a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->