### PR TITLE
fix(ui): stop panel header growing on relayout in Safari

### DIFF
--- a/apps/web/src/components/ui/components/Panel.tsx
+++ b/apps/web/src/components/ui/components/Panel.tsx
@@ -42,7 +42,7 @@ function PanelHeader(props: SlotProps) {
     <Show when={resolved()}>
       <div
         class={cn(
-          'flex flex-none items-center h-full min-h-10 px-2 border-b border-edge-muted overflow-hidden',
+          'flex flex-none items-center min-h-10 px-2 border-b border-edge-muted overflow-hidden',
           props.class
         )}
         style={{ 'grid-area': 'header' }}


### PR DESCRIPTION
## Problem

In Safari, hovering items in the Cmd+K menu made the search input row taller on every hover.

`Panel.Header` set `h-full` (`height: 100%`) while sitting in the panel's `auto`-sized grid row. `CommandMenuShell.Header` adds `my-1` on top of that. WebKit resolves the percentage height against the row size from the previous layout, then adds the margins back into the row's contribution, so every relayout (each selection change swaps the footer hotkey hints) grew the header row by another 8px. Chromium treats the cyclic percentage as `auto` during track sizing, so it never grew there, although the header box did silently overflow its row by the margin size.

## Fix

Drop the redundant `h-full` from `Panel.Header`. Grid items already stretch to fill their row by default, so in Chromium the header now sizes to `min-h-10` plus its margins instead of overflowing, and in WebKit there is no percentage to feed back into the row. Panel total height is unchanged. Headers without vertical margins (every other `Panel.Header` caller) render identically to before.

Verified the row-growth mechanism and the fix with a minimal grid repro in Chromium; a WebKit build was not available in the sandbox, so please sanity-check in Safari.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXqb5DLiJc5EhF76gsfb25)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-class removal on a shared layout primitive; low blast radius with intentional fix for WebKit grid sizing.
> 
> **Overview**
> Fixes a **Safari-only layout bug** where the Cmd+K command menu search row grew taller on each hover/selection change.
> 
> **`Panel.Header`** no longer applies `h-full`; it keeps `min-h-10` and grid placement. In an `auto` grid row, percentage height plus margins (e.g. `my-1` on the command menu header) caused WebKit to feed height back into the row on every relayout. Grid stretch already fills the row, so behavior elsewhere should match while Safari stops accumulating extra header height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f7e6acc0e239cec2f730cd7a7ff29c194a0f05b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->