### PR TITLE
fix(new-layout): various bug fixes and ui/ux improvements

### DIFF
--- a/apps/web/src/components/view-shell/ViewShell.tsx
+++ b/apps/web/src/components/view-shell/ViewShell.tsx
@@ -58,8 +58,6 @@ export type ViewShellLayout = {
 
 type ViewShellInternal = ViewShellLayout & { id: string };
 
-const RESIZE_GUTTER = 8;
-
 const ViewShellContext = createContext<ViewShellInternal>();
 
 function useViewShellInternal(): ViewShellInternal {
@@ -195,12 +193,7 @@ function Root(props: ViewShellRootProps) {
     if (currentWidth === undefined) return false;
 
     const asideMin = asideMode() === 'docked' ? asideLayout().min : 0;
-    const panelCount = asideMode() === 'docked' ? 3 : 2;
-    const minimumWidth =
-      asideMin +
-      mainLayout().min +
-      detailLayout().min +
-      (panelCount - 1) * RESIZE_GUTTER;
+    const minimumWidth = asideMin + mainLayout().min + detailLayout().min;
     return currentWidth >= minimumWidth;
   };
 
@@ -252,11 +245,7 @@ function Root(props: ViewShellRootProps) {
         data-view-shell=""
         data-view-shell-layout={atLayoutBreakpoint() ? layoutKey() : undefined}
       >
-        <Resize.Zone
-          direction="horizontal"
-          gutter={RESIZE_GUTTER}
-          resizable={resizable()}
-        >
+        <Resize.Zone direction="horizontal" resizable={resizable()}>
           {local.children}
         </Resize.Zone>
       </div>
@@ -295,9 +284,7 @@ function Aside(props: ViewShellAsideProps) {
     }
 
     const availableForAside =
-      shellWidth -
-      RESIZE_GUTTER -
-      Math.max(mainLayout.preferredWidth, mainLayout.min);
+      shellWidth - Math.max(mainLayout.preferredWidth, mainLayout.min);
 
     return Math.min(layout.width, Math.max(layout.min, availableForAside));
   };

--- a/apps/web/src/components/view-shell/ViewSidebar.tsx
+++ b/apps/web/src/components/view-shell/ViewSidebar.tsx
@@ -8,7 +8,7 @@ function Root(props: JSX.HTMLAttributes<HTMLElement>) {
     <aside
       {...rest}
       class={cn(
-        'flex size-full min-h-0 min-w-0 flex-col border-r border-edge px-4 pb-5 pt-4',
+        'flex size-full min-h-0 min-w-0 flex-col border-r border-edge',
         local.class
       )}
       data-view-sidebar=""
@@ -24,7 +24,7 @@ function Header(props: JSX.HTMLAttributes<HTMLDivElement>) {
     <div
       {...rest}
       class={cn(
-        'flex min-w-0 shrink-0 items-center justify-between gap-3',
+        'flex min-w-0 shrink-0 items-center justify-between gap-3 border-b border-edge px-4 py-3',
         local.class
       )}
       data-view-sidebar-header=""
@@ -40,7 +40,7 @@ function Title(props: JSX.HTMLAttributes<HTMLHeadingElement>) {
     <h1
       {...rest}
       class={cn(
-        'min-w-0 truncate text-2xl font-semibold tracking-[-0.03em] text-ink',
+        'min-w-0 truncate text-sm font-semibold tracking-[-0.03em] text-ink',
         local.class
       )}
     >
@@ -54,7 +54,7 @@ function Content(props: JSX.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
       {...rest}
-      class={cn('min-h-0 min-w-0 flex-1 overflow-auto', local.class)}
+      class={cn('min-h-0 min-w-0 flex-1 overflow-auto px-4 pb-5', local.class)}
       data-view-sidebar-content=""
     >
       {local.children}

--- a/apps/web/src/features/channels-view/channels-view.tsx
+++ b/apps/web/src/features/channels-view/channels-view.tsx
@@ -1,4 +1,5 @@
 import { ViewShell } from '@app/components/view-shell';
+import { MaybeSoupEntityActionDrawerManager } from '@app/features/soup';
 import { createSizeBreakpoints } from '@app/util/create-size-breakpoints';
 import { useGlobalBlockOrchestrator } from '@components/app/GlobalAppState';
 import { PreviewPanel } from '@components/app/PreviewPanel';
@@ -168,22 +169,24 @@ function ChannelsViewRoot() {
                 </div>
               }
             >
-              <Suspense
-                fallback={
-                  <div class="grid size-full place-items-center text-ink-muted">
-                    <SpinnerIcon
-                      aria-label="Loading channels"
-                      class="size-5 animate-spin"
-                    />
-                  </div>
-                }
-              >
-                <ChannelsMobileView
-                  source={sources[state.mobileTab]}
-                  tab={state.mobileTab}
-                  onTabChange={setMobileTab}
-                />
-              </Suspense>
+              <MaybeSoupEntityActionDrawerManager>
+                <Suspense
+                  fallback={
+                    <div class="grid size-full place-items-center text-ink-muted">
+                      <SpinnerIcon
+                        aria-label="Loading channels"
+                        class="size-5 animate-spin"
+                      />
+                    </div>
+                  }
+                >
+                  <ChannelsMobileView
+                    source={sources[state.mobileTab]}
+                    tab={state.mobileTab}
+                    onTabChange={setMobileTab}
+                  />
+                </Suspense>
+              </MaybeSoupEntityActionDrawerManager>
             </Show>
           </SplitPanel.Body>
         </SplitPanel.Root>

--- a/apps/web/src/features/channels-view/components/ChannelsMobileView.tsx
+++ b/apps/web/src/features/channels-view/components/ChannelsMobileView.tsx
@@ -1,7 +1,11 @@
+import { createListController } from '@app/components/list';
+import { toEntityActionListState } from '@app/features/next-soup/actions';
 import { openEntityInSplitFromUnifiedList } from '@app/features/next-soup/utils';
+import { SoupEntityContextMenu } from '@app/features/soup';
 import { DEBUG_SETTING_KEYS, useDebugSetting } from '@app/lib/debugSettings';
 import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
 import { type PillTabItem, PillTabs } from '@components/app/mobile/PillTabs';
+import { PullToRefresh } from '@components/app/mobile/PullToRefresh';
 import { SplitHeaderLeft } from '@components/app/split-layout/components/SplitHeader';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { useUserId } from '@core/context/user';
@@ -24,7 +28,10 @@ import type { ChannelsDataSource } from '../queries';
 import type { ChannelsQueryScope } from '../types';
 import { channelMentionsUser } from '../utils';
 import { ChannelsEmptyState } from './ChannelsEmptyState';
-import { ConversationCard } from './rail/ChannelRailItems';
+import {
+  CHANNEL_ACTION_VIEW_CONTEXT,
+  ConversationCard,
+} from './rail/ChannelRailItems';
 import { useChannelCalls } from './rail/hooks/useChannelCalls';
 import { useChannelRailActivity } from './rail/hooks/useChannelRailActivity';
 
@@ -60,6 +67,15 @@ export function ChannelsMobileView(props: {
   const channelCalls = useChannelCalls();
   const visibleChannels = createMemo(() => props.source.items());
   const channelActivity = useChannelRailActivity(visibleChannels, channelCalls);
+  const actionController = createListController({
+    items: visibleChannels,
+    getKey: (channel) => channel.id,
+    isSelectable: () => false,
+  });
+  const actionList = toEntityActionListState({
+    controller: actionController,
+    getEntity: (channel) => channel,
+  });
 
   const selectTab = (tab: ChannelsQueryScope) => {
     props.onTabChange(tab);
@@ -119,8 +135,12 @@ export function ChannelsMobileView(props: {
         role="tree"
         aria-label={`${MOBILE_CHANNEL_TABS.find((tab) => tab.value === props.tab)?.label ?? 'Channels'} conversations`}
         aria-busy={props.source.isLoadingMore()}
-        class="size-full min-h-0 overflow-hidden"
+        class="relative size-full min-h-0 overflow-hidden"
       >
+        <PullToRefresh
+          scrollContainer={viewport}
+          onRefresh={props.source.refresh}
+        />
         <div
           ref={setViewport}
           class="scrollbar-hidden size-full min-h-0 overflow-y-auto overscroll-none"
@@ -171,29 +191,48 @@ export function ChannelsMobileView(props: {
                 onScroll={checkNearEnd}
               >
                 {(channel) => (
-                  <ConversationCard
-                    id={`${listId}-channel:${channel.id}`}
-                    class="border-b border-edge-muted/50 px-(--mobile-chrome-gutter) touch:pl-6"
-                    channel={channel}
-                    showLatestMessage={props.tab === 'recents'}
-                    senderId={channel.latestRootMessage?.senderId}
-                    mentionedCurrentUser={channelMentionsUser(
-                      channel,
-                      currentUserId()
-                    )}
-                    unread={channelActivity.unreadChannelIds().has(channel.id)}
-                    muted={isMutedItem(notificationSource.mutedEntities(), {
-                      item_id: channel.id,
-                      item_type: 'channel',
-                    })}
-                    callStatus={channelActivity.callStatuses().get(channel.id)}
-                    incomingCallId={channelActivity
-                      .incomingCallIds()
-                      .get(channel.id)}
-                    selected={state.selectedChannelId === channel.id}
-                    focused={false}
-                    onActivate={() => openChannel(channel)}
-                  />
+                  <SoupEntityContextMenu
+                    entity={channel}
+                    list={actionList}
+                    selectedEntities={() => []}
+                    viewContext={CHANNEL_ACTION_VIEW_CONTEXT}
+                    class="block w-full"
+                    onOpenChange={(open) => {
+                      if (!open) return;
+                      actionController.focus.set(channel.id, {
+                        reason: 'pointer',
+                        force: true,
+                      });
+                    }}
+                  >
+                    <ConversationCard
+                      id={`${listId}-channel:${channel.id}`}
+                      class="border-b border-edge-muted/50 px-(--mobile-chrome-gutter) touch:pl-6"
+                      channel={channel}
+                      showLatestMessage={props.tab === 'recents'}
+                      senderId={channel.latestRootMessage?.senderId}
+                      mentionedCurrentUser={channelMentionsUser(
+                        channel,
+                        currentUserId()
+                      )}
+                      unread={channelActivity
+                        .unreadChannelIds()
+                        .has(channel.id)}
+                      muted={isMutedItem(notificationSource.mutedEntities(), {
+                        item_id: channel.id,
+                        item_type: 'channel',
+                      })}
+                      callStatus={channelActivity
+                        .callStatuses()
+                        .get(channel.id)}
+                      incomingCallId={channelActivity
+                        .incomingCallIds()
+                        .get(channel.id)}
+                      selected={state.selectedChannelId === channel.id}
+                      focused={false}
+                      onActivate={() => openChannel(channel)}
+                    />
+                  </SoupEntityContextMenu>
                 )}
               </Virtualizer>
               <Show when={props.source.isLoadingMore()}>

--- a/apps/web/src/features/channels-view/components/rail/ChannelRailItems.tsx
+++ b/apps/web/src/features/channels-view/components/rail/ChannelRailItems.tsx
@@ -3,19 +3,8 @@ import {
   type EntityActionViewContext,
   toEntityActionListState,
 } from '@app/features/next-soup/actions';
-import {
-  markChannelNotificationsSeenOnOpen,
-  openEntityInNewTab,
-} from '@app/features/next-soup/utils';
-import { SoupEntityActionsMenu } from '@app/features/soup/SoupEntityActionsMenu';
+import { SoupEntityContextMenu } from '@app/features/soup/SoupEntityContextMenu';
 import { joinChannelCall } from '@channel/Call/join-channel-call';
-import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
-import {
-  ContextMenuContent,
-  MenuGroup,
-  MenuItem,
-  MenuSeparator,
-} from '@core/component/ContextMenu';
 import { StaticMarkdown } from '@core/component/LexicalMarkdown/component/core/StaticMarkdown';
 import { toast } from '@core/component/Toast/Toast';
 import { useUserId } from '@core/context/user';
@@ -23,7 +12,6 @@ import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { getDisplayName, tryMacroId } from '@core/user';
 import type { MacroId } from '@core/user/macroId';
 import { type ChannelEntity, Entity } from '@entity';
-import { ContextMenu } from '@kobalte/core/context-menu';
 import ReplyIcon from '@phosphor/arrow-bend-up-left.svg';
 import AtIcon from '@phosphor/at.svg';
 import BellSlashIcon from '@phosphor/bell-slash.svg';
@@ -50,7 +38,7 @@ export type ChannelRailItemProps = {
   onActivate: () => void;
 };
 
-const CHANNEL_RAIL_ACTION_VIEW_CONTEXT: EntityActionViewContext = {
+export const CHANNEL_ACTION_VIEW_CONTEXT: EntityActionViewContext = {
   supportsMarkDone: false,
   senderBucket: undefined,
 };
@@ -62,19 +50,18 @@ export function ChannelRailItemContextMenu(
   }>
 ) {
   const rail = useChannelsRail();
-  const notificationSource = useGlobalNotificationSource();
   const actionList = toEntityActionListState({
     controller: rail.list,
     getEntity: (row) => (row.kind === 'conversation' ? row.channel : undefined),
   });
 
-  const openInNewTab = () => {
-    markChannelNotificationsSeenOnOpen(props.channel, notificationSource);
-    openEntityInNewTab({ entity: props.channel });
-  };
-
   return (
-    <ContextMenu
+    <SoupEntityContextMenu
+      entity={props.channel}
+      list={actionList}
+      selectedEntities={() => []}
+      viewContext={CHANNEL_ACTION_VIEW_CONTEXT}
+      class={props.class}
       onOpenChange={(open) => {
         if (!open) return;
 
@@ -84,23 +71,8 @@ export function ChannelRailItemContextMenu(
         });
       }}
     >
-      <ContextMenu.Trigger class={props.class}>
-        {props.children}
-      </ContextMenu.Trigger>
-      <ContextMenu.Portal>
-        <ContextMenuContent class="w-64 text-xs text-ink-muted">
-          <MenuGroup>
-            <MenuItem text="Open in new tab" onClick={openInNewTab} />
-          </MenuGroup>
-          <MenuSeparator />
-          <SoupEntityActionsMenu
-            entities={[props.channel]}
-            list={actionList}
-            viewContext={CHANNEL_RAIL_ACTION_VIEW_CONTEXT}
-          />
-        </ContextMenuContent>
-      </ContextMenu.Portal>
-    </ContextMenu>
+      {props.children}
+    </SoupEntityContextMenu>
   );
 }
 

--- a/apps/web/src/features/channels-view/components/rail/ChannelsRail.tsx
+++ b/apps/web/src/features/channels-view/components/rail/ChannelsRail.tsx
@@ -384,7 +384,7 @@ export function ChannelsRail(props: ChannelsRailProps) {
     <ChannelsRailProvider value={rail}>
       <aside
         aria-label="Chat navigation"
-        class="flex size-full min-h-0 flex-col gap-3 border-r border-edge bg-panel pt-2"
+        class="flex size-full min-h-0 flex-col gap-3 border-r border-edge bg-panel"
       >
         {props.mode === 'full' ? (
           <ExpandedChannelsRail />

--- a/apps/web/src/features/channels-view/components/rail/ChannelsRail.tsx
+++ b/apps/web/src/features/channels-view/components/rail/ChannelsRail.tsx
@@ -11,6 +11,7 @@ import {
 } from '@components/app/split-layout/layoutUtils';
 import { createHotkeyGroup, registerHotkey } from '@core/hotkey/hotkeys';
 import type { ChannelEntity } from '@entity';
+import { debounce } from '@solid-primitives/scheduled';
 import {
   createEffect,
   createMemo,
@@ -127,6 +128,13 @@ export function ChannelsRail(props: ChannelsRailProps) {
   const [virtualizers, setVirtualizers] = createSignal<
     Partial<Record<ChannelsQueryScope, VirtualizerHandle>>
   >({});
+  const previewAfterNavigation = debounce(setSelectedChannelId, 150);
+  onCleanup(() => previewAfterNavigation.clear());
+
+  const selectTab = (tab: ChannelsTab) => {
+    previewAfterNavigation.clear();
+    setTab(tab);
+  };
 
   const channelCalls = useChannelCalls();
   const channels = createMemo(() =>
@@ -156,6 +164,8 @@ export function ChannelsRail(props: ChannelsRailProps) {
           ? undefined
           : rowKeyForChannel(state.selectedChannelId),
       onActivate: ({ item }) => {
+        previewAfterNavigation.clear();
+
         if (item.kind === 'section') {
           setGroupOpen(item.group, !state.expandedGroups[item.group]);
           return;
@@ -203,7 +213,7 @@ export function ChannelsRail(props: ChannelsRailProps) {
     enabled: panel.isPanelActive,
     ids: () => CHANNEL_TAB_IDS,
     activeId: () => state.tab,
-    setActiveId: setTab,
+    setActiveId: selectTab,
   });
 
   withSplitPanelOwner(listOwnedSlotName('navigation-hotkeys'), () =>
@@ -253,10 +263,11 @@ export function ChannelsRail(props: ChannelsRailProps) {
         },
         onNavigate: (event) => {
           listRoot()?.focus({ preventScroll: true });
+          previewAfterNavigation.clear();
 
           const row = event.result?.item;
           if (row?.kind === 'conversation') {
-            setSelectedChannelId(row.channel.id);
+            previewAfterNavigation(row.channel.id);
           }
         },
       },
@@ -352,7 +363,7 @@ export function ChannelsRail(props: ChannelsRailProps) {
     railId: listDomId,
     list,
     tab: () => state.tab,
-    selectTab: setTab,
+    selectTab,
     setMode: (mode) => props.onModeChange(mode),
     sources: props.sources,
     selectedChannelId: () => state.selectedChannelId,

--- a/apps/web/src/features/channels-view/components/rail/ExpandedChannelsRail.tsx
+++ b/apps/web/src/features/channels-view/components/rail/ExpandedChannelsRail.tsx
@@ -1,3 +1,4 @@
+import { ViewSidebar } from '@app/components/view-shell';
 import { runCreateAction } from '@app/features/command/Launcher';
 import { DEBUG_SETTING_KEYS, useDebugSetting } from '@app/lib/debugSettings';
 import { openNewChannelModal } from '@channel/CreateChannelModal';
@@ -130,27 +131,27 @@ function ExpandedHeader() {
   };
 
   return (
-    <div class="flex shrink-0 flex-col gap-3 px-4">
-      <div class="flex items-center">
-        <SplitPanel.ControlGroup>
+    <div class="flex shrink-0 flex-col gap-3">
+      <ViewSidebar.Header>
+        <div class="flex min-w-0 items-center gap-1">
           <SplitPanel.CloseButton />
+          <ViewSidebar.Title>Chat</ViewSidebar.Title>
+        </div>
+        <SplitPanel.ControlGroup>
           <SplitPanel.BackButton />
           <SplitPanel.ForwardButton />
+          <RailModeButton expanded onToggle={() => rail.setMode('slim')} />
         </SplitPanel.ControlGroup>
+      </ViewSidebar.Header>
+      <div class="px-4">
+        <Tabs
+          aria-label="Chat sidebar views"
+          fullWidth
+          list={CHANNEL_TABS}
+          value={rail.tab()}
+          onChange={selectTab}
+        />
       </div>
-      <div class="flex h-8 items-center gap-2">
-        <RailModeButton expanded onToggle={() => rail.setMode('slim')} />
-        <h1 class="m-0 min-w-0 flex-1 truncate text-base font-semibold tracking-[-0.03em] text-ink">
-          Chat
-        </h1>
-      </div>
-      <Tabs
-        aria-label="Chat sidebar views"
-        fullWidth
-        list={CHANNEL_TABS}
-        value={rail.tab()}
-        onChange={selectTab}
-      />
     </div>
   );
 }

--- a/apps/web/src/features/channels-view/components/rail/ExpandedChannelsRail.tsx
+++ b/apps/web/src/features/channels-view/components/rail/ExpandedChannelsRail.tsx
@@ -140,7 +140,7 @@ function ExpandedHeader() {
       </div>
       <div class="flex h-8 items-center gap-2">
         <RailModeButton expanded onToggle={() => rail.setMode('slim')} />
-        <h1 class="m-0 min-w-0 flex-1 truncate text-2xl font-semibold tracking-[-0.03em] text-ink">
+        <h1 class="m-0 min-w-0 flex-1 truncate text-base font-semibold tracking-[-0.03em] text-ink">
           Chat
         </h1>
       </div>

--- a/apps/web/src/features/channels-view/components/rail/SlimChannelsRail.tsx
+++ b/apps/web/src/features/channels-view/components/rail/SlimChannelsRail.tsx
@@ -224,7 +224,7 @@ function SlimHeader() {
   };
 
   return (
-    <div class="flex shrink-0 flex-col items-center gap-3">
+    <div class="flex shrink-0 flex-col items-center gap-3 pt-2">
       <div class="flex w-full items-center justify-center px-2">
         <SplitPanel.ControlGroup>
           <SplitPanel.CloseButton size="icon-sm" />

--- a/apps/web/src/features/channels-view/queries.ts
+++ b/apps/web/src/features/channels-view/queries.ts
@@ -4,6 +4,7 @@ import {
   defineQueryFilters,
   queryStateFrom,
 } from '@app/features/next-soup/filters/filter-store';
+import { compareDateDesc } from '@core/util/date';
 import { type ChannelEntity, type EntityData, isChannelEntity } from '@entity';
 import {
   type SoupAstItemsQueryArgs,
@@ -48,7 +49,7 @@ export const CHANNELS_QUERY_DEFINITIONS = {
     matches: (channel) => !isDirectMessage(channel),
   },
   direct_messages: {
-    params: { ...CHANNELS_QUERY_PARAMS, sort_method: 'created_at' },
+    params: { ...CHANNELS_QUERY_PARAMS, sort_method: 'updated_at' },
     filters: defineQueryFilters({
       include: {
         channelType: ['direct_message'],
@@ -137,8 +138,16 @@ function useChannelsDataSource(
   const items = createMemo<ChannelEntity[]>((previous) => {
     if (!query.isEnabled || query.isLoading) return previous;
 
-    const channels = (query.data?.entities ?? []).filter(isChannelEntity);
-    return filterChannelsForScope(scope, channels);
+    const channels = filterChannelsForScope(
+      scope,
+      (query.data?.entities ?? []).filter(isChannelEntity)
+    );
+
+    if (scope !== 'direct_messages') return channels;
+
+    return channels
+      .slice()
+      .sort((left, right) => compareDateDesc(left.updatedAt, right.updatedAt));
   }, []);
 
   return {

--- a/apps/web/src/features/email-thread/thread-completion-adapter.tsx
+++ b/apps/web/src/features/email-thread/thread-completion-adapter.tsx
@@ -276,9 +276,14 @@ export function createThreadCompletionAdapter(
         markAsDoneAction.executeWithSoup(
           [selectedRow.original],
           soup,
-          (nextEntity) => {
+          ({ entity: nextEntity }) => {
             const splitHandle = splitPanel?.handle;
             if (!splitHandle) return;
+            if (!nextEntity) {
+              splitHandle.resetPreview();
+              return;
+            }
+
             void openEntityInSplitFromUnifiedList(nextEntity, {
               splitHandle,
               mergeHistory: true,

--- a/apps/web/src/features/email-view/components/EmailInboxSelector.tsx
+++ b/apps/web/src/features/email-view/components/EmailInboxSelector.tsx
@@ -88,7 +88,7 @@ export function EmailInboxSelector(props: EmailInboxSelectorProps) {
           class={cn(
             compact()
               ? 'size-8 shrink-0 rounded-full'
-              : 'h-9 w-full min-w-0 justify-start gap-2.5 rounded-xl bg-surface px-3 font-medium',
+              : 'h-10 w-full min-w-0 justify-start gap-2.5 rounded-xl bg-surface px-3 font-medium',
             props.class
           )}
         >

--- a/apps/web/src/features/email-view/components/EmailInboxSelector.tsx
+++ b/apps/web/src/features/email-view/components/EmailInboxSelector.tsx
@@ -79,7 +79,7 @@ export function EmailInboxSelector(props: EmailInboxSelectorProps) {
       >
         <Combobox.Trigger
           as={Button}
-          variant={compact() ? 'ghost' : 'outline'}
+          variant="ghost"
           size={compact() ? 'sm' : 'md'}
           square={compact()}
           depth={2}
@@ -88,7 +88,7 @@ export function EmailInboxSelector(props: EmailInboxSelectorProps) {
           class={cn(
             compact()
               ? 'size-8 shrink-0 rounded-full'
-              : 'h-10 w-full min-w-0 justify-start gap-2.5 rounded-xl bg-surface px-3 font-medium',
+              : 'h-10 w-full min-w-0 justify-start gap-2.5 rounded-xl bg-surface px-3',
             props.class
           )}
         >

--- a/apps/web/src/features/email-view/components/EmailList.tsx
+++ b/apps/web/src/features/email-view/components/EmailList.tsx
@@ -37,12 +37,14 @@ import CaretDownIcon from '@phosphor/caret-down.svg';
 import CheckIcon from '@phosphor/check.svg';
 import SpinnerIcon from '@phosphor/spinner.svg';
 import { createElementSize } from '@solid-primitives/resize-observer';
-import { Button, cn, Surface } from '@ui';
+import { debounce } from '@solid-primitives/scheduled';
+import { Button, cn } from '@ui';
 import {
   createEffect,
   createMemo,
   createSignal,
   Match,
+  onCleanup,
   type Setter,
   Show,
   Suspense,
@@ -115,6 +117,12 @@ export function EmailList(props: EmailListProps) {
     }).finally(() => finishTouchHighlight?.());
   }
 
+  const previewAfterNavigation = debounce(
+    (entity: EntityData) => openEntity(entity, { mergeHistory: true }),
+    150
+  );
+  onCleanup(() => previewAfterNavigation.clear());
+
   function onActivate({
     item,
     metadata,
@@ -130,6 +138,8 @@ export function EmailList(props: EmailListProps) {
     const sourceRow = source.items().find((row) => row.id === item.id);
 
     if (sourceRow?.kind !== 'entity') return;
+
+    previewAfterNavigation.clear();
 
     const newSplit =
       metadata?.newSplit === true || metadata?.event?.shiftKey === true;
@@ -266,9 +276,11 @@ export function EmailList(props: EmailListProps) {
     enabled: panel.isPanelActive,
     navigation: {
       onNavigate: (event) => {
+        previewAfterNavigation.clear();
+
         const row = event.result?.item;
         if (row?.kind === 'entity' && panel.handle.isControllerSplit()) {
-          openEntity(row.entity, { mergeHistory: true });
+          previewAfterNavigation(row.entity);
         }
 
         if (event.kind !== 'move' || event.direction !== 1) return;
@@ -367,6 +379,7 @@ export function EmailList(props: EmailListProps) {
     if (nextScope === activeScope) return;
 
     activeScope = nextScope;
+    previewAfterNavigation.clear();
     listInteractions.selection.clear();
     list.focus.clear({ reason: 'programmatic' });
     panel.handle.resetPreview();
@@ -410,9 +423,7 @@ export function EmailList(props: EmailListProps) {
 
   return (
     <MaybeSoupEntityActionDrawerManager>
-      <Surface
-        depth={isTouchDevice() ? 0 : 2}
-        hideBorder={isTouchDevice()}
+      <div
         ref={(element: HTMLDivElement) => {
           setGrid(element);
           props.ref?.(element);
@@ -422,10 +433,7 @@ export function EmailList(props: EmailListProps) {
         aria-multiselectable="true"
         aria-activedescendant={list.focus.key()}
         tabIndex={0}
-        class={cn(
-          'soup-list relative flex size-full min-h-0 min-w-0 flex-col overflow-hidden outline-none',
-          isTouchDevice() ? 'rounded-none bg-transparent' : 'rounded-2xl p-2'
-        )}
+        class="soup-list relative flex size-full min-h-0 min-w-0 flex-col overflow-hidden outline-none"
       >
         <PullToRefresh
           scrollContainer={pullScrollContainer}
@@ -693,7 +701,7 @@ export function EmailList(props: EmailListProps) {
             analyticsSource="email_view_selection_toolbar"
           />
         </Show>
-      </Surface>
+      </div>
     </MaybeSoupEntityActionDrawerManager>
   );
 }

--- a/apps/web/src/features/email-view/components/EmailSidebar.tsx
+++ b/apps/web/src/features/email-view/components/EmailSidebar.tsx
@@ -70,15 +70,16 @@ export function EmailSidebar() {
   });
 
   return (
-    <ViewSidebar.Root aria-label="Email navigation" class="gap-4 pt-2">
-      <SplitPanel.ControlGroup>
-        <SplitPanel.CloseButton />
-        <SplitPanel.BackButton />
-        <SplitPanel.ForwardButton />
-      </SplitPanel.ControlGroup>
-
+    <ViewSidebar.Root aria-label="Email navigation" class="gap-4">
       <ViewSidebar.Header>
-        <ViewSidebar.Title>Email</ViewSidebar.Title>
+        <div class="flex min-w-0 items-center gap-1">
+          <SplitPanel.CloseButton />
+          <ViewSidebar.Title>Email</ViewSidebar.Title>
+        </div>
+        <SplitPanel.ControlGroup>
+          <SplitPanel.BackButton />
+          <SplitPanel.ForwardButton />
+        </SplitPanel.ControlGroup>
       </ViewSidebar.Header>
 
       <ViewSidebar.Content class="flex flex-col gap-6">

--- a/apps/web/src/features/email-view/components/EmailSidebar.tsx
+++ b/apps/web/src/features/email-view/components/EmailSidebar.tsx
@@ -6,8 +6,8 @@ import { AnimatedSignalIcon } from '@icon/wide-signal';
 import CalendarBlankIcon from '@phosphor/calendar-blank.svg';
 import EnvelopeIcon from '@phosphor/envelope.svg';
 import FileIcon from '@phosphor/file.svg';
+import ComposeIcon from '@phosphor/note-pencil.svg';
 import PaperPlaneTiltIcon from '@phosphor/paper-plane-tilt.svg';
-import PlusIcon from '@phosphor/plus.svg';
 import UsersThreeIcon from '@phosphor/users-three.svg';
 import { Button } from '@ui';
 import { type Component, For } from 'solid-js';
@@ -72,7 +72,7 @@ export function EmailSidebar() {
   return (
     <ViewSidebar.Root
       aria-label="Email navigation"
-      class="gap-4 border-r-0 pt-2"
+      class="gap-4 pt-2"
     >
       <SplitPanel.ControlGroup>
         <SplitPanel.CloseButton />
@@ -82,21 +82,23 @@ export function EmailSidebar() {
 
       <ViewSidebar.Header>
         <ViewSidebar.Title>Email</ViewSidebar.Title>
-        <Button
-          type="button"
-          variant="cta"
-          size="md"
-          class="rounded-lg px-3"
-          onClick={composeEmail}
-        >
-          <PlusIcon class="size-4 shrink-0" />
-          New
-        </Button>
       </ViewSidebar.Header>
 
-      <ViewSidebar.Content class="flex flex-col gap-3 pt-1">
-        <EmailInboxSelector variant="sidebar" />
-        <EmailNavigation />
+      <ViewSidebar.Content class="flex flex-col gap-6">
+        <Button
+          type="button"
+          variant="ghost"
+          class="h-10 shrink-0 justify-start gap-3 rounded-xl bg-hover px-3 text-ink"
+          onClick={composeEmail}
+        >
+          <ComposeIcon class="size-4 shrink-0" />
+          Compose
+        </Button>
+
+        <div class="flex flex-col gap-3">
+          <EmailInboxSelector variant="sidebar" />
+          <EmailNavigation />
+        </div>
       </ViewSidebar.Content>
     </ViewSidebar.Root>
   );

--- a/apps/web/src/features/email-view/components/EmailSidebar.tsx
+++ b/apps/web/src/features/email-view/components/EmailSidebar.tsx
@@ -70,10 +70,7 @@ export function EmailSidebar() {
   });
 
   return (
-    <ViewSidebar.Root
-      aria-label="Email navigation"
-      class="gap-4 pt-2"
-    >
+    <ViewSidebar.Root aria-label="Email navigation" class="gap-4 pt-2">
       <SplitPanel.ControlGroup>
         <SplitPanel.CloseButton />
         <SplitPanel.BackButton />
@@ -85,20 +82,20 @@ export function EmailSidebar() {
       </ViewSidebar.Header>
 
       <ViewSidebar.Content class="flex flex-col gap-6">
-        <Button
-          type="button"
-          variant="ghost"
-          class="h-10 shrink-0 justify-start gap-3 rounded-xl bg-hover px-3 text-ink"
-          onClick={composeEmail}
-        >
-          <ComposeIcon class="size-4 shrink-0" />
-          Compose
-        </Button>
-
         <div class="flex flex-col gap-3">
           <EmailInboxSelector variant="sidebar" />
-          <EmailNavigation />
+          <Button
+            type="button"
+            variant="ghost"
+            class="h-10 shrink-0 justify-start gap-3 rounded-xl bg-hover px-3 text-ink"
+            onClick={composeEmail}
+          >
+            <ComposeIcon class="size-4 shrink-0" />
+            Compose
+          </Button>
         </div>
+
+        <EmailNavigation />
       </ViewSidebar.Content>
     </ViewSidebar.Root>
   );

--- a/apps/web/src/features/email-view/components/EmailSidebar.tsx
+++ b/apps/web/src/features/email-view/components/EmailSidebar.tsx
@@ -87,7 +87,8 @@ export function EmailSidebar() {
           <Button
             type="button"
             variant="ghost"
-            class="h-10 shrink-0 justify-start gap-3 rounded-xl bg-hover px-3 text-ink"
+            depth={2}
+            class="h-10 shrink-0 justify-start gap-3 rounded-xl bg-surface px-3"
             onClick={composeEmail}
           >
             <ComposeIcon class="size-4 shrink-0" />

--- a/apps/web/src/features/email-view/email-view.tsx
+++ b/apps/web/src/features/email-view/email-view.tsx
@@ -7,7 +7,6 @@ import { StaticMarkdownContext } from '@core/component/LexicalMarkdown/component
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { ListEntityMetadataQueryProvider } from '@entity';
 import SpinnerIcon from '@phosphor/spinner.svg';
-import { cn, Surface } from '@ui';
 import {
   createSignal,
   onMount,
@@ -30,18 +29,9 @@ export type EmailViewProps = {
 
 function EmailListFallback() {
   return (
-    <Surface
-      depth={isTouchDevice() ? 0 : 2}
-      hideBorder={isTouchDevice()}
-      class={cn(
-        'grid size-full min-h-0 min-w-0 place-items-center text-ink-muted',
-        isTouchDevice()
-          ? 'rounded-none bg-transparent pt-(--mobile-content-inset-top) pb-(--mobile-content-inset-bottom)'
-          : 'rounded-2xl'
-      )}
-    >
+    <div class="grid size-full min-h-0 min-w-0 place-items-center text-ink-muted touch:pt-(--mobile-content-inset-top) touch:pb-(--mobile-content-inset-bottom)">
       <SpinnerIcon aria-label="Loading email" class="size-5 animate-spin" />
-    </Surface>
+    </div>
   );
 }
 

--- a/apps/web/src/features/inbox-view/components/InboxHeader.tsx
+++ b/apps/web/src/features/inbox-view/components/InboxHeader.tsx
@@ -16,7 +16,7 @@ export function InboxHeader(props: ParentProps) {
       </Show>
       <Show when={!isTouchDevice()}>
         <div class="flex h-8 min-w-0 items-center">
-          <h1 class="m-0 min-w-0 flex-1 truncate text-2xl font-semibold tracking-[-0.035em] text-ink">
+          <h1 class="m-0 min-w-0 flex-1 truncate text-base font-semibold tracking-[-0.035em] text-ink">
             Notifications
           </h1>
         </div>

--- a/apps/web/src/features/inbox-view/components/InboxList.tsx
+++ b/apps/web/src/features/inbox-view/components/InboxList.tsx
@@ -37,12 +37,14 @@ import {
 import CaretDownIcon from '@phosphor/caret-down.svg';
 import CheckIcon from '@phosphor/check.svg';
 import SpinnerIcon from '@phosphor/spinner.svg';
+import { debounce } from '@solid-primitives/scheduled';
 import { Button, cn } from '@ui';
 import {
   createEffect,
   createMemo,
   createSignal,
   Match,
+  onCleanup,
   type Setter,
   Show,
   Switch,
@@ -146,10 +148,13 @@ export function InboxList(props: InboxListProps) {
 
     if (sourceRow?.kind !== 'entity') return;
 
+    previewAfterNavigation.clear();
+
     const newSplit =
       metadata?.newSplit === true || metadata?.event?.shiftKey === true;
 
     if (!isTouchDevice() && !newSplit) {
+      markEntitySeen(sourceRow.entity);
       showPreview(sourceRow.entity);
       return;
     }
@@ -168,9 +173,11 @@ export function InboxList(props: InboxListProps) {
   }
 
   function showPreview(entity: WithNotification<EntityData>) {
-    markEntitySeen(entity);
     props.onPreviewEntityChange(entity);
   }
+
+  const previewAfterNavigation = debounce(showPreview, 150);
+  onCleanup(() => previewAfterNavigation.clear());
 
   async function openEntity(
     entity: WithNotification<EntityData>,
@@ -296,9 +303,11 @@ export function InboxList(props: InboxListProps) {
     enabled: panel.isPanelActive,
     navigation: {
       onNavigate: (event) => {
+        previewAfterNavigation.clear();
+
         const row = event.result?.item;
         if (!isTouchDevice() && row?.kind === 'entity') {
-          showPreview(row.entity);
+          previewAfterNavigation(row.entity);
         }
 
         if (event.kind !== 'move' || event.direction !== 1) return;
@@ -386,6 +395,7 @@ export function InboxList(props: InboxListProps) {
     if (nextTab === activeTab) return;
 
     activeTab = nextTab;
+    previewAfterNavigation.clear();
     listInteractions.selection.clear();
     list.focus.clear({ reason: 'programmatic' });
     setPersistedListState((current) => ({ ...current, scrollOffset: 0 }));

--- a/apps/web/src/features/inbox-view/components/InboxList.tsx
+++ b/apps/web/src/features/inbox-view/components/InboxList.tsx
@@ -6,6 +6,7 @@ import {
   useListInteractions,
 } from '@app/components/list';
 import {
+  type EntityActionNavigationHandler,
   resolveEntityActionViewContext,
   toEntityActionListState,
   useEntityActionHotkeys,
@@ -83,6 +84,7 @@ type InboxListActivationMetadata = {
 };
 
 type InboxListProps = {
+  previewEntity: EntityData | undefined;
   onPreviewEntityChange: (entity: EntityData | undefined) => void;
 };
 
@@ -264,6 +266,17 @@ export function InboxList(props: InboxListProps) {
     return row?.kind === 'entity' ? row.entity : undefined;
   };
 
+  const createActionNavigationHandler = ():
+    | EntityActionNavigationHandler
+    | undefined => {
+    if (props.previewEntity === undefined) return;
+
+    return ({ entity }) => {
+      previewAfterNavigation.clear();
+      props.onPreviewEntityChange(entity);
+    };
+  };
+
   let listRoot: HTMLDivElement | undefined;
   const [collapseRow, setCollapseRow] =
     createSignal<(rowId: string) => Promise<void>>();
@@ -336,6 +349,7 @@ export function InboxList(props: InboxListProps) {
     restoreFocus: () => listRoot?.focus(),
     viewContext: entityActionViewContext,
     splitHandle: panel.handle,
+    createActionNavigationHandler,
     condition: panel.isPanelActive,
   });
 
@@ -346,6 +360,7 @@ export function InboxList(props: InboxListProps) {
       viewContext: entityActionViewContext(),
       viewedProjectId: viewedProjectIdFromContent(content),
       splitHandle: panel.handle,
+      createActionNavigationHandler,
     });
   }
 

--- a/apps/web/src/features/inbox-view/inbox-view.tsx
+++ b/apps/web/src/features/inbox-view/inbox-view.tsx
@@ -31,6 +31,7 @@ function InboxFallback() {
 }
 
 function NotificationsListPane(props: {
+  previewEntity: EntityData | undefined;
   onPreviewEntityChange: (entity: EntityData | undefined) => void;
 }) {
   return (
@@ -39,7 +40,10 @@ function NotificationsListPane(props: {
         <InboxTabs />
       </InboxHeader>
       <Suspense fallback={<InboxFallback />}>
-        <InboxList onPreviewEntityChange={props.onPreviewEntityChange} />
+        <InboxList
+          previewEntity={props.previewEntity}
+          onPreviewEntityChange={props.onPreviewEntityChange}
+        />
       </Suspense>
     </>
   );
@@ -91,6 +95,7 @@ function InboxViewRoot() {
                   >
                     <ViewShell.Aside class="flex flex-col border-r border-edge bg-panel">
                       <NotificationsListPane
+                        previewEntity={previewEntity()}
                         onPreviewEntityChange={setPreviewEntity}
                       />
                     </ViewShell.Aside>
@@ -129,6 +134,7 @@ function InboxViewRoot() {
               <ViewShell.Root aside={false} main={{ min: 224 }}>
                 <ViewShell.Main>
                   <NotificationsListPane
+                    previewEntity={previewEntity()}
                     onPreviewEntityChange={setPreviewEntity}
                   />
                 </ViewShell.Main>

--- a/apps/web/src/features/next-soup/actions/entity-action-context.ts
+++ b/apps/web/src/features/next-soup/actions/entity-action-context.ts
@@ -13,6 +13,15 @@ export type EntityActionViewContext = {
   senderBucket: EntityActionSenderBucket | undefined;
 };
 
+export type EntityActionNavigationEvent = {
+  actionId: string;
+  entity: EntityData | undefined;
+};
+
+export type EntityActionNavigationHandler = (
+  event: EntityActionNavigationEvent
+) => void;
+
 /** Soup list capabilities used by entity actions. */
 export type EntityActionListState = {
   focus: Pick<SoupState['focus'], 'id' | 'index' | 'set'>;

--- a/apps/web/src/features/next-soup/actions/index.ts
+++ b/apps/web/src/features/next-soup/actions/index.ts
@@ -1,6 +1,8 @@
 export {
   type EntityActionListFocusTarget,
   type EntityActionListState,
+  type EntityActionNavigationEvent,
+  type EntityActionNavigationHandler,
   type EntityActionSenderBucket,
   type EntityActionViewContext,
   resolveEntityActionViewContext,

--- a/apps/web/src/features/next-soup/actions/make-create-reminder-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-create-reminder-action.ts
@@ -2,7 +2,10 @@ import { openReminderComposer } from '@app/features/reminders/reminder-composer'
 import { enableReminders, isFeatureEnabled } from '@core/constant/featureFlags';
 import type { EntityData } from '@entity';
 import { reminderTarget } from '@queries/reminders/reminders';
-import type { EntityActionListState } from './entity-action-context';
+import type {
+  EntityActionListState,
+  EntityActionNavigationHandler,
+} from './entity-action-context';
 import type { makeMarkDoneAction } from './make-mark-done-action';
 
 /**
@@ -17,6 +20,7 @@ import type { makeMarkDoneAction } from './make-mark-done-action';
 export type ReminderCreatedList = {
   soup: EntityActionListState;
   advances: boolean;
+  onNavigate?: EntityActionNavigationHandler;
 };
 
 /** What the invoking surface does with its row once the reminder exists. */
@@ -63,7 +67,10 @@ export const makeCreateReminderAction = (
     entities: EntityData[],
     soup: EntityActionListState,
     /** Whether the list moves on once the row is marked done. */
-    opts: { advances: boolean }
+    opts: {
+      advances: boolean;
+      onNavigate?: EntityActionNavigationHandler;
+    }
   ) => {
     const [entity] = entities;
     if (!entity || !canExecute(entity)) return;
@@ -72,7 +79,11 @@ export const makeCreateReminderAction = (
     // them, by way of marking the row done.
     openReminderComposer(entity, {
       onCreated: () =>
-        options?.onCreated?.(entity, { soup, advances: opts.advances }),
+        options?.onCreated?.(entity, {
+          soup,
+          advances: opts.advances,
+          ...(opts.onNavigate ? { onNavigate: opts.onNavigate } : {}),
+        }),
     });
   };
 
@@ -108,15 +119,20 @@ export const markReminderTargetDone =
     markDone: MarkDoneAction,
     /** Follows the list's focus in an attached split, as mark-done's own
      *  entry points do. */
-    onNavigate?: (entity: EntityData) => void
+    onNavigate?: EntityActionNavigationHandler
   ): ReminderCreatedHandler =>
   async (entity, list) => {
     if (!markDone.canExecute(entity)) return;
 
     if (list?.advances) {
-      await markDone.executeWithSoup([entity], list.soup, onNavigate, {
-        silent: true,
-      });
+      await markDone.executeWithSoup(
+        [entity],
+        list.soup,
+        list.onNavigate ?? onNavigate,
+        {
+          silent: true,
+        }
+      );
       return;
     }
 

--- a/apps/web/src/features/next-soup/actions/make-mark-done-action.test.ts
+++ b/apps/web/src/features/next-soup/actions/make-mark-done-action.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
     content: vi.fn(() => ({ id: 'other' })),
     isControllerSplit: vi.fn(() => true),
     referredFrom: vi.fn(() => undefined),
+    resetPreview: vi.fn(),
   },
   executeMarkEntitiesDone: vi.fn(async () => [] as string[]),
   executeMarkEntitiesUndone: vi.fn(async () => {}),
@@ -120,6 +121,7 @@ describe('makeMarkDoneAction', () => {
     mocks.controller.content.mockReturnValue({ id: 'other' });
     mocks.controller.isControllerSplit.mockReturnValue(true);
     mocks.controller.referredFrom.mockReturnValue(undefined);
+    mocks.controller.resetPreview.mockClear();
     mocks.executeMarkEntitiesDone.mockClear();
     mocks.executeMarkEntitiesDone.mockResolvedValue([]);
     mocks.executeMarkEntitiesUndone.mockClear();
@@ -161,6 +163,37 @@ describe('makeMarkDoneAction', () => {
     await action.executeWithSoup([currentEntity], soup);
 
     expect(mocks.openEntityInSplitFromUnifiedList).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it('uses an explicit navigation handler instead of the split Controller', async () => {
+    const { soup } = createSoup();
+    const onNavigate = vi.fn();
+    const { action, dispose } = createAction();
+
+    await action.executeWithSoup([currentEntity], soup, onNavigate);
+
+    expect(onNavigate).toHaveBeenCalledWith({
+      actionId: 'mark-done',
+      entity: nextEntity,
+    });
+    expect(mocks.openEntityInSplitFromUnifiedList).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it('passes no target to the navigation handler when no item remains', async () => {
+    const { soup, focusSet } = createSoup();
+    soup.navigate.peekOffset = vi.fn(() => undefined);
+    const onNavigate = vi.fn();
+    const { action, dispose } = createAction();
+
+    await action.executeWithSoup([currentEntity], soup, onNavigate);
+
+    expect(focusSet).toHaveBeenCalledWith(undefined);
+    expect(onNavigate).toHaveBeenCalledWith({
+      actionId: 'mark-done',
+      entity: undefined,
+    });
     dispose();
   });
 

--- a/apps/web/src/features/next-soup/actions/make-mark-done-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-mark-done-action.ts
@@ -23,7 +23,10 @@ import {
   toNotificationEntityRef,
 } from '@queries/notification/entity-mutations';
 import { type UndoHandle, useUndoableMutation } from '@queries/undo';
-import type { EntityActionListState } from './entity-action-context';
+import type {
+  EntityActionListState,
+  EntityActionNavigationHandler,
+} from './entity-action-context';
 
 // Valid list views where the mark done should be allowed to run
 const VALID_MARK_DONE_LIST_VIEWS: `${ListView}-${string}`[] = [
@@ -305,7 +308,7 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
   const executeWithSoup = async (
     entities: EntityData[],
     soup: EntityActionListState,
-    onNavigate?: (entity: EntityData) => void,
+    onNavigate?: EntityActionNavigationHandler,
     opts?: MarkDoneExecuteWithSoupOpts
   ) => {
     // Apply execute's already-done filter up front so navigation, selection
@@ -361,15 +364,28 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
 
     if (nextRow) {
       soup.focus.set(nextRow.id);
+    } else {
+      soup.focus.set(undefined);
+    }
+
+    if (onNavigate) {
+      onNavigate({
+        actionId: 'mark-done',
+        entity: nextRow?.original,
+      });
+    } else {
       const controller = splitPanel?.handle;
       if (controller?.isControllerSplit()) {
-        void openEntityInSplitFromUnifiedList(nextRow.original, {
-          splitHandle: controller,
-          mergeHistory: true,
-          notificationSource: options.notificationSource(),
-        });
+        if (nextRow) {
+          void openEntityInSplitFromUnifiedList(nextRow.original, {
+            splitHandle: controller,
+            mergeHistory: true,
+            notificationSource: options.notificationSource(),
+          });
+        } else {
+          controller.resetPreview();
+        }
       }
-      onNavigate?.(nextRow.original);
     }
 
     // When marking done navigated the view to the next item, undo navigates
@@ -377,8 +393,12 @@ export const makeMarkDoneAction = (options: MakeMarkDoneOptions) => {
     const firstEntity = targets[0];
     const navigateBack =
       opts?.navigateBack ??
-      (nextRow && onNavigate && firstEntity
-        ? () => onNavigate(firstEntity)
+      (onNavigate && firstEntity
+        ? () =>
+            onNavigate({
+              actionId: 'mark-done',
+              entity: firstEntity,
+            })
         : undefined);
 
     await execute(targets, restoreFocus, { ...opts, navigateBack });

--- a/apps/web/src/features/next-soup/actions/use-block-entity-commands.ts
+++ b/apps/web/src/features/next-soup/actions/use-block-entity-commands.ts
@@ -18,6 +18,7 @@ import { type EntityData, isDocumentEntity, isTaskEntity } from '@entity';
 import { SYSTEM_PROPERTY_IDS } from '@property/constants';
 import type { Property, PropertyDefinitionDomain } from '@property/types';
 import { createEffect, onCleanup } from 'solid-js';
+import type { EntityActionNavigationEvent } from './entity-action-context';
 import {
   makeAddTagAction,
   makeCopyAction,
@@ -128,9 +129,16 @@ export const useBlockEntityCommands = (
   };
 
   /** Follows the list's next row into this split, as the triage flow does. */
-  const advanceSplitTo = (nextEntity: EntityData) => {
+  const advanceSplitTo = ({
+    entity: nextEntity,
+  }: EntityActionNavigationEvent) => {
     const splitHandle = splitPanel?.handle;
     if (!splitHandle) return;
+    if (!nextEntity) {
+      splitHandle.resetPreview();
+      return;
+    }
+
     void openEntityInSplitFromUnifiedList(nextEntity, {
       splitHandle,
       mergeHistory: true,

--- a/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
+++ b/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
@@ -14,6 +14,7 @@ import type { Property, PropertyDefinitionDomain } from '@property/types';
 import { type Accessor, onCleanup } from 'solid-js';
 import type {
   EntityActionListState,
+  EntityActionNavigationHandler,
   EntityActionViewContext,
 } from './entity-action-context';
 import {
@@ -46,6 +47,9 @@ type UseEntityActionHotkeysOptions = {
   restoreFocus: (entityId?: string) => void | Promise<void>;
   viewContext: Accessor<EntityActionViewContext>;
   splitHandle?: SplitHandle;
+  createActionNavigationHandler?: () =>
+    | EntityActionNavigationHandler
+    | undefined;
   condition?: () => boolean;
 };
 
@@ -119,11 +123,13 @@ export const useEntityActionHotkeys = (
     return [];
   };
 
-  const openNextEntity = (entity: EntityData) => {
+  const openNextEntity: EntityActionNavigationHandler = ({ entity }) => {
     if (!splitHandle) return;
-    // Preview Controllers are synchronized centrally by executeWithSoup so
-    // every mark-done entry point, including menus and swipe, behaves alike.
-    if (splitHandle.isControllerSplit()) return;
+    if (!entity) {
+      if (splitHandle.isControllerSplit()) splitHandle.resetPreview();
+      return;
+    }
+
     const handleContent = splitHandle.content().type;
     if (handleContent === 'component' || handleContent === 'project') return;
     openEntityInSplitFromUnifiedList(entity, {
@@ -181,7 +187,11 @@ export const useEntityActionHotkeys = (
       if (entities.length === 0) return false;
       if (!entities.every(markDone.canExecute)) return false;
 
-      markDone.executeWithSoup(entities, list, openNextEntity);
+      markDone.executeWithSoup(
+        entities,
+        list,
+        options.createActionNavigationHandler?.() ?? openNextEntity
+      );
       return true;
     },
     condition: () => {
@@ -540,6 +550,7 @@ export const useEntityActionHotkeys = (
       if (!createReminderAction.canExecute(entities[0])) return false;
       createReminderAction.executeWithSoup(entities, list, {
         advances: marksDoneOnThisView(),
+        onNavigate: options.createActionNavigationHandler?.() ?? openNextEntity,
       });
       return true;
     },

--- a/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
+++ b/apps/web/src/features/next-soup/actions/use-entity-action-hotkeys.ts
@@ -130,7 +130,18 @@ export const useEntityActionHotkeys = (
       return;
     }
 
-    const handleContent = splitHandle.content().type;
+    if (splitHandle.isControllerSplit()) {
+      openEntityInSplitFromUnifiedList(entity, {
+        splitHandle,
+        mergeHistory: true,
+        referredFrom: splitHandle.referredFrom(),
+        notificationSource,
+      });
+      return;
+    }
+
+    const handleContent = splitHandle.content()?.type;
+    if (!handleContent) return;
     if (handleContent === 'component' || handleContent === 'project') return;
     openEntityInSplitFromUnifiedList(entity, {
       splitHandle,

--- a/apps/web/src/features/soup/SoupEntityContextMenu.tsx
+++ b/apps/web/src/features/soup/SoupEntityContextMenu.tsx
@@ -15,6 +15,7 @@ import {
 } from '@property/tags';
 import type { EntityType } from '@service-properties/generated/schemas/entityType';
 import type { SoupProperty } from '@service-storage/generated/schemas/soupProperty';
+import { cn } from '@ui';
 import {
   type Accessor,
   createSignal,
@@ -31,6 +32,7 @@ interface SoupEntityContextMenuProps {
   list: EntityActionListState;
   selectedEntities: Accessor<EntityData[]>;
   viewContext: EntityActionViewContext;
+  class?: string;
   onOpenChange?: (open: boolean) => void;
 }
 
@@ -88,7 +90,7 @@ export const SoupEntityContextMenu: FlowComponent<
     <Switch>
       <Match when={isMobile()}>
         <div
-          class="size-full"
+          class={cn('size-full', props.class)}
           data-soup-entity
           ref={(el) => {
             touchHandler(el, () => ({
@@ -109,7 +111,7 @@ export const SoupEntityContextMenu: FlowComponent<
       <Match when={true}>
         <ContextMenu onOpenChange={props.onOpenChange}>
           <ContextMenu.Trigger
-            class="size-full group/cm-trigger"
+            class={cn('size-full group/cm-trigger', props.class)}
             on:contextmenu={(event: MouseEvent) =>
               setMenuPosition({ x: event.clientX, y: event.clientY })
             }

--- a/apps/web/src/features/soup/createSoupEntityActions.ts
+++ b/apps/web/src/features/soup/createSoupEntityActions.ts
@@ -1,5 +1,6 @@
 import {
   type EntityActionListState,
+  type EntityActionNavigationHandler,
   type EntityActionViewContext,
   makeBlockSenderAction,
   makeCopyAction,
@@ -72,6 +73,10 @@ type BuildActionGroups = (
      * their click/hotkey equivalents, including Preview Pair routing.
      */
     splitHandle?: SplitHandle;
+    /** Creates a view-owned follow-up for action-driven navigation. */
+    createActionNavigationHandler?: () =>
+      | EntityActionNavigationHandler
+      | undefined;
   }
 ) => SoupEntityActionGroup[];
 
@@ -144,7 +149,13 @@ export function createSoupEntityActions(): {
   const buildActionGroups: BuildActionGroups = (
     soup,
     entities,
-    { viewContext, viewedProjectId, openTagPicker, splitHandle }
+    {
+      viewContext,
+      viewedProjectId,
+      openTagPicker,
+      splitHandle,
+      createActionNavigationHandler,
+    }
   ) => {
     const canExecuteAll = (canExecute: (e: EntityData) => boolean) =>
       entities.length > 0 && entities.every(canExecute);
@@ -180,7 +191,12 @@ export function createSoupEntityActions(): {
           id: 'mark-done',
           label: 'Mark Done',
           hotkeyToken: TOKENS.entity.action.markDone,
-          onClick: handle(markDone.executeWithSoup),
+          onClick: () =>
+            markDone.executeWithSoup(
+              entities,
+              soup,
+              createActionNavigationHandler?.()
+            ),
         });
       }
     }
@@ -358,10 +374,13 @@ export function createSoupEntityActions(): {
         hotkeyToken: TOKENS.entity.action.createReminder,
         // Not `handle`: the mark-done that follows needs this view's answer to
         // whether the list moves on, the same one Mark Done above is gated by.
-        onClick: () =>
-          createReminderAction.executeWithSoup(entities, soup, {
+        onClick: () => {
+          const onNavigate = createActionNavigationHandler?.();
+          return createReminderAction.executeWithSoup(entities, soup, {
             advances: marksDoneOnThisView,
-          }),
+            onNavigate,
+          });
+        },
       });
     }
 

--- a/apps/web/src/features/soup/entity-notifications.ts
+++ b/apps/web/src/features/soup/entity-notifications.ts
@@ -73,7 +73,7 @@ export function scopeChannelNotificationsForEntity(
   return notifications;
 }
 
-type EntityWithRawNotifications = EntityData & {
+type EntityWithRawNotifications<T extends EntityData> = T & {
   notifications?: UnifiedNotification[] | Accessor<UnifiedNotification[]>;
 };
 
@@ -81,11 +81,11 @@ type EntityWithRawNotifications = EntityData & {
  * Normalizes GraphQL notification arrays and the global notification source
  * into the accessor shape expected by reusable list-entity components.
  */
-export function withEntityNotifications(
-  entity: EntityWithRawNotifications,
+export function withEntityNotifications<T extends EntityData>(
+  entity: EntityWithRawNotifications<T>,
   source: NotificationSource,
   options: { scopeChannelThreads?: boolean } = {}
-): WithNotification<EntityData> {
+): WithNotification<T> {
   const attached = entity.notifications;
   const read = (): UnifiedNotification[] => {
     if (typeof attached === 'function') return attached();

--- a/apps/web/src/features/tasks-view/components/TasksSidebar.tsx
+++ b/apps/web/src/features/tasks-view/components/TasksSidebar.tsx
@@ -3,137 +3,201 @@ import {
   useViewTabHotkeys,
   ViewSidebar,
 } from '@app/components/view-shell';
+import { FavoriteIcon } from '@app/features/favorites/FavoriteIcon';
 import { addUnique, removeValue } from '@app/lib/signals/store-array-updaters';
+import {
+  favoriteSplitContent,
+  useFavoriteDisplayName,
+} from '@app/util/favorites';
 import { useSplitLayout } from '@components/app/split-layout/layout';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { SplitPanel } from '@components/app/split-panel';
-import { EntityIcon } from '@core/component/EntityIcon';
+import CheckSquareIcon from '@phosphor/check-square.svg';
+import ListChecksIcon from '@phosphor/list-checks.svg';
 import NoteIcon from '@phosphor/note-pencil.svg';
 import PlusIcon from '@phosphor/plus.svg';
-import UsersIcon from '@phosphor/users-three.svg';
-import { useCurrentTeamQuery } from '@queries/team/teams';
+import { useFavoritesData } from '@queries/favorites/favorites';
+import type { Favorite } from '@service-storage/generated/schemas/favorite';
 import { Button } from '@ui';
-import { For } from 'solid-js';
+import { createMemo, For, Show } from 'solid-js';
 import { Dynamic } from 'solid-js/web';
-import {
-  PERSONAL_TASK_TABS,
-  type TaskTabItem,
-  TEAM_TASK_TABS,
-} from '../constants';
+import { useTaskFilters } from '../filters/use-task-filters';
 import { useTasksView } from '../tasks-view-context';
+import type { TaskTab } from '../types';
 
-function TaskIcon(props: { class?: string }) {
-  return (
-    <EntityIcon
-      targetType="task"
-      size="fill"
-      theme="monochrome"
-      class={props.class}
-    />
-  );
-}
+const TASK_NAV_ITEMS = [
+  { id: 'my-tasks', label: 'My Tasks', icon: CheckSquareIcon },
+  { id: 'team-tasks', label: 'All Tasks', icon: ListChecksIcon },
+  { id: 'created-by-me', label: 'Created by me', icon: NoteIcon },
+] satisfies { id: TaskTab; label: string; icon: typeof NoteIcon }[];
 
-const TAB_ICONS = {
-  'my-tasks': TaskIcon,
-  'created-by-me': NoteIcon,
-  'team-tasks': TaskIcon,
-} as const;
-
-function Tab(props: {
-  item: TaskTabItem;
-  onNavigate?: () => void;
-  class?: string;
-}) {
+export function TasksNavigation(props: { onNavigate?: () => void }) {
   const { state, setTab } = useTasksView();
 
   return (
+    <ViewSidebar.Nav aria-label="Task views">
+      <For each={TASK_NAV_ITEMS}>
+        {(item) => (
+          <ViewSidebar.Item
+            active={state.tab === item.id}
+            class="font-normal"
+            onClick={() => {
+              setTab(item.id);
+              props.onNavigate?.();
+            }}
+          >
+            <Dynamic
+              component={item.icon}
+              aria-hidden="true"
+              class="size-4 shrink-0"
+            />
+            <span class="truncate">{item.label}</span>
+          </ViewSidebar.Item>
+        )}
+      </For>
+    </ViewSidebar.Nav>
+  );
+}
+
+function FavoriteRow(props: {
+  favorite: Favorite;
+  onOpen: (favorite: Favorite) => void;
+}) {
+  const name = useFavoriteDisplayName(props.favorite);
+
+  return (
     <ViewSidebar.Item
-      active={state.tab === props.item.id}
-      class={props.class}
-      onClick={() => {
-        setTab(props.item.id);
-        props.onNavigate?.();
-      }}
+      class="font-normal"
+      title={name()}
+      onClick={() => props.onOpen(props.favorite)}
     >
-      <Dynamic
-        component={TAB_ICONS[props.item.id]}
-        aria-hidden="true"
-        class="size-4 shrink-0"
-      />
-      <span class="truncate">{props.item.label}</span>
+      <span class="flex size-4 shrink-0 items-center justify-center">
+        <FavoriteIcon favorite={props.favorite} class="size-4" />
+      </span>
+      <span class="truncate">{name()}</span>
     </ViewSidebar.Item>
   );
 }
 
-export function TasksNavigation(props: { onNavigate?: () => void }) {
-  const { state, setState } = useTasksView();
-  const team = useCurrentTeamQuery();
-  const teamName = () => team.data?.team.name ?? 'Team';
-  const isTeamExpanded = () =>
-    !state.collapsedSidebarSectionIds.includes('team');
-  const setTeamExpanded = (expanded: boolean) =>
-    setState(
-      'collapsedSidebarSectionIds',
-      expanded ? removeValue('team') : addUnique('team')
-    );
+function TaskFavorites(props: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const data = useFavoritesData();
+  const layout = useSplitLayout();
+  const favorites = createMemo(() =>
+    (data()?.favorites ?? [])
+      .filter(
+        (favorite) =>
+          favorite.entityType === 'document' &&
+          favorite.documentSubType === 'task'
+      )
+      .sort((left, right) => left.sortOrder - right.sortOrder)
+  );
+
+  const openFavorite = (favorite: Favorite) => {
+    layout.openWithSplit(favoriteSplitContent(favorite), {
+      referredFrom: 'sidebar',
+    });
+  };
 
   return (
-    <div class="flex flex-col gap-3">
-      <ViewSidebar.Nav aria-label="Personal task tabs">
-        <For each={PERSONAL_TASK_TABS}>
-          {(item) => <Tab item={item} onNavigate={props.onNavigate} />}
-        </For>
-      </ViewSidebar.Nav>
+    <CollapsibleSection.Root
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+    >
+      <CollapsibleSection.Trigger class="text-xs">
+        <CollapsibleSection.Indicator class="order-first ml-0" />
+        <span class="truncate">Favorites</span>
+      </CollapsibleSection.Trigger>
+      <CollapsibleSection.Content>
+        <ViewSidebar.Nav aria-label="Favorite tasks">
+          <For each={favorites()}>
+            {(favorite) => (
+              <FavoriteRow favorite={favorite} onOpen={openFavorite} />
+            )}
+          </For>
+          <Show when={favorites().length === 0}>
+            <p class="px-3 py-2 text-sm text-ink-extra-muted">
+              No favorites yet
+            </p>
+          </Show>
+        </ViewSidebar.Nav>
+      </CollapsibleSection.Content>
+    </CollapsibleSection.Root>
+  );
+}
 
-      <CollapsibleSection.Root
-        open={isTeamExpanded()}
-        onOpenChange={setTeamExpanded}
-      >
-        <CollapsibleSection.Trigger>
-          <UsersIcon aria-hidden="true" class="size-4 shrink-0" />
-          <span class="truncate">{teamName()}</span>
-          <CollapsibleSection.Indicator />
-        </CollapsibleSection.Trigger>
-        <CollapsibleSection.Content>
-          <ViewSidebar.Nav aria-label={`${teamName()} task tabs`}>
-            <For each={TEAM_TASK_TABS}>
-              {(item) => (
-                <Tab
-                  item={item}
-                  onNavigate={props.onNavigate}
-                  class="pl-8 pr-3"
-                />
-              )}
-            </For>
-          </ViewSidebar.Nav>
-        </CollapsibleSection.Content>
-      </CollapsibleSection.Root>
-    </div>
+function TaskTags(props: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const filters = useTaskFilters();
+  const tags = () =>
+    filters.groups().find((group) => group.id === 'tags')?.options ?? [];
+
+  return (
+    <CollapsibleSection.Root
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+    >
+      <CollapsibleSection.Trigger class="text-xs">
+        <CollapsibleSection.Indicator class="order-first ml-0" />
+        <span class="truncate">Tags</span>
+      </CollapsibleSection.Trigger>
+      <CollapsibleSection.Content>
+        <ViewSidebar.Nav aria-label="Task tags">
+          <For each={tags()}>
+            {(tag) => {
+              const selected = () => filters.isSelected('tags', tag.id);
+
+              return (
+                <ViewSidebar.Item
+                  active={selected()}
+                  aria-pressed={selected()}
+                  class="font-normal"
+                  onClick={() =>
+                    filters.setSelected('tags', tag.id, !selected())
+                  }
+                >
+                  <span class="flex size-4 shrink-0 items-center justify-center">
+                    {tag.icon?.()}
+                  </span>
+                  <span class="truncate">{tag.label}</span>
+                </ViewSidebar.Item>
+              );
+            }}
+          </For>
+        </ViewSidebar.Nav>
+      </CollapsibleSection.Content>
+    </CollapsibleSection.Root>
   );
 }
 
 export function TasksSidebar() {
   const layout = useSplitLayout();
   const panel = useSplitPanelOrThrow();
-  const { state, setTab } = useTasksView();
+  const { state, setState, setTab } = useTasksView();
 
   useViewTabHotkeys({
     scopeId: panel.splitHotkeyScope,
     enabled: panel.isPanelActive,
-    ids: () => [...PERSONAL_TASK_TABS, ...TEAM_TASK_TABS].map((tab) => tab.id),
+    ids: () => TASK_NAV_ITEMS.map((tab) => tab.id),
     activeId: () => state.tab,
     setActiveId: setTab,
   });
 
-  const createTask = () => {
-    layout.popoverSplit({ type: 'component', id: 'task-compose' });
-  };
+  const sectionOpen = (id: string) =>
+    !state.collapsedSidebarSectionIds.includes(id);
+
+  const setSectionOpen = (id: string, open: boolean) =>
+    setState(
+      'collapsedSidebarSectionIds',
+      open ? removeValue(id) : addUnique(id)
+    );
 
   return (
-    <ViewSidebar.Root
-      aria-label="Tasks navigation"
-      class="gap-3 border-r-0 pt-2"
-    >
+    <ViewSidebar.Root aria-label="Tasks navigation" class="gap-3 bg-panel pt-2">
       <div class="flex items-center">
         <SplitPanel.ControlGroup>
           <SplitPanel.CloseButton />
@@ -144,20 +208,34 @@ export function TasksSidebar() {
 
       <ViewSidebar.Header class="h-8">
         <ViewSidebar.Title>Tasks</ViewSidebar.Title>
-        <Button
-          type="button"
-          variant="cta"
-          size="md"
-          class="rounded-lg px-3"
-          onClick={createTask}
-        >
-          <PlusIcon class="size-4 shrink-0" />
-          New
-        </Button>
       </ViewSidebar.Header>
 
-      <ViewSidebar.Content>
-        <TasksNavigation />
+      <ViewSidebar.Content class="flex flex-col gap-6">
+        <div class="flex shrink-0 flex-col gap-6">
+          <Button
+            type="button"
+            variant="ghost"
+            class="h-10 shrink-0 justify-start gap-3 rounded-xl bg-hover px-3 text-ink"
+            onClick={() =>
+              layout.popoverSplit({ type: 'component', id: 'task-compose' })
+            }
+          >
+            <PlusIcon class="size-4 shrink-0" />
+            New task
+          </Button>
+
+          <TasksNavigation />
+        </div>
+
+        <TaskFavorites
+          open={sectionOpen('favorites')}
+          onOpenChange={(open) => setSectionOpen('favorites', open)}
+        />
+
+        <TaskTags
+          open={sectionOpen('tags')}
+          onOpenChange={(open) => setSectionOpen('tags', open)}
+        />
       </ViewSidebar.Content>
     </ViewSidebar.Root>
   );

--- a/apps/web/src/features/tasks-view/components/TasksSidebar.tsx
+++ b/apps/web/src/features/tasks-view/components/TasksSidebar.tsx
@@ -215,7 +215,8 @@ export function TasksSidebar() {
           <Button
             type="button"
             variant="ghost"
-            class="h-10 shrink-0 justify-start gap-3 rounded-xl bg-hover px-3 text-ink"
+            depth={2}
+            class="h-10 shrink-0 justify-start gap-3 rounded-xl bg-surface px-3"
             onClick={() =>
               layout.popoverSplit({ type: 'component', id: 'task-compose' })
             }

--- a/apps/web/src/features/tasks-view/components/TasksSidebar.tsx
+++ b/apps/web/src/features/tasks-view/components/TasksSidebar.tsx
@@ -197,7 +197,7 @@ export function TasksSidebar() {
     );
 
   return (
-    <ViewSidebar.Root aria-label="Tasks navigation" class="gap-3 bg-panel pt-2">
+    <ViewSidebar.Root aria-label="Tasks navigation" class="gap-4 bg-panel pt-2">
       <div class="flex items-center">
         <SplitPanel.ControlGroup>
           <SplitPanel.CloseButton />

--- a/apps/web/src/features/tasks-view/components/TasksSidebar.tsx
+++ b/apps/web/src/features/tasks-view/components/TasksSidebar.tsx
@@ -197,17 +197,16 @@ export function TasksSidebar() {
     );
 
   return (
-    <ViewSidebar.Root aria-label="Tasks navigation" class="gap-4 bg-panel pt-2">
-      <div class="flex items-center">
-        <SplitPanel.ControlGroup>
+    <ViewSidebar.Root aria-label="Tasks navigation" class="gap-4 bg-panel">
+      <ViewSidebar.Header>
+        <div class="flex min-w-0 items-center gap-1">
           <SplitPanel.CloseButton />
+          <ViewSidebar.Title>Tasks</ViewSidebar.Title>
+        </div>
+        <SplitPanel.ControlGroup>
           <SplitPanel.BackButton />
           <SplitPanel.ForwardButton />
         </SplitPanel.ControlGroup>
-      </div>
-
-      <ViewSidebar.Header class="h-8">
-        <ViewSidebar.Title>Tasks</ViewSidebar.Title>
       </ViewSidebar.Header>
 
       <ViewSidebar.Content class="flex flex-col gap-6">

--- a/apps/web/src/features/tasks-view/components/task-list/TaskList.tsx
+++ b/apps/web/src/features/tasks-view/components/task-list/TaskList.tsx
@@ -45,12 +45,14 @@ import { PROPERTY_OPTION_IDS, SYSTEM_PROPERTY_IDS } from '@property';
 import { useTagSets } from '@property/tags/tag-sets-context';
 import { useBulkSaveEntityPropertiesMutation } from '@queries/properties/entity';
 import { EntityType } from '@service-properties/generated/schemas/entityType';
-import { Button, cn, Surface } from '@ui';
+import { debounce } from '@solid-primitives/scheduled';
+import { Button, cn } from '@ui';
 import {
   createEffect,
   createMemo,
   createSignal,
   Match,
+  onCleanup,
   type Setter,
   Show,
   Suspense,
@@ -145,6 +147,12 @@ export function TaskList(props: TaskListProps) {
     });
   }
 
+  const previewAfterNavigation = debounce(
+    (entity: EntityData) => openEntity(entity, { mergeHistory: true }),
+    150
+  );
+  onCleanup(() => previewAfterNavigation.clear());
+
   function onActivate({
     item,
     metadata,
@@ -177,6 +185,8 @@ export function TaskList(props: TaskListProps) {
       .find((row) => row.kind === 'entity' && row.id === item.id);
 
     if (sourceRow?.kind !== 'entity') return;
+
+    previewAfterNavigation.clear();
 
     const newSplit =
       metadata?.newSplit === true || metadata?.event?.shiftKey === true;
@@ -317,11 +327,11 @@ export function TaskList(props: TaskListProps) {
     enabled: panel.isPanelActive,
     navigation: {
       onNavigate: (event) => {
+        previewAfterNavigation.clear();
+
         const row = event.result?.item;
         if (row?.kind === 'entity' && panel.handle.isControllerSplit()) {
-          openEntity(row.entity, {
-            mergeHistory: true,
-          });
+          previewAfterNavigation(row.entity);
         }
 
         if (event.kind !== 'move' || event.direction !== 1) return;
@@ -379,6 +389,7 @@ export function TaskList(props: TaskListProps) {
     if (nextTab === activeTab) return;
 
     activeTab = nextTab;
+    previewAfterNavigation.clear();
     listInteractions.selection.clear();
     list.focus.clear({ reason: 'programmatic' });
     panel.handle.resetPreview();
@@ -427,9 +438,7 @@ export function TaskList(props: TaskListProps) {
 
   return (
     <MaybeSoupEntityActionDrawerManager>
-      <Surface
-        depth={isTouchDevice() ? 0 : 2}
-        hideBorder={isTouchDevice()}
+      <div
         ref={(element: HTMLDivElement) => {
           setGrid(element);
           props.ref?.(element);
@@ -439,13 +448,7 @@ export function TaskList(props: TaskListProps) {
         aria-multiselectable="true"
         aria-activedescendant={list.focus.key()}
         tabIndex={0}
-        class={cn(
-          '@container/u-list flex min-h-0 min-w-0 flex-col outline-none',
-          {
-            'rounded-2xl p-2': !isTouchDevice(),
-            'rounded-none bg-transparent p-0': isTouchDevice(),
-          }
-        )}
+        class="@container/u-list relative flex size-full min-h-0 min-w-0 flex-col overflow-hidden outline-none"
       >
         <ListLayoutProvider ref={grid}>
           <ResponsiveTaskListHeader />
@@ -722,7 +725,7 @@ export function TaskList(props: TaskListProps) {
             />
           </Show>
         </ListLayoutProvider>
-      </Surface>
+      </div>
     </MaybeSoupEntityActionDrawerManager>
   );
 }

--- a/apps/web/src/features/tasks-view/queries/use-tasks-query.ts
+++ b/apps/web/src/features/tasks-view/queries/use-tasks-query.ts
@@ -10,6 +10,8 @@ import {
   sortItems,
   useSearchContext,
 } from '@app/features/soup';
+import { withEntityNotifications } from '@app/features/soup/entity-notifications';
+import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
 import {
   type EntityData,
   isTaskEntity,
@@ -58,6 +60,10 @@ export function useTasksDataSource(
   state: TasksDataSourceInput,
   options: UseTasksDataSourceOptions
 ): TasksDataSource {
+  const notificationSource = useGlobalNotificationSource();
+  const attachNotifications = (entity: TaskEntityWithProperties) =>
+    withEntityNotifications(entity, notificationSource);
+
   const facetContext = createMemo((): TaskFacetContext => {
     const tagPropertyDefinitionByOptionId = new Map<string, string>();
     for (const set of options.tagSets()) {
@@ -104,7 +110,7 @@ export function useTasksDataSource(
       if (!isTaskEntity(entity)) continue;
       if (!taskMatchesView(entity, context)) continue;
 
-      selected.push(entity);
+      selected.push(attachNotifications(entity));
     }
     return selected;
   };
@@ -173,7 +179,7 @@ export function useTasksDataSource(
   const continuations: TaskGroupContinuationReader = {
     entities: (groupKey) =>
       (groupQueryFor(groupKey)?.data()?.entities ?? []).flatMap((entity) =>
-        isTaskEntity(entity) ? [entity] : []
+        isTaskEntity(entity) ? [attachNotifications(entity)] : []
       ),
     hasMore: (groupKey) => groupQueryFor(groupKey)?.hasNextPage() ?? false,
     isLoading: (groupKey) =>

--- a/apps/web/src/features/tasks-view/tasks-view.tsx
+++ b/apps/web/src/features/tasks-view/tasks-view.tsx
@@ -1,10 +1,8 @@
 import { ViewShell } from '@app/components/view-shell';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { SplitPanel } from '@components/app/split-panel';
-import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import { ListEntityMetadataQueryProvider } from '@entity';
 import SpinnerIcon from '@phosphor/spinner.svg';
-import { cn, Surface } from '@ui';
 import { createSignal, onMount, Suspense } from 'solid-js';
 import { TasksHeader } from './components/TasksHeader';
 import { TasksSidebar } from './components/TasksSidebar';
@@ -19,16 +17,9 @@ export type TasksViewProps = {
 
 function TasksListFallback() {
   return (
-    <Surface
-      depth={isTouchDevice() ? 0 : 2}
-      hideBorder={isTouchDevice()}
-      class={cn('grid min-h-0 min-w-0 place-items-center text-ink-muted', {
-        'rounded-2xl': !isTouchDevice(),
-        'rounded-none bg-transparent': isTouchDevice(),
-      })}
-    >
+    <div class="grid size-full min-h-0 min-w-0 place-items-center text-ink-muted">
       <SpinnerIcon aria-label="Loading tasks" class="size-5 animate-spin" />
-    </Surface>
+    </div>
   );
 }
 

--- a/apps/web/src/lib/queries/channel/message.ts
+++ b/apps/web/src/lib/queries/channel/message.ts
@@ -6,7 +6,9 @@ import { throwOnErr } from '@core/util/result';
 import {
   bumpSoupEntityTouchedAt,
   invalidateSoupEntity,
+  optimisticUpdateSoupItemUpdatedAt,
   refetchSoupEntity,
+  type SoupTransaction,
 } from '@queries/soup/normalized-cache';
 import { type MutationCallbacks, withCallbacks } from '@queries/utils';
 import {
@@ -415,7 +417,10 @@ type SendMessageParams = {
   senderId: string;
 };
 
-type SendMessageContext = InsertMessageContext | undefined;
+type SendMessageContext = {
+  insert: InsertMessageContext | undefined;
+  updatedAt: SoupTransaction | undefined;
+};
 
 /**
  * Mutation to send an channel message.
@@ -453,13 +458,20 @@ export function useSendMessageMutation(
           await queryClient.cancelQueries({
             queryKey: getChannelMessagesQueryKeyPrefix(vars.channelID),
           });
-          return optimisticInsertChannelMessage({
+          const insert = optimisticInsertChannelMessage({
             channelId: vars.channelID,
             optimisticId: vars.optimisticId,
             senderId: vars.senderId,
             optimisticAttachments: vars.optimisticAttachments,
             ...vars.message,
           });
+          const updatedAt = optimisticUpdateSoupItemUpdatedAt(
+            vars.channelID,
+            'channel',
+            new Date().toISOString()
+          );
+
+          return { insert, updatedAt };
         },
         onSuccess(data, variables) {
           const threadId = variables.message.thread_id ?? undefined;
@@ -492,9 +504,10 @@ export function useSendMessageMutation(
         onError(error, vars, context) {
           console.error('failed to send message', error);
           toast.failure('Failed to send message');
-          if (context) {
-            rollbackInsertChannelMessage(vars.channelID, context);
+          if (context?.insert) {
+            rollbackInsertChannelMessage(vars.channelID, context.insert);
           }
+          context?.updatedAt?.rollback();
         },
         onSettled: (_data, _error, variables) => {
           softInvalidateTargetCaches(

--- a/apps/web/src/lib/queries/soup/normalized-cache/operations.ts
+++ b/apps/web/src/lib/queries/soup/normalized-cache/operations.ts
@@ -895,7 +895,7 @@ export function optimisticUpdateSoupItemUpdatedAt(
   itemId: string,
   tag: SoupEntityTag,
   updatedAt: string
-) {
+): SoupTransaction | undefined {
   const current = getSoupEntityById(itemId);
   if (!current || current.tag !== tag) return;
 
@@ -908,7 +908,7 @@ export function optimisticUpdateSoupItemUpdatedAt(
     )
       return;
 
-    optimisticUpdateSoupEntity({
+    return optimisticUpdateSoupEntity({
       tag: 'channel',
       data: { channel: { id: itemId, updated_at: updatedAt } },
       frecency_score: current.frecency_score,
@@ -924,7 +924,7 @@ export function optimisticUpdateSoupItemUpdatedAt(
 
     if (!shouldUpdateOptimisticTimestamp(timestamp, updatedAt)) return;
 
-    optimisticUpdateSoupEntity({
+    return optimisticUpdateSoupEntity({
       tag: current.tag,
       data: { id: itemId, updatedAt },
       frecency_score: current.frecency_score,

--- a/docs/AGENT_GUIDE/surfaces.md
+++ b/docs/AGENT_GUIDE/surfaces.md
@@ -37,6 +37,13 @@ rows and date headers by when you were last notified about the item, so a fresh 
 on an old task sits under "Today"; with it off they order by content recency. Keyboard:
 `j`/`k` move between rows and update the preview; alternate activation opens a new split.
 
+## Tasks — `/app/component/tasks`
+
+Task navigation uses `My Tasks`, `All Tasks`, and `Created by me`. The desktop
+sidebar has a full-width `New task` action, a collapsible list of task favorites,
+and a collapsible list of tags. Selecting a tag filters the current task view;
+selecting it again clears that tag filter. Favorite rows open their tasks.
+
 ## Email — `/app/component/mail`
 
 Full email client. Tabs: `Signal` / `Noise` / `Sent` / `Calendar` / `Drafts` / `Shared` /


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes span mark-done navigation, split preview behavior, and optimistic soup cache updates on send—user-visible triage flows across mail, inbox, tasks, and chat.
> 
> **Overview**
> This PR tightens **ViewShell** layout math (drops explicit resize gutter padding from inline-detail and aside sizing) and standardizes **ViewSidebar** chrome—header border/padding, smaller titles, padding moved into header/content slots—used across Chat, Email, and Tasks.
> 
> **List UX** gets **150ms debounced preview** when moving focus with keyboard in Channels rail, Email, Tasks, and Notifications (clicks still open immediately). Email/Tasks lists shed the rounded `Surface` wrapper for a flat full-bleed grid. **Mark done / remind / thread archive** now share an **`EntityActionNavigationHandler`** so views like Notifications can drive preview updates (including **`resetPreview`** when nothing is left) instead of always opening the next entity in the split; Inbox wires this through hotkeys and context menus.
> 
> **Channels**: mobile adds pull-to-refresh and unified **`SoupEntityContextMenu`** (with action drawer on mobile); desktop rail replaces the bespoke context menu with the same component; DMs sort by **`updated_at`**; sending a message optimistically bumps the channel’s soup **`updated_at`** with rollback on failure.
> 
> **Tasks sidebar** is reworked: flat nav tabs, ghost **New task**, collapsible **Favorites** and **Tags** (tags toggle filters), plus notification attachment on task query rows. **Email** sidebar moves compose to a ghost row and aligns header controls with other surfaces. Docs add a Tasks surface section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c23d8dc4c9d12fc18a74475e896b8f6969fe16f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->