### PR TITLE
fix(local-stack): give LocalStack a real grace period before the health gate

### DIFF
--- a/tooling/xtask/crates/xtask_local/src/local/gen_compose.rs
+++ b/tooling/xtask/crates/xtask_local/src/local/gen_compose.rs
@@ -251,7 +251,8 @@ fn add_localstack_service(
                 interval: Some("10s".to_string()),
                 timeout: Some("10s".to_string()),
                 retries: 5,
-                start_period: Some("15s".to_string()),
+                start_period: Some("180s".to_string()),
+                start_interval: Some("2s".to_string()),
                 ..Default::default()
             }),
             ports: dct::Ports::Short(vec![format!("{}:4566", instance.port(Port::LocalStack))]),


### PR DESCRIPTION
Follow-up to #6337, which was necessary but not sufficient.

## What #6337 missed

It replaced LocalStack's DNS-dependent probe with a loopback `curl`, but kept the image's `start_period: 15s` / `retries: 5` / `interval: 10s`. That budget only holds if each probe is *slow*: the image's own probe took ~40s per attempt, so five retries spanned ~200s and accidentally acted as a long boot grace period. A 0.07s probe removes that padding, leaving `15s + 5×10s ≈ 65s`.

LocalStack needs longer than that here. Its startup blocks fetching a cert from `api.localstack.cloud` over the same unreachable DNS:

```
Failed to resolve 'api.localstack.cloud' ([Errno -3] Temporary failure in name resolution)
```

Measured cold boot: **87.4s** (container start `20:17:45.11`, `Ready.` at `20:19:12.53`). So the gate still fired first and the bring-up still died at the infra stage with `container macro-localstack-1 is unhealthy` — observed twice.

## Fix

Raise `start_period`. Docker doesn't count failures inside it against `retries`, so a slow boot can't fail the stack while a fast one still reports healthy on its first probe — it costs nothing on a healthy machine. `start_interval` polls every 2s inside that window so a normal boot is detected promptly rather than waiting out the 10s `interval`.

## Testing

Two cold boots with this change, each tearing down and recreating the container:

| run | infra stage | localstack |
| --- | --- | --- |
| A | `Starting infra (docker compose up -d --wait) Done 1m31s` | healthy |
| B | `Starting infra (docker compose up -d --wait) Done 1m30s` | healthy |

Run B completed the full `just stack up` (exit 0, 34 containers, frontend serving). Two runs without this change failed the same gate. Also `cargo check -p xtask_local --features local-stack` and `just check` — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects local/docker-compose LocalStack health gating; no runtime app, auth, or production paths.
> 
> **Overview**
> Extends the **generated LocalStack service healthcheck** so `docker compose up --wait` tolerates slow cold starts after the faster loopback `curl` probe.
> 
> **`start_period`** rises from **15s to 180s**, so probe failures during boot do not consume the retry budget while LocalStack can take ~90s+ (e.g. DNS to `api.localstack.cloud`). **`start_interval: 2s`** is added so readiness is detected quickly inside that grace window instead of waiting on the 10s probe interval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87c57fc849fe476bb51728c43ea62251e46272b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->