### PR TITLE
feat(calendar): scope recurring event edits to this or all events

### DIFF
--- a/apps/web/src/features/calendar/components/composer/EventForm.tsx
+++ b/apps/web/src/features/calendar/components/composer/EventForm.tsx
@@ -1,7 +1,14 @@
 import { MarkdownTextarea } from '@core/component/LexicalMarkdown/component/core/MarkdownTextarea';
 import SpinnerIcon from '@phosphor/spinner.svg';
+import type { CalendarUpdateScope } from '@service-email/client';
 import { Button, cn, Layer } from '@ui';
-import { createEffect, createUniqueId, Show } from 'solid-js';
+import {
+  createEffect,
+  createSignal,
+  createUniqueId,
+  For,
+  Show,
+} from 'solid-js';
 import {
   calendarDescriptionToEditorHtml,
   exportCalendarDescription,
@@ -38,8 +45,20 @@ export interface EventFormProps {
   onCalendarChange?: (calendarId: string, color: string) => void;
   onDirtyChange?: (dirty: boolean) => void;
   onCancel: () => void;
-  onSubmit: (values: EventEditorSubmitValues) => void;
+  onSubmit: (
+    values: EventEditorSubmitValues,
+    scope?: CalendarUpdateScope
+  ) => void;
 }
+
+/** Whether edits to a recurring event patch one occurrence or the whole series. */
+const RECURRING_EDIT_SCOPE_OPTIONS = [
+  { scope: 'this_event', label: 'This event' },
+  { scope: 'all', label: 'All events' },
+] as const satisfies readonly {
+  scope: CalendarUpdateScope;
+  label: string;
+}[];
 
 /** Create/edit event form laid out like the standalone task composer. */
 export function EventForm(props: EventFormProps) {
@@ -52,6 +71,10 @@ export function EventForm(props: EventFormProps) {
   const state = controller.state;
   const isEdit = () => props.isEdit ?? false;
   const formIsDisabled = () => props.pending || props.disabled === true;
+
+  // Recurring edits default to the whole series, matching the long-standing
+  // behavior; "this event" writes a single-occurrence exception.
+  const [editScope, setEditScope] = createSignal<CalendarUpdateScope>('all');
 
   // An invalid range already speaks for itself; only one line shows at a time.
   const pastEventWarning = () =>
@@ -94,7 +117,10 @@ export function EventForm(props: EventFormProps) {
   const submit = () => {
     const values = controller.submitValues();
     if (!values || formIsDisabled()) return;
-    props.onSubmit(values);
+    props.onSubmit(
+      values,
+      props.showRecurringEditNotice ? editScope() : undefined
+    );
   };
 
   return (
@@ -221,7 +247,11 @@ export function EventForm(props: EventFormProps) {
               value={controller.selectedRecurrenceOption()}
               onChange={controller.changeRecurrenceChoice}
               disabled={formIsDisabled()}
-              readOnly={fieldIsReadOnly('recurrence')}
+              // A single occurrence has no recurrence rule of its own, so the
+              // recurrence cannot be edited while the scope is one event.
+              readOnly={
+                fieldIsReadOnly('recurrence') || editScope() === 'this_event'
+              }
             />
             <Show when={!isOutOfOffice()}>
               <EventComposerGuestsPill
@@ -324,9 +354,26 @@ export function EventForm(props: EventFormProps) {
 
       <div class="flex shrink-0 items-center justify-end gap-3">
         <Show when={props.showRecurringEditNotice}>
-          <p class="mr-auto text-xs text-ink-extra-muted">
-            Changes apply to all occurrences
-          </p>
+          <div
+            role="radiogroup"
+            aria-label="Apply changes to"
+            class="mr-auto flex items-center gap-3 text-xs text-ink-muted"
+          >
+            <For each={RECURRING_EDIT_SCOPE_OPTIONS}>
+              {(option) => (
+                <label class="flex items-center gap-1.5">
+                  <input
+                    type="radio"
+                    name="event-edit-scope"
+                    checked={editScope() === option.scope}
+                    onChange={() => setEditScope(option.scope)}
+                    disabled={formIsDisabled()}
+                  />
+                  {option.label}
+                </label>
+              )}
+            </For>
+          </div>
         </Show>
         <Button
           type="button"

--- a/apps/web/src/features/calendar/hooks/use-event-editor.ts
+++ b/apps/web/src/features/calendar/hooks/use-event-editor.ts
@@ -5,6 +5,7 @@ import {
   useCreateCalendarEventMutation,
   useUpdateCalendarEventMutation,
 } from '@queries/calendar/mutations';
+import type { CalendarUpdateScope } from '@service-email/client';
 import { type Accessor, createMemo } from 'solid-js';
 import {
   calendarEventToEditorInitialValues,
@@ -113,7 +114,10 @@ export function useEventEditor(props: UseEventEditorProps) {
 
   const pending = () => create.isPending || update.isPending;
 
-  const save = (values: EventEditorSubmitValues) => {
+  const save = (
+    values: EventEditorSubmitValues,
+    scope?: CalendarUpdateScope
+  ) => {
     if (pending()) return;
 
     const event = props.event();
@@ -122,9 +126,22 @@ export function useEventEditor(props: UseEventEditorProps) {
         values.recurrenceLines !== undefined &&
         values.recurrenceLines.join('\n') !== initialLines().join('\n');
 
+      // A single occurrence has no recurrence of its own, so editing the
+      // recurrence rule is always a whole-series change regardless of the
+      // chosen scope.
+      const effectiveScope: CalendarUpdateScope = recurrenceChanged
+        ? 'all'
+        : (scope ?? 'all');
+      const targetsOneOccurrence = effectiveScope === 'this_event';
+
       update.mutate({
         eventId: event.eventId,
         calendarId: event.calendarId,
+        scope: effectiveScope,
+        recurrenceId: targetsOneOccurrence
+          ? (event.recurrenceId ?? event.occurrenceKey)
+          : undefined,
+        occurrenceKey: targetsOneOccurrence ? event.occurrenceKey : undefined,
         patch: {
           title: values.title,
           time: values.time,

--- a/apps/web/src/lib/queries/calendar/mutations.ts
+++ b/apps/web/src/lib/queries/calendar/mutations.ts
@@ -4,6 +4,7 @@ import { type MutationCallbacks, withCallbacks } from '@queries/utils';
 import {
   type CalendarDeletionScope,
   type CalendarRsvpScope,
+  type CalendarUpdateScope,
   emailClient,
 } from '@service-email/client';
 import type { CalendarEvent as CalendarEventEntity } from '@service-email/generated/schemas/calendarEvent';
@@ -396,7 +397,16 @@ export interface UpdateCalendarEventArgs {
   eventId: string;
   /** Calendar whose copy of the event is patched. Omit for the canonical copy. */
   calendarId?: string;
-  patch: Omit<UpdateCalendarEventRequest, 'calendarId'>;
+  /** How much of a recurring series to patch; defaults to all of it. */
+  scope?: CalendarUpdateScope;
+  /** Original-start key of the occurrence a scoped update targets. */
+  recurrenceId?: string;
+  /** Cache key of the occurrence a scoped update targets, for the optimistic update. */
+  occurrenceKey?: string;
+  patch: Omit<
+    UpdateCalendarEventRequest,
+    'calendarId' | 'scope' | 'recurrenceId'
+  >;
 }
 
 type UpdateCallbacks = MutationCallbacks<
@@ -469,7 +479,12 @@ function applyEventPatch(
   return { ...item, event, occurrence };
 }
 
-/** Patches event fields; recurring events update the whole series. */
+/**
+ * Patches event fields. A recurring event patches the whole series by
+ * default; a `this_event` scope writes the patch as a single-occurrence
+ * exception addressed by `recurrenceId`, so the optimistic update lands on
+ * that occurrence alone.
+ */
 export function useUpdateCalendarEventMutation(callbacks?: UpdateCallbacks) {
   return useMutation(() => ({
     mutationFn: async (args: UpdateCalendarEventArgs) =>
@@ -477,6 +492,8 @@ export function useUpdateCalendarEventMutation(callbacks?: UpdateCallbacks) {
         emailClient.updateCalendarEvent(args.eventId, {
           ...args.patch,
           calendarId: args.calendarId,
+          scope: args.scope,
+          recurrenceId: args.recurrenceId,
         })
       ),
     ...withCallbacks<
@@ -486,10 +503,18 @@ export function useUpdateCalendarEventMutation(callbacks?: UpdateCallbacks) {
       CalendarMutationContext
     >(
       {
-        onMutate: (args) =>
-          patchOccurrenceCaches(
-            patchEventItems(args.eventId, (item) => applyEventPatch(item, args))
-          ),
+        onMutate: (args) => {
+          const patchesOneOccurrence =
+            args.scope === 'this_event' && args.occurrenceKey !== undefined;
+          return patchOccurrenceCaches(
+            patchEventItems(args.eventId, (item) =>
+              patchesOneOccurrence &&
+              item.occurrence.occurrenceKey !== args.occurrenceKey
+                ? item
+                : applyEventPatch(item, args)
+            )
+          );
+        },
         onError: (_error, _args, context) => context?.rollback(),
         onSettled: (_data, _error, args) => {
           invalidateCalendarEventPreviews(args.eventId);

--- a/apps/web/src/lib/queries/calendar/tests/mutations.test.tsx
+++ b/apps/web/src/lib/queries/calendar/tests/mutations.test.tsx
@@ -596,4 +596,67 @@ describe('useUpdateCalendarEventMutation', () => {
       startsAt: '2026-08-05T09:00:00Z',
     });
   });
+
+  it('scopes an optimistic edit to the targeted occurrence, or widens to the series', async () => {
+    const keys = [
+      '2026-08-04T09:00:00Z',
+      '2026-08-05T09:00:00Z',
+      '2026-08-06T09:00:00Z',
+    ];
+    const occurrence = (key: string): CalendarOccurrenceItem =>
+      ({
+        event: {
+          id: 'event-4',
+          title: 'Standup',
+          description: 'series notes',
+          recurrenceLines: ['RRULE:FREQ=DAILY'],
+          time: { kind: 'timed', startsAt: key, endsAt: key },
+          attendees: [],
+        },
+        occurrence: {
+          eventId: 'event-4',
+          occurrenceKey: key,
+          recurrenceId: key,
+          time: { kind: 'timed', startsAt: key, endsAt: key },
+        },
+      }) as unknown as CalendarOccurrenceItem;
+    testQueryClient.setQueryData(
+      calendarKeys.occurrences('user', viewportA).queryKey,
+      { items: keys.map(occurrence), syncStatus: 'ready' }
+    );
+    updateCalendarEventMock.mockResolvedValue(ok({ id: 'event-4' }));
+    const update = renderHook(() => useUpdateCalendarEventMutation());
+    const descriptionAt = (key: string) =>
+      viewportData(viewportA)?.items.find(
+        (item) => item.occurrence.occurrenceKey === key
+      )?.event.description;
+
+    await update.mutateAsync({
+      eventId: 'event-4',
+      scope: 'this_event',
+      recurrenceId: keys[1],
+      occurrenceKey: keys[1],
+      patch: { description: 'this day only' },
+    });
+
+    expect(descriptionAt(keys[0])).toBe('series notes');
+    expect(descriptionAt(keys[1])).toBe('this day only');
+    expect(descriptionAt(keys[2])).toBe('series notes');
+    expect(updateCalendarEventMock).toHaveBeenCalledWith('event-4', {
+      description: 'this day only',
+      calendarId: undefined,
+      scope: 'this_event',
+      recurrenceId: keys[1],
+    });
+
+    await update.mutateAsync({
+      eventId: 'event-4',
+      scope: 'all',
+      patch: { description: 'shared notes' },
+    });
+
+    expect(descriptionAt(keys[0])).toBe('shared notes');
+    expect(descriptionAt(keys[1])).toBe('shared notes');
+    expect(descriptionAt(keys[2])).toBe('shared notes');
+  });
 });

--- a/apps/web/src/lib/service-clients/service-email/client.ts
+++ b/apps/web/src/lib/service-clients/service-email/client.ts
@@ -57,6 +57,9 @@ export type CalendarDeletionScope = 'all' | 'this_event' | 'this_and_following';
 /** How much of a recurring series a calendar RSVP answers for. */
 export type CalendarRsvpScope = 'all' | 'this_event';
 
+/** How much of a recurring series a calendar update applies to. */
+export type CalendarUpdateScope = 'all' | 'this_event';
+
 function emailLinkHeaders(linkId?: string): Record<string, string> | undefined {
   return linkId ? { [EMAIL_LINK_ID_HEADER]: linkId } : undefined;
 }


### PR DESCRIPTION
Editing a recurring event always patched the whole series, so attaching a doc (or any description/field change) to one occurrence was impossible — the change bled onto every future instance. The static "Changes apply to all occurrences" footer notice made this a dead end rather than a choice.

## Approach

The backend, email API, and generated client already support occurrence-scoped updates (`scope: "all" | "this_event"` + `recurrenceId`, writing a single-occurrence provider exception) — the RSVP and delete flows already use the same machinery. This change wires that scope through the edit form, which was the only surface still hardcoding the whole series.

- **EventForm** replaces the static recurring-edit notice with a "This event / All events" radio group (mirrors the RSVP/delete scope pickers) and passes the choice to `onSubmit`.
- **use-event-editor** threads the chosen scope into `update.mutate`, resolving `recurrenceId`/`occurrenceKey` for a `this_event` edit.
- **useUpdateCalendarEventMutation** forwards `scope`/`recurrenceId` to the client and scopes its optimistic cache patch to the single occurrence so a per-day edit doesn't visually bleed onto the rest of the series before the refetch lands.

## Behavior notes

- Default stays "All events", preserving today's behavior; the per-occurrence path is opt-in.
- A recurrence-rule change is inherently a series operation (a single occurrence has no recurrence of its own, and the backend rejects the combination), so changing the recurrence forces `all` scope, and the recurrence pill is read-only while "This event" is selected.

## Left out

No "this and following" option: the provider API can't express a forward-scoped single write, matching the existing RSVP scope and the documented backend constraint. Drag-to-reschedule (Page.tsx) still defaults to whole-series and is unchanged.

Verified with `just check`, type-check, and the calendar unit suites (including new coverage that a `this_event` edit patches only the targeted occurrence and an `all` edit widens to every one). An end-to-end browser pass was not possible in this environment — the dev sandbox's browser has no authenticated session against the dev backend.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches calendar update API payloads and optimistic occurrence cache patching; wrong scope or recurrence handling could affect recurring series data, though defaults preserve prior whole-series behavior.
> 
> **Overview**
> Recurring event edits can now target **this occurrence** or **the whole series**, instead of always patching every instance.
> 
> The event composer replaces the static “Changes apply to all occurrences” text with a **This event / All events** radio group (default **All events**). Submit passes `CalendarUpdateScope` through `use-event-editor` into the update mutation with `recurrenceId` and `occurrenceKey` for single-occurrence saves. Recurrence UI is read-only when **This event** is selected, and recurrence lines are omitted from the patch for that scope so provider rules aren’t violated.
> 
> `useUpdateCalendarEventMutation` forwards `scope`/`recurrenceId` to the email client and limits optimistic cache updates to the matching `occurrenceKey` when scope is `this_event`. A new `CalendarUpdateScope` type is exported from the service client; unit tests cover per-occurrence vs series-wide optimistic behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d3dcf7f2c90a139db9559a9889bad8091dbebb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->