### PR TITLE
feat(email): allow mark done on the mail Calendar tab

### DIFF
--- a/apps/web/src/features/next-soup/actions/make-mark-done-action.test.ts
+++ b/apps/web/src/features/next-soup/actions/make-mark-done-action.test.ts
@@ -68,7 +68,10 @@ vi.mock('@app/features/next-soup/utils', () => ({
   restoreSoupFocus: vi.fn(),
 }));
 
-import { makeMarkDoneAction } from './make-mark-done-action';
+import {
+  canExecuteMarkDoneOnView,
+  makeMarkDoneAction,
+} from './make-mark-done-action';
 
 const currentEntity = {
   type: 'email',
@@ -114,6 +117,19 @@ function createAction() {
     dispose,
   }));
 }
+
+describe('canExecuteMarkDoneOnView', () => {
+  it('allows mark done on every thread-listing mail tab', () => {
+    for (const tab of ['important', 'noise', 'calendar', 'shared', 'all']) {
+      expect(canExecuteMarkDoneOnView('mail', tab)).toBe(true);
+    }
+  });
+
+  it('keeps mark done off tabs whose rows are not triaged', () => {
+    expect(canExecuteMarkDoneOnView('mail', 'drafts')).toBe(false);
+    expect(canExecuteMarkDoneOnView('mail', 'sent')).toBe(false);
+  });
+});
 
 describe('makeMarkDoneAction', () => {
   beforeEach(() => {

--- a/apps/web/src/features/next-soup/actions/make-mark-done-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-mark-done-action.ts
@@ -35,6 +35,9 @@ const VALID_MARK_DONE_LIST_VIEWS: `${ListView}-${string}`[] = [
   'mail-important',
   'mail-all',
   'mail-noise',
+  // Calendar lists invite threads from the "all" email view, so done rows
+  // stay in place and flip to the done state exactly like mail "All".
+  'mail-calendar',
   'mail-shared',
   // Completing a reminder is the whole point of the Reminders view: without
   // it the only way to clear one is to delete it. Done is listed too so a


### PR DESCRIPTION
## Summary

Mark done was unavailable on the mail view's **Calendar** tab: `VALID_MARK_DONE_LIST_VIEWS` in `make-mark-done-action.ts` listed Signal, Noise, Shared, and All but not `mail-calendar`, so `supportsMarkDone` resolved to `false` there and every entry point (`e` / `shift+e`, row action menu, swipe, split-panel command) was hidden.

## Change

- Add `mail-calendar` to the allowed views. The Calendar tab queries the `all` email view (same as the All tab), so done rows stay in place and flip to the done state rather than disappearing, and mark not done works on them too.
- Add unit tests for `canExecuteMarkDoneOnView` covering the thread-listing mail tabs and confirming Drafts/Sent stay excluded.

Resolves Macro task MACRO-3329.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRHda9LRcUmhnbhCWJ9NQJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small allowlist change plus tests; no auth, data migration, or mutation-path changes beyond exposing an existing action on one more tab.
> 
> **Overview**
> Enables **mark done** (and related entry points gated by `supportsMarkDone`) on the mail **Calendar** tab by adding `mail-calendar` to the allowed list views in `make-mark-done-action.ts`. Behavior matches mail **All**: done rows remain in the list and flip to done rather than leaving the view.
> 
> Adds unit tests for exported `canExecuteMarkDoneOnView`, asserting thread-style mail tabs (including **calendar**) allow mark done while **drafts** and **sent** stay disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b99da2ebf19f9e7801fbda54a2ffa7807e0e0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->