### PR TITLE
Refactor inbox selector to single-select with sidebar and menu variants

### DIFF
--- a/apps/web/src/components/app/split-panel/SplitPanel.tsx
+++ b/apps/web/src/components/app/split-panel/SplitPanel.tsx
@@ -2,7 +2,7 @@ import { TOKENS } from '@core/hotkey/tokens';
 import CaretLeftIcon from '@phosphor/caret-left.svg';
 import CaretRightIcon from '@phosphor/caret-right.svg';
 import CloseIcon from '@phosphor/x.svg';
-import { Button, type ButtonProps, cn } from '@ui';
+import { Button, type ButtonProps, cn, pressHandlers } from '@ui';
 import {
   createContext,
   type JSX,
@@ -153,7 +153,10 @@ function ControlGroup(props: JSX.HTMLAttributes<HTMLDivElement>) {
   );
 }
 
-type SplitControlButtonProps = Omit<ButtonProps, 'children' | 'onClick'> & {
+type SplitControlButtonProps = Omit<
+  ButtonProps,
+  'children' | 'onClick' | 'onMouseDown'
+> & {
   children?: JSX.Element;
 };
 
@@ -182,14 +185,14 @@ function BackButton(props: SplitControlButtonProps) {
       square={local.square ?? true}
       class={cn(
         !local.size && 'p-1',
-        'rounded-lg touch:active:bg-transparent',
+        'rounded-lg transition-none touch:active:bg-transparent',
         local.class
       )}
       aria-label={local['aria-label']}
       label={label()}
       hotkey={local.hotkey ?? TOKENS.split.go.back}
       disabled={Boolean(local.disabled) || !controller.canGoBack()}
-      onClick={() => controller.goBack()}
+      {...pressHandlers(() => controller.goBack())}
     >
       {local.children ?? <CaretLeftIcon />}
     </Button>
@@ -221,14 +224,14 @@ function ForwardButton(props: SplitControlButtonProps) {
       square={local.square ?? true}
       class={cn(
         !local.size && 'p-1',
-        'rounded-lg touch:active:bg-transparent',
+        'rounded-lg transition-none touch:active:bg-transparent',
         local.class
       )}
       aria-label={local['aria-label']}
       label={label()}
       hotkey={local.hotkey ?? TOKENS.split.go.forward}
       disabled={Boolean(local.disabled) || !controller.canGoForward()}
-      onClick={() => controller.goForward()}
+      {...pressHandlers(() => controller.goForward())}
     >
       {local.children ?? <CaretRightIcon />}
     </Button>
@@ -259,12 +262,12 @@ function CloseButton(props: SplitControlButtonProps) {
         variant={local.variant}
         size={local.size ?? 'sm'}
         square={local.square ?? true}
-        class={cn('rounded-lg', local.class)}
+        class={cn('rounded-lg transition-none', local.class)}
         aria-label={local['aria-label']}
         label={label()}
         hotkey={local.hotkey ?? TOKENS.split.close}
         disabled={Boolean(local.disabled)}
-        onClick={() => controller.close()}
+        {...pressHandlers(() => controller.close())}
       >
         {local.children ?? <CloseIcon />}
       </Button>

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -137,5 +137,6 @@ export {
   PALETTE_COLORS,
   type PaletteColor,
 } from './utils/palette';
+export { pressHandlers } from './utils/press';
 export type { VariantProps } from './utils/variants';
 export { createVariants } from './utils/variants';

--- a/apps/web/src/components/ui/utils/press.ts
+++ b/apps/web/src/components/ui/utils/press.ts
@@ -1,0 +1,25 @@
+/**
+ * Handlers for a control that acts on press rather than release: `activate`
+ * runs on primary-button mousedown, so the result lands the instant the button
+ * goes down. The click that follows is a no-op, but a click with no preceding
+ * mousedown still activates: keyboard activation (`detail` is 0 for those), or
+ * a trackpad tap whose mousedown never reached us. Spread onto a button.
+ */
+export function pressHandlers(activate: (event: MouseEvent) => void) {
+  let pressHandled = false;
+
+  return {
+    onMouseDown: (event: MouseEvent) => {
+      if (event.button !== 0) return;
+      pressHandled = true;
+      activate(event);
+    },
+    onClick: (event: MouseEvent) => {
+      const handled = pressHandled;
+      pressHandled = false;
+      if (event.button !== 0) return;
+      if (handled && event.detail !== 0) return;
+      activate(event);
+    },
+  };
+}

--- a/apps/web/src/components/view-shell/ViewSidebar.tsx
+++ b/apps/web/src/components/view-shell/ViewSidebar.tsx
@@ -90,7 +90,7 @@ function Item(props: NavRowProps) {
       active={local.active}
       aria-current={ariaCurrent()}
       class={cn(
-        'h-9 gap-2.5 rounded-xl px-3 py-2 text-sm font-medium text-ink-muted not-disabled:hover:bg-hover not-disabled:hover:text-ink',
+        'h-9 gap-2.5 rounded-xl px-3 py-2 text-sm font-medium text-ink-muted transition-none not-disabled:hover:bg-hover not-disabled:hover:text-ink',
         local.active && 'bg-active text-ink not-disabled:hover:bg-active',
         local.class
       )}

--- a/apps/web/src/features/email-view/components/EmailFilterDrawer.tsx
+++ b/apps/web/src/features/email-view/components/EmailFilterDrawer.tsx
@@ -4,7 +4,9 @@ import { Accordion } from '@kobalte/core/accordion';
 import { batch, For } from 'solid-js';
 import { useEmailView } from '../email-view-context';
 import { useEmailFilters } from '../filters/use-email-filters';
-import { EmailInboxSelector } from './EmailInboxSelector';
+import { EmailInboxDrawerSection } from './EmailInboxSelector';
+
+const INBOX_SECTION_ID = 'inbox';
 
 export function EmailFilterDrawer() {
   const { state, setInboxIds } = useEmailView();
@@ -25,11 +27,13 @@ export function EmailFilterDrawer() {
       }
     >
       <MobileDrawer.Label class="pt-4">Filters</MobileDrawer.Label>
-      <div class="px-3 pb-3 empty:hidden">
-        <EmailInboxSelector />
-      </div>
-      <Accordion multiple collapsible defaultValue={[filters.groups[0].id]}>
+      <Accordion
+        multiple
+        collapsible
+        defaultValue={[INBOX_SECTION_ID, filters.groups[0].id]}
+      >
         <div class="flex flex-col gap-3">
+          <EmailInboxDrawerSection value={INBOX_SECTION_ID} />
           <For each={filters.groups}>
             {(group) => (
               <MobileFilterDrawer.Section

--- a/apps/web/src/features/email-view/components/EmailHeader.tsx
+++ b/apps/web/src/features/email-view/components/EmailHeader.tsx
@@ -3,7 +3,7 @@ import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { SplitPanel } from '@components/app/split-panel';
 import MenuIcon from '@phosphor/list.svg';
 import PlusIcon from '@phosphor/plus.svg';
-import { Button, Dropdown } from '@ui';
+import { Button, Dropdown, pressHandlers } from '@ui';
 import { createSignal } from 'solid-js';
 import { composeEmail } from '../compose-email';
 import { useEmailView } from '../email-view-context';
@@ -84,8 +84,8 @@ export function EmailHeader(props: EmailHeaderProps) {
             type="button"
             variant="cta"
             size="md"
-            class="rounded-lg px-3"
-            onClick={composeEmail}
+            class="rounded-lg px-3 transition-none"
+            {...pressHandlers(() => composeEmail())}
           >
             <PlusIcon class="size-4 shrink-0" />
             New

--- a/apps/web/src/features/email-view/components/EmailHeader.tsx
+++ b/apps/web/src/features/email-view/components/EmailHeader.tsx
@@ -8,7 +8,7 @@ import { createSignal } from 'solid-js';
 import { composeEmail } from '../compose-email';
 import { useEmailView } from '../email-view-context';
 import { EmailControls } from './EmailControls';
-import { EmailInboxSelector } from './EmailInboxSelector';
+import { EmailInboxMenu } from './EmailInboxSelector';
 import { EmailNavigation } from './EmailSidebar';
 
 export type EmailHeaderProps = {
@@ -79,7 +79,7 @@ export function EmailHeader(props: EmailHeaderProps) {
           Email
         </h1>
         <div class="ml-auto flex shrink-0 items-center gap-2">
-          <EmailInboxSelector variant="compact" />
+          <EmailInboxMenu />
           <Button
             type="button"
             variant="cta"

--- a/apps/web/src/features/email-view/components/EmailInboxSelector.tsx
+++ b/apps/web/src/features/email-view/components/EmailInboxSelector.tsx
@@ -8,7 +8,7 @@ import CheckIcon from '@phosphor/check.svg';
 import PlusIcon from '@phosphor/plus.svg';
 import TrayIcon from '@phosphor/tray.svg';
 import { useEmailLinksQuery } from '@queries/email/link';
-import { Button, cn, Dropdown } from '@ui';
+import { Button, cn, Dropdown, pressHandlers } from '@ui';
 import { createMemo, For, type JSX, Show } from 'solid-js';
 import { useEmailView } from '../email-view-context';
 
@@ -117,8 +117,8 @@ export function EmailInboxList(props: { class?: string }) {
           <ViewSidebar.Item
             active={selection.isAll()}
             aria-current={selection.isAll() ? 'true' : undefined}
-            onClick={selection.selectAll}
             class="min-w-0 flex-1"
+            {...pressHandlers(selection.selectAll)}
           >
             <AllInboxesIcon />
             <span class="truncate">All inboxes</span>
@@ -129,9 +129,9 @@ export function EmailInboxList(props: { class?: string }) {
               variant="ghost"
               size="sm"
               square
-              class="size-8 shrink-0 rounded-full text-ink-muted"
+              class="size-8 shrink-0 rounded-full text-ink-muted transition-none"
               label="Connect another account"
-              onClick={selection.addInbox}
+              {...pressHandlers(selection.addInbox)}
             >
               <PlusIcon class="size-4" />
             </Button>
@@ -144,7 +144,7 @@ export function EmailInboxList(props: { class?: string }) {
               aria-current={
                 selection.isSelected(option.id) ? 'true' : undefined
               }
-              onClick={() => selection.select(option.id)}
+              {...pressHandlers(() => selection.select(option.id))}
             >
               <span
                 aria-hidden="true"

--- a/apps/web/src/features/email-view/components/EmailInboxSelector.tsx
+++ b/apps/web/src/features/email-view/components/EmailInboxSelector.tsx
@@ -1,112 +1,300 @@
-import { useInboxPicker } from '@app/features/next-soup/soup-view/filters-bar/inbox-picker';
-import { SearchableMultiSelect } from '@app/features/next-soup/soup-view/filters-bar/searchable-multi-select';
+import { MobileFilterDrawer, ViewSidebar } from '@app/components/view-shell';
 import { useFeatureFlag } from '@app/lib/analytics/posthog';
+import { inboxIconProps } from '@core/component/inboxIcon';
+import { UserIcon, type UserIconSize } from '@core/component/UserIcon';
 import { enableMultiInbox } from '@core/constant/featureFlags';
 import { useAddInboxFlow } from '@core/email-link';
-import { Combobox } from '@kobalte/core/combobox';
-import CaretDownIcon from '@phosphor/caret-down.svg';
+import CheckIcon from '@phosphor/check.svg';
 import PlusIcon from '@phosphor/plus.svg';
 import TrayIcon from '@phosphor/tray.svg';
-import { Button, cn } from '@ui';
-import { Show } from 'solid-js';
+import { useEmailLinksQuery } from '@queries/email/link';
+import { Button, cn, Dropdown } from '@ui';
+import { createMemo, For, type JSX, Show } from 'solid-js';
 import { useEmailView } from '../email-view-context';
 
-export type EmailInboxSelectorProps = {
-  /**
-   * `sidebar` is the full-width row at the top of the Email sidebar;
-   * `compact` is the icon-only trigger the narrow header falls back to when
-   * the sidebar is collapsed.
-   */
-  variant?: 'sidebar' | 'compact';
-  class?: string;
-};
+const ALL_INBOXES_ID = 'all';
+
+type InboxOption = { id: string; label: string; photoUrl?: string };
 
 /**
- * Scopes the list to a subset of the user's linked inboxes. Multi-select,
- * default = all. Shown whenever the multi-inbox flag is on (or the user
- * already has multiple inboxes); with a single inbox it names the account
- * and offers "Connect another account" inside the menu.
+ * Single-select over the user's linked inboxes: one inbox, or all of them.
+ * `undefined` in view state means all; a chosen inbox is stored as `[id]`.
+ * A stale multi-id selection persisted by the old picker still filters the
+ * list, and every included inbox reads as selected until the user picks one.
  */
-export function EmailInboxSelector(props: EmailInboxSelectorProps) {
+function useInboxSelection() {
   const { state, setInboxIds } = useEmailView();
-  const picker = useInboxPicker({
-    selectedIds: () => state.inboxIds,
-    setSelectedIds: setInboxIds,
-  });
+  const linksQuery = useEmailLinksQuery();
   const multiInboxFlag = useFeatureFlag(enableMultiInbox);
   const addInbox = useAddInboxFlow();
 
-  const soleActiveInbox = () => {
-    const ids = picker.activeIds();
-    if (ids.length !== 1) return undefined;
+  const options = createMemo((): InboxOption[] =>
+    (linksQuery.isSuccess ? linksQuery.data.links : [])
+      .map((link) => ({
+        id: link.id,
+        label: link.email_address,
+        photoUrl: link.photo_url ?? undefined,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  );
 
-    return picker.options().find((option) => option.id === ids[0]);
-  };
-
-  const label = () => {
-    const sole = soleActiveInbox();
-    if (sole) return sole.label;
-
+  const isAll = () => state.inboxIds === undefined;
+  const isSelected = (id: string) => state.inboxIds?.includes(id) ?? false;
+  const selectedId = () => {
     const ids = state.inboxIds;
-    if (ids === undefined) return 'All inboxes';
-    if (ids.length === 0) return 'No inboxes';
-    // A lone id that no longer resolves to a linked inbox still reads as one.
-    if (ids.length === 1) return '1 inbox';
-    return `${ids.length} inboxes`;
+    return ids?.length === 1 ? ids[0] : undefined;
+  };
+  const selectedOption = () => {
+    const id = selectedId();
+    return id === undefined
+      ? undefined
+      : options().find((option) => option.id === id);
   };
 
-  const compact = () => props.variant === 'compact';
+  return {
+    options,
+    /** Shown whenever the flag is on or the user already has several inboxes. */
+    visible: () => multiInboxFlag().enabled || options().length > 1,
+    canAddInbox: () => multiInboxFlag().enabled,
+    addInbox: () => void addInbox(),
+    isAll,
+    isSelected,
+    selectedOption,
+    selectAll: () => setInboxIds(undefined),
+    select: (id: string) => setInboxIds([id]),
+    label: () => {
+      const sole = selectedOption();
+      if (sole) return sole.label;
+      if (isAll()) return 'All inboxes';
+      const count = state.inboxIds?.length ?? 0;
+      if (count === 0) return 'No inboxes';
+      return count === 1 ? '1 inbox' : `${count} inboxes`;
+    },
+  };
+}
+
+function InboxAvatar(props: { option: InboxOption; size: UserIconSize }) {
+  return (
+    <UserIcon
+      {...inboxIconProps(props.option.label)}
+      photoUrl={props.option.photoUrl}
+      size={props.size}
+      suppressClick
+      showTooltip={false}
+    />
+  );
+}
+
+function AllInboxesIcon(props: { class?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      class={cn(
+        'flex size-6 shrink-0 items-center justify-center',
+        props.class
+      )}
+    >
+      <TrayIcon class="size-5" />
+    </span>
+  );
+}
+
+/**
+ * The inbox list at the top of the Email sidebar: `All inboxes` (with a
+ * `Connect another account` button beside it) followed by one row per inbox.
+ * Clicking a row selects that inbox alone; there is no multi-select.
+ */
+export function EmailInboxList(props: { class?: string }) {
+  const selection = useInboxSelection();
 
   return (
-    <Show when={multiInboxFlag().enabled || picker.hasMultiple()}>
-      <SearchableMultiSelect
-        options={picker.options}
-        activeIds={picker.activeIds}
-        onChange={(ids) => (ids.length ? picker.onChange(ids) : picker.reset())}
-        onOnly={picker.selectOnly}
-        placeholder="Search inboxes..."
-        placement="bottom-start"
-        preserveOrder
-        action={
-          multiInboxFlag().enabled
-            ? {
-                label: 'Connect another account',
-                icon: () => <PlusIcon class="size-4" />,
-                onSelect: () => void addInbox(),
-              }
-            : undefined
-        }
+    <Show when={selection.visible()}>
+      <ViewSidebar.Nav
+        aria-label="Inboxes"
+        class={cn('border-b border-edge pb-3', props.class)}
       >
-        <Combobox.Trigger
-          as={Button}
-          variant={compact() ? 'ghost' : 'outline'}
-          size={compact() ? 'sm' : 'md'}
-          square={compact()}
-          depth={2}
-          aria-label={`Inbox: ${label()}`}
-          tooltip={compact() ? label() : undefined}
-          class={cn(
-            compact()
-              ? 'size-8 shrink-0 rounded-full'
-              : 'h-9 w-full min-w-0 justify-start gap-2.5 rounded-xl bg-surface px-3 font-medium',
-            props.class
+        <div class="flex min-w-0 items-center gap-1">
+          <ViewSidebar.Item
+            active={selection.isAll()}
+            aria-current={selection.isAll() ? 'true' : undefined}
+            onClick={selection.selectAll}
+            class="min-w-0 flex-1"
+          >
+            <AllInboxesIcon />
+            <span class="truncate">All inboxes</span>
+          </ViewSidebar.Item>
+          <Show when={selection.canAddInbox()}>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              square
+              class="size-8 shrink-0 rounded-full text-ink-muted"
+              label="Connect another account"
+              onClick={selection.addInbox}
+            >
+              <PlusIcon class="size-4" />
+            </Button>
+          </Show>
+        </div>
+        <For each={selection.options()}>
+          {(option) => (
+            <ViewSidebar.Item
+              active={selection.isSelected(option.id)}
+              aria-current={
+                selection.isSelected(option.id) ? 'true' : undefined
+              }
+              onClick={() => selection.select(option.id)}
+            >
+              <span
+                aria-hidden="true"
+                class="flex size-6 shrink-0 items-center"
+              >
+                <InboxAvatar option={option} size="md" />
+              </span>
+              <span class="truncate">{option.label}</span>
+            </ViewSidebar.Item>
           )}
+        </For>
+      </ViewSidebar.Nav>
+    </Show>
+  );
+}
+
+/**
+ * Icon-only trigger the narrow header falls back to while the sidebar is
+ * collapsed; opens the same single-select list as a menu.
+ */
+export function EmailInboxMenu(props: { class?: string }) {
+  const selection = useInboxSelection();
+
+  const radioValue = () => {
+    if (selection.isAll()) return ALL_INBOXES_ID;
+    return selection.selectedOption()?.id ?? '';
+  };
+
+  const onRadioChange = (value: string) => {
+    if (value === ALL_INBOXES_ID) selection.selectAll();
+    else selection.select(value);
+  };
+
+  return (
+    <Show when={selection.visible()}>
+      <Dropdown placement="bottom-end">
+        <Dropdown.Trigger
+          variant="ghost"
+          size="sm"
+          square
+          depth={2}
+          aria-label={`Inbox: ${selection.label()}`}
+          tooltip={selection.label()}
+          class={cn('size-8 shrink-0 rounded-full', props.class)}
         >
           <Show
-            when={soleActiveInbox()?.icon}
+            when={selection.selectedOption()}
             fallback={<TrayIcon aria-hidden="true" class="size-4 shrink-0" />}
           >
-            {(icon) => icon()()}
+            {(option) => <InboxAvatar option={option()} size="sm" />}
           </Show>
-          <Show when={!compact()}>
-            <span class="min-w-0 flex-1 truncate text-left">{label()}</span>
-            <CaretDownIcon
-              aria-hidden="true"
-              class="size-3 shrink-0 text-ink-extra-muted"
-            />
+        </Dropdown.Trigger>
+        <Dropdown.Content class="min-w-56">
+          <Dropdown.Group>
+            <Dropdown.RadioGroup value={radioValue()} onChange={onRadioChange}>
+              <InboxRadioItem
+                value={ALL_INBOXES_ID}
+                icon={<TrayIcon class="size-4" />}
+              >
+                All inboxes
+              </InboxRadioItem>
+              <For each={selection.options()}>
+                {(option) => (
+                  <InboxRadioItem
+                    value={option.id}
+                    icon={<InboxAvatar option={option} size="sm" />}
+                  >
+                    {option.label}
+                  </InboxRadioItem>
+                )}
+              </For>
+            </Dropdown.RadioGroup>
+          </Dropdown.Group>
+          <Show when={selection.canAddInbox()}>
+            <Dropdown.Group>
+              <Dropdown.Item closeOnSelect onSelect={selection.addInbox}>
+                <span
+                  aria-hidden="true"
+                  class="flex size-4 shrink-0 items-center justify-center"
+                >
+                  <PlusIcon class="size-4" />
+                </span>
+                <span class="flex-1">Connect another account</span>
+              </Dropdown.Item>
+            </Dropdown.Group>
           </Show>
-        </Combobox.Trigger>
-      </SearchableMultiSelect>
+        </Dropdown.Content>
+      </Dropdown>
+    </Show>
+  );
+}
+
+function InboxRadioItem(props: {
+  value: string;
+  icon?: JSX.Element;
+  children: JSX.Element;
+}) {
+  return (
+    <Dropdown.RadioItem closeOnSelect value={props.value}>
+      <span
+        aria-hidden="true"
+        class="flex size-4 shrink-0 items-center justify-center [&_svg]:size-4"
+      >
+        {props.icon}
+      </span>
+      <span class="min-w-0 flex-1 truncate">{props.children}</span>
+      <Dropdown.ItemIndicator>
+        <CheckIcon class="size-3.5 text-accent" />
+      </Dropdown.ItemIndicator>
+    </Dropdown.RadioItem>
+  );
+}
+
+/**
+ * Inbox section of the mobile filter drawer; must render inside the drawer's
+ * `Accordion`. Radio semantics match the sidebar list: one inbox or all.
+ */
+export function EmailInboxDrawerSection(props: { value: string }) {
+  const selection = useInboxSelection();
+
+  return (
+    <Show when={selection.visible()}>
+      <MobileFilterDrawer.Section
+        value={props.value}
+        label="Inbox"
+        activeCount={selection.isAll() ? 0 : 1}
+      >
+        <div role="radiogroup" aria-label="Inbox">
+          <MobileFilterDrawer.Option
+            selectionMode="single"
+            checked={selection.isAll()}
+            onChange={selection.selectAll}
+            icon={<TrayIcon class="size-4" />}
+          >
+            All inboxes
+          </MobileFilterDrawer.Option>
+          <For each={selection.options()}>
+            {(option) => (
+              <MobileFilterDrawer.Option
+                selectionMode="single"
+                checked={selection.isSelected(option.id)}
+                onChange={() => selection.select(option.id)}
+                icon={<InboxAvatar option={option} size="sm" />}
+              >
+                {option.label}
+              </MobileFilterDrawer.Option>
+            )}
+          </For>
+        </div>
+      </MobileFilterDrawer.Section>
     </Show>
   );
 }

--- a/apps/web/src/features/email-view/components/EmailSidebar.tsx
+++ b/apps/web/src/features/email-view/components/EmailSidebar.tsx
@@ -9,7 +9,7 @@ import FileIcon from '@phosphor/file.svg';
 import PaperPlaneTiltIcon from '@phosphor/paper-plane-tilt.svg';
 import PlusIcon from '@phosphor/plus.svg';
 import UsersThreeIcon from '@phosphor/users-three.svg';
-import { Button } from '@ui';
+import { Button, pressHandlers } from '@ui';
 import { type Component, For } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
 import { composeEmail } from '../compose-email';
@@ -34,10 +34,10 @@ function Tab(props: { item: EmailTabItem; onNavigate?: () => void }) {
   return (
     <ViewSidebar.Item
       active={state.tab === props.item.id}
-      onClick={() => {
+      {...pressHandlers(() => {
         setTab(props.item.id);
         props.onNavigate?.();
-      }}
+      })}
     >
       <span aria-hidden="true" class="flex size-4 shrink-0 items-center">
         <Dynamic component={TAB_ICONS[props.item.id]} class="size-4" />
@@ -86,8 +86,8 @@ export function EmailSidebar() {
           type="button"
           variant="cta"
           size="md"
-          class="rounded-lg px-3"
-          onClick={composeEmail}
+          class="rounded-lg px-3 transition-none"
+          {...pressHandlers(() => composeEmail())}
         >
           <PlusIcon class="size-4 shrink-0" />
           New

--- a/apps/web/src/features/email-view/components/EmailSidebar.tsx
+++ b/apps/web/src/features/email-view/components/EmailSidebar.tsx
@@ -16,7 +16,7 @@ import { composeEmail } from '../compose-email';
 import { EMAIL_TAB_IDS, EMAIL_TABS, type EmailTabItem } from '../constants';
 import { useEmailView } from '../email-view-context';
 import type { EmailTab } from '../types';
-import { EmailInboxSelector } from './EmailInboxSelector';
+import { EmailInboxList } from './EmailInboxSelector';
 
 const TAB_ICONS: Record<EmailTab, Component<{ class?: string }>> = {
   important: AnimatedSignalIcon,
@@ -95,7 +95,7 @@ export function EmailSidebar() {
       </ViewSidebar.Header>
 
       <ViewSidebar.Content class="flex flex-col gap-3 pt-1">
-        <EmailInboxSelector variant="sidebar" />
+        <EmailInboxList />
         <EmailNavigation />
       </ViewSidebar.Content>
     </ViewSidebar.Root>

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -92,7 +92,10 @@ section when the user can pick one: `All inboxes` or a single address, never sev
 `Clear all` resets those filters and the inbox selection. Desktop keeps its sidebar,
 search field, filter menu and preview control. The sidebar lists the inboxes above the
 tabs as plain rows; clicking one shows only that inbox, and the `+` beside
-`All inboxes` (`Connect another account`) starts the add-inbox flow.
+`All inboxes` (`Connect another account`) starts the add-inbox flow. Sidebar rows,
+`New`, and the panel's back, forward and close controls act on primary-button
+mousedown, so the selection changes before the click completes; a normal click
+still works.
 
 ## Search
 

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -87,10 +87,12 @@ With the new app views enabled, mobile and tablet Email use a floating, horizont
 scrolling row of those tabs, with `Open email filters` at the left. The rest of the
 view is the email list, which scrolls beneath the header and supports pull to refresh
 and swiping left to mark emails done in Signal and Noise. The filter button opens a
-bottom drawer for status, done, attachment and calendar filters, plus the inbox
-selector when available. `Clear all`
-resets those filters and the inbox selection. Desktop keeps its sidebar, search field,
-filter menu and preview control.
+bottom drawer for status, done, attachment and calendar filters, plus an `Inbox`
+section when the user can pick one: `All inboxes` or a single address, never several.
+`Clear all` resets those filters and the inbox selection. Desktop keeps its sidebar,
+search field, filter menu and preview control. The sidebar lists the inboxes above the
+tabs as plain rows; clicking one shows only that inbox, and the `+` beside
+`All inboxes` (`Connect another account`) starts the add-inbox flow.
 
 ## Search
 


### PR DESCRIPTION
## Summary

Refactors the email inbox selector from a multi-select component to a single-select interface with three variants: a sidebar list, a compact menu dropdown, and a mobile filter drawer section. The new implementation simplifies inbox selection to "all inboxes" or a single inbox, removing the previous multi-select behavior while maintaining backward compatibility with stale multi-id selections.

## Key Changes

- **Replaced multi-select with single-select logic**: Inbox selection now supports either all inboxes (`undefined`) or a single inbox ID, simplifying the mental model and UI
- **Split into three export functions**:
  - `EmailInboxList`: Full-width sidebar navigation showing all inboxes as plain rows
  - `EmailInboxMenu`: Icon-only dropdown trigger for collapsed header state
  - `EmailInboxDrawerSection`: Mobile filter drawer integration with radio semantics
- **Extracted `useInboxSelection` hook**: Centralizes selection state, options fetching, and computed properties (label, visibility, selected option)
- **Added avatar components**: `InboxAvatar` renders user icons with email-based fallbacks; `AllInboxesIcon` shows a tray icon for the all-inboxes option
- **Updated imports**: Replaced `SearchableMultiSelect` and `useInboxPicker` with `Dropdown`, `MobileFilterDrawer`, `ViewSidebar`, and direct `useEmailLinksQuery`
- **Updated consumers**: `EmailHeader.tsx` and `EmailSidebar.tsx` now import and use the appropriate variant (`EmailInboxMenu` and `EmailInboxList`)
- **Updated mobile drawer**: `EmailFilterDrawer.tsx` now includes `EmailInboxDrawerSection` inside the accordion with other filters
- **Updated documentation**: `docs/AGENT_GUIDE/surfaces.md` clarifies that the inbox section is single-select and describes the sidebar layout

## Implementation Details

- Stale multi-id selections from the old picker are still filtered by the list but display as selected until the user picks a single inbox
- The "Connect another account" action is conditionally shown only when the multi-inbox feature flag is enabled
- Inbox options are sorted alphabetically by email address and fetched via `useEmailLinksQuery`
- All three variants share the same selection logic through the `useInboxSelection` hook, ensuring consistent behavior across responsive breakpoints

https://claude.ai/code/session_01D6Fpr47R3vBSs29M7dLW9N

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Inbox selection semantics change from multi-select to one-or-all, which alters how users scope the mail list; press-on-mousedown is a broad interaction change across email and split-panel controls.
> 
> **Overview**
> Replaces the email **multi-inbox** combobox with **single-select** behavior: **all inboxes** (`undefined`) or **one** linked account (`[id]`). The UI is split into **`EmailInboxList`** (sidebar rows + connect `+`), **`EmailInboxMenu`** (collapsed-header dropdown with radio items), and **`EmailInboxDrawerSection`** (mobile filter accordion). Legacy multi-id selections still filter until the user picks a single inbox.
> 
> Introduces shared **`pressHandlers`** (exported from `@ui`) so primary actions run on **mousedown** while keyboard and odd click paths still work. Wired into split-panel navigation, email **New**, sidebar tabs, and inbox rows; related controls add **`transition-none`** to avoid hover/press animation lag.
> 
> Agent guide **surfaces.md** documents the new inbox section and press-to-activate controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efc2d2743fa4a7b3f4ca9857607e67e1bcade161. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->