### PR TITLE
Add "Ask Macro" button to channel header for AI chat

### DIFF
--- a/apps/web/src/features/block-channel/component/NewChannelBlockAdapter.tsx
+++ b/apps/web/src/features/block-channel/component/NewChannelBlockAdapter.tsx
@@ -1,4 +1,9 @@
 import {
+  ChatWithAgentButton,
+  ChatWithAgentIcon,
+  openChatWithAgent,
+} from '@app/features/chat/ChatWithAgentButton';
+import {
   makeRenameAction,
   useBlockEntityCommands,
 } from '@app/features/next-soup/actions';
@@ -185,6 +190,19 @@ function NewTop(props: { channelId: string }) {
     });
   };
 
+  // Seed for "Ask Macro": a new chat with this channel @mentioned, so the
+  // user does not have to create an agent and mention the channel by hand.
+  const askMacroEntity = () => {
+    const type = channelType();
+    if (!type) return undefined;
+    return {
+      type: 'channel' as const,
+      id: props.channelId,
+      name: channelName() ?? 'New Channel',
+      channelType: type,
+    };
+  };
+
   // Mobile has no room for inline tabs; the title file-menu drawer leads with
   // them instead, as a titled radio group mirroring the active tab. Built
   // from tabs() so the call tab keeps its live-call label.
@@ -222,6 +240,17 @@ function NewTop(props: { channelId: string }) {
           mobileViews={isMobile() ? mobileViews() : undefined}
           tools={[
             {
+              label: 'Ask Macro',
+              icon: ChatWithAgentIcon,
+              action: () => {
+                const entity = askMacroEntity();
+                if (!entity) return;
+                void openChatWithAgent(entity);
+              },
+              // Desktop gets a header button instead (see below).
+              condition: () => isMobile() && !!askMacroEntity(),
+            },
+            {
               group: 'file',
               label: 'Rename',
               icon: RenameIcon,
@@ -239,6 +268,16 @@ function NewTop(props: { channelId: string }) {
           ]}
         />
       </SplitTitleFileMenu>
+      {/* Desktop only: on mobile the action lives in the title drawer above. */}
+      <Show when={!isMobile() && askMacroEntity()}>
+        {(entity) => (
+          <SplitHeaderRight>
+            <HeaderIsland>
+              <ChatWithAgentButton entity={entity()} label="Ask Macro" />
+            </HeaderIsland>
+          </SplitHeaderRight>
+        )}
+      </Show>
       {/* Hidden once the user has joined — the call surface owns the UI. */}
       <Show when={ENABLE_CALLS && !call.isInThisChannel()}>
         <SplitHeaderRight>

--- a/apps/web/src/features/chat/ChatWithAgentButton.tsx
+++ b/apps/web/src/features/chat/ChatWithAgentButton.tsx
@@ -128,7 +128,11 @@ export async function openChatWithMessageReplacingSplit(
   await createAndOpenChat({ message, replaceSplit: splitHandle });
 }
 
-export function ChatWithAgentButton(props: { entity: ChatWithAgentEntity }) {
+export function ChatWithAgentButton(props: {
+  entity: ChatWithAgentEntity;
+  /** Button text; defaults to "Chat". */
+  label?: string;
+}) {
   const [hovering, setHovering] = createSignal(false);
 
   return (
@@ -143,7 +147,7 @@ export function ChatWithAgentButton(props: { entity: ChatWithAgentEntity }) {
       class="bg-surface"
     >
       <AnimatedStarIcon triggerAnimation={hovering()} />
-      <span class="text-xs">Chat</span>
+      <span class="text-xs">{props.label ?? 'Chat'}</span>
     </Button>
   );
 }

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -122,7 +122,9 @@ their own loaded pages and load more as their active list approaches the end.
 ## Channel tabs
 
 Radio group at the top of the channel pane: `Messages` / `Attachments` / `Participants`,
-plus a `Call` button. Clicking the radio input can time out — click the adjacent label text
+plus `Ask Macro` and `Call` buttons. `Ask Macro` opens a new chat pane with the channel
+already @mentioned as context (see ai-chat.md). On mobile it lives in the channel title's
+`...` drawer instead. Clicking the radio input can time out — click the adjacent label text
 instead.
 
 `Participants` tab:


### PR DESCRIPTION
## Summary
Adds an "Ask Macro" button to the channel header that opens a new chat pane with the channel already @mentioned as context, streamlining the workflow for users who want to ask an AI agent about a channel without manually creating a chat and mentioning it.

## Changes
- **NewChannelBlockAdapter.tsx**: 
  - Import `ChatWithAgentButton`, `ChatWithAgentIcon`, and `openChatWithAgent` from the chat feature
  - Add `askMacroEntity()` helper to create a channel entity for the chat context
  - Add "Ask Macro" tool to the mobile title drawer menu (conditionally shown on mobile only)
  - Add desktop-only "Ask Macro" button in the header using `ChatWithAgentButton` component
  
- **ChatWithAgentButton.tsx**:
  - Add optional `label` prop to `ChatWithAgentButton` to customize button text (defaults to "Chat")
  - Update button rendering to use the provided label or fall back to "Chat"

- **docs/AGENT_GUIDE/channels.md**:
  - Document the new "Ask Macro" button in the channel tabs section
  - Note that it opens a new chat with the channel pre-mentioned as context
  - Clarify that on mobile it appears in the channel title's `...` drawer instead

## Implementation Details
- The "Ask Macro" entity is created with the channel's type, ID, name, and channel type to provide proper context to the AI agent
- Mobile and desktop have different UX: mobile uses the title drawer menu, desktop uses a header button
- The button is only shown when a valid channel entity can be created (i.e., when channel type is available)

https://claude.ai/code/session_01KSZVPMagSX7KzvydT6zvNx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only entry point reusing existing `openChatWithAgent` flow; no auth, data, or messaging logic changes.
> 
> **Overview**
> Adds **Ask Macro** to the channel chrome so users can start an AI chat with the current channel already @mentioned, without manually creating a chat and mentioning it.
> 
> On **desktop**, a header **Ask Macro** button uses `ChatWithAgentButton` with a new optional `label` prop (still defaults to **Chat** elsewhere). On **mobile**, the same action appears in the channel title `...` menu via `openChatWithAgent` and a small `askMacroEntity()` helper that seeds channel id, name, and type. The agent guide documents the button and mobile placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0abae1ca87609ce6726c33f90dc4c7d16aee077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->