### PR TITLE
perf(email): drop the redundant dedupe in attachment discovery

### DIFF
--- a/crates/email_db_client/src/attachments/provider/upload.rs
+++ b/crates/email_db_client/src/attachments/provider/upload.rs
@@ -193,7 +193,11 @@ pub async fn fetch_job_attachments_for_backfill(
             JOIN public.email_messages message ON message.thread_id = eligible.thread_id
             WHERE message.from_contact_id IS NOT NULL
 
-            UNION
+            -- UNION ALL, not UNION: `qualified_threads` already applies
+            -- SELECT DISTINCT to this result, so a set-union dedupe here
+            -- sorts the whole participant set only to have the work thrown
+            -- away. Duplicates cannot change the final thread set.
+            UNION ALL
 
             SELECT message.thread_id, recipient.contact_id
             FROM eligible_threads eligible

--- a/crates/macro_db_client/migrations/20260910144341_email_messages_thread_id_from_contact_id_index.sql
+++ b/crates/macro_db_client/migrations/20260910144341_email_messages_thread_id_from_contact_id_index.sql
@@ -1,0 +1,10 @@
+-- no-transaction
+-- The attachment-discovery query's `participants` CTE
+-- (email_db_client::attachments::provider::upload) joins every message of
+-- every attachment-bearing thread by thread_id and projects from_contact_id.
+-- The existing (thread_id, internal_date_ts) indexes locate the messages but
+-- not the contact, so each row costs a heap fetch; this makes that arm
+-- index-only.
+-- Single statement: see 20260910144339 for the CONCURRENTLY constraint.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_email_messages_thread_id_from_contact_id
+    ON email_messages (thread_id, from_contact_id);


### PR DESCRIPTION
fetch_job_attachments_for_backfill built its `participants` CTE with UNION, which sorts and de-duplicates every (thread, contact) pair across all of a link`s attachment-bearing threads. `qualified_threads` then applies SELECT DISTINCT to the same rows, so the first dedupe is paid in full and immediately discarded. UNION ALL cannot change the final thread set.

Also indexes (thread_id, from_contact_id) on email_messages. The first arm of that CTE walks every message in every eligible thread and projects from_contact_id, which the existing (thread_id, internal_date_ts) indexes do not carry -- so each row costs a heap fetch.

The other three indexes this query wants already exist: idx_email_messages_link_id_thread_id_has_atts,
idx_email_messages_link_id_sent_covering, and
idx_email_contacts_link_id_lower_email.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Query semantics stay the same (distinct threads unchanged); the migration only adds a concurrent index with no application logic changes.
> 
> **Overview**
> Speeds up post-backfill attachment discovery for `fetch_job_attachments_for_backfill` without changing which threads qualify.
> 
> The **`participants` CTE** now uses **`UNION ALL`** instead of **`UNION`**, because **`qualified_threads`** already **`SELECT DISTINCT`** on thread IDs—so the extra sort/dedupe on every (thread, contact) pair was wasted work.
> 
> A new **`CREATE INDEX CONCURRENTLY`** on **`email_messages (thread_id, from_contact_id)`** lets the “sender” arm of **`participants`** read **`from_contact_id`** from the index instead of heap-fetching every message row in eligible threads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe4369eaec7c063acdd94c573a80d9ca3d3776b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->