### PR TITLE
chore(db): remove dead indices

### DIFF
--- a/crates/macro_db_client/migrations/20260910135629_drop_idx_email_messages_thread_id_internal_date_ts.sql
+++ b/crates/macro_db_client/migrations/20260910135629_drop_idx_email_messages_thread_id_internal_date_ts.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_email_messages_thread_id_internal_date_ts;

--- a/crates/macro_db_client/migrations/20260910135630_drop_idx_email_messages_latest_content.sql
+++ b/crates/macro_db_client/migrations/20260910135630_drop_idx_email_messages_latest_content.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_email_messages_latest_content;

--- a/crates/macro_db_client/migrations/20260910135631_drop_idx_email_sfs_mappings_destination.sql
+++ b/crates/macro_db_client/migrations/20260910135631_drop_idx_email_sfs_mappings_destination.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_email_sfs_mappings_destination;

--- a/crates/macro_db_client/migrations/20260910135633_drop_idx_email_messages_link_thread_date.sql
+++ b/crates/macro_db_client/migrations/20260910135633_drop_idx_email_messages_link_thread_date.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_email_messages_link_thread_date;

--- a/crates/macro_db_client/migrations/20260910135634_drop_idx_email_messages_thread_date_not_draft.sql
+++ b/crates/macro_db_client/migrations/20260910135634_drop_idx_email_messages_thread_date_not_draft.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_email_messages_thread_date_not_draft;

--- a/crates/macro_db_client/migrations/20260910135635_drop_idx_email_threads_non_spam_ts_id.sql
+++ b/crates/macro_db_client/migrations/20260910135635_drop_idx_email_threads_non_spam_ts_id.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_email_threads_non_spam_ts_id;


### PR DESCRIPTION
using claude and datadog I went through our db monitoring and identified a lot of unused indices. I validated they are unused through datadog as well as querying postgres directly.

there are more unused indices but this PR removes what claude coined as "the big 6" which should improve the write speed for emails a good bit

 Expected benefits:
 - Less write overhead: fewer indexes to maintain during email ingestion, updates, and deletion.
 - Lower database I/O and WAL generation, reducing replication work.
 - Less index-maintenance work and reduced competition for database cache.
 - Smaller backups and replicas once the indexes are removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dropping indexes is reversible only by recreating them; if usage monitoring missed a rare query, those reads could regress until a replacement index is added.
> 
> **Overview**
> Removes six PostgreSQL indexes on email tables that were identified as unused (Datadog + direct Postgres validation). Each change is a separate migration using **`DROP INDEX CONCURRENTLY`** with **`-- no-transaction`**, matching the repo’s existing pattern for online index drops without blocking writes.
> 
> **Dropped indexes:** `idx_email_messages_thread_id_internal_date_ts`, `idx_email_messages_latest_content`, `idx_email_sfs_mappings_destination`, `idx_email_messages_link_thread_date`, `idx_email_messages_thread_date_not_draft`, and `idx_email_threads_non_spam_ts_id` on `email_messages`, `email_sfs_mappings`, and `email_threads`.
> 
> The intent is to cut index maintenance on email write paths; read queries that secretly relied on one of these would fall back to other plans and could get slower.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe64e58e7c63cf95c98de7883abc89366d091a82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->