### PR TITLE
chore(agents): add agent sessions to the activity system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,7 @@ dependencies = [
 name = "agent_session"
 version = "0.1.0"
 dependencies = [
+ "activity",
  "agent",
  "agent-client-protocol",
  "agent_fold",
@@ -5233,6 +5234,7 @@ name = "document_storage_service"
 version = "0.1.0"
 dependencies = [
  "activity",
+ "agent_session",
  "ai_tools",
  "ai_usage",
  "analytics_client",

--- a/apps/web/src/features/activity/context/activity-context.test.tsx
+++ b/apps/web/src/features/activity/context/activity-context.test.tsx
@@ -16,6 +16,13 @@ vi.mock('@property/editor/hooks/useAllProperties', () => ({
   useAllProperties: () => () => [],
 }));
 vi.mock('@property/hooks', () => ({ usePropertyEntityDisplay: () => ({}) }));
+vi.mock('@queries/preview', () => ({
+  useItemPreview: () => [() => undefined],
+  isAccessiblePreviewItem: () => false,
+}));
+vi.mock('@core/component/EntityIcon', () => ({
+  EntityIcon: () => null,
+}));
 vi.mock('@service-storage/graphql-soup', () => ({
   getGraphqlSoupClient: () => ({}),
 }));

--- a/apps/web/src/features/activity/context/activity-context.tsx
+++ b/apps/web/src/features/activity/context/activity-context.tsx
@@ -1,3 +1,4 @@
+import { EntityIcon as CoreEntityIcon } from '@core/component/EntityIcon';
 import { useUserId } from '@core/context/user';
 import { tryMacroId, useDisplayName } from '@core/user';
 import { useAllProperties } from '@property/editor/hooks/useAllProperties';
@@ -8,17 +9,19 @@ import {
   firstPartyBotName,
   getBotDisplayName,
 } from '@queries/channel/message-sender';
-import type { EntityType } from '@service-properties/generated/schemas/entityType';
+import { isAccessiblePreviewItem, useItemPreview } from '@queries/preview';
 import { getGraphqlSoupClient } from '@service-storage/graphql-soup';
 import type { Client } from '@urql/core';
 import {
   type Accessor,
   createContext,
+  createMemo,
   getOwner,
   type JSX,
   runWithOwner,
   useContext,
 } from 'solid-js';
+import type { ActivityDisplayEntityType } from '../core/event';
 
 /** Resolved display for one referenced entity: name, icon, and link target. */
 export type EntityDisplay = {
@@ -64,7 +67,7 @@ export type ActivityContext = {
   /** Name, icon, and link target for a referenced entity. */
   entityDisplay: (
     entityId: Accessor<string>,
-    entityType: Accessor<EntityType>
+    entityType: Accessor<ActivityDisplayEntityType>
   ) => EntityDisplay;
   /** The property definition behind a property-changed row, when known. */
   propertyDefinition: (
@@ -107,8 +110,13 @@ function appActivityContext(): ActivityContext {
       if (!list || list.isPending) return undefined;
       return getBotDisplayName(`bot|${id}`, undefined, list.data ?? []);
     },
-    entityDisplay: (entityId, entityType) =>
-      usePropertyEntityDisplay(entityId, entityType),
+    entityDisplay: (entityId, entityType) => {
+      const type = entityType();
+      if (type === 'AGENT_SESSION') {
+        return agentSessionEntityDisplay(entityId);
+      }
+      return usePropertyEntityDisplay(entityId, () => type);
+    },
     propertyDefinition: (propertyId) => {
       const definitions = useAllProperties();
       return () => {
@@ -116,5 +124,29 @@ function appActivityContext(): ActivityContext {
         return id ? definitions().find((def) => def.id === id) : undefined;
       };
     },
+  };
+}
+
+function agentSessionEntityDisplay(entityId: Accessor<string>): EntityDisplay {
+  const previewWrapper = () =>
+    useItemPreview(() => ({
+      id: entityId(),
+      type: 'agent_session' as const,
+    }))[0];
+  const preview = createMemo(() => previewWrapper()?.());
+  return {
+    name: () => {
+      const item = preview();
+      if (!item || item.loading) return 'Loading...';
+      if (isAccessiblePreviewItem(item)) return item.name;
+      return 'Agent session';
+    },
+    icon: () => <CoreEntityIcon targetType="agent" size="xs" />,
+    isLoading: () => {
+      const item = preview();
+      return !item || item.loading;
+    },
+    blockOrFileType: () => 'agent',
+    linkParams: () => undefined,
   };
 }

--- a/apps/web/src/features/activity/core/event.ts
+++ b/apps/web/src/features/activity/core/event.ts
@@ -20,6 +20,7 @@ export type ActivityEntityType =
   | 'email-thread'
   | 'channel'
   | 'user'
+  | 'agent-session'
   | { kind: 'unsupported'; raw: string };
 
 export type ActivityEvent = {
@@ -54,9 +55,12 @@ export type PropertyEntityType =
   | 'CHANNEL'
   | 'USER';
 
-export function toPropertyEntityType(
+/** Entity kinds the activity UI can resolve a name, icon, and link for. */
+export type ActivityDisplayEntityType = PropertyEntityType | 'AGENT_SESSION';
+
+export function toDisplayEntityType(
   entityType: ActivityEntityType
-): PropertyEntityType | undefined {
+): ActivityDisplayEntityType | undefined {
   return match(entityType)
     .with({ kind: 'unsupported' }, () => undefined)
     .with('document', () => 'DOCUMENT' as const)
@@ -65,5 +69,6 @@ export function toPropertyEntityType(
     .with('email-thread', () => 'THREAD' as const)
     .with('channel', () => 'CHANNEL' as const)
     .with('user', () => 'USER' as const)
+    .with('agent-session', () => 'AGENT_SESSION' as const)
     .exhaustive();
 }

--- a/apps/web/src/features/activity/primitives/entity-activity.test.ts
+++ b/apps/web/src/features/activity/primitives/entity-activity.test.ts
@@ -13,7 +13,9 @@ afterEach(() => {
   for (const dispose of disposals.splice(0)) dispose();
 });
 
-function setup(entityType: 'DOCUMENT' | 'USER' = 'DOCUMENT') {
+function setup(
+  entityType: 'DOCUMENT' | 'USER' | 'AGENT_SESSION' = 'DOCUMENT'
+) {
   const context = createMockActivityContext();
   let state!: EntityActivityState;
   const dispose = createRoot((rootDispose) => {
@@ -76,5 +78,10 @@ describe('createEntityActivityState', () => {
     const { state, graphql } = setup('USER');
     expect(state.isEnabled()).toBe(false);
     expect(graphql.pending).toHaveLength(0);
+  });
+
+  it('is enabled for agent sessions', () => {
+    const { state } = setup('AGENT_SESSION');
+    expect(state.isEnabled()).toBe(true);
   });
 });

--- a/apps/web/src/features/activity/primitives/entity-activity.test.ts
+++ b/apps/web/src/features/activity/primitives/entity-activity.test.ts
@@ -13,9 +13,7 @@ afterEach(() => {
   for (const dispose of disposals.splice(0)) dispose();
 });
 
-function setup(
-  entityType: 'DOCUMENT' | 'USER' | 'AGENT_SESSION' = 'DOCUMENT'
-) {
+function setup(entityType: 'DOCUMENT' | 'USER' | 'AGENT_SESSION' = 'DOCUMENT') {
   const context = createMockActivityContext();
   let state!: EntityActivityState;
   const dispose = createRoot((rootDispose) => {

--- a/apps/web/src/features/activity/primitives/entity-activity.ts
+++ b/apps/web/src/features/activity/primitives/entity-activity.ts
@@ -1,8 +1,10 @@
-import type { EntityType } from '@service-properties/generated/schemas/entityType';
 import { type Accessor, createMemo } from 'solid-js';
 import type { ActivityContext } from '../context/activity-context';
 import type { ActivityEvent } from '../core/event';
-import { createEntityActivityQuery } from '../queries/entity-query';
+import {
+  createEntityActivityQuery,
+  type EntityActivityEntityType,
+} from '../queries/entity-query';
 
 export type EntityActivityView =
   | { t: 'loading' }
@@ -22,7 +24,10 @@ export type EntityActivityState = {
  */
 export function createEntityActivityState(
   context: Pick<ActivityContext, 'graphql'>,
-  options: { entityId: Accessor<string>; entityType: Accessor<EntityType> }
+  options: {
+    entityId: Accessor<string>;
+    entityType: Accessor<EntityActivityEntityType>;
+  }
 ): EntityActivityState {
   const query = createEntityActivityQuery(context, {
     entityType: options.entityType,

--- a/apps/web/src/features/activity/primitives/entity-opener.test.ts
+++ b/apps/web/src/features/activity/primitives/entity-opener.test.ts
@@ -60,6 +60,19 @@ describe('createEntityOpener', () => {
     expect(opener()).toBeUndefined();
   });
 
+  it('resolves agent sessions as a linkable entity', () => {
+    const onOpen = vi.fn();
+    const opener = setup(createMockActivityContext(), 'agent-session', onOpen);
+    expect(opener()?.display.name()).toBe('Entity doc-1');
+    opener()?.handlers?.onClick(click(false));
+    expect(onOpen).toHaveBeenCalledWith({
+      block: 'md',
+      id: 'doc-1',
+      params: undefined,
+      newSplit: false,
+    });
+  });
+
   it('does nothing when the display has no block mapping', () => {
     const onOpen = vi.fn();
     const context = createMockActivityContext({

--- a/apps/web/src/features/activity/primitives/entity-opener.ts
+++ b/apps/web/src/features/activity/primitives/entity-opener.ts
@@ -5,7 +5,7 @@ import type {
   EntityDisplay,
   OpenEntityTarget,
 } from '../context/activity-context';
-import { type ActivityEntityType, toPropertyEntityType } from '../core/event';
+import { type ActivityEntityType, toDisplayEntityType } from '../core/event';
 
 export type EntityOpener = {
   display: EntityDisplay;
@@ -28,7 +28,7 @@ export function createEntityOpener(
   onOpen: ((target: OpenEntityTarget) => void) | undefined
 ): Accessor<EntityOpener | undefined> {
   return createMemo(() => {
-    const type = toPropertyEntityType(entityType());
+    const type = toDisplayEntityType(entityType());
     if (!type) return undefined;
     const display = context.entityDisplay(entityId, () => type);
     if (!onOpen) return { display };

--- a/apps/web/src/features/activity/queries/decode.test.ts
+++ b/apps/web/src/features/activity/queries/decode.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { decodeActivityEvent } from './decode';
 import {
+  agentSessionCreatedEvent,
   callStartedEvent,
   createdEvent,
   deletedEvent,
@@ -55,6 +56,9 @@ describe('decodeActivityEvent', () => {
     expect(decodeActivityEvent(createdEvent).entityType).toBe('document');
     expect(decodeActivityEvent(messagedEvent).entityType).toBe('channel');
     expect(decodeActivityEvent(sentEvent).entityType).toBe('email-thread');
+    expect(decodeActivityEvent(agentSessionCreatedEvent).entityType).toBe(
+      'agent-session'
+    );
   });
 
   it('keeps the unknown-action tag so describeAction can humanize it', () => {

--- a/apps/web/src/features/activity/queries/decode.ts
+++ b/apps/web/src/features/activity/queries/decode.ts
@@ -51,6 +51,7 @@ export function decodeEntityType(
     .with('EMAIL_THREAD', () => 'email-thread' as const)
     .with('CHANNEL', () => 'channel' as const)
     .with('USER', () => 'user' as const)
+    .with('AGENT_SESSION', () => 'agent-session' as const)
     .otherwise((raw) => ({ kind: 'unsupported' as const, raw }));
 }
 

--- a/apps/web/src/features/activity/queries/entity-query.test.ts
+++ b/apps/web/src/features/activity/queries/entity-query.test.ts
@@ -8,17 +8,17 @@ const NIL = '00000000-0000-0000-0000-000000000000';
 
 describe('buildEntityActivityInput', () => {
   it('opts agent sessions into Soup by id', () => {
-    expect(buildEntityActivityInput('AGENT_SESSION', 'session-1')).toMatchObject(
-      {
-        initial: {
-          limit: 1,
-          filters: {
-            documentFilter: { literal: { id: NIL } },
-            agentSessionFilter: { literal: { id: 'session-1' } },
-          },
+    expect(
+      buildEntityActivityInput('AGENT_SESSION', 'session-1')
+    ).toMatchObject({
+      initial: {
+        limit: 1,
+        filters: {
+          documentFilter: { literal: { id: NIL } },
+          agentSessionFilter: { literal: { id: 'session-1' } },
         },
-      }
-    );
+      },
+    });
   });
 
   it('does not issue a lookup for users', () => {

--- a/apps/web/src/features/activity/queries/entity-query.test.ts
+++ b/apps/web/src/features/activity/queries/entity-query.test.ts
@@ -1,7 +1,30 @@
 import { describe, expect, it } from 'vitest';
 import { soupPage } from '../tests/wire';
+import { buildEntityActivityInput } from './entity-query';
 import { createdEvent } from './fixtures';
 import { selectEntityActivity } from './select-entity-activity';
+
+const NIL = '00000000-0000-0000-0000-000000000000';
+
+describe('buildEntityActivityInput', () => {
+  it('opts agent sessions into Soup by id', () => {
+    expect(buildEntityActivityInput('AGENT_SESSION', 'session-1')).toMatchObject(
+      {
+        initial: {
+          limit: 1,
+          filters: {
+            documentFilter: { literal: { id: NIL } },
+            agentSessionFilter: { literal: { id: 'session-1' } },
+          },
+        },
+      }
+    );
+  });
+
+  it('does not issue a lookup for users', () => {
+    expect(buildEntityActivityInput('USER', 'user-1')).toBeUndefined();
+  });
+});
 
 describe('selectEntityActivity', () => {
   it('returns entity-missing when the soup page omits the entity', () => {

--- a/apps/web/src/features/activity/queries/entity-query.ts
+++ b/apps/web/src/features/activity/queries/entity-query.ts
@@ -1,10 +1,11 @@
 import { createUrqlQuery } from '@app/lib/urql-solid/create-urql-query';
-import { buildEntityPropertiesInput } from '@queries/properties/graphql/entity';
+import { buildGraphqlEntitySoupInput } from '@queries/soup/graphql/entity-input';
 import type { EntityType } from '@service-properties/generated/schemas/entityType';
 import {
   EntityActivityDocument,
   type EntityActivityQuery,
   type EntityActivityQueryVariables,
+  type SoupInput,
 } from '@service-storage/graphql/generated/graphql';
 import { type Accessor, createMemo } from 'solid-js';
 import type { ActivityContext } from '../context/activity-context';
@@ -16,18 +17,44 @@ import {
 /** Rows requested for a side-panel activity preview. */
 export const ENTITY_ACTIVITY_PREVIEW_LIMIT = 20;
 
+const NIL_ENTITY_ID = '00000000-0000-0000-0000-000000000000';
+
+/** Soup-backed entity kinds the entity activity query can address. */
+export type EntityActivityEntityType = EntityType | 'AGENT_SESSION';
+
 type EntityActivityQueryOptions = {
-  entityType: Accessor<EntityType>;
+  entityType: Accessor<EntityActivityEntityType>;
   entityId: Accessor<string>;
   enabled: Accessor<boolean>;
   limit?: number;
 };
 
+/** Exact Soup input for one entity's activity edge. */
+export function buildEntityActivityInput(
+  entityType: EntityActivityEntityType,
+  entityId: string
+): SoupInput | undefined {
+  if (entityType === 'AGENT_SESSION') {
+    const base = buildGraphqlEntitySoupInput('DOCUMENT', NIL_ENTITY_ID);
+    if (!base || !('initial' in base) || !base.initial) return undefined;
+    return {
+      initial: {
+        ...base.initial,
+        filters: {
+          ...base.initial.filters,
+          agentSessionFilter: { literal: { id: entityId } },
+        },
+      },
+    };
+  }
+  return buildGraphqlEntitySoupInput(entityType, entityId);
+}
+
 /**
  * Live urql query for one Soup-backed entity's recent activity, newest
- * first. Reuses the exact-single-entity Soup input builder from the
- * properties query, so the same entity types are supported (everything but
- * `USER`) and the query pauses (`isEnabled` false) for the rest.
+ * first. Reuses the exact-single-entity Soup input builder so the same
+ * entity types are supported (everything but `USER`, plus agent sessions)
+ * and the query pauses (`isEnabled` false) for the rest.
  */
 export function createEntityActivityQuery(
   context: Pick<ActivityContext, 'graphql'>,
@@ -36,7 +63,7 @@ export function createEntityActivityQuery(
   const input = createMemo(() => {
     const entityId = options.entityId();
     if (!options.enabled() || entityId.length === 0) return undefined;
-    return buildEntityPropertiesInput(options.entityType(), entityId);
+    return buildEntityActivityInput(options.entityType(), entityId);
   });
 
   const result = createUrqlQuery<

--- a/apps/web/src/features/activity/queries/fixtures.ts
+++ b/apps/web/src/features/activity/queries/fixtures.ts
@@ -110,3 +110,11 @@ export const unsupportedEntityEvent: ActivityEventFieldsFragment = {
   entityId: 'team-1',
   action: { __typename: 'GraphqlActivityCreated' },
 };
+
+export const agentSessionCreatedEvent: ActivityEventFieldsFragment = {
+  ...BASE,
+  id: 'evt-13',
+  entityType: 'AGENT_SESSION',
+  entityId: 'session-1',
+  action: { __typename: 'GraphqlActivityCreated' },
+};

--- a/apps/web/src/features/activity/views/entity-activity-section.tsx
+++ b/apps/web/src/features/activity/views/entity-activity-section.tsx
@@ -1,6 +1,5 @@
 import { SidePanel } from '@components/app/side-panel/SidePanel';
 import CaretUpDownIcon from '@phosphor/caret-up-down.svg';
-import type { EntityType } from '@service-properties/generated/schemas/entityType';
 import { cn } from '@ui';
 import {
   createMemo,
@@ -24,6 +23,7 @@ import type { RailEnds } from '../core/feed-rows';
 import { foldPanel } from '../core/fold-panel';
 import { createActorName } from '../primitives/actor-name';
 import { createEntityActivityState } from '../primitives/entity-activity';
+import type { EntityActivityEntityType } from '../queries/entity-query';
 import { useEntityActivityFlag } from '../use-entity-activity-flag';
 
 /** Newest entries shown before the section folds behind its toggle. */
@@ -31,7 +31,7 @@ const PANEL_HEAD_LIMIT = 3;
 
 export interface EntityActivitySectionProps {
   entityId: string;
-  entityType: EntityType;
+  entityType: EntityActivityEntityType;
   order?: number;
 }
 

--- a/apps/web/src/features/block-agent/component/sidepanel/AgentSidePanelSections.tsx
+++ b/apps/web/src/features/block-agent/component/sidepanel/AgentSidePanelSections.tsx
@@ -5,11 +5,11 @@
  * `<SidePanel.Section>` elements that self-register into the enclosing
  * `<SidePanel.Layout>`.
  *
- * Everything rendered here is derived from state the block already holds —
- * the session record, the fold's metadata, and pure summaries over the
- * folded transcript (`state/session-summary.ts`).
+ * The Details/Plan/files/session-stats sections are derived from state the
+ * block already holds. Activity is the shared entity-activity timeline.
  */
 
+import { EntityActivitySectionConditional } from '@app/features/activity/views/entity-activity-section';
 import { SidePanel, useSidePanel } from '@components/app/side-panel';
 import { useSplitPanel } from '@components/app/split-layout/layoutUtils';
 import { registerHotkey } from '@core/hotkey/hotkeys';
@@ -33,7 +33,8 @@ import {
 import { harnessTitle } from '../AgentSplitHeader';
 
 export function AgentSidePanelSections() {
-  const { session, bot, metadata, messages, status } = useAgentSession();
+  const { sessionId, session, bot, metadata, messages, status } =
+    useAgentSession();
 
   const plan = createMemo(() => latestPlan(messages()));
   const files = createMemo(() => changedFiles(messages()));
@@ -180,12 +181,17 @@ export function AgentSidePanelSections() {
       </Show>
 
       <Show when={activity().some((item) => item.count > 0)}>
-        <SidePanel.Section id="activity" title="Activity" order={30}>
+        <SidePanel.Section id="session-stats" title="This session" order={30}>
           <div class="text-xs text-ink-muted">
             <CountSummary items={activity()} />
           </div>
         </SidePanel.Section>
       </Show>
+      <EntityActivitySectionConditional
+        entityId={sessionId() ?? ''}
+        entityType="AGENT_SESSION"
+        order={35}
+      />
     </>
   );
 }

--- a/apps/web/src/lib/core/component/AI/component/tool/ReadActivity.test.tsx
+++ b/apps/web/src/lib/core/component/AI/component/tool/ReadActivity.test.tsx
@@ -140,6 +140,22 @@ describe('ReadActivity renderer', () => {
     const { container } = renderTool([
       {
         actorId: 'macro|user@example.com',
+        entityType: 'team',
+        entityId: 'team-raw-id',
+        action: { type: 'created' },
+        occurredAt: '2026-08-19T17:30:00Z',
+      },
+    ]);
+
+    expect(screen.getByRole('button', { name: /1 activity/i })).toBeTruthy();
+    expect(container.textContent).toContain('Created');
+    expect(container.textContent).not.toContain('team-raw-id');
+  });
+
+  it('renders an agent session as a named entity', () => {
+    const { container } = renderTool([
+      {
+        actorId: 'macro|user@example.com',
         entityType: 'agent_session',
         entityId: 'agent-session-raw-id',
         action: { type: 'created' },
@@ -148,7 +164,7 @@ describe('ReadActivity renderer', () => {
     ]);
 
     expect(screen.getByRole('button', { name: /1 activity/i })).toBeTruthy();
-    expect(container.textContent).toContain('Created');
+    expect(container.textContent).toContain('Launch plan');
     expect(container.textContent).not.toContain('agent-session-raw-id');
   });
 

--- a/apps/web/src/lib/core/component/AI/component/tool/ReadActivity.tsx
+++ b/apps/web/src/lib/core/component/AI/component/tool/ReadActivity.tsx
@@ -28,6 +28,7 @@ function decodeToolEntityType(raw: string): ActivityEntityType {
     .with('email_thread', () => 'email-thread' as const)
     .with('channel', () => 'channel' as const)
     .with('user', () => 'user' as const)
+    .with('agent_session', () => 'agent-session' as const)
     .otherwise((value) => ({ kind: 'unsupported' as const, raw: value }));
 }
 

--- a/crates/agent_session/Cargo.toml
+++ b/crates/agent_session/Cargo.toml
@@ -35,7 +35,7 @@ schema = ["dep:utoipa", "agent_runtime_protocol/utoipa", "macro_user_id/schema"]
 test-utils = ["dep:mockall", "agent_fold/test-utils"]
 
 [dependencies]
-
+activity = { path = "../activity", default-features = false }
 agent-client-protocol = { workspace = true }
 harness_id = { path = "../harness_id" }
 agent = { path = "../agent", optional = true }

--- a/crates/agent_session/src/domain/activity.rs
+++ b/crates/agent_session/src/domain/activity.rs
@@ -1,0 +1,100 @@
+//! What counts as activity in the agent-session domain.
+//!
+//! Opening, prompting, and renaming are user (or delegated) acts on the
+//! session. The runtime answering, asking a question, and tearing down are
+//! consequences of a prompt, not acts by the subject. Deleting a session
+//! removes the row, so its activities are purged like other hard deletes.
+
+#[cfg(test)]
+mod test;
+
+use ::activity::{
+    Action, Activity, ActivitySource, Actor, CommonAction, DomainActivity, EntityType, Ingest,
+    event_time,
+};
+use macro_uuid::Uuid;
+
+use super::events::AgentSessionLifecycleEvent;
+
+/// Agent-session-exclusive actions. Common lifecycle actions go through
+/// [`Activity::common`] and need no representation here.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AgentSessionAction {
+    /// The subject sent a prompt in the session.
+    Messaged,
+}
+
+/// An agent-session-exclusive activity.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentSessionActivity {
+    /// The session acted on.
+    pub session_id: String,
+    /// What happened to it.
+    pub action: AgentSessionAction,
+}
+
+impl DomainActivity for AgentSessionActivity {
+    const ENTITY_TYPE: EntityType = EntityType::AgentSession;
+
+    fn entity_id(&self) -> &str {
+        &self.session_id
+    }
+
+    fn into_action(self) -> Action {
+        match self.action {
+            AgentSessionAction::Messaged => Action::Messaged,
+        }
+    }
+}
+
+impl ActivitySource for AgentSessionLifecycleEvent {
+    /// Maps one `macro.agent_session_lifecycle` event to its ingest outcome.
+    ///
+    /// Exhaustive on purpose: a new event variant fails compilation here
+    /// until someone classifies it or explicitly drops it.
+    fn ingest(&self, event_id: Uuid) -> Ingest {
+        let now = || event_time(event_id);
+        let session_id = self.session_id().to_string();
+        let owner = self.identity().owner_id.clone();
+        let common = |action: CommonAction| {
+            Ingest::Insert(vec![Activity::common(
+                event_id,
+                0,
+                Actor::new_from_user(owner.clone()),
+                None,
+                EntityType::AgentSession,
+                session_id.clone(),
+                action,
+                now(),
+            )])
+        };
+
+        match self {
+            AgentSessionLifecycleEvent::Opened(_) => common(CommonAction::Created),
+            AgentSessionLifecycleEvent::TurnStarted(metadata) => match &metadata.actor {
+                Some(actor) => Ingest::Insert(vec![Activity::from_domain(
+                    event_id,
+                    0,
+                    Actor::new_from_user(actor.clone()),
+                    None,
+                    AgentSessionActivity {
+                        session_id,
+                        action: AgentSessionAction::Messaged,
+                    },
+                    now(),
+                )]),
+                None => Ingest::Ignore,
+            },
+            AgentSessionLifecycleEvent::Renamed(_) => common(CommonAction::Edited),
+            // The session row is gone once this event is published.
+            AgentSessionLifecycleEvent::Deleted(_) => {
+                Ingest::Purge(vec![(EntityType::AgentSession, session_id)])
+            }
+            AgentSessionLifecycleEvent::TurnEnded(_)
+            | AgentSessionLifecycleEvent::Settled(_)
+            | AgentSessionLifecycleEvent::WaitingForInput(_)
+            | AgentSessionLifecycleEvent::InputReceived(_)
+            | AgentSessionLifecycleEvent::Stopped(_) => Ingest::Ignore,
+        }
+    }
+}

--- a/crates/agent_session/src/domain/activity/test.rs
+++ b/crates/agent_session/src/domain/activity/test.rs
@@ -1,0 +1,164 @@
+use ::activity::Action;
+use bots::domain::models::BotId;
+use macro_user_id::user_id::MacroUserIdStr;
+use macro_uuid::Uuid;
+
+use macro_event_broker::Event;
+
+use super::*;
+use crate::domain::events::{
+    InputReceivedMetadata, SessionDeletedMetadata, SessionIdentity, SessionOpenedMetadata,
+    SessionRenamedMetadata, SessionSettledMetadata, SessionStoppedMetadata, TurnEndedMetadata,
+    TurnStartedMetadata, WaitingForInputMetadata,
+};
+use crate::domain::model::{AgentSessionId, TurnId};
+
+fn user(id: &str) -> MacroUserIdStr<'static> {
+    MacroUserIdStr::try_from(id.to_string()).expect("valid user id")
+}
+
+fn envelope(event: AgentSessionLifecycleEvent) -> Event<AgentSessionLifecycleEvent> {
+    Event::with_event_id(Uuid::now_v7(), event)
+}
+
+fn identity() -> SessionIdentity {
+    SessionIdentity {
+        session_id: AgentSessionId::TEST_A,
+        session_name: "Fix the flaky test".to_owned(),
+        bot_id: BotId::TEST_A,
+        bot_name: "Macro Coder".to_owned(),
+        owner_id: user("macro|owner@macro.com"),
+        origin: None,
+    }
+}
+
+fn session_id() -> String {
+    AgentSessionId::TEST_A.to_string()
+}
+
+fn single_activity(ingest: Ingest) -> Activity {
+    match ingest {
+        Ingest::Insert(mut activities) => {
+            assert_eq!(activities.len(), 1);
+            activities.pop().unwrap()
+        }
+        other => panic!("expected a single activity, got {other:?}"),
+    }
+}
+
+#[test]
+fn opened_maps_to_created_on_the_owner() {
+    let event = envelope(AgentSessionLifecycleEvent::Opened(SessionOpenedMetadata {
+        identity: identity(),
+        model: "claude".to_owned(),
+        harness: "claude_code".to_owned(),
+    }));
+
+    let activity = single_activity(event.event.ingest(event.event_id));
+    assert_eq!(activity.action, Action::Created);
+    assert_eq!(activity.entity_type, EntityType::AgentSession);
+    assert_eq!(activity.entity_id, session_id());
+    assert_eq!(activity.subject_id, "macro|owner@macro.com");
+    assert_eq!(activity.actor.as_ref(), "macro|owner@macro.com");
+}
+
+#[test]
+fn user_prompt_maps_to_messaged() {
+    let event = envelope(AgentSessionLifecycleEvent::TurnStarted(
+        TurnStartedMetadata {
+            identity: identity(),
+            turn: TurnId(0),
+            action_id: agent_runtime_protocol::domain::action::AgentActionId::mint(),
+            actor: Some(user("macro|teo@macro.com")),
+            announcement_message_id: None,
+        },
+    ));
+
+    let activity = single_activity(event.event.ingest(event.event_id));
+    assert_eq!(activity.action, Action::Messaged);
+    assert_eq!(activity.entity_type, EntityType::AgentSession);
+    assert_eq!(activity.subject_id, "macro|teo@macro.com");
+}
+
+#[test]
+fn actorless_prompt_is_dropped() {
+    let event = envelope(AgentSessionLifecycleEvent::TurnStarted(
+        TurnStartedMetadata {
+            identity: identity(),
+            turn: TurnId(0),
+            action_id: agent_runtime_protocol::domain::action::AgentActionId::mint(),
+            actor: None,
+            announcement_message_id: None,
+        },
+    ));
+    assert_eq!(event.event.ingest(event.event_id), Ingest::Ignore);
+}
+
+#[test]
+fn renamed_maps_to_edited() {
+    let event = envelope(AgentSessionLifecycleEvent::Renamed(
+        SessionRenamedMetadata {
+            identity: identity(),
+        },
+    ));
+    assert_eq!(
+        single_activity(event.event.ingest(event.event_id)).action,
+        Action::Edited
+    );
+}
+
+#[test]
+fn deleted_purges_the_session() {
+    let event = envelope(AgentSessionLifecycleEvent::Deleted(
+        SessionDeletedMetadata {
+            identity: identity(),
+        },
+    ));
+    assert_eq!(
+        event.event.ingest(event.event_id),
+        Ingest::Purge(vec![(EntityType::AgentSession, session_id())])
+    );
+}
+
+#[test]
+fn runtime_consequences_are_dropped() {
+    let identity = identity();
+    let action_id = agent_runtime_protocol::domain::action::AgentActionId::mint();
+    let ignored = [
+        AgentSessionLifecycleEvent::TurnEnded(TurnEndedMetadata {
+            identity: identity.clone(),
+            turn: TurnId(0),
+            action_id: action_id.clone(),
+            actor: Some(user("macro|owner@macro.com")),
+            announcement_message_id: None,
+            stop_reason: "end_turn".to_owned(),
+            queued_remaining: 0,
+        }),
+        AgentSessionLifecycleEvent::Settled(SessionSettledMetadata {
+            identity: identity.clone(),
+            last_turn: None,
+        }),
+        AgentSessionLifecycleEvent::WaitingForInput(WaitingForInputMetadata {
+            identity: identity.clone(),
+            turn: TurnId(1),
+            action_id: action_id.clone(),
+            announcement_message_id: None,
+            question: "Which approach?".to_owned(),
+        }),
+        AgentSessionLifecycleEvent::InputReceived(InputReceivedMetadata {
+            identity: identity.clone(),
+            turn: TurnId(1),
+            action_id,
+        }),
+        AgentSessionLifecycleEvent::Stopped(SessionStoppedMetadata {
+            identity,
+            reason: "transport closed".to_owned(),
+            turn_in_flight: None,
+        }),
+    ];
+
+    for event in ignored {
+        let envelope = envelope(event);
+        assert_eq!(envelope.event.ingest(envelope.event_id), Ingest::Ignore);
+    }
+}

--- a/crates/agent_session/src/domain/mod.rs
+++ b/crates/agent_session/src/domain/mod.rs
@@ -1,3 +1,5 @@
+/// Event-to-activity mappings for this domain.
+pub mod activity;
 pub mod connection;
 pub mod error;
 pub mod events;

--- a/docs/AGENT_GUIDE/ai-chat.md
+++ b/docs/AGENT_GUIDE/ai-chat.md
@@ -146,6 +146,10 @@ to open the title menu (caret), then **Rename** — that opens the generic entit
 rename dialog. Do not expect a tap on the name itself to start
 an inline edit.
 
+The side panel (toggle with `]`) includes Details, Plan, Changed files, This
+session (tool-call counts for the current transcript), and Activity (the same
+glyph-rail history as `/app/component/activity`: created, prompted, renamed).
+
 ### Sharing a session
 
 Saved sessions have **Share** and **Copy Share Link** in the desktop header;

--- a/docs/AGENT_GUIDE/ai-chat.md
+++ b/docs/AGENT_GUIDE/ai-chat.md
@@ -148,7 +148,7 @@ an inline edit.
 
 The side panel (toggle with `]`) includes Details, Plan, Changed files, This
 session (tool-call counts for the current transcript), and Activity (the same
-glyph-rail history as `/app/component/activity`: created, prompted, renamed).
+glyph-rail history as `/app/component/activity`: created, sent a message, edited).
 
 ### Sharing a session
 

--- a/services/document_storage_service/Cargo.toml
+++ b/services/document_storage_service/Cargo.toml
@@ -28,6 +28,7 @@ location_check = []
 
 [dependencies]
 activity = { path = "../../crates/activity" }
+agent_session = { path = "../../crates/agent_session", default-features = false }
 ai_tools = { path = "../../crates/ai_tools" }
 ai_usage = { path = "../../crates/ai_usage" }
 analytics_client = { path = "../../crates/analytics_client" }

--- a/services/document_storage_service/src/service/activity.rs
+++ b/services/document_storage_service/src/service/activity.rs
@@ -6,6 +6,7 @@
 //! machinery lives in the `activity` crate. These arms are pure wiring.
 
 use activity::Ingest;
+use agent_session::domain::events::AgentSessionLifecycleMacroEvent;
 use call::domain::events::CallMacroEvent;
 use channels::domain::broker_events::ChannelMacroEvent;
 use chat::domain::events::ChatMacroEvent;
@@ -28,6 +29,7 @@ mod source {
             EmailMacroEvent,
             PropertyMacroEvent,
             CallMacroEvent,
+            AgentSessionLifecycleMacroEvent,
     );
 }
 pub(crate) use source::ActivitySourceEvent;
@@ -48,5 +50,6 @@ pub(crate) fn ingest(event: &ActivitySourceEvent) -> Ingest {
         ActivitySourceEvent::EmailMacroEvent(e) => arm(e.event()),
         ActivitySourceEvent::PropertyMacroEvent(e) => arm(e.event()),
         ActivitySourceEvent::CallMacroEvent(e) => arm(e.event()),
+        ActivitySourceEvent::AgentSessionLifecycleMacroEvent(e) => arm(e.event()),
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agent sessions now flow through the shared activity log the same way chats, documents, and channels already do.

## Mapping

`macro.agent_session_lifecycle` events are classified in the agent-session domain (`ActivitySource`). DSS only consumes the topic:

- `Opened` → `Created` (owner)
- `TurnStarted` with an actor → `Messaged` on the session
- `TurnStarted` with no actor → ignored (runtime / delegated)
- `Renamed` → `Edited`
- `Deleted` → `Purge` (the session row is gone)
- `TurnEnded`, `Settled`, `WaitingForInput`, `InputReceived`, `Mentioned`, `Stopped` → ignored

No new durable `Action` variant. Prompts reuse `Messaged`. Mentions notify named users; the prompt is already recorded as `Messaged`.

## UI

- GraphQL `AGENT_SESSION` and tool `agent_session` decode as a first-class activity entity
- Feed rows resolve session name/icon/link from item preview
- Agent side panel gets an **Activity** section (Soup opt-in via `agentSessionFilter`; sessions stay off by default in Soup)
- Existing tool-count section is renamed **This session** so it does not collide with `id="activity"`

## Tests

- `cargo test -p agent_session --lib domain::activity --no-default-features` — 7 passed
- Frontend activity decode / entity query / opener / ReadActivity tests passed
- `just check` passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef33998a-45ad-4bd4-b97a-94d13d9e73d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef33998a-45ad-4bd4-b97a-94d13d9e73d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

