### PR TITLE
feat(new-layout): add top bars for list views

### DIFF
--- a/apps/web/src/components/view-shell/ViewShell.tsx
+++ b/apps/web/src/components/view-shell/ViewShell.tsx
@@ -342,6 +342,24 @@ function Main(props: JSX.HTMLAttributes<HTMLElement>) {
   );
 }
 
+function TopBar(props: JSX.HTMLAttributes<HTMLDivElement>) {
+  const [local, rest] = splitProps(props, ['children', 'class']);
+  return (
+    <div
+      {...rest}
+      class={cn(
+        'flex h-12 min-w-0 shrink-0 items-center border-b border-edge px-4 py-3 touch:hidden',
+        local.class
+      )}
+      data-view-shell-top-bar=""
+    >
+      <h1 class="min-w-0 truncate text-sm font-semibold tracking-[-0.03em] text-ink">
+        {local.children}
+      </h1>
+    </div>
+  );
+}
+
 function Header(props: JSX.HTMLAttributes<HTMLElement>) {
   const [local, rest] = splitProps(props, ['children', 'class']);
   return (
@@ -443,6 +461,7 @@ export const ViewShell = Object.assign(Root, {
   Root,
   Aside,
   Main,
+  TopBar,
   Header,
   Content,
   Detail,

--- a/apps/web/src/components/view-shell/ViewShell.tsx
+++ b/apps/web/src/components/view-shell/ViewShell.tsx
@@ -366,7 +366,7 @@ function Header(props: JSX.HTMLAttributes<HTMLElement>) {
     <header
       {...rest}
       class={cn(
-        'shrink-0 px-4 pb-3 pt-2 touch:px-(--mobile-chrome-gutter) touch:pt-[calc(var(--safe-top,0px)+0.5rem)]',
+        'shrink-0 px-4 py-4 touch:px-(--mobile-chrome-gutter) touch:pt-[calc(var(--safe-top,0px)+0.5rem)]',
         local.class
       )}
       data-view-shell-header=""

--- a/apps/web/src/components/view-shell/ViewSidebar.tsx
+++ b/apps/web/src/components/view-shell/ViewSidebar.tsx
@@ -24,7 +24,7 @@ function Header(props: JSX.HTMLAttributes<HTMLDivElement>) {
     <div
       {...rest}
       class={cn(
-        'flex min-w-0 shrink-0 items-center justify-between gap-3 border-b border-edge px-4 py-3',
+        'flex h-12 min-w-0 shrink-0 items-center justify-between gap-3 border-b border-edge px-4 py-3',
         local.class
       )}
       data-view-sidebar-header=""

--- a/apps/web/src/features/email-view/components/EmailHeader.tsx
+++ b/apps/web/src/features/email-view/components/EmailHeader.tsx
@@ -1,4 +1,8 @@
-import { SearchBar, useViewControlHotkeys } from '@app/components/view-shell';
+import {
+  SearchBar,
+  useViewControlHotkeys,
+  ViewShell,
+} from '@app/components/view-shell';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { SplitPanel } from '@components/app/split-panel';
 import MenuIcon from '@phosphor/list.svg';
@@ -6,6 +10,7 @@ import PlusIcon from '@phosphor/plus.svg';
 import { Button, Dropdown, pressHandlers } from '@ui';
 import { createSignal } from 'solid-js';
 import { composeEmail } from '../compose-email';
+import { EMAIL_TABS } from '../constants';
 import { useEmailView } from '../email-view-context';
 import { EmailControls } from './EmailControls';
 import { EmailInboxMenu } from './EmailInboxSelector';
@@ -15,6 +20,14 @@ export type EmailHeaderProps = {
   /** Restores list focus when Escape leaves the search field. */
   onSearchEscape?: () => void;
 };
+
+export function EmailTopBar() {
+  const { state } = useEmailView();
+  const title = () =>
+    EMAIL_TABS.find((tab) => tab.id === state.tab)?.label ?? 'Email';
+
+  return <ViewShell.TopBar>{title()}</ViewShell.TopBar>;
+}
 
 export function EmailHeader(props: EmailHeaderProps) {
   const panel = useSplitPanelOrThrow();

--- a/apps/web/src/features/email-view/email-view.tsx
+++ b/apps/web/src/features/email-view/email-view.tsx
@@ -15,7 +15,7 @@ import {
   Suspense,
 } from 'solid-js';
 import { EmailFilterDrawer } from './components/EmailFilterDrawer';
-import { EmailHeader } from './components/EmailHeader';
+import { EmailHeader, EmailTopBar } from './components/EmailHeader';
 import { EmailList } from './components/EmailList';
 import { EmailSidebar } from './components/EmailSidebar';
 import { EMAIL_TABS } from './constants';
@@ -48,6 +48,7 @@ function EmailDesktopLayout(
         <EmailSidebar />
       </ViewShell.Aside>
       <ViewShell.Main>
+        <EmailTopBar />
         <ViewShell.Header>
           <EmailHeader onSearchEscape={props.onSearchEscape} />
         </ViewShell.Header>

--- a/apps/web/src/features/tasks-view/components/TasksHeader.tsx
+++ b/apps/web/src/features/tasks-view/components/TasksHeader.tsx
@@ -1,4 +1,8 @@
-import { SearchBar, useViewControlHotkeys } from '@app/components/view-shell';
+import {
+  SearchBar,
+  useViewControlHotkeys,
+  ViewShell,
+} from '@app/components/view-shell';
 import { useSplitLayout } from '@components/app/split-layout/layout';
 import { useSplitPanelOrThrow } from '@components/app/split-layout/layoutUtils';
 import { SplitPanel } from '@components/app/split-panel';
@@ -17,6 +21,14 @@ export type TasksHeaderProps = {
   /** Restores list focus when Escape leaves the search field. */
   onSearchEscape?: () => void;
 };
+
+export function TasksTopBar() {
+  const { state } = useTasksView();
+  const title = () =>
+    TASK_TABS.find((tab) => tab.id === state.tab)?.label ?? 'Tasks';
+
+  return <ViewShell.TopBar>{title()}</ViewShell.TopBar>;
+}
 
 export function TasksHeader(props: TasksHeaderProps) {
   const panel = useSplitPanelOrThrow();

--- a/apps/web/src/features/tasks-view/tasks-view.tsx
+++ b/apps/web/src/features/tasks-view/tasks-view.tsx
@@ -4,7 +4,7 @@ import { SplitPanel } from '@components/app/split-panel';
 import { ListEntityMetadataQueryProvider } from '@entity';
 import SpinnerIcon from '@phosphor/spinner.svg';
 import { createSignal, onMount, Suspense } from 'solid-js';
-import { TasksHeader } from './components/TasksHeader';
+import { TasksHeader, TasksTopBar } from './components/TasksHeader';
 import { TasksSidebar } from './components/TasksSidebar';
 import { TaskList } from './components/task-list/TaskList';
 import { TasksViewProvider } from './tasks-view-context';
@@ -42,6 +42,7 @@ function TasksViewRoot() {
               <TasksSidebar />
             </ViewShell.Aside>
             <ViewShell.Main>
+              <TasksTopBar />
               <ViewShell.Header>
                 <TasksHeader onSearchEscape={() => listElement()?.focus()} />
               </ViewShell.Header>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Desktop-only layout and styling in view shell and email/tasks headers; no auth, data, or API changes.
> 
> **Overview**
> Adds a shared **`ViewShell.TopBar`** slot for desktop list layouts: fixed 48px bar with bottom border and a truncated **h1**, hidden on touch (`touch:hidden`). **`ViewShell.Header`** padding is normalized to `py-4`; **`ViewSidebar.Header`** gets matching **`h-12`** height.
> 
> **Email** and **Tasks** desktop shells now render **`EmailTopBar`** / **`TasksTopBar`** above the existing header; each title tracks the active tab from **`EMAIL_TABS`** / **`TASK_TABS`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54cc20b14d77b3e1c3a05acf8df8a8e3fbb9ddd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->