### PR TITLE
fix(agents): place agent sessions between channels and companies in @ menu

### DIFF
--- a/apps/web/src/lib/core/component/LexicalMarkdown/component/menu/MentionsMenu/MentionsMenu.tsx
+++ b/apps/web/src/lib/core/component/LexicalMarkdown/component/menu/MentionsMenu/MentionsMenu.tsx
@@ -257,8 +257,8 @@ function MentionsMenuInner(props: MentionsMenuProps) {
     const combined: MentionItem[] = [
       ...users,
       ...(docs() ?? []),
-      ...agentSessions(),
       ...(channels() ?? []),
+      ...agentSessions(),
       ...(companies() ?? []),
       ...(emails() ?? []),
       ...(dates() ?? []),
@@ -305,12 +305,6 @@ function MentionsMenuInner(props: MentionsMenuProps) {
 
     const buckets: BucketConfig[] = [
       {
-        id: 'agentSessions',
-        label: 'Recent agent sessions',
-        getData: agentSessions,
-        getFullCount: () => agentSessions().length,
-      },
-      {
         id: 'users',
         label: groups().length > 0 ? 'People & Groups' : 'People',
         getData: () => usersAndGroups() ?? [],
@@ -333,6 +327,12 @@ function MentionsMenuInner(props: MentionsMenuProps) {
         hasMore: channelsMention.hasMore,
         isLoadingMore: channelsMention.isLoadingMore,
         loadMore: channelsMention.loadMore,
+      },
+      {
+        id: 'agentSessions',
+        label: 'Recent agent sessions',
+        getData: agentSessions,
+        getFullCount: () => agentSessions().length,
       },
       {
         id: 'companies',

--- a/docs/AGENT_GUIDE/channels.md
+++ b/docs/AGENT_GUIDE/channels.md
@@ -26,8 +26,9 @@ session-specific.
 
 ## Message composer
 
-The shared `@` menu also offers `Recent agent sessions` (the latest 500 accessible
-sessions, searchable by title or persona). These inline chips show the shared
+The shared `@` menu also offers `Recent agent sessions` after Channels and
+before Companies (the latest 500 accessible sessions, searchable by title or
+persona). These inline chips show the shared
 agent icon and an underlined session name, and open the existing session when clicked.
 They are references, not bot invocations: selecting a session does not start a new
 agent run. Sending or editing a message that references a session you own grants

--- a/docs/AGENT_GUIDE/documents.md
+++ b/docs/AGENT_GUIDE/documents.md
@@ -35,8 +35,9 @@ their relative depths and order.
 
 ## Reference hover previews
 
-The `@` menu includes `Recent agent sessions`, searched by session or persona name
-within the 500 most recently updated accessible sessions. Menu rows show the
+The `@` menu includes `Recent agent sessions` after Channels and before
+Companies. Search by session or persona name within the 500 most recently
+updated accessible sessions. Menu rows show the
 session title followed by a muted persona name, including `@Cursor` and
 `@macro(new)` for built-in personas. Names from the session API take precedence;
 older responses use the shared built-in name resolver or cached custom bots.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The `@` mentions menu listed Recent agent sessions first, above People. This moves that section to sit between Channels and Companies so people and documents stay at the top.

Desktop bucket order is now:

- People
- Documents, Agents, & Tasks
- Channels
- Recent agent sessions
- Companies
- Emails
- Dates

Verified in a local document editor: People → Documents → Channels → Recent agent sessions → Dates (Companies is hidden when CRM is off). Channel composer matches, with the current channel omitted from the Channels bucket as before.

Agent-guide copy for documents and channels mentions the new section position.

## Test plan

- Open a document or channel composer and type `@`
- Confirm People (and Documents) appear before Recent agent sessions
- Confirm Recent agent sessions sits between Channels and Companies
- Confirm selecting a session still inserts the existing mention chip
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e8ec5cd-ae34-496e-ae53-94e700f8e7fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e8ec5cd-ae34-496e-ae53-94e700f8e7fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

