### PR TITLE
fix(local-stack): don't gate the stack on LocalStack's DNS-dependent healthcheck

### DIFF
--- a/tooling/xtask/crates/xtask_local/src/local/gen_compose.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/gen_compose.rs
@@ -233,6 +233,27 @@ fn add_localstack_service(
             // shows up as `"kms": "disabled"` on its health endpoint rather
             // than as a connection error.
             environment: kv(&[("SERVICES", "sqs,dynamodb,s3,kms")]),
+            // Probe the readiness endpoint over loopback instead of the
+            // image's own healthcheck, which shells out to `localstack status
+            // services`. That CLI resolves `localhost.localstack.cloud`, a
+            // public name; where DNS cannot reach it the probe takes ~40s
+            // against its 10s timeout, so the container never reports healthy
+            // and `compose up --wait` fails the whole stack even though
+            // LocalStack is serving fine. Overriding only the probe keeps
+            // `LOCALSTACK_HOST` unset, so the hostname LocalStack advertises
+            // in returned SQS/S3 URLs stays `localstack`, which is how every
+            // other container addresses it.
+            healthcheck: Some(dct::Healthcheck {
+                test: Some(dct::HealthcheckTest::Multiple(vec![
+                    "CMD-SHELL".to_string(),
+                    "curl -fsS http://localhost:4566/_localstack/health".to_string(),
+                ])),
+                interval: Some("10s".to_string()),
+                timeout: Some("10s".to_string()),
+                retries: 5,
+                start_period: Some("15s".to_string()),
+                ..Default::default()
+            }),
             ports: dct::Ports::Short(vec![format!("{}:4566", instance.port(Port::LocalStack))]),
             networks: net_aliases(&[
                 ("databases", &["localstack"]),


### PR DESCRIPTION
## Problem

`localstack/localstack:4` ships a healthcheck that shells out to `localstack status services --format=json`. That CLI probes `localhost.localstack.cloud` — a public hostname that has to resolve through DNS. On a machine that cannot reach public DNS, the probe takes **~40s** against its own **10s** timeout, so the container never reports healthy, `docker compose up -d --wait` exits 1, and the whole bring-up dies at the infra stage:

```
container macro-localstack-1 is unhealthy
Error: `docker` exited with exit status: 1
```

The application services never start. LocalStack itself is serving fine throughout — its HTTP readiness endpoint reports `sqs`/`dynamodb`/`s3`/`kms` available, and the container log says `Ready.`. Only the probe fails.

The container's own DNS is what breaks; its log shows the same failure fetching an unrelated cert:

```
Failed to resolve 'api.localstack.cloud' ([Errno -3] Temporary failure in name resolution)
```

## Fix

Override just the probe to curl the readiness endpoint over loopback. Measured inside the running container:

| probe | time |
| --- | --- |
| `localstack status services --format=json` (image default) | **40.37s** → exceeds the 10s timeout |
| `curl -fsS http://localhost:4566/_localstack/health` | **0.072s** |

## Why not `LOCALSTACK_HOST`

Setting `LOCALSTACK_HOST=localhost:4566` also silences the DNS lookup and was my first attempt, but it doubles as the hostname LocalStack advertises in returned SQS and S3 URLs. Every other container addresses it as `localstack` (`LOCAL_AWS_URL=http://localstack:4566`, plus the network aliases), so repointing it at `localhost` risks handing containers URLs that resolve to themselves. This change leaves it unset.

## Testing

- `cargo check -p xtask_local --features local-stack` — clean.
- `just check` — OK, no warnings.
- Replacement probe verified against a live `macro-localstack-1` (timings above).

Not exercised: a full `stack up` on a machine with working DNS. The generated compose output is gitignored and no test or fixture asserts the localstack block, so this is generator-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generator-only change to local dev compose; no runtime service or auth/data-path impact.
> 
> **Overview**
> **LocalStack** in the generated docker-compose override now defines an explicit **healthcheck** that curls `http://localhost:4566/_localstack/health` on loopback, instead of inheriting the image default that runs `localstack status services` and depends on resolving `localhost.localstack.cloud`.
> 
> On hosts without working public DNS that default probe can run ~40s and miss the 10s timeout, so the container stays **unhealthy** and `compose up --wait` fails the stack even when LocalStack is ready. The override uses a 10s interval/timeout, 5 retries, and a 15s start period.
> 
> **`LOCALSTACK_HOST` is not set**, so advertised SQS/S3 URLs keep using the `localstack` hostname other services already use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 564d2999b6b5636b9055d1fc908162dda576fcfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->