### PR TITLE
fix(channels): stop iOS from holding scroll corrections after touchcancel and clamps

### DIFF
--- a/apps/web/patches/@tanstack%2Fvirtual-core@3.17.8.patch
+++ b/apps/web/patches/@tanstack%2Fvirtual-core@3.17.8.patch
@@ -1,0 +1,40 @@
+diff --git a/dist/cjs/index.cjs b/dist/cjs/index.cjs
+index e470032a9572b3ced764ca02238a8c6be435a9d4..47370bb39e710198ed36af156150d290bdd09a41 100644
+--- a/dist/cjs/index.cjs
++++ b/dist/cjs/index.cjs
+@@ -470,9 +470,15 @@ class Virtualizer {
+             onTouchEnd,
+             addEventListenerOptions
+           );
++          scrollEl.addEventListener(
++            "touchcancel",
++            onTouchEnd,
++            addEventListenerOptions
++          );
+           this.unsubs.push(() => {
+             scrollEl.removeEventListener("touchstart", onTouchStart);
+             scrollEl.removeEventListener("touchend", onTouchEnd);
++            scrollEl.removeEventListener("touchcancel", onTouchEnd);
+             if (this._iosTouchEndTimerId !== null && this.targetWindow != null) {
+               this.targetWindow.clearTimeout(this._iosTouchEndTimerId);
+               this._iosTouchEndTimerId = null;
+diff --git a/dist/esm/index.js b/dist/esm/index.js
+index 2495b26cf2c3589213546b3958eaadf2eb6b751d..32c1bc32b9a1b68bef77f8aeca8bb8f5ab3134bc 100644
+--- a/dist/esm/index.js
++++ b/dist/esm/index.js
+@@ -468,9 +468,15 @@ class Virtualizer {
+             onTouchEnd,
+             addEventListenerOptions
+           );
++          scrollEl.addEventListener(
++            "touchcancel",
++            onTouchEnd,
++            addEventListenerOptions
++          );
+           this.unsubs.push(() => {
+             scrollEl.removeEventListener("touchstart", onTouchStart);
+             scrollEl.removeEventListener("touchend", onTouchEnd);
++            scrollEl.removeEventListener("touchcancel", onTouchEnd);
+             if (this._iosTouchEndTimerId !== null && this.targetWindow != null) {
+               this.targetWindow.clearTimeout(this._iosTouchEndTimerId);
+               this._iosTouchEndTimerId = null;

--- a/apps/web/src/features/channel/Channel/ThreadList.tsx
+++ b/apps/web/src/features/channel/Channel/ThreadList.tsx
@@ -27,6 +27,7 @@ import {
 } from 'solid-js';
 import { NEAR_BOTTOM_THRESHOLD } from './constants';
 import { createScrollLifecycle } from './create-scroll-lifecycle';
+import { createScrollSource } from './create-scroll-source';
 
 type ScrollAlignment = NonNullable<ScrollToOptions['align']>;
 
@@ -130,8 +131,7 @@ export function ThreadList(props: ThreadListProps) {
   const initialSizes = new Map(
     snapshot?.measurements?.map(({ key, size }) => [key, size])
   );
-  let programmaticOffset: number | undefined;
-  let userScrollActive = false;
+  const scrollSource = createScrollSource(scrollIntent.isUserInteracting);
   let stateQueued = false;
   let nearTopFired = false;
   let nearBottomFired = false;
@@ -257,27 +257,19 @@ export function ThreadList(props: ThreadListProps) {
       const deferredPrepend =
         (options.adjustments ?? 0) > 0 &&
         offset > domOffset + 1.5 &&
-        (userScrollActive || scrollIntent.isUserInteracting());
+        (scrollSource.isGestureActive() || scrollIntent.isUserInteracting());
       elementScroll(deferredPrepend ? domOffset : offset, options, instance);
-      programmaticOffset =
+      scrollSource.markProgrammatic(
         options.behavior === 'smooth'
           ? undefined
-          : instance.scrollElement?.scrollTop;
+          : instance.scrollElement?.scrollTop
+      );
     },
     observeElementOffset: (instance, callback) =>
       observeElementOffset(instance, (offset, isScrolling) => {
-        // An instant navigation/correction is not touch momentum. Reporting
-        // its scroll event as momentum makes iOS defer size compensation and
-        // replay it after scrollToIndex has already reconciled the same sizes.
-        const isOwnScroll =
-          programmaticOffset !== undefined &&
-          Math.abs(offset - programmaticOffset) < 1.5;
-        programmaticOffset = undefined;
-        if (isScrolling && !isOwnScroll) userScrollActive = true;
-        callback(offset, isScrolling && !isOwnScroll);
-        // Keep the gesture active while the end callback flushes any deferred
-        // correction, including momentum lasting past the input-event timeout.
-        if (!isScrolling || isOwnScroll) userScrollActive = false;
+        const isUserScroll = scrollSource.classify(offset, isScrolling);
+        callback(offset, isUserScroll);
+        scrollSource.release(isUserScroll);
       }),
     observeElementRect: (instance, callback) =>
       observeElementRect(instance, (rect) => {

--- a/apps/web/src/features/channel/Channel/create-scroll-source.ts
+++ b/apps/web/src/features/channel/Channel/create-scroll-source.ts
@@ -1,0 +1,37 @@
+/**
+ * Decide which of the virtualizer's scroll events count as user scrolling.
+ *
+ * TanStack treats any event reported as scrolling as touch momentum on iOS
+ * and defers size compensation until `scrollend`. An instant navigation or
+ * correction is not momentum, so its own scroll event is not reported.
+ */
+export function createScrollSource(_isUserInteracting: () => boolean) {
+  let programmaticOffset: number | undefined;
+  let gestureActive = false;
+
+  return {
+    /** Record where an instant programmatic scroll landed in the DOM. */
+    markProgrammatic(offset: number | undefined) {
+      programmaticOffset = offset;
+    },
+    /** A gesture, including momentum past the input-event timeout, is driving scrolling. */
+    isGestureActive: () => gestureActive,
+    /** Classify one scroll event before forwarding it to the virtualizer. */
+    classify(offset: number, isScrolling: boolean) {
+      const isOwnScroll =
+        programmaticOffset !== undefined &&
+        Math.abs(offset - programmaticOffset) < 1.5;
+      programmaticOffset = undefined;
+      const isUserScroll = isScrolling && !isOwnScroll;
+      if (isUserScroll) gestureActive = true;
+      return isUserScroll;
+    },
+    /**
+     * Call after the virtualizer handled the event. The gesture stays active
+     * while the end callback flushes any deferred correction.
+     */
+    release(isUserScroll: boolean) {
+      if (!isUserScroll) gestureActive = false;
+    },
+  };
+}

--- a/apps/web/src/features/channel/Channel/create-scroll-source.ts
+++ b/apps/web/src/features/channel/Channel/create-scroll-source.ts
@@ -2,10 +2,13 @@
  * Decide which of the virtualizer's scroll events count as user scrolling.
  *
  * TanStack treats any event reported as scrolling as touch momentum on iOS
- * and defers size compensation until `scrollend`. An instant navigation or
- * correction is not momentum, so its own scroll event is not reported.
+ * and defers size compensation until `scrollend`. Only a gesture may be
+ * reported that way: an instant navigation or correction is not momentum, and
+ * neither is the browser clamping scrollTop after content shrank. A clamp
+ * fires no `scrollend`, so reporting it would hold the deferral until the
+ * next real scroll and leave a sent message off the bottom.
  */
-export function createScrollSource(_isUserInteracting: () => boolean) {
+export function createScrollSource(isUserInteracting: () => boolean) {
   let programmaticOffset: number | undefined;
   let gestureActive = false;
 
@@ -22,7 +25,8 @@ export function createScrollSource(_isUserInteracting: () => boolean) {
         programmaticOffset !== undefined &&
         Math.abs(offset - programmaticOffset) < 1.5;
       programmaticOffset = undefined;
-      const isUserScroll = isScrolling && !isOwnScroll;
+      const isUserScroll =
+        isScrolling && !isOwnScroll && (gestureActive || isUserInteracting());
       if (isUserScroll) gestureActive = true;
       return isUserScroll;
     },

--- a/apps/web/src/features/channel/Channel/tests/thread-list-scroll.test.ts
+++ b/apps/web/src/features/channel/Channel/tests/thread-list-scroll.test.ts
@@ -1,5 +1,6 @@
 import { createScrollIntentTracker } from '@core/util/scroll-intent';
 import { describe, expect, it, vi } from 'vitest';
+import { createScrollSource } from '../create-scroll-source';
 
 function scrollSurface(onUserIntent: () => void) {
   const tracker = createScrollIntentTracker(onUserIntent);
@@ -76,5 +77,62 @@ describe('createScrollIntentTracker', () => {
 
     const farFuture = Date.now() + 500;
     expect(tracker.lastDirection(farFuture)).toBe(undefined);
+  });
+});
+
+describe('createScrollSource', () => {
+  function source(interacting = false) {
+    let isInteracting = interacting;
+    const scrollSource = createScrollSource(() => isInteracting);
+    const scroll = (offset: number, isScrolling = true) => {
+      const isUserScroll = scrollSource.classify(offset, isScrolling);
+      scrollSource.release(isUserScroll);
+      return isUserScroll;
+    };
+    return {
+      scrollSource,
+      scroll,
+      setInteracting: (value: boolean) => {
+        isInteracting = value;
+      },
+    };
+  }
+
+  it('reports a gesture and its momentum until the end event', () => {
+    const { scrollSource, scroll, setInteracting } = source(true);
+    expect(scroll(100)).toBe(true);
+    setInteracting(false);
+    expect(scroll(180)).toBe(true);
+    expect(scrollSource.isGestureActive()).toBe(true);
+    expect(scroll(180, false)).toBe(false);
+    expect(scrollSource.isGestureActive()).toBe(false);
+  });
+
+  it('does not report an instant programmatic scroll', () => {
+    const { scrollSource, scroll } = source();
+    scrollSource.markProgrammatic(640);
+    expect(scroll(640.5)).toBe(false);
+  });
+
+  it('does not report the browser clamping scrollTop after content shrank', () => {
+    const { scrollSource, scroll } = source();
+    scrollSource.markProgrammatic(1233);
+    expect(scroll(1233)).toBe(false);
+    // No scrollend follows a clamp, so a misreport here would hold iOS size
+    // compensation until the next real scroll.
+    expect(scroll(1224)).toBe(false);
+    expect(scrollSource.isGestureActive()).toBe(false);
+  });
+
+  it('keeps the gesture active while the end event is being handled', () => {
+    const { scrollSource, setInteracting } = source(true);
+    expect(scrollSource.classify(100, true)).toBe(true);
+    scrollSource.release(true);
+    setInteracting(false);
+    const isUserScroll = scrollSource.classify(100, false);
+    expect(isUserScroll).toBe(false);
+    expect(scrollSource.isGestureActive()).toBe(true);
+    scrollSource.release(isUserScroll);
+    expect(scrollSource.isGestureActive()).toBe(false);
   });
 });

--- a/apps/web/src/features/channel/docs/sticky-scrolling.md
+++ b/apps/web/src/features/channel/docs/sticky-scrolling.md
@@ -51,6 +51,12 @@ Viewport and inset changes explicitly scroll to the end only if previously pinne
 The offset observer distinguishes instant programmatic scrolls from user scrolling,
 so iOS does not replay deferred momentum adjustments after a navigation has already
 accounted for those measurements. Actual touch/momentum deferral remains in the core.
+That deferral holds while a finger is on the list. iOS ends a touch that turns into
+a scroll, or that the OS takes over, with `touchcancel` rather than `touchend`;
+`@tanstack/virtual-core` only released on `touchend`, so one such touch left every
+later end correction deferred and a longer sent message lost the pin for good.
+The patch in `apps/web/patches` releases on `touchcancel` too; drop it once upstream
+does the same.
 
 Message IDs also key Solid's rendered components, preserving editors and expanded
 threads across pagination. `Key` owns each row's virtual-item accessor; a shared

--- a/apps/web/src/features/channel/docs/sticky-scrolling.md
+++ b/apps/web/src/features/channel/docs/sticky-scrolling.md
@@ -48,9 +48,13 @@ insets. Short conversations are bottom aligned. Before TanStack writes a scroll
 correction, `scrollToFn` synchronously commits the current total to the sizer;
 otherwise a growing last row can clamp the scroll against the old DOM extent.
 Viewport and inset changes explicitly scroll to the end only if previously pinned.
-The offset observer distinguishes instant programmatic scrolls from user scrolling,
-so iOS does not replay deferred momentum adjustments after a navigation has already
-accounted for those measurements. Actual touch/momentum deferral remains in the core.
+The offset observer (`create-scroll-source.ts`) reports a scroll event as user
+scrolling only during a gesture and its momentum, never for an instant programmatic
+scroll or for the browser clamping `scrollTop` after content shrank. Anything reported
+as scrolling makes iOS defer size compensation until `scrollend`, and a clamp fires no
+`scrollend`: a card row measured small, the clamp was misreported, and the card's
+growth once its preview resolved stayed deferred until the next real scroll.
+Actual touch/momentum deferral remains in the core.
 That deferral holds while a finger is on the list. iOS ends a touch that turns into
 a scroll, or that the OS takes over, with `touchcancel` rather than `touchend`;
 `@tanstack/virtual-core` only released on `touchend`, so one such touch left every

--- a/apps/web/tests/e2e/local-channel-send-scroll.spec.ts
+++ b/apps/web/tests/e2e/local-channel-send-scroll.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from '@playwright/test';
+import { devices, expect, type Page, test } from '@playwright/test';
 import { gotoApp, LOCAL_E2E, uniqueE2EText } from './helpers/local-app';
 import { observeBottomPresentation } from './helpers/scroll-presentation';
 
@@ -231,3 +231,89 @@ for (const viewport of [
     }
   });
 }
+
+// An iPhone user agent switches TanStack Virtual onto its iOS WebKit path,
+// which defers scroll corrections while a finger is on the list. iOS ends a
+// touch that becomes a scroll (or that the OS takes over) with touchcancel,
+// never touchend, so that deferral must also release on touchcancel.
+test('iPhone: sends stay pinned after a touch on the list ends in touchcancel', async ({
+  page: setupPage,
+  browser,
+  browserName,
+  context: setupContext,
+}) => {
+  test.skip(browserName !== 'chromium', 'dispatches touches through CDP');
+  test.setTimeout(120_000);
+  const channelId = await createOverflowingChannel(setupPage);
+  const context = await browser.newContext({
+    ...devices['iPhone 13'],
+    storageState: await setupContext.storageState(),
+  });
+  try {
+    const page = await context.newPage();
+    const presentation = await observeBottomPresentation(
+      page,
+      CHANNEL_SCROLL_SELECTOR,
+      BOTTOM_TOLERANCE_PX
+    );
+    await page.goto(setupPage.url());
+    const input = composer(page, channelId);
+    const collapsedInput = page.getByRole('button', {
+      name: /Type @ to share/,
+    });
+    await expect(
+      input.or(collapsedInput).filter({ visible: true }).first()
+    ).toBeVisible();
+    if (await collapsedInput.isVisible()) await collapsedInput.tap();
+    await expect(input).toBeVisible();
+    await positionFromBottom(page, 0);
+
+    const box = (await page.locator(CHANNEL_SCROLL_SELECTOR).boundingBox())!;
+    const touch = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+    const cdp = await context.newCDPSession(page);
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchStart',
+      touchPoints: [touch],
+    });
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [{ ...touch, y: touch.y + 40 }],
+    });
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchCancel',
+      touchPoints: [],
+    });
+    await positionFromBottom(page, 0);
+    await presentation.reset();
+
+    for (const text of [
+      'iPhone send one',
+      'Wrapped iPhone text. '.repeat(40),
+      'After wrapping',
+      Array.from({ length: 22 }, (_, index) => `Tall line ${index}`).join('\n'),
+      'After tall 🙂',
+    ]) {
+      await input.fill(text);
+      const sent = page.waitForResponse(
+        (response) =>
+          response.request().method() === 'POST' &&
+          response.url().endsWith(`/channels/${channelId}/message`)
+      );
+      await page
+        .getByRole('button', { name: 'Send message', exact: true })
+        .tap();
+      expect((await sent).ok()).toBe(true);
+      await page.waitForTimeout(350);
+      expect(
+        (await scrollPosition(page)).gap,
+        text.slice(0, 24)
+      ).toBeLessThanOrEqual(BOTTOM_TOLERANCE_PX);
+    }
+    const report = await presentation.read();
+    expect(report.first).toBeDefined();
+    expect(report.firstViolation).toBeUndefined();
+    expect(report.violationCount).toBe(0);
+  } finally {
+    await context.close();
+  }
+});

--- a/bun.lock
+++ b/bun.lock
@@ -410,6 +410,7 @@
     "@lexical/table@0.45.0": "apps/web/patches/@lexical%2Ftable@0.45.0.patch",
     "@tanstack/solid-query@5.90.3": "apps/web/patches/@tanstack%2Fsolid-query@5.90.3.patch",
     "ai-fallback@2.0.1": "apps/web/patches/ai-fallback@2.0.1.patch",
+    "@tanstack/virtual-core@3.17.8": "apps/web/patches/@tanstack%2Fvirtual-core@3.17.8.patch",
     "solid-gesture@0.0.3": "apps/web/patches/solid-gesture@0.0.3.patch",
     "@kobalte/core@0.13.11": "apps/web/patches/@kobalte%2Fcore@0.13.11.patch",
     "virtua@0.48.8": "apps/web/patches/virtua@0.48.8.patch",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
 		"virtua@0.48.8": "apps/web/patches/virtua@0.48.8.patch",
 		"@tanstack/solid-query@5.90.3": "apps/web/patches/@tanstack%2Fsolid-query@5.90.3.patch",
 		"@lexical/table@0.45.0": "apps/web/patches/@lexical%2Ftable@0.45.0.patch",
-		"ai-fallback@2.0.1": "apps/web/patches/ai-fallback@2.0.1.patch"
+		"ai-fallback@2.0.1": "apps/web/patches/ai-fallback@2.0.1.patch",
+		"@tanstack/virtual-core@3.17.8": "apps/web/patches/@tanstack%2Fvirtual-core@3.17.8.patch"
 	},
 	"private": true,
 	"scripts": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

On iOS, sending a message could leave the channel list above the bottom, and every later send stayed there. `@tanstack/virtual-core` defers `scrollTop` corrections on iOS WebKit while it believes a finger is on the list or a scroll is in flight, and releases that deferral on `touchend` or `scrollend`. Two ways to arm the deferral with nothing to release it:

1. **`touchcancel`.** iOS ends a touch that becomes a scroll, or that the OS takes over, with `touchcancel`, never `touchend`. The core only clears `_iosTouching` on `touchend`, so one such touch left every later end-anchor correction deferred forever.
2. **Clamp scroll events.** `ThreadList` reported any scroll event that was not its own programmatic scroll as user scrolling. The browser clamping `scrollTop` after content shrank is such an event, and a clamp fires no `scrollend`, so the core's `isScrolling` stuck at `true`. A card row measures small (preview placeholder), the sizer shrinks, the browser clamps, then the card grows once its preview resolves and that growth stays deferred. No finger involved. Message rows with document/channel cards and mentions are the common trigger, which is why this looks related to the recent preview work: those rows now render a placeholder and grow when the batched preview lands.

## Scope

- `apps/web/patches/@tanstack%2Fvirtual-core@3.17.8.patch` (root `package.json` `patchedDependencies`, `bun.lock`): run the `touchend` handler on `touchcancel` too, in both `dist/esm` and `dist/cjs`. Latest upstream (3.17.9) has the same gap; this is the fix to send upstream.
- `apps/web/src/features/channel/Channel/create-scroll-source.ts` (new) and `ThreadList.tsx`: the offset observer's decision moves into `createScrollSource`. A scroll event is reported as user scrolling only during a gesture and its momentum (`scrollIntent.isUserInteracting()` or an already active gesture), never for an instant programmatic scroll or a clamp.
- `apps/web/src/features/channel/Channel/tests/thread-list-scroll.test.ts`: unit tests for `createScrollSource` (gesture + momentum until the end event, programmatic scroll, clamp after a programmatic scroll, gesture kept active while the end event is handled).
- `apps/web/tests/e2e/local-channel-send-scroll.spec.ts`: iPhone 13 emulation, CDP `touchStart`/`touchMove`/`touchCancel` on the list, then sends including wrapped and tall messages.
- `apps/web/src/features/channel/docs/sticky-scrolling.md`: both constraints and when to drop the patch.

Out of scope: the iOS `clearComposer` blur/refocus on send in `ChannelInput.tsx` (dictation workaround), a separate keyboard-flicker concern.

## Tradeoffs

An app-level `touchcancel` listener would have to poke `virtualizer._iosTouching`, a private field; the dependency patch is smaller and upstreamable. The clamp fix lives in the app because the core cannot tell a clamp from a user scroll without the intent tracker `ThreadList` already has.

## Blast Radius

Virtualizer iOS path only for the patch. The classification change affects every channel list: scroll events with no user intent behind them (programmatic scrolls by other code, clamps) are now reported to TanStack as not scrolling, which is what its `isScrolling`/`scrollDirection` semantics expect. Wheel, touch drag, scrollbar drag and keyboard scrolling still go through `scrollIntent`.

## Verification

- `touchcancel` e2e against the unpatched core: fails with `Wrapped iPhone text.` gap `155` px; passes with the patch.
- Clamp mechanism, instrumented core on iPhone emulation with card/mention sends: `observe {offset: 1224, isScrolling: true}` right after `scrollToIndex` to `1233` (clamp), then `defer {delta: 49}` for the card growth and `flush?` blocked with `isScrolling: true`; no `scrollend` followed until the next send, gap `49` px. With the `ThreadList` change the same run shows no `defer` and every send pinned (gap `0`). The natural repro depends on preview timing (32 ms window in the trace), so it is covered by the unit tests rather than a flaky e2e.
- Unit tests: 11 pass; the clamp test fails on the previous classification (verified by temporarily restoring it).
- Full `local-channel-send-scroll.spec.ts` (desktop, three touch viewports, iPhone touchcancel): 5 pass.
- `just check` passes.
- `local-channel-scroll.spec.ts` and `local-channel-thread-navigation.spec.ts` fail before and after this change on a stale route assertion (`/app/channel/<id>` vs `/app/component/channels/channel/<id>?preview=0`); unrelated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08838-da0a-7392-8a9b-1e0c46b0ed8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08838-da0a-7392-8a9b-1e0c46b0ed8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

