### PR TITLE
perf(crm): constrain team_id on crm_domains in the domain lookup

### DIFF
--- a/.sqlx/query-d10c5e6c2a50c028d658c0344e9f99b9fc874cd804534bc2b7bfd8a147379a08.json
+++ b/.sqlx/query-d10c5e6c2a50c028d658c0344e9f99b9fc874cd804534bc2b7bfd8a147379a08.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT c.id, c.hidden\n            FROM crm_companies c\n            JOIN crm_domains d ON d.company_id = c.id\n            WHERE c.team_id = $1\n              AND LOWER(d.domain) = $2\n            LIMIT 1\n            ",
+  "query": "\n            SELECT c.id, c.hidden\n            FROM crm_companies c\n            JOIN crm_domains d ON d.company_id = c.id\n            WHERE c.team_id = $1\n              AND d.team_id = $1\n              AND LOWER(d.domain) = $2\n            LIMIT 1\n            ",
   "describe": {
     "columns": [
       {
@@ -25,5 +25,5 @@
       false
     ]
   },
-  "hash": "ebd8690a2a7068b485816697c3d6660c82f616f8f3456a6137b872043404d282"
+  "hash": "d10c5e6c2a50c028d658c0344e9f99b9fc874cd804534bc2b7bfd8a147379a08"
 }

--- a/crates/crm/src/outbound/companies_repo.rs
+++ b/crates/crm/src/outbound/companies_repo.rs
@@ -104,6 +104,15 @@ impl CompaniesRepositoryImpl {
 
     /// Look up the company owning `(team, lower(domain))`. Returns
     /// `(id, hidden)`; `hidden` is read so new contacts can inherit it.
+    ///
+    /// `d.team_id` is filtered as well as `c.team_id`: the two are invariably
+    /// equal (`crm_domains.team_id` is NOT NULL and every insert writes the
+    /// owning company's team, which is never updated), but only the predicate
+    /// on `crm_domains` lets the planner probe
+    /// `crm_domains_team_id_lower_domain_unique (team_id, LOWER(domain))`.
+    /// Without it the leading index column is unconstrained, so the lookup
+    /// degrades to a full scan of `crm_domains` joined against every company
+    /// in the team — while holding this team+domain's advisory lock.
     async fn find_company_by_domain(
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         team_id: &uuid::Uuid,
@@ -115,6 +124,7 @@ impl CompaniesRepositoryImpl {
             FROM crm_companies c
             JOIN crm_domains d ON d.company_id = c.id
             WHERE c.team_id = $1
+              AND d.team_id = $1
               AND LOWER(d.domain) = $2
             LIMIT 1
             "#,


### PR DESCRIPTION
find_company_by_domain filtered c.team_id on crm_companies and LOWER(d.domain) on crm_domains. crm_domains already has a unique index on (team_id, LOWER(domain)), but with only its trailing column constrained the planner cannot probe it -- it scans the whole index (or the table) and joins that against every company in the team. Datadog reports the query as blocking 30.4% of executions on the host, and it runs inside the per-(team, domain) advisory lock, so the wait fans out to every concurrent populate for the same domain.

Adding d.team_id = $1 turns it into a single unique-index probe followed by a primary-key lookup:

  before  Index Cond: (lower(domain) = $2)                  + Materialize
  after   Index Cond: (team_id = $1 AND lower(domain) = $2)

The predicate cannot change the result. crm_domains.team_id is NOT NULL, backfilled from the parent company by 20260514130000, written from the same team_id on every insert, and crm_companies.team_id is never updated -- d.team_id and c.team_id are invariably equal.

No new index; the one this needs has been there since May.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Query-only optimization with an equivalent filter; no schema or API changes, though correctness relies on the invariant that domain rows always share the company’s team_id.
> 
> **Overview**
> Speeds up **`find_company_by_domain`** by adding **`AND d.team_id = $1`** alongside the existing **`c.team_id`** filter. That lets Postgres use the **`(team_id, LOWER(domain))`** unique index on **`crm_domains`** instead of scanning domains by **`lower(domain)`** alone while joined to every company on the team—a path that was especially painful because the query runs under the per-(team, domain) advisory lock during **`populate_contact`** and manual company creation.
> 
> The extra predicate is documented as **semantically redundant** (**`d.team_id`** always matches the parent company’s team). The **sqlx** offline query cache entry is updated to match the new SQL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e601309325dbf416a3faed03b687db1c55752b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->