### PR TITLE
fix(agent): mobile composer focus bounce; model sheet search and Auto dedupe

### DIFF
--- a/apps/web/src/components/app/split-layout/mobile/MobileSplitContainer.tsx
+++ b/apps/web/src/components/app/split-layout/mobile/MobileSplitContainer.tsx
@@ -41,9 +41,6 @@ export function MobileSplitContainer(props: MobileSplitContainerProps) {
   const slotAData = slotDataFor(mobileSwipeLayout.slotASplitId);
   const slotBData = slotDataFor(mobileSwipeLayout.slotBSplitId);
 
-  const renderKeyForSplit = (split: SplitState) =>
-    `${split.id}:${split.content.type}:${split.content.id}`;
-
   return (
     <div
       class="relative size-full overflow-hidden"
@@ -66,11 +63,14 @@ export function MobileSplitContainer(props: MobileSplitContainerProps) {
             }
           >
             {/*
-             * Key by split and content so SplitPanel remounts when a slot
-             * receives a new split, even if it has the same content id.
+             * Key by split id so SplitPanel remounts when a slot receives a
+             * new split — and only then. Content changes inside a split
+             * (navigation, or the agent block adopting its real session id
+             * mid-typing) swap the mount without tearing the panel down,
+             * matching the desktop layout.
              */}
-            <Show when={renderKeyForSplit(a().split)} keyed>
-              {(_renderKey) => (
+            <Show when={a().split.id} keyed>
+              {(_splitId) => (
                 <Suspense>
                   <SplitPanel
                     split={a().split}
@@ -98,8 +98,8 @@ export function MobileSplitContainer(props: MobileSplitContainerProps) {
               motion.handleTransitionEnd(e, !mobileSwipeLayout.fgIsSlotA())
             }
           >
-            <Show when={renderKeyForSplit(b().split)} keyed>
-              {(_renderKey) => (
+            <Show when={b().split.id} keyed>
+              {(_splitId) => (
                 <Suspense>
                   <SplitPanel
                     split={b().split}

--- a/apps/web/src/features/block-agent/debug/Gallery.tsx
+++ b/apps/web/src/features/block-agent/debug/Gallery.tsx
@@ -39,9 +39,12 @@ import {
   ToolStatusTitle,
 } from '../ui';
 
-/** A Cursor-shaped catalog: long enough to scroll, with one grouped tail. */
+/**
+ * A Cursor-shaped catalog: long enough to scroll, with one grouped tail. Auto
+ * arrives under a family of its own, as Cursor files it.
+ */
 const FIXTURE_MODELS: ModelOption[] = [
-  { id: 'auto', name: 'Auto', description: null, group: null },
+  { id: 'default', name: 'Auto', description: null, group: 'Auto' },
   {
     id: 'grok-4.6-high-fast',
     name: 'Cursor Grok 4.6 High Fast',

--- a/apps/web/src/features/block-agent/ui/AgentInput.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentInput.tsx
@@ -154,10 +154,20 @@ export function AgentInput(props: AgentInputProps) {
   // (channel EditorShell / chat surface) so the whole box is tappable,
   // including on touch — pointerdown stays inside the user gesture that
   // iOS needs to raise the keyboard.
+  //
+  // The tap's own default must not run afterwards: a mousedown on a target
+  // with nothing focusable above it blurs the active element — the editor
+  // just focused — and the keyboard drops again. Cancel pointerdown, and
+  // mousedown too because a real iPhone still synthesises it after a
+  // cancelled pointerdown (see `keepEditorFocus` in TouchSelectionToolbar).
+  // Taps inside the contenteditable keep their defaults so the caret lands
+  // under the finger.
   const focusEditor = (event: Event) => {
     const target = event.target as HTMLElement | null;
-    if (target?.closest('button')) return;
-    editor.controls.focus();
+    if (!target || target.closest('button')) return;
+    if (editor.lexical.getRootElement()?.contains(target)) return;
+    event.preventDefault();
+    if (event.type === 'pointerdown') editor.controls.focus();
   };
 
   return (
@@ -175,6 +185,7 @@ export function AgentInput(props: AgentInputProps) {
         <div
           class="flex items-end gap-1 px-2 py-1.5 touch:flex-col touch:items-stretch touch:gap-1.5 touch:px-3 touch:pt-2.5 touch:pb-2"
           onPointerDown={focusEditor}
+          onMouseDown={focusEditor}
         >
           {/* No vertical padding of its own: the shell is min-h-8 and editor
             paragraphs carry my-1.5, so the row's py-1.5 is the whole frame —

--- a/apps/web/src/features/block-agent/ui/AgentModelSelector.tsx
+++ b/apps/web/src/features/block-agent/ui/AgentModelSelector.tsx
@@ -7,9 +7,10 @@
  * own. Renders nothing until the harness has advertised its models.
  *
  * Touch devices get a bottom sheet (`MobileDrawer`, the same chrome as the
- * split title menu) listing every model with a check on the current one.
- * Desktop keeps a popover: a compact scrolling list for short catalogs, the
- * searchable `ModelCatalogPicker` for long ones.
+ * split title menu) listing every model with a check on the current one, and
+ * a search field once the catalog is long enough to need one. Desktop keeps
+ * a popover: a compact scrolling list for short catalogs, the searchable
+ * `ModelCatalogPicker` for long ones.
  *
  * Harnesses advertise as many models as they like, so the desktop list
  * scrolls rather than growing without bound: it shows at most
@@ -20,14 +21,20 @@
 
 import { MobileDrawer } from '@components/app/mobile/MobileDrawer';
 import { ModelCatalogPicker } from '@core/component/AI/component/input/ModelCatalogPicker';
-import { isLargeModelCatalog } from '@core/component/AI/component/input/modelCatalog';
+import {
+  type CatalogModelOption,
+  isLargeModelCatalog,
+  matchesModelQuery,
+} from '@core/component/AI/component/input/modelCatalog';
 import { ScrollIndicators } from '@core/component/VerticalScrollIndicators';
 import { isTouchDevice } from '@core/mobile/isTouchDevice';
 import Check from '@phosphor/check.svg';
+import SearchIcon from '@phosphor/magnifying-glass.svg';
 import CaretDown from '@phosphor-icons/core/regular/caret-down.svg?component-solid';
 import type { ModelOption } from '@service-agent-fold/generated/types';
 import { Button, cn, Dropdown } from '@ui';
 import { createMemo, createSignal, For, Show } from 'solid-js';
+import { groupOptions, withoutRedundantGroups } from './model-groups';
 import { TextShimmer } from './TextShimmer';
 
 /** Compact ghost pill — same size as the short-list trigger and chat's selector. */
@@ -40,6 +47,8 @@ const ROW_HEIGHT_PX = 28;
 const MAX_VISIBLE_ROWS = 10;
 /** The scroll container's own top padding, inside the capped window. */
 const LIST_PADDING_PX = 6;
+/** Past this many models the sheet gets a search field. */
+const SEARCHABLE_MODEL_COUNT = 8;
 
 /**
  * Ten whole rows plus half of the eleventh, clamped to the room the popper
@@ -66,41 +75,43 @@ export interface AgentModelSelectorProps {
   onSelect: (model: string) => void;
 }
 
-/** Consecutive options under one harness heading (`null` = no heading). */
-type ModelGroup = { label: string | null; options: ModelOption[] };
-
-function groupOptions(options: ModelOption[]): ModelGroup[] {
-  const groups: ModelGroup[] = [];
-  for (const option of options) {
-    const label = option.group ?? null;
-    const last = groups[groups.length - 1];
-    if (last && last.label === label) last.options.push(option);
-    else groups.push({ label, options: [option] });
-  }
-  return groups;
-}
-
 export function AgentModelSelector(props: AgentModelSelectorProps) {
   const [listRef, setListRef] = createSignal<HTMLElement>();
   const [sheetOpen, setSheetOpen] = createSignal(false);
+  const [query, setQuery] = createSignal('');
   const shown = () => props.changingTo ?? props.model;
   const label = () =>
     props.options.find((option) => option.id === shown())?.name ??
     shown() ??
     'Model';
-  const catalogOptions = () =>
-    props.options.map((option) => ({
-      id: option.id,
-      label: option.name,
-      description: option.description ?? undefined,
-      group: option.group ?? undefined,
-    }));
+  const options = createMemo(() => withoutRedundantGroups(props.options));
+  const toCatalogOption = (option: ModelOption): CatalogModelOption => ({
+    id: option.id,
+    label: option.name,
+    description: option.description ?? undefined,
+    group: option.group ?? undefined,
+  });
+  const catalogOptions = () => options().map(toCatalogOption);
   const useCatalog = () => isLargeModelCatalog(catalogOptions());
-  const groups = createMemo(() => groupOptions(props.options));
+  const searchable = () => props.options.length > SEARCHABLE_MODEL_COUNT;
+  const groups = createMemo(() => {
+    const normalizedQuery = query().trim().toLowerCase();
+    const matching = normalizedQuery
+      ? options().filter((option) =>
+          matchesModelQuery(toCatalogOption(option), normalizedQuery)
+        )
+      : options();
+    return groupOptions(matching);
+  });
   const disabled = () => props.disabled || props.changingTo !== undefined;
 
+  const openSheet = (open: boolean) => {
+    setSheetOpen(open);
+    if (!open) setQuery('');
+  };
+
   const pick = (id: string) => {
-    setSheetOpen(false);
+    openSheet(false);
     if (id !== props.model) props.onSelect(id);
   };
 
@@ -108,7 +119,7 @@ export function AgentModelSelector(props: AgentModelSelectorProps) {
     <MobileDrawer
       side="bottom"
       open={sheetOpen()}
-      onOpenChange={setSheetOpen}
+      onOpenChange={openSheet}
       preventScroll={false}
       preventScrollbarShift={false}
     >
@@ -132,7 +143,25 @@ export function AgentModelSelector(props: AgentModelSelectorProps) {
         <MobileDrawer.Overlay class="fixed inset-0 z-modal-overlay bg-modal-overlay pattern-diagonal-4 pattern-edge-muted" />
         <MobileDrawer.Content aria-label="Choose a model">
           <MobileDrawer.Handle />
+          <Show when={searchable()}>
+            <div class="mx-4 mb-3 flex shrink-0 items-center gap-2 rounded-lg border border-edge-muted bg-surface px-3 py-2">
+              <SearchIcon class="size-3.5 shrink-0 text-ink-muted" />
+              <input
+                type="text"
+                aria-label="Search models"
+                placeholder="Search models"
+                value={query()}
+                onInput={(event) => setQuery(event.currentTarget.value)}
+                class="min-w-0 flex-1 bg-transparent text-sm text-ink outline-none placeholder:text-ink-placeholder"
+              />
+            </div>
+          </Show>
           <MobileDrawer.ScrollBody>
+            <Show when={groups().length === 0}>
+              <div class="px-4 py-6 text-center text-sm text-ink-muted">
+                No models match that search.
+              </div>
+            </Show>
             <For each={groups()}>
               {(group) => (
                 <>
@@ -196,7 +225,7 @@ export function AgentModelSelector(props: AgentModelSelectorProps) {
             style={{ 'max-height': LIST_MAX_HEIGHT }}
           >
             <div class="flex flex-col p-1.5">
-              <For each={props.options}>
+              <For each={options()}>
                 {(option) => (
                   <Dropdown.Item
                     class={cn(

--- a/apps/web/src/features/block-agent/ui/model-groups.test.ts
+++ b/apps/web/src/features/block-agent/ui/model-groups.test.ts
@@ -1,0 +1,57 @@
+import type { ModelOption } from '@service-agent-fold/generated/types';
+import { describe, expect, it } from 'vitest';
+import { groupOptions, withoutRedundantGroups } from './model-groups';
+
+const option = (
+  id: string,
+  name: string,
+  group: string | null
+): ModelOption => ({ id, name, description: null, group });
+
+describe('withoutRedundantGroups', () => {
+  it('drops a heading that only repeats its single member', () => {
+    const options = [
+      option('default', 'Auto', 'Auto'),
+      option('opus-5', 'Claude Opus 5', 'Claude Opus'),
+      option('opus-4.8', 'Claude Opus 4.8', 'Claude Opus'),
+    ];
+
+    expect(withoutRedundantGroups(options).map((o) => o.group)).toEqual([
+      null,
+      'Claude Opus',
+      'Claude Opus',
+    ]);
+  });
+
+  it('keeps a singleton heading that says something new', () => {
+    const options = [option('sol', 'GPT-5.6 Sol', 'GPT')];
+
+    expect(withoutRedundantGroups(options)[0]?.group).toBe('GPT');
+  });
+
+  it('keeps a heading shared by two members named after it', () => {
+    const options = [option('a', 'Auto', 'Auto'), option('b', 'Auto', 'Auto')];
+
+    expect(withoutRedundantGroups(options).map((o) => o.group)).toEqual([
+      'Auto',
+      'Auto',
+    ]);
+  });
+});
+
+describe('groupOptions', () => {
+  it('buckets consecutive options under one heading', () => {
+    const groups = groupOptions([
+      option('default', 'Auto', null),
+      option('opus-5', 'Claude Opus 5', 'Claude Opus'),
+      option('opus-4.8', 'Claude Opus 4.8', 'Claude Opus'),
+      option('kimi', 'Kimi K3', 'Kimi'),
+    ]);
+
+    expect(groups.map((g) => [g.label, g.options.length])).toEqual([
+      [null, 1],
+      ['Claude Opus', 2],
+      ['Kimi', 1],
+    ]);
+  });
+});

--- a/apps/web/src/features/block-agent/ui/model-groups.ts
+++ b/apps/web/src/features/block-agent/ui/model-groups.ts
@@ -1,0 +1,40 @@
+/**
+ * Shaping a harness's model list for the pickers: the headings it grouped
+ * models under, minus the ones that would only repeat a model's own name.
+ */
+
+import type { ModelOption } from '@service-agent-fold/generated/types';
+
+/** Consecutive options under one harness heading (`null` = no heading). */
+export type ModelGroup = { label: string | null; options: ModelOption[] };
+
+/**
+ * Drop a heading whose only member carries the same name — Cursor files
+ * "Auto" under a family of its own, which would render as "Auto" twice.
+ */
+export function withoutRedundantGroups(options: ModelOption[]): ModelOption[] {
+  const groupSizes = new Map<string, number>();
+  for (const option of options) {
+    if (option.group) {
+      groupSizes.set(option.group, (groupSizes.get(option.group) ?? 0) + 1);
+    }
+  }
+  return options.map((option) =>
+    option.group &&
+    option.group === option.name &&
+    groupSizes.get(option.group) === 1
+      ? { ...option, group: null }
+      : option
+  );
+}
+
+export function groupOptions(options: ModelOption[]): ModelGroup[] {
+  const groups: ModelGroup[] = [];
+  for (const option of options) {
+    const label = option.group ?? null;
+    const last = groups[groups.length - 1];
+    if (last && last.label === label) last.options.push(option);
+    else groups.push({ label, options: [option] });
+  }
+  return groups;
+}


### PR DESCRIPTION
## What

Two mobile agent-session fixes, frontend only. (The shared rename dialog work that was here earlier was pulled out; agent sessions should join the entity union first, in a separate PR.)

### Composer loses focus on tap (two causes)

**Freshly created session.** `MobileSplitContainer` keyed each panel on `split.id:content.type:content.id`. The agent block mounts on a placeholder id and adopts the real session id when the create resolves, so on mobile the whole panel remounted ~500 ms after you tapped the composer: focus fell to `<body>` and the keyboard closed. Desktop never keyed on content. The panel is now keyed on the split id alone, which is what the adopt-content-id contract in `orchestrator.tsx` promises.

**Existing session.** `AgentInput` focuses the editor on `pointerdown` so the whole box is tappable on a phone, but the tap's own default then runs against a non-editable target (on touch most of the box is padding and the controls footer). A `mousedown` with nothing focusable above it blurs the active element, so the keyboard rises and drops in one tap. The handler now cancels `pointerdown` and `mousedown` for taps outside the contenteditable (mousedown too, because a real iPhone still synthesises it after a cancelled pointerdown, per `keepEditorFocus` in `TouchSelectionToolbar`). Taps on the text itself and on buttons keep their defaults.

### Model sheet

- Search field on the mobile bottom sheet for catalogs over eight models, using the same `matchesModelQuery` as the desktop catalog picker, plus an empty state.
- Cursor files "Auto" under a single-member family also named "Auto", so grouped lists showed the heading and the row. `withoutRedundantGroups` drops a heading whose only member repeats its name. The backend inference in `cursor_cloud_agents` is the real source; this is the frontend guard.

## Verification

- Reproduced the create-flow remount in emulated touch Chrome against a local stack with a `MutationObserver` on `#agent-input-text-area`: before, the composer detached and `activeElement` fell to `BODY` at the moment the URL swapped placeholder → real id; after, it stays mounted and focused.
- Verified the tap handler paths in emulation: padding taps are cancelled and end with the editor focused, taps on the contenteditable and on buttons are not cancelled. The keyboard staying up needs a real-device tap to confirm.
- Model sheet on `/component/agent-ui`: single "Auto" row, no "Auto" heading, search filters (`opus` → two rows), empty state renders.
- `just check`, `tsc --noEmit`, and the block-agent / split-layout vitest suites pass. New unit tests in `model-groups.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only mobile UX and model list presentation; split keying aligns mobile with desktop and reduces accidental remounts rather than changing server or auth behavior.
> 
> **Overview**
> Fixes **mobile agent composer focus** and improves the **model picker** on touch.
> 
> **Mobile split panels** now key `SplitPanel` on `split.id` only (not content type/id), so when a new agent session swaps a placeholder id for the real session id the composer stays mounted and focused—matching desktop instead of remounting and dropping the keyboard.
> 
> **AgentInput** cancels default `pointerdown`/`mousedown` on taps outside the Lexical root (padding/footer) after programmatic focus, so iOS doesn’t blur the editor on the synthesized `mousedown`; taps on the editable and buttons are unchanged.
> 
> **Agent model UI**: mobile bottom sheet gets **search** when there are more than eight models (same `matchesModelQuery` as desktop), with an empty state; shared **`model-groups`** helpers drop redundant group headings when a lone model’s group label duplicates its name (e.g. “Auto”); gallery fixture updated accordingly. Unit tests cover grouping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3f16e5946c476462ef328504b1fbc5a9e7d00f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->