### PR TITLE
fix(agent_inmem): read the egress route off the advertised URL's base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "url",
  "workspace-hack",
 ]
 

--- a/crates/agent_inmem/Cargo.toml
+++ b/crates/agent_inmem/Cargo.toml
@@ -40,7 +40,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt", "time", "macros"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
-url = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/crates/agent_inmem/src/outbound/egress_mcp.rs
+++ b/crates/agent_inmem/src/outbound/egress_mcp.rs
@@ -10,7 +10,9 @@
 //! What it is given is still the ACP server list, URLs and all, because that
 //! is what every harness is given. The URL's path names the server and the
 //! `Authorization` header carries the session token; both are read here the
-//! way the proxy's router reads them.
+//! way the proxy's router reads them - minus the proxy's own route prefix,
+//! which the gateway strips before the router sees a request and nothing
+//! strips here.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -63,12 +65,22 @@ type CallError = StreamableHttpError<EgressCallError>;
 /// service with the same pools, not two configured alike.
 pub struct EgressMcpClient<Egress> {
     egress: Arc<Egress>,
+    base_url: String,
 }
 
 impl<Egress> EgressMcpClient<Egress> {
-    /// A client over the service the proxy's listener also serves.
-    pub fn new(egress: Arc<Egress>) -> Self {
-        Self { egress }
+    /// A client over the service the proxy's listener also serves, told the
+    /// proxy's public address.
+    ///
+    /// It must be the same value the advertised server URLs were built from -
+    /// the harness's `SandboxEgress::base_url` - because that is what comes
+    /// back off the front of them here. Trimmed the way the provisioner trims
+    /// it, so a configured trailing slash cannot make the two disagree.
+    pub fn new(egress: Arc<Egress>, base_url: &str) -> Self {
+        Self {
+            egress,
+            base_url: base_url.trim_end_matches('/').to_owned(),
+        }
     }
 }
 
@@ -77,8 +89,14 @@ impl<Egress> Clone for EgressMcpClient<Egress> {
     fn clone(&self) -> Self {
         Self {
             egress: Arc::clone(&self.egress),
+            base_url: self.base_url.clone(),
         }
     }
+}
+
+/// The refusal for a URL this proxy does not serve.
+fn not_an_egress_url(uri: &str) -> CallError {
+    StreamableHttpError::Client(EgressCallError::NotAnEgressUrl(uri.to_owned()))
 }
 
 /// Where a request is going, read off the pieces rmcp hands over.
@@ -87,13 +105,19 @@ struct Addressed {
     target: EgressTarget,
 }
 
-fn address(uri: &str, auth_header: Option<String>) -> Result<Addressed, CallError> {
-    let url = url::Url::parse(uri).map_err(|_| {
-        StreamableHttpError::Client(EgressCallError::NotAnEgressUrl(uri.to_owned()))
-    })?;
-    let destination = McpDestination::from_path(url.path()).ok_or_else(|| {
-        StreamableHttpError::Client(EgressCallError::NotAnEgressUrl(uri.to_owned()))
-    })?;
+/// Read a request's destination off an advertised URL.
+///
+/// The advertised URL is the proxy's base URL with a route appended, and that
+/// base may be a path on a shared host
+/// (`https://dev-gateway.macro.com/agent-harness-egress`). A sandbox dials it
+/// whole and the gateway strips the prefix, so the router only ever reads
+/// `/mcp/{slug}`. Nothing strips anything on the way here, so the base comes
+/// off first and what is left is read the way the router reads it.
+fn address(base_url: &str, uri: &str, auth_header: Option<String>) -> Result<Addressed, CallError> {
+    let route = uri
+        .strip_prefix(base_url)
+        .ok_or_else(|| not_an_egress_url(uri))?;
+    let destination = McpDestination::from_path(route).ok_or_else(|| not_an_egress_url(uri))?;
     let token = auth_header
         .map(SessionToken::new)
         .ok_or(StreamableHttpError::Client(EgressCallError::NoSessionToken))?;
@@ -189,7 +213,7 @@ where
         auth_header: Option<String>,
         custom_headers: HashMap<HeaderName, HeaderValue>,
     ) -> Result<StreamableHttpPostResponse, CallError> {
-        let Addressed { token, target } = address(&uri, auth_header)?;
+        let Addressed { token, target } = address(&self.base_url, &uri, auth_header)?;
         let body = serde_json::to_vec(&message)?;
         let mut request = build_request(
             Method::POST,
@@ -259,7 +283,7 @@ where
         auth_header: Option<String>,
         custom_headers: HashMap<HeaderName, HeaderValue>,
     ) -> Result<(), CallError> {
-        let Addressed { token, target } = address(&uri, auth_header)?;
+        let Addressed { token, target } = address(&self.base_url, &uri, auth_header)?;
         let request = build_request(
             Method::DELETE,
             &uri,
@@ -293,7 +317,7 @@ where
         auth_header: Option<String>,
         custom_headers: HashMap<HeaderName, HeaderValue>,
     ) -> Result<BoxStream<'static, Result<Sse, SseError>>, CallError> {
-        let Addressed { token, target } = address(&uri, auth_header)?;
+        let Addressed { token, target } = address(&self.base_url, &uri, auth_header)?;
         let mut request = build_request(
             Method::GET,
             &uri,

--- a/crates/agent_inmem/src/outbound/egress_mcp/test.rs
+++ b/crates/agent_inmem/src/outbound/egress_mcp/test.rs
@@ -92,6 +92,11 @@ impl EgressService for StubEgress {
     }
 }
 
+/// The proxy's address as a deployment behind the shared gateway configures
+/// it: a path on a host serving many services. What broke was reading a route
+/// off a URL built on one of these.
+const BASE_URL: &str = "https://gateway.example/agent-harness-egress";
+
 fn hubspot() -> EgressTarget {
     EgressTarget::McpServer(McpDestination::Connected(
         McpServerSlug::parse("hubspot").expect("slug"),
@@ -101,10 +106,9 @@ fn hubspot() -> EgressTarget {
 #[tokio::test]
 async fn a_handshake_and_tool_listing_go_through_the_service_as_the_session() {
     let egress = Arc::new(StubEgress::default());
-    let client = EgressMcpClient::new(Arc::clone(&egress));
-    let config =
-        StreamableHttpClientTransportConfig::with_uri("http://egress.internal/mcp/hubspot")
-            .auth_header("session-token");
+    let client = EgressMcpClient::new(Arc::clone(&egress), BASE_URL);
+    let config = StreamableHttpClientTransportConfig::with_uri(format!("{BASE_URL}/mcp/hubspot"))
+        .auth_header("session-token");
     let transport = StreamableHttpClientTransport::with_client(client, config);
 
     let server = client_info().serve(transport).await.expect("handshake");
@@ -132,11 +136,11 @@ async fn a_handshake_and_tool_listing_go_through_the_service_as_the_session() {
 #[tokio::test]
 async fn a_url_off_the_proxy_routes_is_refused_before_the_service_is_called() {
     let egress = Arc::new(StubEgress::default());
-    let client = EgressMcpClient::new(Arc::clone(&egress));
+    let client = EgressMcpClient::new(Arc::clone(&egress), BASE_URL);
 
     let error = client
         .post_message(
-            Arc::from("http://egress.internal/git/info/refs"),
+            Arc::from("https://gateway.example/agent-harness-egress/git/info/refs"),
             ClientJsonRpcMessage::notification(
                 rmcp::model::ClientNotification::InitializedNotification(Default::default()),
             ),
@@ -159,11 +163,11 @@ async fn a_url_off_the_proxy_routes_is_refused_before_the_service_is_called() {
 #[tokio::test]
 async fn a_server_entry_without_a_token_is_refused_before_the_service_is_called() {
     let egress = Arc::new(StubEgress::default());
-    let client = EgressMcpClient::new(Arc::clone(&egress));
+    let client = EgressMcpClient::new(Arc::clone(&egress), BASE_URL);
 
     let error = client
         .delete_session(
-            Arc::from("http://egress.internal/mcp/hubspot"),
+            Arc::from("https://gateway.example/agent-harness-egress/mcp/hubspot"),
             Arc::from("stub-session"),
             None,
             HashMap::new(),
@@ -183,13 +187,13 @@ async fn a_server_entry_without_a_token_is_refused_before_the_service_is_called(
 #[tokio::test]
 async fn the_macro_route_names_macros_own_server() {
     let egress = Arc::new(StubEgress::default());
-    let client = EgressMcpClient::new(Arc::clone(&egress));
+    let client = EgressMcpClient::new(Arc::clone(&egress), BASE_URL);
 
     // The stub answers DELETE with 405, which the client reads as "nothing to
     // delete", so this exercises the address step alone.
     client
         .delete_session(
-            Arc::from("http://egress.internal/mcp-macro"),
+            Arc::from("https://gateway.example/agent-harness-egress/mcp-macro"),
             Arc::from("stub-session"),
             Some("session-token".to_owned()),
             HashMap::new(),
@@ -203,4 +207,83 @@ async fn the_macro_route_names_macros_own_server() {
             EgressTarget::McpServer(McpDestination::Macro)
         )]
     );
+}
+
+/// A `delete_session` the stub answers with 405, which the client reads as
+/// "nothing to delete": the cheapest way to exercise the address step alone.
+async fn address_only(
+    egress: &Arc<StubEgress>,
+    base_url: &str,
+    uri: &'static str,
+) -> Result<(), CallError> {
+    EgressMcpClient::new(Arc::clone(egress), base_url)
+        .delete_session(
+            Arc::from(uri),
+            Arc::from("stub-session"),
+            Some("session-token".to_owned()),
+            HashMap::new(),
+        )
+        .await
+}
+
+#[tokio::test]
+async fn a_route_under_the_proxys_own_path_prefix_is_read_off_it() {
+    let egress = Arc::new(StubEgress::default());
+
+    address_only(
+        &egress,
+        BASE_URL,
+        "https://gateway.example/agent-harness-egress/mcp/hubspot",
+    )
+    .await
+    .expect("405 is fine");
+
+    assert_eq!(egress.seen(), vec![("session-token".to_owned(), hubspot())]);
+}
+
+#[tokio::test]
+async fn a_base_url_with_no_path_reads_the_same_routes() {
+    let egress = Arc::new(StubEgress::default());
+
+    address_only(
+        &egress,
+        "http://localhost:8102",
+        "http://localhost:8102/mcp/hubspot",
+    )
+    .await
+    .expect("405 is fine");
+
+    assert_eq!(egress.seen(), vec![("session-token".to_owned(), hubspot())]);
+}
+
+#[tokio::test]
+async fn a_trailing_slash_on_the_base_url_does_not_hide_the_route() {
+    let egress = Arc::new(StubEgress::default());
+
+    address_only(
+        &egress,
+        "https://gateway.example/agent-harness-egress/",
+        "https://gateway.example/agent-harness-egress/mcp/hubspot",
+    )
+    .await
+    .expect("405 is fine");
+
+    assert_eq!(egress.seen(), vec![("session-token".to_owned(), hubspot())]);
+}
+
+#[tokio::test]
+async fn a_url_that_is_not_under_the_proxys_base_is_refused() {
+    let egress = Arc::new(StubEgress::default());
+
+    let error = address_only(&egress, BASE_URL, "https://gateway.example/mcp/hubspot")
+        .await
+        .expect_err("not this proxy");
+    assert!(
+        matches!(
+            error,
+            StreamableHttpError::Client(EgressCallError::NotAnEgressUrl(_))
+        ),
+        "{error:?}"
+    );
+    assert!(egress.seen().is_empty());
 }

--- a/services/agent_harness_service/src/main.rs
+++ b/services/agent_harness_service/src/main.rs
@@ -343,6 +343,11 @@ async fn run() -> anyhow::Result<()> {
         ReqwestForwarder::new()?,
     ));
 
+    // The proxy's public address, read once: the provisioner builds the
+    // advertised server URLs from it and the in-memory client reads them back
+    // against it, so the two must be the same string.
+    let egress_base_url = AgentHarnessEgressUrl::new()?.to_string();
+
     let mut inmem_model_engine: Option<Arc<dyn TurnEngine>> = None;
     let inmem = match inmem_bot {
         Some(_) => {
@@ -361,9 +366,10 @@ async fn run() -> anyhow::Result<()> {
                 manager: InMemAgentManager::new(
                     engine,
                     frames,
-                    Arc::new(AcpMcpConnector::new(EgressMcpClient::new(Arc::clone(
-                        &egress,
-                    )))),
+                    Arc::new(AcpMcpConnector::new(EgressMcpClient::new(
+                        Arc::clone(&egress),
+                        &egress_base_url,
+                    ))),
                 )
                 .with_dev_commands(enable_dev_commands),
             })
@@ -532,10 +538,7 @@ async fn run() -> anyhow::Result<()> {
         HarnessKeyedConnections::new(PgHarnessBindings::new(pool.clone()), Arc::clone(&runtimes)),
         prompt_context,
         prompt_composer,
-        EgressProvisioner::new(
-            Arc::clone(&mcp_connections),
-            AgentHarnessEgressUrl::new()?.to_string(),
-        ),
+        EgressProvisioner::new(Arc::clone(&mcp_connections), egress_base_url),
         RedisCommandForwarder::new(redis.clone()),
         defaults,
     ));


### PR DESCRIPTION
## Why

Chasing *"why doesn't this agent session have Datadog?"* landed on a bug in the in-process egress client. This is that bug alone, off `main`, so it can go in without waiting on the extraction in #6308.

**The bug.** The harness advertises MCP servers as absolute URLs built on the egress proxy's public address, which in dev and prod is a path on the shared gateway: `https://dev-gateway.macro.com/agent-harness-egress/mcp/datadog`. Sandboxed and external harnesses dial that whole; the gateway strips its route prefix, so the egress router only ever reads `/mcp/datadog` off the request line.

The **in-memory** harness hands each request to `EgressServiceImpl` in process through a shared `Arc` — no gateway in between to strip anything — and still named the destination with `McpDestination::from_path(url.path())`, which wants a root-relative route. `/agent-harness-egress/mcp/datadog` matches nothing.

Result: `NotAnEgressUrl`, logged as a `warn!` and skipped. **Every** connected Pipedream app silently produced no tools. It looked like "Datadog is broken" only because Macro's own server is filtered out of the dial list and served natively, so it kept working.

## What this does

`EgressMcpClient::new` now takes the proxy's base URL — the same value `EgressProvisioner` builds the advertised URLs from, read once in the composition root so the two cannot drift — and takes it off the front of each URI before reading the route. What is left goes to `McpDestination::from_path` exactly as the router reads it.

Prefix-stripping rather than re-parsing, because the advertised URL is that base with a route concatenated onto it; the two strings come from one config value in one process, so they match exactly by construction. A URL that is *not* under the base is refused by name (`NotAnEgressUrl`) rather than parsed as though it were.

`McpDestination::from_path` is untouched — the router's use of it is correct, and it stays root-relative.

## Relation to #6308

#6308 fixes this by deleting `EgressMcpClient` outright and dialing the proxy over HTTP like every other harness, which is the better end state — one code path, and this class of bug becomes impossible. It also moves egress into its own service, its own subdomain and its own Doppler project, so it is a hard cutover that needs human steps before it can deploy.

This PR is the bug fix on its own. If #6308 lands, this code goes away with it; the two do not conflict in intent, only in the same file.

## Testing

`agent_inmem` 50 pass, `agent_harness_service` 6 pass; `cargo clippy --all-targets` on both warning-clean; `just check` clean; `cargo run -p xtask -- deps --check` clean.

Four new tests cover the regression and its edges: a route under the proxy's path prefix addresses correctly (this is what was broken), a bare-host base URL (the local default) still works, a configured trailing slash does not hide the route, and a URL outside the base is refused before the service is called. The existing tests now run against a gateway-prefixed base rather than a bare host, which is what deployments actually configure.

Not verified: nothing has run against a live stack or in a browser. Local Rust tests ran with `SQLX_OFFLINE=true` because this machine's dev database is behind on migrations — no query in the change is new or edited, so nothing here depends on that cache being re-prepared.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how in-memory harness resolves MCP egress targets; wrong base URL would still break third-party tools, but scope is limited to the in-process path and is covered by new tests.
> 
> **Overview**
> Fixes the in-process **EgressMcpClient** so connected Pipedream MCP apps load tools again when the harness advertises gateway-prefixed URLs (e.g. `…/agent-harness-egress/mcp/datadog`). The client no longer uses `url.path()` on the full URI; it **strips the same public base URL** the provisioner uses to build those URLs, then passes the remainder to `McpDestination::from_path` like the egress router does after the gateway strips its prefix.
> 
> **EgressMcpClient::new** now requires that base URL (trailing slash normalized). **agent_harness_service** reads `AgentHarnessEgressUrl` once into `egress_base_url` and shares it between **EgressProvisioner** and the in-memory connector so advertised URLs and in-process parsing cannot drift. The **`url`** dependency is dropped from `agent_inmem`.
> 
> Tests were updated for gateway-style bases and four new cases cover prefix routing, bare localhost, trailing slash on the base, and refusing URLs not under the proxy base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a608706b597c95c1e27cbea55aad0a9e6173470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->