### PR TITLE
feat: unread badges in sidebar

### DIFF
--- a/apps/web/src/components/app/sidebar-next/list-nav.tsx
+++ b/apps/web/src/components/app/sidebar-next/list-nav.tsx
@@ -12,9 +12,11 @@ import { Button, cn } from '@ui';
 import { createSignal, onCleanup } from 'solid-js';
 import { NavGlyph } from './nav-glyph';
 import type { SidebarNextNavItem } from './nav-items';
+import { SidebarUnreadDot } from './unread-dot';
 
 export type ListNavProps = {
   item: SidebarNextNavItem;
+  unread?: boolean;
   onContextMenuOpenChange?: (open: boolean) => void;
 };
 
@@ -172,6 +174,7 @@ export const ListNav = (props: ListNavProps) => {
         size="icon-md"
         class="cursor-default rounded-xl"
         label={props.item.label}
+        aria-description={props.unread ? 'Unread items' : undefined}
         tooltip={`Go to ${props.item.label}`}
         tooltipPlacement="right"
         hotkey={[TOKENS.sidebar.goToLeader, props.item.hotkeyToken]}
@@ -182,6 +185,7 @@ export const ListNav = (props: ListNavProps) => {
         // tests use keep working.
         data-active={isActive() ? '' : undefined}
         data-sidebar-next-item={props.item.id}
+        data-unread={props.unread ? '' : undefined}
         onMouseDown={onMouseDown}
         onClick={onClick}
       >
@@ -209,6 +213,7 @@ export const ListNav = (props: ListNavProps) => {
           filled={isActive()}
           class={cn('size-5.5', isActive() && 'text-accent')}
         />
+        <SidebarUnreadDot active={props.unread} />
       </Button>
     </SidebarOpenInSplitMenu>
   );

--- a/apps/web/src/components/app/sidebar-next/list-nav.tsx
+++ b/apps/web/src/components/app/sidebar-next/list-nav.tsx
@@ -7,9 +7,10 @@ import {
 } from '@components/app/app-sidebar/sidebar';
 import { useSplitLayout } from '@components/app/split-layout/layout';
 import { TOKENS } from '@core/hotkey/tokens';
+import PhoneCallIcon from '@phosphor-fill/phone-call-fill.svg';
 import { useLocation } from '@solidjs/router';
 import { Button, cn } from '@ui';
-import { createSignal, onCleanup } from 'solid-js';
+import { createSignal, onCleanup, Show } from 'solid-js';
 import { NavGlyph } from './nav-glyph';
 import type { SidebarNextNavItem } from './nav-items';
 import { SidebarUnreadDot } from './unread-dot';
@@ -17,6 +18,7 @@ import { SidebarUnreadDot } from './unread-dot';
 export type ListNavProps = {
   item: SidebarNextNavItem;
   unread?: boolean;
+  activeCall?: boolean;
   onContextMenuOpenChange?: (open: boolean) => void;
 };
 
@@ -174,7 +176,11 @@ export const ListNav = (props: ListNavProps) => {
         size="icon-md"
         class="cursor-default rounded-xl"
         label={props.item.label}
-        aria-description={props.unread ? 'Unread items' : undefined}
+        aria-description={
+          [props.unread && 'Unread items', props.activeCall && 'Active call']
+            .filter(Boolean)
+            .join('. ') || undefined
+        }
         tooltip={`Go to ${props.item.label}`}
         tooltipPlacement="right"
         hotkey={[TOKENS.sidebar.goToLeader, props.item.hotkeyToken]}
@@ -186,6 +192,7 @@ export const ListNav = (props: ListNavProps) => {
         data-active={isActive() ? '' : undefined}
         data-sidebar-next-item={props.item.id}
         data-unread={props.unread ? '' : undefined}
+        data-active-call={props.activeCall ? '' : undefined}
         onMouseDown={onMouseDown}
         onClick={onClick}
       >
@@ -213,7 +220,17 @@ export const ListNav = (props: ListNavProps) => {
           filled={isActive()}
           class={cn('size-5.5', isActive() && 'text-accent')}
         />
-        <SidebarUnreadDot active={props.unread} />
+        <Show
+          when={props.activeCall}
+          fallback={<SidebarUnreadDot active={props.unread} />}
+        >
+          <span
+            aria-hidden="true"
+            class="pointer-events-none absolute top-0 right-0 flex size-3.5 items-center justify-center text-accent"
+          >
+            <PhoneCallIcon class="size-full" />
+          </span>
+        </Show>
       </Button>
     </SidebarOpenInSplitMenu>
   );

--- a/apps/web/src/components/app/sidebar-next/queries/use-sidebar-unread.test.ts
+++ b/apps/web/src/components/app/sidebar-next/queries/use-sidebar-unread.test.ts
@@ -1,0 +1,143 @@
+import type { EmailEntity } from '@entity/types/entity';
+import type { UnifiedNotification } from '@notifications/types';
+import { createRoot, createSignal } from 'solid-js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useSidebarUnread } from './use-sidebar-unread';
+
+const mocks = vi.hoisted(() => ({
+  inbox: vi.fn(),
+  email: vi.fn(),
+  notifications: vi.fn(),
+}));
+
+vi.mock('@app/features/inbox-view/queries/use-inbox-query', () => ({
+  useInboxEntitiesQuery: mocks.inbox,
+}));
+vi.mock('@queries/soup/items', () => ({
+  useSoupAstItemsQuery: mocks.email,
+}));
+vi.mock('@components/app/GlobalAppState', () => ({
+  useGlobalNotificationSource: () => ({ notifications: mocks.notifications }),
+}));
+// Query builders import the soup barrel, which otherwise opens real sockets.
+vi.mock('@service-storage/websocket', () => ({
+  storageWS: { reconnectIfDisconnected: vi.fn() },
+  createWebSocketJob: vi.fn(),
+}));
+vi.mock('@service-connection/websocket', () => ({
+  ws: { addEventListener: vi.fn(), send: vi.fn() },
+  state: () => 'closed',
+  createConnectionBlockWebsocketEffect: vi.fn(),
+  createConnectionWebsocketEffect: vi.fn(),
+}));
+
+const unreadEmail: EmailEntity = {
+  id: 'email',
+  type: 'email',
+  name: 'Important email',
+  ownerId: 'user',
+  isRead: false,
+  isDraft: false,
+  isImportant: true,
+  done: false,
+};
+
+const message: UnifiedNotification = {
+  id: 'notification',
+  entity_id: 'channel',
+  entity_type: 'channel',
+  created_at: '2026-09-10T12:00:00Z',
+  updated_at: '2026-09-10T12:00:00Z',
+  done: false,
+  sent: true,
+  viewed_at: null,
+  notification_event_type: 'channel_message_send',
+  notification_metadata: {
+    tag: 'channel_message_send',
+    content: { channelType: 'directMessage', messageId: 'message' },
+  },
+};
+
+let dispose: VoidFunction;
+afterEach(() => {
+  dispose?.();
+  vi.clearAllMocks();
+});
+
+function setup() {
+  return createRoot((cleanup) => {
+    dispose = cleanup;
+    const [loading, setLoading] = createSignal(true);
+    const [emails, setEmails] = createSignal<EmailEntity[]>([]);
+    const [notifications, setNotifications] = createSignal<
+      UnifiedNotification[]
+    >([]);
+    const query = {
+      get isLoading() {
+        return loading();
+      },
+      get data() {
+        if (loading()) throw new Error('Read pending resource');
+        return { entities: emails() };
+      },
+    };
+    mocks.inbox.mockReturnValue({
+      query,
+      transformEntities: (items: EmailEntity[]) =>
+        items.filter((item) => !item.done),
+    });
+    mocks.email.mockReturnValue(query);
+    mocks.notifications.mockImplementation(notifications);
+    return {
+      unread: useSidebarUnread(),
+      setLoading,
+      setEmails,
+      setNotifications,
+    };
+  });
+}
+
+describe('sidebar unread presence', () => {
+  it('does not read pending resources or badge unrelated navigation', () => {
+    const { unread } = setup();
+    for (const id of ['inbox', 'mail', 'channels', 'documents', 'agents']) {
+      expect(unread(id)).toBe(false);
+    }
+    expect(mocks.inbox).toHaveBeenCalledWith({
+      tab: 'signal',
+      facets: { read: ['unread'] },
+    });
+  });
+
+  it('reacts to read, unread, and done changes in loaded rows', () => {
+    const { unread, setLoading, setEmails } = setup();
+    setLoading(false);
+    setEmails([unreadEmail]);
+    expect(unread('inbox')).toBe(true);
+    expect(unread('mail')).toBe(true);
+    setEmails([{ ...unreadEmail, isRead: true }]);
+    expect(unread('inbox')).toBe(false);
+    expect(unread('mail')).toBe(false);
+    setEmails([unreadEmail]);
+    expect(unread('mail')).toBe(true);
+    setEmails([{ ...unreadEmail, done: true }]);
+    expect(unread('inbox')).toBe(false);
+    expect(unread('mail')).toBe(false);
+  });
+
+  it('uses unread channel messages, ignoring seen, completed, and other entities', () => {
+    const { unread, setNotifications } = setup();
+    setNotifications([message]);
+    expect(unread('channels')).toBe(true);
+    setNotifications([{ ...message, viewed_at: message.created_at }]);
+    expect(unread('channels')).toBe(false);
+    setNotifications([{ ...message, done: true }]);
+    expect(unread('channels')).toBe(false);
+    setNotifications([{ ...message, entity_type: 'document' }]);
+    expect(unread('channels')).toBe(false);
+    setNotifications([message, { ...message, id: 'another' }]);
+    expect(unread('channels')).toBe(true);
+    setNotifications([]);
+    expect(unread('channels')).toBe(false);
+  });
+});

--- a/apps/web/src/components/app/sidebar-next/queries/use-sidebar-unread.test.ts
+++ b/apps/web/src/components/app/sidebar-next/queries/use-sidebar-unread.test.ts
@@ -48,7 +48,7 @@ const message: UnifiedNotification = {
   entity_type: 'channel',
   created_at: '2026-09-10T12:00:00Z',
   updated_at: '2026-09-10T12:00:00Z',
-  done: false,
+  state: 'unseen',
   sent: true,
   viewed_at: null,
   notification_event_type: 'channel_message_send',
@@ -129,9 +129,11 @@ describe('sidebar unread presence', () => {
     const { unread, setNotifications } = setup();
     setNotifications([message]);
     expect(unread('channels')).toBe(true);
-    setNotifications([{ ...message, viewed_at: message.created_at }]);
+    setNotifications([
+      { ...message, state: 'seen', viewed_at: message.created_at },
+    ]);
     expect(unread('channels')).toBe(false);
-    setNotifications([{ ...message, done: true }]);
+    setNotifications([{ ...message, state: 'done' }]);
     expect(unread('channels')).toBe(false);
     setNotifications([{ ...message, entity_type: 'document' }]);
     expect(unread('channels')).toBe(false);

--- a/apps/web/src/components/app/sidebar-next/queries/use-sidebar-unread.ts
+++ b/apps/web/src/components/app/sidebar-next/queries/use-sidebar-unread.ts
@@ -1,6 +1,7 @@
 import { buildEmailQuery } from '@app/features/email-view/queries/email-query';
 import { soupItemMatchesInboxTab } from '@app/features/inbox-view/queries/inbox-item-filter';
 import { useInboxEntitiesQuery } from '@app/features/inbox-view/queries/use-inbox-query';
+import { EMPTY_TAG_FACET_CONTEXT } from '@app/features/soup/filters/facets/tag-facet';
 import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
 import { unreadFilterFn } from '@entity/utils/filter';
 import { notificationIsRead } from '@entity/utils/notification';
@@ -20,6 +21,7 @@ export function useSidebarUnread() {
         tab: 'important',
         inboxIds: undefined,
         facets: { read: ['unread'] },
+        facetContext: EMPTY_TAG_FACET_CONTEXT,
       }),
     () => ({
       meta: { insertFilter: (item) => soupItemMatchesInboxTab(item, 'signal') },

--- a/apps/web/src/components/app/sidebar-next/queries/use-sidebar-unread.ts
+++ b/apps/web/src/components/app/sidebar-next/queries/use-sidebar-unread.ts
@@ -1,0 +1,59 @@
+import { buildEmailQuery } from '@app/features/email-view/queries/email-query';
+import { soupItemMatchesInboxTab } from '@app/features/inbox-view/queries/inbox-item-filter';
+import { useInboxEntitiesQuery } from '@app/features/inbox-view/queries/use-inbox-query';
+import { useGlobalNotificationSource } from '@components/app/GlobalAppState';
+import { unreadFilterFn } from '@entity/utils/filter';
+import { notificationIsRead } from '@entity/utils/notification';
+import { useSoupAstItemsQuery } from '@queries/soup/items';
+import { createMemo } from 'solid-js';
+
+/** Presence in the loaded unread page, never a total or a pagination loop. */
+export function useSidebarUnread() {
+  const notificationSource = useGlobalNotificationSource();
+  const inbox = useInboxEntitiesQuery({
+    tab: 'signal',
+    facets: { read: ['unread'] },
+  });
+  const email = useSoupAstItemsQuery(
+    () =>
+      buildEmailQuery({
+        tab: 'important',
+        inboxIds: undefined,
+        facets: { read: ['unread'] },
+      }),
+    () => ({
+      meta: { insertFilter: (item) => soupItemMatchesInboxTab(item, 'signal') },
+    })
+  );
+
+  // Guard resource reads so loading a badge cannot suspend the app shell.
+  // Re-check cached rows: optimistic read/done changes can leave them in a page.
+  const inboxUnread = createMemo(() => {
+    if (inbox.query.isLoading) return false;
+    return inbox
+      .transformEntities(inbox.query.data?.entities ?? [])
+      .some(unreadFilterFn);
+  });
+  const emailUnread = createMemo(() => {
+    if (email.isLoading) return false;
+    return (email.data?.entities ?? []).some(
+      (entity) => entity.type === 'email' && !entity.isRead && !entity.done
+    );
+  });
+  const channelsUnread = createMemo(() =>
+    notificationSource
+      .notifications()
+      .some(
+        (notification) =>
+          notification.entity_type === 'channel' &&
+          !notificationIsRead(notification)
+      )
+  );
+
+  return (id: string): boolean => {
+    if (id === 'inbox') return inboxUnread();
+    if (id === 'mail') return emailUnread();
+    if (id === 'channels') return channelsUnread();
+    return false;
+  };
+}

--- a/apps/web/src/components/app/sidebar-next/sidebar-rail.tsx
+++ b/apps/web/src/components/app/sidebar-next/sidebar-rail.tsx
@@ -12,6 +12,7 @@ import { SidebarRailCreateButton } from './create-button';
 import { FooterActions } from './footer-actions';
 import { ListNav } from './list-nav';
 import { visibleNavItems } from './nav-items';
+import { useSidebarUnread } from './queries/use-sidebar-unread';
 import { SearchRailButton } from './search-bar-button';
 import { useNavItemGates } from './use-nav-item-gates';
 
@@ -38,6 +39,7 @@ export const SidebarRail = (props: SidebarRailProps) => {
   const gates = useNavItemGates();
   const analytics = useAnalytics();
   const layout = useSplitLayout();
+  const hasUnread = useSidebarUnread();
 
   const isExpanded = () => (props.sidebarState ?? 'expanded') === 'expanded';
 
@@ -76,7 +78,7 @@ export const SidebarRail = (props: SidebarRailProps) => {
           <For each={visibleNavItems(gates())}>
             {(item) => (
               <li class="flex">
-                <ListNav item={item} />
+                <ListNav item={item} unread={hasUnread(item.id)} />
               </li>
             )}
           </For>

--- a/apps/web/src/components/app/sidebar-next/sidebar-rail.tsx
+++ b/apps/web/src/components/app/sidebar-next/sidebar-rail.tsx
@@ -7,6 +7,7 @@ import {
 } from '@components/app/app-sidebar/sidebar';
 import { useSplitLayout } from '@components/app/split-layout/layout';
 import { hotkeyScopeNeutralAttribute } from '@core/dom-selectors';
+import { useActiveCallsQuery } from '@queries/call/call';
 import { For } from 'solid-js';
 import { SidebarRailCreateButton } from './create-button';
 import { FooterActions } from './footer-actions';
@@ -40,6 +41,10 @@ export const SidebarRail = (props: SidebarRailProps) => {
   const analytics = useAnalytics();
   const layout = useSplitLayout();
   const hasUnread = useSidebarUnread();
+  const activeCallsQuery = useActiveCallsQuery();
+  // Keep the rail mounted while the shared call query loads.
+  const hasActiveCall = () =>
+    !activeCallsQuery.isPending && (activeCallsQuery.data?.length ?? 0) > 0;
 
   const isExpanded = () => (props.sidebarState ?? 'expanded') === 'expanded';
 
@@ -78,7 +83,11 @@ export const SidebarRail = (props: SidebarRailProps) => {
           <For each={visibleNavItems(gates())}>
             {(item) => (
               <li class="flex">
-                <ListNav item={item} unread={hasUnread(item.id)} />
+                <ListNav
+                  item={item}
+                  unread={hasUnread(item.id)}
+                  activeCall={item.id === 'channels' && hasActiveCall()}
+                />
               </li>
             )}
           </For>

--- a/apps/web/src/components/app/sidebar-next/unread-dot.tsx
+++ b/apps/web/src/components/app/sidebar-next/unread-dot.tsx
@@ -1,0 +1,19 @@
+import { UnreadIndicator } from '@entity/components/UnreadIndicator';
+import { cn } from '@ui';
+
+/** Fixed geometry keeps the glyph still as unread state changes. */
+export function SidebarUnreadDot(props: { active?: boolean }) {
+  return (
+    <span
+      aria-hidden="true"
+      data-sidebar-unread-dot
+      class={cn(
+        'pointer-events-none absolute right-1 top-1 rounded-full ring-2 ring-surface',
+        'transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-none',
+        props.active ? 'scale-100 opacity-100' : 'scale-75 opacity-0'
+      )}
+    >
+      <UnreadIndicator active class="size-1.5" />
+    </span>
+  );
+}

--- a/apps/web/src/features/inbox-view/queries/use-inbox-query.ts
+++ b/apps/web/src/features/inbox-view/queries/use-inbox-query.ts
@@ -97,9 +97,10 @@ function matchesTab(
     .exhaustive();
 }
 
-export function useInboxDataSource(
-  state: InboxDataSourceInput
-): InboxDataSource {
+/** Shared feed membership for the Inbox list and its sidebar unread indicator. */
+export function useInboxEntitiesQuery(
+  state: Pick<InboxDataSourceInput, 'tab' | 'facets'>
+) {
   const notificationSource = useGlobalNotificationSource();
   const userId = useUserId();
 
@@ -153,6 +154,15 @@ export function useInboxDataSource(
       )
       .filter((entity) => matchesTab(entity, context.tab, notificationSource));
   };
+
+  return { query, viewContext, transformEntities };
+}
+
+export function useInboxDataSource(
+  state: InboxDataSourceInput
+): InboxDataSource {
+  const { query, viewContext, transformEntities } =
+    useInboxEntitiesQuery(state);
 
   const { entityPool } = useSearchContext();
   const localPool = createMemo(() => {

--- a/docs/AGENT_GUIDE/navigation.md
+++ b/docs/AGENT_GUIDE/navigation.md
@@ -37,6 +37,14 @@ Splits: the app is a tiling window manager. A second pane appends its own segmen
 - Bottom: button named after the user's email — menu with `Command menu (Ctrl K)`,
   `Settings (Ctrl ;)`, `Log out`.
 
+With the new app views enabled, the outer sidebar is an icon rail. Notifications,
+Email, and Chat show a small accent dot when the loaded data contains an unread
+item. Notifications uses Signal; Email uses Important across all linked inboxes.
+Noise does not light either dot. These are presence indicators, not counts; they
+do not fetch additional pages to find every unread item. Opening a view alone does
+not clear its dot — reading or completing the represented items does. The button's
+accessible description is `Unread items` while its dot is active.
+
 ## Favorites
 
 Use an entity's command/context menu to add or remove it from Favorites; drag rows


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Sidebar badges add parallel inbox/email soup queries and depend on loading guards and shared inbox transform logic; behavior is covered by new unit tests but could affect shell performance or badge accuracy if query filters drift from the main views.
> 
> **Overview**
> Adds **presence-based unread indicators** on the new icon sidebar rail for Notifications (Signal inbox), Email (Important unread), and Chat (unread channel notifications), plus an **active-call** phone icon on Chat when calls are in progress.
> 
> `useSidebarUnread` drives the dots from existing queries without suspending the shell while data loads, and re-validates cached rows after optimistic read/done updates. Inbox query logic is split into **`useInboxEntitiesQuery`** so the main inbox list and sidebar badge share the same feed membership. Rail buttons expose `data-unread` / `data-active-call`, `aria-description` for accessibility, and show either `SidebarUnreadDot` or the call icon. Agent navigation docs describe dot semantics (presence only, not counts; opening a view does not clear them).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6167f441246a0a90ee6f253bb4ccc3762923789. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->