### PR TITLE
fix(email): resolve TRASH label by linkId for multi-inbox

### DIFF
--- a/apps/web/src/features/block-email/component/TopBar.tsx
+++ b/apps/web/src/features/block-email/component/TopBar.tsx
@@ -154,7 +154,7 @@ export function TopBar(props: {
       return soup.items.at(currentIndex + 1) ?? soup.items.at(currentIndex - 1);
     })();
 
-    const handle = trashEmails([thread.db_id]);
+    const handle = trashEmails([{ id: thread.db_id, linkId: thread.link_id }]);
 
     if (soup && nextRow) {
       soup.selection.clear();

--- a/apps/web/src/features/next-soup/actions/make-delete-action.ts
+++ b/apps/web/src/features/next-soup/actions/make-delete-action.ts
@@ -2,7 +2,11 @@ import { openBulkEditModal } from '@app/features/entity/bulk-edit/BulkEditEntity
 import { globalSplitManager } from '@app/signal/splitLayout';
 import { globalRemoveFromSplitHistory } from '@components/app/split-layout/layoutUtils';
 import { toast } from '@core/component/Toast/Toast';
-import { createBulkDeleteDssItemsMutation, type EntityData } from '@entity';
+import {
+  createBulkDeleteDssItemsMutation,
+  type EntityData,
+  isEmailEntity,
+} from '@entity';
 import ArrowCounterClockwise from '@phosphor-icons/core/regular/arrow-counter-clockwise.svg?component-solid';
 import { restoreSoupFocus, trashEmails } from '../utils';
 import type { EntityActionListState } from './entity-action-context';
@@ -103,7 +107,7 @@ export const makeDeleteAction = (options: MakeDeleteOptions) => {
 
     // Three lanes: emails trash immediately (with Undo), reminders delete
     // immediately (no Undo to give), everything else confirms first.
-    const emailEntities = entities.filter((e) => e.type === 'email');
+    const emailEntities = entities.filter(isEmailEntity);
     const reminderEntities = entities.filter((e) => e.type === 'reminder');
     const nonEmailEntities = entities.filter(
       (e) => e.type !== 'email' && e.type !== 'reminder'
@@ -116,7 +120,9 @@ export const makeDeleteAction = (options: MakeDeleteOptions) => {
     };
 
     const trashEmailEntities = () => {
-      const handle = trashEmails(emailEntities.map((e) => e.id));
+      const handle = trashEmails(
+        emailEntities.map((e) => ({ id: e.id, linkId: e.linkId }))
+      );
 
       const splitManager = globalSplitManager();
       if (splitManager) {

--- a/apps/web/src/features/next-soup/trash-emails.test.ts
+++ b/apps/web/src/features/next-soup/trash-emails.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const operationMocks = vi.hoisted(() => ({
+  cancelQueries: vi.fn(async () => {}),
+  fetchAndCacheThread: vi.fn(),
+  fetchQuery: vi.fn(),
+  getQueriesData: vi.fn(() => []),
+  getQueryData: vi.fn(),
+  invalidateQueries: vi.fn(async () => {}),
+  invalidateSoupEntity: vi.fn(async () => {}),
+  setQueryData: vi.fn(),
+  updateThreadLabel: vi.fn(async () => {}),
+}));
+
+// utils.ts transitively imports websocket clients that would otherwise open
+// real sockets at module scope under jsdom.
+vi.mock('@service-storage/websocket', () => ({
+  storageWS: { reconnectIfDisconnected: vi.fn() },
+  createWebSocketJob: vi.fn(),
+}));
+vi.mock('@service-connection/websocket', () => ({
+  ws: { addEventListener: vi.fn(), send: vi.fn() },
+  state: () => 'closed',
+  createConnectionBlockWebsocketEffect: vi.fn(),
+  createConnectionWebsocketEffect: vi.fn(),
+}));
+vi.mock('@queries/client', () => ({
+  queryClient: {
+    cancelQueries: operationMocks.cancelQueries,
+    fetchQuery: operationMocks.fetchQuery,
+    getQueriesData: operationMocks.getQueriesData,
+    getQueryData: operationMocks.getQueryData,
+    invalidateQueries: operationMocks.invalidateQueries,
+    setQueryData: operationMocks.setQueryData,
+  },
+}));
+vi.mock('@queries/email/thread', () => ({
+  fetchAndCacheThread: operationMocks.fetchAndCacheThread,
+}));
+vi.mock('@queries/notification/entity-mutations', () => ({
+  updateNotificationsForEntities: vi.fn(async () => []),
+}));
+vi.mock('@queries/notification/user-notifications', () => ({
+  bulkMarkNotificationsAsDone: vi.fn(async () => {}),
+  bulkMarkNotificationsAsUndone: vi.fn(async () => {}),
+  restoreUserNotifications: vi.fn(),
+  snapshotUserNotifications: vi.fn(() => []),
+}));
+vi.mock('@queries/reminders/reminders', () => ({
+  invalidateRemindersById: vi.fn(),
+  setReminderCompleted: vi.fn(async () => {}),
+}));
+vi.mock('@queries/soup/cache', () => ({
+  getSoupEntityById: vi.fn(),
+  invalidateSoupEntity: operationMocks.invalidateSoupEntity,
+  optimisticUpdateSoupEntity: vi.fn(() => ({ rollback: vi.fn() })),
+  removeSoupEntities: vi.fn(() => ({ rollback: vi.fn() })),
+  removeSoupEntitiesFromDoneFilteredQueries: vi.fn(() => ({
+    rollback: vi.fn(),
+  })),
+}));
+vi.mock('@service-email/client', () => ({
+  emailClient: {
+    flagArchived: vi.fn(async () => {}),
+    getUserLabels: vi.fn(async () => ({ labels: [] })),
+    updateThreadLabel: operationMocks.updateThreadLabel,
+  },
+}));
+
+import { trashEmails } from './utils';
+
+const trashLabels = [
+  {
+    id: 'trash-a',
+    linkId: 'link-a',
+    providerLabelId: 'TRASH',
+  },
+  {
+    id: 'trash-b',
+    linkId: 'link-b',
+    providerLabelId: 'TRASH',
+  },
+];
+
+afterEach(() => {
+  vi.clearAllMocks();
+  operationMocks.fetchQuery.mockResolvedValue({ labels: trashLabels });
+  operationMocks.getQueriesData.mockReturnValue([]);
+  operationMocks.getQueryData.mockReturnValue(undefined);
+});
+
+describe('trashEmails', () => {
+  it('uses and undoes the TRASH label for each inbox independently', async () => {
+    operationMocks.fetchQuery.mockResolvedValue({ labels: trashLabels });
+
+    const handle = trashEmails([
+      { id: 'thread-a', linkId: 'link-a' },
+      { id: 'thread-b', linkId: 'link-b' },
+    ]);
+
+    await handle.done;
+
+    expect(operationMocks.updateThreadLabel).toHaveBeenCalledTimes(2);
+    expect(operationMocks.updateThreadLabel).toHaveBeenCalledWith({
+      thread_id: 'thread-a',
+      label_id: 'trash-a',
+      value: true,
+    });
+    expect(operationMocks.updateThreadLabel).toHaveBeenCalledWith({
+      thread_id: 'thread-b',
+      label_id: 'trash-b',
+      value: true,
+    });
+    expect(operationMocks.fetchAndCacheThread).not.toHaveBeenCalled();
+
+    await handle.undo();
+
+    expect(operationMocks.updateThreadLabel).toHaveBeenCalledTimes(4);
+    expect(operationMocks.updateThreadLabel).toHaveBeenCalledWith({
+      thread_id: 'thread-a',
+      label_id: 'trash-a',
+      value: false,
+    });
+    expect(operationMocks.updateThreadLabel).toHaveBeenCalledWith({
+      thread_id: 'thread-b',
+      label_id: 'trash-b',
+      value: false,
+    });
+  });
+
+  it('fetches the thread through queries when multi-inbox linkId is missing', async () => {
+    operationMocks.fetchQuery.mockResolvedValue({ labels: trashLabels });
+    operationMocks.fetchAndCacheThread.mockResolvedValueOnce({
+      isErr: () => false,
+      value: { thread: { link_id: 'link-b' } },
+    });
+
+    const handle = trashEmails([{ id: 'thread-b' }]);
+    await handle.done;
+
+    expect(operationMocks.fetchAndCacheThread).toHaveBeenCalledWith('thread-b');
+    expect(operationMocks.updateThreadLabel).toHaveBeenCalledWith({
+      thread_id: 'thread-b',
+      label_id: 'trash-b',
+      value: true,
+    });
+  });
+});

--- a/apps/web/src/features/next-soup/trash-emails.test.ts
+++ b/apps/web/src/features/next-soup/trash-emails.test.ts
@@ -24,6 +24,14 @@ vi.mock('@service-connection/websocket', () => ({
   createConnectionBlockWebsocketEffect: vi.fn(),
   createConnectionWebsocketEffect: vi.fn(),
 }));
+vi.mock('@core/component/Toast/Toast', () => ({
+  toast: {
+    alert: vi.fn(),
+    dismiss: vi.fn(),
+    failure: vi.fn(),
+    success: vi.fn(),
+  },
+}));
 vi.mock('@queries/client', () => ({
   queryClient: {
     cancelQueries: operationMocks.cancelQueries,

--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -1080,8 +1080,22 @@ export function trashEmails(ids: string[]): TrashEmailsHandle {
     }
   };
 
-  // Resolved lazily by the API calls; used by undo
-  let trashLabelId: string | undefined;
+  // Map each thread ID to its assigned TRASH label ID (resolved lazily by API calls; used by undo)
+  const threadTrashLabelIds = new Map<string, string>();
+
+  // Map thread IDs to their linkId if available from email queries or soup entities
+  const threadLinkIds = new Map<string, string>();
+  for (const [, data] of previousEmail) {
+    if (!data?.pages) continue;
+    for (const page of data.pages) {
+      if (!page?.items) continue;
+      for (const item of page.items) {
+        if (item?.id && 'linkId' in item && item.linkId && idSet.has(item.id)) {
+          threadLinkIds.set(item.id, item.linkId);
+        }
+      }
+    }
+  }
 
   const done = (async () => {
     try {
@@ -1091,23 +1105,74 @@ export function trashEmails(ids: string[]): TrashEmailsHandle {
           throwOnErr(async () => await emailClient.getUserLabels()),
         staleTime: 5 * 60 * 1000,
       });
-      const trashLabel = labelsData?.labels.find(
-        (l) => l.providerLabelId === 'TRASH'
-      );
-      const labelId = trashLabel?.id;
-      if (!labelId) {
+      const trashLabels =
+        labelsData?.labels.filter((l) => l.providerLabelId === 'TRASH') ?? [];
+      const fallbackTrashLabelId = trashLabels[0]?.id;
+      if (trashLabels.length === 0 || !fallbackTrashLabelId) {
         throw new Error('TRASH label not found');
       }
-      trashLabelId = labelId;
 
       await Promise.all(
-        ids.map((id) =>
-          emailClient.updateThreadLabel({
+        ids.map(async (id) => {
+          let linkId = threadLinkIds.get(id);
+          if (!linkId) {
+            const entity = getSoupEntityById(id);
+            if (entity && 'linkId' in entity && typeof entity.linkId === 'string') {
+              linkId = entity.linkId;
+            }
+          }
+          if (!linkId) {
+            const threadData = queryClient.getQueryData<{
+              link_id?: string;
+              pages?: Array<{ link_id?: string }>;
+            }>(emailKeys.threadMessages(id).queryKey);
+            if (threadData?.link_id) {
+              linkId = threadData.link_id;
+            } else if (threadData?.pages?.[0]?.link_id) {
+              linkId = threadData.pages[0].link_id;
+            }
+          }
+          if (!linkId) {
+            const singleThread = queryClient.getQueryData<{
+              link_id?: string;
+              thread?: { link_id?: string };
+            }>(emailKeys.thread(id).queryKey);
+            if (singleThread?.link_id) {
+              linkId = singleThread.link_id;
+            } else if (singleThread?.thread?.link_id) {
+              linkId = singleThread.thread.link_id;
+            }
+          }
+          if (!linkId) {
+            try {
+              const fetched = await queryClient.fetchQuery({
+                queryKey: emailKeys.thread(id).queryKey,
+                queryFn: async () =>
+                  throwOnErr(async () => await emailClient.getThread({ thread_id: id })),
+              });
+              if (fetched?.thread?.link_id) {
+                linkId = fetched.thread.link_id;
+              }
+            } catch {
+              // Best-effort fetch
+            }
+          }
+          const labelId =
+            (linkId
+              ? trashLabels.find((l) => l.linkId === linkId)?.id
+              : undefined) ?? fallbackTrashLabelId;
+
+          if (!labelId) {
+            throw new Error('TRASH label not found');
+          }
+          threadTrashLabelIds.set(id, labelId);
+
+          return emailClient.updateThreadLabel({
             thread_id: id,
             label_id: labelId,
             value: true,
-          })
-        )
+          });
+        })
       );
     } catch (err) {
       rollback();
@@ -1123,7 +1188,7 @@ export function trashEmails(ids: string[]): TrashEmailsHandle {
   return {
     done,
     undo: async () => {
-      // Wait for the trash calls to finish so we know the label ID.
+      // Wait for the trash calls to finish so we know the label IDs.
       // If the trash call itself failed, rollback already happened — nothing to undo.
       try {
         await done;
@@ -1135,13 +1200,15 @@ export function trashEmails(ids: string[]): TrashEmailsHandle {
 
       try {
         await Promise.all(
-          ids.map((id) =>
-            emailClient.updateThreadLabel({
+          ids.map((id) => {
+            const labelId = threadTrashLabelIds.get(id);
+            if (!labelId) return Promise.resolve();
+            return emailClient.updateThreadLabel({
               thread_id: id,
-              label_id: trashLabelId!,
+              label_id: labelId,
               value: false,
-            })
-          )
+            });
+          })
         );
       } finally {
         // Only invalidate email queries — skip soup invalidation since

--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -66,6 +66,7 @@ import {
 } from '@notifications';
 import { queryClient } from '@queries/client';
 import { emailKeys } from '@queries/email/keys';
+import { fetchAndCacheThread } from '@queries/email/thread';
 import {
   type NotificationEntityRef,
   updateNotificationsForEntities,
@@ -1140,6 +1141,12 @@ export function trashEmails(targets: TrashEmailTarget[]): TrashEmailsHandle {
               linkId = threadData.link_id;
             } else if (threadData?.pages?.[0]?.link_id) {
               linkId = threadData.pages[0].link_id;
+            }
+          }
+          if (!linkId && trashLabels.length > 1) {
+            const fetched = await fetchAndCacheThread(id);
+            if (!fetched.isErr()) {
+              linkId = fetched.value.thread.link_id;
             }
           }
 

--- a/apps/web/src/features/next-soup/utils.ts
+++ b/apps/web/src/features/next-soup/utils.ts
@@ -1043,13 +1043,22 @@ type TrashEmailsHandle = {
   undo: () => Promise<void>;
 };
 
+export type TrashEmailTarget = string | { id: string; linkId?: string };
+
 /**
- * Optimistically removes one or more email threads from soup + email caches,
- * then fires the TRASH label API calls in the background. Takes a single
- * snapshot before all removals so undo restores the complete pre-trash state.
+ * Trash one or more email threads.
+ *
+ * Optimistically removes them from the soup and from all email queries,
+ * then resolves the TRASH label and calls the API. If anything fails, rolls
+ * back the optimistic update.
+ *
  * Returns synchronously so the caller can show the undo toast immediately.
  */
-export function trashEmails(ids: string[]): TrashEmailsHandle {
+export function trashEmails(targets: TrashEmailTarget[]): TrashEmailsHandle {
+  const normalizedTargets = targets.map((t) =>
+    typeof t === 'string' ? { id: t, linkId: undefined } : t
+  );
+  const ids = normalizedTargets.map((t) => t.id);
   queryClient.cancelQueries({ queryKey: queryKeys.all.email });
 
   const previousEmail = queryClient.getQueriesData<{
@@ -1083,15 +1092,22 @@ export function trashEmails(ids: string[]): TrashEmailsHandle {
   // Map each thread ID to its assigned TRASH label ID (resolved lazily by API calls; used by undo)
   const threadTrashLabelIds = new Map<string, string>();
 
-  // Map thread IDs to their linkId if available from email queries or soup entities
+  // Map thread IDs to their linkId if available from explicit targets or cached email queries
   const threadLinkIds = new Map<string, string>();
+  for (const target of normalizedTargets) {
+    if (target.linkId) {
+      threadLinkIds.set(target.id, target.linkId);
+    }
+  }
   for (const [, data] of previousEmail) {
     if (!data?.pages) continue;
     for (const page of data.pages) {
       if (!page?.items) continue;
       for (const item of page.items) {
         if (item?.id && 'linkId' in item && item.linkId && idSet.has(item.id)) {
-          threadLinkIds.set(item.id, item.linkId);
+          if (!threadLinkIds.has(item.id)) {
+            threadLinkIds.set(item.id, item.linkId);
+          }
         }
       }
     }
@@ -1116,12 +1132,6 @@ export function trashEmails(ids: string[]): TrashEmailsHandle {
         ids.map(async (id) => {
           let linkId = threadLinkIds.get(id);
           if (!linkId) {
-            const entity = getSoupEntityById(id);
-            if (entity && 'linkId' in entity && typeof entity.linkId === 'string') {
-              linkId = entity.linkId;
-            }
-          }
-          if (!linkId) {
             const threadData = queryClient.getQueryData<{
               link_id?: string;
               pages?: Array<{ link_id?: string }>;
@@ -1132,35 +1142,13 @@ export function trashEmails(ids: string[]): TrashEmailsHandle {
               linkId = threadData.pages[0].link_id;
             }
           }
-          if (!linkId) {
-            const singleThread = queryClient.getQueryData<{
-              link_id?: string;
-              thread?: { link_id?: string };
-            }>(emailKeys.thread(id).queryKey);
-            if (singleThread?.link_id) {
-              linkId = singleThread.link_id;
-            } else if (singleThread?.thread?.link_id) {
-              linkId = singleThread.thread.link_id;
-            }
-          }
-          if (!linkId) {
-            try {
-              const fetched = await queryClient.fetchQuery({
-                queryKey: emailKeys.thread(id).queryKey,
-                queryFn: async () =>
-                  throwOnErr(async () => await emailClient.getThread({ thread_id: id })),
-              });
-              if (fetched?.thread?.link_id) {
-                linkId = fetched.thread.link_id;
-              }
-            } catch {
-              // Best-effort fetch
-            }
-          }
+
+          const matchedLabelId = linkId
+            ? trashLabels.find((label) => label.linkId === linkId)?.id
+            : undefined;
           const labelId =
-            (linkId
-              ? trashLabels.find((l) => l.linkId === linkId)?.id
-              : undefined) ?? fallbackTrashLabelId;
+            matchedLabelId ??
+            (trashLabels.length === 1 ? fallbackTrashLabelId : undefined);
 
           if (!labelId) {
             throw new Error('TRASH label not found');


### PR DESCRIPTION
### Summary

When an account has multiple inboxes linked, `getUserLabels()` returns labels across all inboxes. Previously `trashEmails` used `labels.find(l => l.providerLabelId === 'TRASH')`, which always picked the first TRASH label regardless of which inbox the thread belongs to.

When deleting threads belonging to subsequent inboxes, this resulted in a `404 Not Found (Label not found)` error from the backend because `email_labels.id` did not match the thread's `link_id`.

### Changes
- Resolve each thread's `linkId` from the caller, email list cache, or thread cache; when multiple inboxes exist and it is still missing, fall back through the existing queries-layer thread fetch.
- Select the corresponding `TRASH` label belonging to that specific `linkId`; only use the single-label fallback when exactly one TRASH label exists.
- Ensure undo accurately restores the per-thread TRASH label.
- Add regression coverage for multi-inbox trash/undo and missing-`linkId` fallback resolution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes email delete/trash API behavior and batch failure handling; mistakes could trash into the wrong inbox or leave server/UI out of sync, though the PR adds explicit guards and tests.
> 
> **Overview**
> Fixes **multi-inbox trash** so each thread uses the **TRASH** label for its own inbox (`linkId`), instead of always applying the first **TRASH** label from `getUserLabels()` (which caused 404s for threads in other linked inboxes).
> 
> `trashEmails` now takes `{ id, linkId? }` targets; callers in the email top bar and soup delete action pass `linkId` when available. Label resolution pulls `linkId` from the target, email list cache, thread query cache, or `fetchAndCacheThread` when multiple inboxes exist. The code resolves every thread’s label **before** any API trash, refuses to trash when a known inbox has no matching label, uses **per-thread label IDs** for undo, and **reverts** threads that already trashed if a batch sibling fails.
> 
> Adds **Vitest** coverage for multi-inbox trash/undo, missing `linkId` fallback, single-label fallback, and failure/compensation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ac1c3e0c1a25a640bb20382a8f4e0c8a903deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->