### PR TITLE
fix(dockerfile): support podman for agent harness container

### DIFF
--- a/crates/agent_harness/container/Dockerfile
+++ b/crates/agent_harness/container/Dockerfile
@@ -2,14 +2,14 @@
 # sidecar the harness dials.
 
 # Sidecar install
-FROM rust:1.94.0-slim-bullseye AS sidecar-build
+FROM docker.io/library/rust:1.94.0-slim-bullseye AS sidecar-build
 WORKDIR /build
 COPY sidecar/Cargo.toml sidecar/Cargo.lock ./
 COPY sidecar/src ./src
 RUN cargo build --locked --release
 
 # Macro nix devshell hard install
-FROM ubuntu:22.04 AS nix-build
+FROM docker.io/library/ubuntu:22.04 AS nix-build
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl xz-utils && \
@@ -55,7 +55,7 @@ RUN bash -c 'source /env/dev-env.sh && \
     rm -rf /root/.cache/nix
 
 # Runtime
-FROM ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 
 # curl: the ensure script's readiness probe. nixbld users: nix.conf names the
 # group, and source builds inside the sandbox need it.


### PR DESCRIPTION
Stops podmans shortcut lookup (which fails)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time image reference change only; no runtime behavior or application logic affected.
> 
> **Overview**
> **Fully qualifies all base image references** in the agent harness `Dockerfile` so builds work under Podman, which can fail when resolving short names like `ubuntu:22.04` or `rust:…` via shortcut lookup.
> 
> Every `FROM` now uses the `docker.io/library/…` prefix for the Rust sidecar build stage and both Ubuntu stages (nix-build and runtime); image contents and build steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aa1a1a757664d2305ad3f0f7da2e459223d3967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->