### PR TITLE
Optimize rail navigation with mousedown activation and pending state

### DIFF
--- a/apps/web/src/components/app/sidebar-next/list-nav.tsx
+++ b/apps/web/src/components/app/sidebar-next/list-nav.tsx
@@ -9,12 +9,32 @@ import { useSplitLayout } from '@components/app/split-layout/layout';
 import { TOKENS } from '@core/hotkey/tokens';
 import { useLocation } from '@solidjs/router';
 import { Button, cn } from '@ui';
+import { createSignal } from 'solid-js';
 import { NavGlyph } from './nav-glyph';
 import type { SidebarNextNavItem } from './nav-items';
 
 export type ListNavProps = {
   item: SidebarNextNavItem;
   onContextMenuOpenChange?: (open: boolean) => void;
+};
+
+type PendingNav = {
+  itemId: SidebarNextNavItem['id'];
+  /** The active split's content when the item was pressed. */
+  activeContentKey: string | undefined;
+};
+
+/**
+ * The nav item pressed most recently, highlighted before the split layout
+ * catches up. Shared across every rail button so only one item is ever
+ * pending. It stops applying the moment the active content changes — to the
+ * pressed view, or to anything else — so a stale press never sticks.
+ */
+const [pendingNav, setPendingNav] = createSignal<PendingNav>();
+
+const activeContentKey = () => {
+  const content = globalSplitManager()?.activeSplit()?.content();
+  return content ? `${content.type}:${content.id}` : undefined;
 };
 
 /**
@@ -38,7 +58,7 @@ export const ListNav = (props: ListNavProps) => {
 
   // Read the manager signal live: it is undefined until the split layout
   // mounts, which happens after the sidebar.
-  const isActive = () => {
+  const matchesActiveContent = () => {
     const activeContent = globalSplitManager()?.activeSplit()?.content();
     // With no active split to match on, fall back to the URL path.
     if (!activeContent) {
@@ -53,6 +73,17 @@ export const ListNav = (props: ListNavProps) => {
     );
   };
 
+  // Optimistic: the pressed item takes the highlight on mousedown, before the
+  // view swaps in. The pending press only counts while the active content is
+  // still what it was at press time; once anything moves, the real state wins.
+  const isActive = () => {
+    const pending = pendingNav();
+    if (pending && pending.activeContentKey === activeContentKey()) {
+      return pending.itemId === props.item.id;
+    }
+    return matchesActiveContent();
+  };
+
   const navigate = (event: MouseEvent) => {
     if (event.button !== 0) return;
     // The row acts on mousedown to beat the focus change, so suppress the
@@ -65,6 +96,11 @@ export const ListNav = (props: ListNavProps) => {
     const expected = content();
     const isSameContent =
       activeContent?.type === expected.type && activeContent.id === expected.id;
+
+    setPendingNav({
+      itemId: props.item.id,
+      activeContentKey: activeContentKey(),
+    });
 
     if (!isSameContent || event.shiftKey) {
       navigateToSidebarView({

--- a/apps/web/src/components/app/sidebar-next/list-nav.tsx
+++ b/apps/web/src/components/app/sidebar-next/list-nav.tsx
@@ -9,7 +9,7 @@ import { useSplitLayout } from '@components/app/split-layout/layout';
 import { TOKENS } from '@core/hotkey/tokens';
 import { useLocation } from '@solidjs/router';
 import { Button, cn } from '@ui';
-import { createSignal } from 'solid-js';
+import { createSignal, onCleanup } from 'solid-js';
 import { NavGlyph } from './nav-glyph';
 import type { SidebarNextNavItem } from './nav-items';
 
@@ -84,8 +84,29 @@ export const ListNav = (props: ListNavProps) => {
     return matchesActiveContent();
   };
 
+  // Opening a view is a synchronous store replace plus the new view's first
+  // render, all inside the event handler. Painted in the same frame, the
+  // highlight would only appear once that render finished. Let the browser
+  // paint the pending highlight first, then navigate on the next tick.
+  let scheduledFrame: number | undefined;
+  let scheduledTick: ReturnType<typeof setTimeout> | undefined;
+  const afterNextPaint = (run: () => void) => {
+    if (scheduledFrame !== undefined) cancelAnimationFrame(scheduledFrame);
+    if (scheduledTick !== undefined) clearTimeout(scheduledTick);
+    scheduledFrame = requestAnimationFrame(() => {
+      scheduledFrame = undefined;
+      scheduledTick = setTimeout(() => {
+        scheduledTick = undefined;
+        run();
+      }, 0);
+    });
+  };
+  onCleanup(() => {
+    if (scheduledFrame !== undefined) cancelAnimationFrame(scheduledFrame);
+    if (scheduledTick !== undefined) clearTimeout(scheduledTick);
+  });
+
   const navigate = (event: MouseEvent) => {
-    if (event.button !== 0) return;
     // The row acts on mousedown to beat the focus change, so suppress the
     // default selection/focus behaviour.
     event.preventDefault();
@@ -103,17 +124,40 @@ export const ListNav = (props: ListNavProps) => {
     });
 
     if (!isSameContent || event.shiftKey) {
-      navigateToSidebarView({
-        viewId: props.item.id,
-        params: props.item.params,
-        shiftKey: event.shiftKey,
-        activeSplit,
-        openWithSplit: layout.openWithSplit,
-        referredFrom: 'sidebar',
+      const { shiftKey } = event;
+      afterNextPaint(() => {
+        navigateToSidebarView({
+          viewId: props.item.id,
+          params: props.item.params,
+          shiftKey,
+          activeSplit: globalSplitManager()?.activeSplit(),
+          openWithSplit: layout.openWithSplit,
+          referredFrom: 'sidebar',
+        });
+        globalSplitManager()?.returnFocus();
       });
+      return;
     }
 
     globalSplitManager()?.returnFocus();
+  };
+
+  // A primary press navigates on mousedown. The click that follows is a no-op,
+  // but a click with no preceding mousedown still has to navigate: keyboard
+  // activation (`detail` is 0 for those), or a trackpad tap whose mousedown
+  // never reached us.
+  let pressHandled = false;
+  const onMouseDown = (event: MouseEvent) => {
+    if (event.button !== 0) return;
+    pressHandled = true;
+    navigate(event);
+  };
+  const onClick = (event: MouseEvent) => {
+    const handled = pressHandled;
+    pressHandled = false;
+    if (event.button !== 0) return;
+    if (handled && event.detail !== 0) return;
+    navigate(event);
   };
 
   return (
@@ -138,7 +182,8 @@ export const ListNav = (props: ListNavProps) => {
         // tests use keep working.
         data-active={isActive() ? '' : undefined}
         data-sidebar-next-item={props.item.id}
-        onMouseDown={navigate}
+        onMouseDown={onMouseDown}
+        onClick={onClick}
       >
         {/* Flush to the screen edge: the button sits inside the rail's own
             `px-3`, so -12px lands the bar's outer edge at x=0. Absolutely

--- a/apps/web/src/features/channels-view/components/rail/ChannelRailItems.tsx
+++ b/apps/web/src/features/channels-view/components/rail/ChannelRailItems.tsx
@@ -55,6 +55,15 @@ const CHANNEL_RAIL_ACTION_VIEW_CONTEXT: EntityActionViewContext = {
   senderBucket: undefined,
 };
 
+/**
+ * Rail rows activate on mousedown rather than click so the selection lands
+ * the instant the button goes down. Only the primary button counts: the
+ * context menu owns the secondary button and middle-click stays inert.
+ */
+export function isPrimaryMouseDown(event: MouseEvent) {
+  return event.button === 0;
+}
+
 export function ChannelRailItemContextMenu(
   props: ParentProps<{
     channel: ChannelEntity;
@@ -172,6 +181,7 @@ export function IncomingCallActions(props: {
             class="rounded-md"
             label="Accept incoming call"
             onPointerDown={(event) => event.stopPropagation()}
+            onMouseDown={(event) => event.stopPropagation()}
             onClick={(event) => {
               event.preventDefault();
               event.stopPropagation();
@@ -189,6 +199,7 @@ export function IncomingCallActions(props: {
             class="rounded-md"
             label="Decline incoming call"
             onPointerDown={(event) => event.stopPropagation()}
+            onMouseDown={(event) => event.stopPropagation()}
             onClick={(event) => {
               event.preventDefault();
               event.stopPropagation();
@@ -287,7 +298,7 @@ export function ConversationCard(props: ConversationCardProps) {
       role="treeitem"
       tabIndex={-1}
       class={cn(
-        'relative w-full min-w-0 overflow-hidden px-2 py-3 text-left outline-none transition-colors',
+        'relative w-full min-w-0 overflow-hidden px-2 py-3 text-left outline-none',
         props.selected && !isTouchDevice() && 'bg-active',
         !props.selected && !isTouchDevice() && props.focused && 'bg-hover',
         (!props.selected || isTouchDevice()) && 'bg-transparent',
@@ -298,7 +309,9 @@ export function ConversationCard(props: ConversationCardProps) {
         props.class
       )}
       aria-current={props.selected ? 'page' : undefined}
-      onClick={props.onActivate}
+      onMouseDown={(event) => {
+        if (isPrimaryMouseDown(event)) props.onActivate();
+      }}
     >
       <div
         class={cn(

--- a/apps/web/src/features/channels-view/components/rail/ChannelsRailSection.tsx
+++ b/apps/web/src/features/channels-view/components/rail/ChannelsRailSection.tsx
@@ -113,7 +113,7 @@ function CollapsibleSectionHeader(props: {
   return (
     <div
       class={cn(
-        'flex w-full items-center rounded-xl text-xs font-semibold uppercase tracking-wide text-ink-extra-muted transition-colors hover:bg-hover hover:text-ink-muted',
+        'flex w-full items-center rounded-xl text-xs font-semibold uppercase tracking-wide text-ink-extra-muted hover:bg-hover hover:text-ink-muted',
         props.focused && 'bg-hover text-ink-muted',
         !props.focused && props.focusWithin && 'text-ink-muted',
         props.class

--- a/apps/web/src/features/channels-view/components/rail/ExpandedChannelsRail.tsx
+++ b/apps/web/src/features/channels-view/components/rail/ExpandedChannelsRail.tsx
@@ -19,6 +19,7 @@ import {
   ChannelRailItemContextMenu,
   ConversationCard,
   IncomingCallActions,
+  isPrimaryMouseDown,
 } from './ChannelRailItems';
 import {
   domIdForRow,
@@ -82,7 +83,7 @@ function ChannelOption(props: { channel: ChannelEntity }) {
         role="treeitem"
         tabIndex={-1}
         class={cn(
-          'relative flex w-full min-w-0 items-center gap-2 rounded-xl px-2 text-left outline-none transition-colors',
+          'relative flex w-full min-w-0 items-center gap-2 rounded-xl px-2 text-left outline-none',
           isDirectMessage(props.channel) ? 'min-h-10 py-2' : 'h-8',
           item().selected && !isTouchDevice() && 'bg-active text-ink',
           (!item().selected || isTouchDevice()) && 'text-ink-muted',
@@ -96,7 +97,10 @@ function ChannelOption(props: { channel: ChannelEntity }) {
             'hover:bg-hover hover:text-ink'
         )}
         aria-current={item().selected ? 'page' : undefined}
-        onClick={() => rail.activateRow(rowKeyForChannel(props.channel.id))}
+        onMouseDown={(event) => {
+          if (!isPrimaryMouseDown(event)) return;
+          rail.activateRow(rowKeyForChannel(props.channel.id));
+        }}
       >
         <ChannelAvatar channel={props.channel} />
         <span class="min-w-0 flex-1 truncate text-sm font-medium">
@@ -184,7 +188,10 @@ function ExpandedGroupSection(props: { config: GroupConfig }) {
           tabIndex={-1}
           class="relative flex h-full min-w-0 flex-1 items-center gap-2 rounded-xl px-2 text-left outline-none"
           aria-expanded={section().open}
-          onClick={() => rail.activateRow(rowKeyForSection(props.config.group))}
+          onMouseDown={(event) => {
+            if (!isPrimaryMouseDown(event)) return;
+            rail.activateRow(rowKeyForSection(props.config.group));
+          }}
         >
           <CaretDownIcon
             class={cn(

--- a/apps/web/src/features/channels-view/components/rail/SlimChannelsRail.tsx
+++ b/apps/web/src/features/channels-view/components/rail/SlimChannelsRail.tsx
@@ -27,6 +27,7 @@ import {
   ChannelCallIndicator,
   ChannelMutedIndicator,
   ChannelRailItemContextMenu,
+  isPrimaryMouseDown,
 } from './ChannelRailItems';
 import {
   domIdForRow,
@@ -142,7 +143,7 @@ function SlimChannelItem(props: { channel: ChannelEntity }) {
           role="treeitem"
           tabIndex={-1}
           class={cn(
-            'flex size-10 items-center justify-center rounded-full text-left outline-none transition-colors',
+            'flex size-10 items-center justify-center rounded-full text-left outline-none',
             item().selected && !isTouchDevice() && 'bg-active text-ink',
             (!item().selected || isTouchDevice()) && 'text-ink-muted',
             !item().selected &&
@@ -155,7 +156,10 @@ function SlimChannelItem(props: { channel: ChannelEntity }) {
               'hover:bg-hover hover:text-ink'
           )}
           aria-current={item().selected ? 'page' : undefined}
-          onClick={() => rail.activateRow(rowKeyForChannel(props.channel.id))}
+          onMouseDown={(event) => {
+            if (!isPrimaryMouseDown(event)) return;
+            rail.activateRow(rowKeyForChannel(props.channel.id));
+          }}
         >
           <span class="relative">
             <SlimChannelAvatar channel={props.channel} />
@@ -291,7 +295,10 @@ function SlimGroupSection(props: { config: GroupConfig }) {
           class="relative flex size-10 min-w-10 flex-none items-center justify-center rounded-full outline-none"
           aria-expanded={section().open}
           aria-label={props.config.label}
-          onClick={() => rail.activateRow(rowKeyForSection(props.config.group))}
+          onMouseDown={(event) => {
+            if (!isPrimaryMouseDown(event)) return;
+            rail.activateRow(rowKeyForSection(props.config.group));
+          }}
         >
           <span class="flex items-center justify-center [&_svg]:size-4">
             <Dynamic component={props.config.icon} />

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -107,6 +107,8 @@ On desktop, the Chat rail has `Browse` and `Recents` tabs. Browse contains
 independently paginated `Channels` and `DMs` sections; collapsing a section
 does not discard its loaded pages. Recents has its own pagination cursor.
 Each list is virtualized, so offscreen conversations may not exist in the DOM.
+Rows and section headers act on primary-button mousedown, so the selection
+and highlight change before the click completes; a normal click still works.
 
 Arrow Down / `j` at the last loaded conversation holds focus while that
 section loads its next page. Once loading finishes, the next press advances


### PR DESCRIPTION
## Summary
Improve the responsiveness of sidebar rail navigation by activating items on `mousedown` instead of `click`, with optimistic UI feedback that shows the pending selection before the view actually changes.

## Key Changes

- **Optimistic pending navigation state**: Added a module-level `pendingNav` signal in `list-nav.tsx` that tracks the most recently pressed item and its context. The pending highlight applies immediately on `mousedown` and clears once the active content changes, ensuring stale presses never stick.

- **Mousedown-based activation**: Converted all rail item activation from `onClick` to `onMouseDown` across multiple rail components (`ChannelRailItems.tsx`, `ExpandedChannelsRail.tsx`, `SlimChannelsRail.tsx`). Added a new `isPrimaryMouseDown()` helper to ensure only primary button clicks trigger navigation, preserving context menu and middle-click behavior.

- **Event propagation fixes**: Added `onMouseDown` event handlers to incoming call action buttons to prevent mousedown from bubbling to the parent row, which would trigger unwanted navigation.

- **Removed transition-colors class**: Stripped `transition-colors` from rail items and section headers to eliminate animation delays that would make the optimistic UI feel sluggish.

- **Documentation update**: Updated `docs/AGENT_GUIDE/channels.md` to document that rows and section headers activate on primary-button mousedown, so selection changes before the click completes.

## Implementation Details

The optimistic state works by comparing the `activeContentKey` (a derived signal combining content type and ID) at press time with the current active content. If they match, the pending item's highlight takes precedence over the real state. This ensures the UI feels instant while remaining correct—the moment anything navigates away, the real state wins.

https://claude.ai/code/session_0113sgUD57muBFL8ByUT9P43

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX and event-timing changes in sidebar/channel navigation only; no auth or data paths, with primary-button guards and click fallbacks for keyboard/tap.
> 
> **Overview**
> Makes sidebar and chat rail navigation feel instant by activating on **primary-button mousedown** instead of waiting for `click`, with immediate selection/highlight feedback.
> 
> **Sidebar (`list-nav.tsx`)** adds shared **optimistic `pendingNav` state** so the pressed icon shows active before the split content updates; pending clears as soon as active content changes. Actual `navigateToSidebarView` is deferred until after the next paint (`requestAnimationFrame` + `setTimeout(0)`), and **mousedown/click splitting** keeps keyboard and tap paths working while ignoring duplicate clicks after mousedown.
> 
> **Channels rail** introduces **`isPrimaryMouseDown`** and switches channel rows, conversation cards, and section headers in expanded/slim rails to mousedown activation (secondary/middle unchanged). Incoming call accept/decline buttons **stop mousedown propagation** so rows don’t navigate. **`transition-colors`** is removed from several rail surfaces so highlights don’t lag behind the optimistic state.
> 
> **Docs** note that chat rail rows/headers act on primary mousedown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cb422ae6351d6b3323452a1ef09656ba691a667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->