### PR TITLE
fix(crm): backfill all owned inboxes

### DIFF
--- a/services/email_service/src/pubsub/backfill/depopulate_crm_for_user.rs
+++ b/services/email_service/src/pubsub/backfill/depopulate_crm_for_user.rs
@@ -3,7 +3,7 @@ use crm::domain::service::CrmService;
 use models_email::email::service::backfill::DepopulateCrmForUserPayload;
 use models_email::email::service::pubsub::{DetailedError, FailureReason, ProcessingError};
 
-/// Removes every CRM source row owned by the user's email link within
+/// Removes every CRM source row owned by the user's email links within
 /// `payload.team_id`, plus the team's contact / company rows orphaned
 /// as a result (preserving companies with `email_sync = false`).
 ///
@@ -15,7 +15,7 @@ use models_email::email::service::pubsub::{DetailedError, FailureReason, Process
 /// contacts on them — so we tear down based on link ownership inside
 /// the team, not message presence.
 ///
-/// No-ops (acks the message) when the user has no email link.
+/// No-ops (acks the message) when the user has no owned email link.
 /// Team-deletion does NOT go through this path; the
 /// `crm_companies.team_id` FK cascade handles it in macrodb.
 #[tracing::instrument(skip(ctx), err, fields(macro_id = %payload.macro_id, team_id = %payload.team_id))]
@@ -24,38 +24,37 @@ pub async fn depopulate_crm_for_user(
     payload: &DepopulateCrmForUserPayload,
 ) -> Result<(), ProcessingError> {
     let macro_id_str = payload.macro_id.0.as_ref();
-    // Must resolve the same link `populate_crm_for_user` seeded from — the
-    // inbox whose address matches the macro_id email — so teardown targets
-    // the link that was actually populated.
-    let email_address = payload.macro_id.email_str();
 
-    let link = email_db_client::links::get::fetch_link_by_macro_id_and_email_address(
-        &ctx.db,
-        macro_id_str,
-        email_address,
-    )
-    .await
-    .map_err(|e| {
-        ProcessingError::Retryable(DetailedError {
-            reason: FailureReason::DatabaseQueryFailed,
-            source: e.context("Failed to fetch link by macro_id and email_address"),
-        })
-    })?;
-
-    let Some(link) = link else {
-        tracing::debug!("User has no email link; skipping CRM teardown");
-        return Ok(());
-    };
-
-    ctx.crm_service
-        .depopulate_link_in_team(&payload.team_id, &link.id)
+    // Mirror populate_crm_for_user exactly: fetch all accessible inboxes, then
+    // keep only links owned by this macro_id. Delegated/shared inboxes belong
+    // to another macro user and must not be torn down here.
+    let mut links = email_db_client::links::get::fetch_inboxes_for_macro_id(&ctx.db, macro_id_str)
         .await
         .map_err(|e| {
             ProcessingError::Retryable(DetailedError {
                 reason: FailureReason::DatabaseQueryFailed,
-                source: anyhow::Error::from(e).context("Failed to depopulate CRM for link in team"),
+                source: e.context("Failed to fetch inboxes for macro_id"),
             })
         })?;
+    links.retain(|link| link.macro_id.as_ref() == macro_id_str);
+
+    if links.is_empty() {
+        tracing::debug!("User has no owned email link; skipping CRM teardown");
+        return Ok(());
+    }
+
+    for link in links {
+        ctx.crm_service
+            .depopulate_link_in_team(&payload.team_id, &link.id)
+            .await
+            .map_err(|e| {
+                ProcessingError::Retryable(DetailedError {
+                    reason: FailureReason::DatabaseQueryFailed,
+                    source: anyhow::Error::from(e)
+                        .context("Failed to depopulate CRM for link in team"),
+                })
+            })?;
+    }
 
     Ok(())
 }

--- a/services/email_service/src/pubsub/backfill/populate_crm_for_user.rs
+++ b/services/email_service/src/pubsub/backfill/populate_crm_for_user.rs
@@ -6,11 +6,11 @@ use models_email::email::service::pubsub::{DetailedError, FailureReason, Process
 
 /// Seeds the team's CRM tables with every contact the user has sent email
 /// to in the past. Triggered when a user is added to a team — the user only
-/// has their macro_id at this point, so this handler resolves the link and
-/// team itself, then fans out one `PopulateCrmContact` job per distinct
-/// recipient of a sent message on that link.
+/// has their macro_id at this point, so this handler resolves the user's owned
+/// inboxes and team itself, then fans out one `PopulateCrmContact` job per
+/// distinct contact on each owned inbox.
 ///
-/// No-ops (acks the message) when the user has no email link or no team
+/// No-ops (acks the message) when the user has no owned email link or no team
 /// membership. The downstream `PopulateCrmContact` consumer is idempotent
 /// and re-checks the team membership + per-domain killswitch, so racing
 /// removals between fan-out and consumption are safe.
@@ -20,27 +20,24 @@ pub async fn populate_crm_for_user(
     payload: &PopulateCrmForUserPayload,
 ) -> Result<(), ProcessingError> {
     let macro_id_str = payload.macro_id.0.as_ref();
-    // Resolve the user's own inbox — the link whose address matches the email
-    // embedded in the macro_id — not merely the newest link on the macro_id.
-    let email_address = payload.macro_id.email_str();
 
-    let link = email_db_client::links::get::fetch_link_by_macro_id_and_email_address(
-        &ctx.db,
-        macro_id_str,
-        email_address,
-    )
-    .await
-    .map_err(|e| {
-        ProcessingError::Retryable(DetailedError {
-            reason: FailureReason::DatabaseQueryFailed,
-            source: e.context("Failed to fetch link by macro_id and email_address"),
-        })
-    })?;
+    // `fetch_inboxes_for_macro_id` includes delegated/shared inboxes. CRM
+    // backfill should cover every inbox owned by this macro_id, but it must not
+    // seed CRM data from inboxes that are only delegated to the user.
+    let mut links = email_db_client::links::get::fetch_inboxes_for_macro_id(&ctx.db, macro_id_str)
+        .await
+        .map_err(|e| {
+            ProcessingError::Retryable(DetailedError {
+                reason: FailureReason::DatabaseQueryFailed,
+                source: e.context("Failed to fetch inboxes for macro_id"),
+            })
+        })?;
+    links.retain(|link| link.macro_id.as_ref() == macro_id_str);
 
-    let Some(link) = link else {
-        tracing::debug!("User has no email link; skipping CRM fan-out");
+    if links.is_empty() {
+        tracing::debug!("User has no owned email link; skipping CRM fan-out");
         return Ok(());
-    };
+    }
 
     let team_id = ctx
         .crm_service
@@ -58,34 +55,37 @@ pub async fn populate_crm_for_user(
         return Ok(());
     }
 
-    let self_email = link.email_address.0.as_ref().to_ascii_lowercase();
+    for link in links {
+        let self_email = link.email_address.0.as_ref().to_ascii_lowercase();
 
-    // The by_link queries aggregate MIN/MAX of `internal_date_ts` per
-    // contact, so each fan-out job carries the contact's full known
-    // activity range. The consumer stamps `first_interaction` /
-    // `last_interaction` directly from those endpoints.
-    //
-    // Two fan-outs: sent recipients (`is_sent=true`, may create new
-    // `crm_companies` rows), then received senders (`is_sent=false`,
-    // only updates already-tracked rows). Sent first so received-pass
-    // contacts at brand-new companies can also land. Both passes are
-    // idempotent.
-    let sent_recipients =
-        email_db_client::contacts::get::fetch_sent_message_recipient_contacts_by_link(
-            &ctx.db, link.id,
-        )
-        .await
-        .map_err(|e| {
-            ProcessingError::Retryable(DetailedError {
-                reason: FailureReason::DatabaseQueryFailed,
-                source: e.context("Failed to fetch sent-message recipients"),
-            })
-        })?;
+        // The by_link queries aggregate MIN/MAX of `internal_date_ts` per
+        // contact, so each fan-out job carries the contact's full known
+        // activity range. The consumer stamps `first_interaction` /
+        // `last_interaction` directly from those endpoints.
+        //
+        // Two fan-outs: sent recipients (`is_sent=true`, may create new
+        // `crm_companies` rows), then received senders (`is_sent=false`,
+        // only updates already-tracked rows). Sent first so received-pass
+        // contacts at brand-new companies can also land. Both passes are
+        // idempotent.
+        let sent_recipients =
+            email_db_client::contacts::get::fetch_sent_message_recipient_contacts_by_link(
+                &ctx.db, link.id,
+            )
+            .await
+            .map_err(|e| {
+                ProcessingError::Retryable(DetailedError {
+                    reason: FailureReason::DatabaseQueryFailed,
+                    source: e.context("Failed to fetch sent-message recipients"),
+                })
+            })?;
 
-    enqueue_populate_crm_contacts(ctx, link.id, &self_email, sent_recipients, true).await?;
+        enqueue_populate_crm_contacts(ctx, link.id, &self_email, sent_recipients, true).await?;
 
-    let received_senders =
-        email_db_client::contacts::get::fetch_received_sender_contacts_by_link(&ctx.db, link.id)
+        let received_senders =
+            email_db_client::contacts::get::fetch_received_sender_contacts_by_link(
+                &ctx.db, link.id,
+            )
             .await
             .map_err(|e| {
                 ProcessingError::Retryable(DetailedError {
@@ -94,5 +94,8 @@ pub async fn populate_crm_for_user(
                 })
             })?;
 
-    enqueue_populate_crm_contacts(ctx, link.id, &self_email, received_senders, false).await
+        enqueue_populate_crm_contacts(ctx, link.id, &self_email, received_senders, false).await?;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary

CRM user backfill currently resolves only the inbox whose address matches the email embedded in the user's `macro_id`. That avoids selecting a delegated/shared inbox, but it also skips any additional inboxes that are genuinely owned by the same Macro user.

This change keeps the ownership boundary from #4782 while expanding backfill and teardown to every **owned** inbox:

- resolve the user's accessible inboxes with the existing `fetch_inboxes_for_macro_id`
- explicitly filter to links where `link.macro_id == payload.macro_id`
- populate CRM contacts for each owned link
- depopulate the same complete set of owned links on team removal
- exclude delegated/shared inboxes from both paths

## Why

A Macro user can have multiple `email_links` owned by the same `macro_id`. Restricting CRM backfill to only the address embedded in `macro_id` leaves historical contacts from the user's other owned inboxes unseeded. Using all accessible inboxes without filtering would be too broad because `fetch_inboxes_for_macro_id` also returns delegated/shared inboxes.

The ownership filter gives the intended middle ground: **all owned inboxes, no delegated inboxes**.

## Scope

Only the CRM per-user populate/depopulate handlers change. No schema, API, migration, or delegated-inbox behavior changes.

## Validation

The branch is based directly on current upstream `main` and contains one commit touching only:

- `services/email_service/src/pubsub/backfill/populate_crm_for_user.rs`
- `services/email_service/src/pubsub/backfill/depopulate_crm_for_user.rs`

CI should exercise formatting/build checks; the populate/depopulate paths remain symmetric and reuse the existing multi-inbox resolver.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which CRM rows are seeded and torn down on team join/leave; wrong ownership filtering could omit contacts or affect delegated inboxes, though idempotent downstream consumers limit blast radius.
> 
> **Overview**
> CRM per-user **populate** and **depopulate** backfill no longer target a single inbox resolved from the email embedded in `macro_id`. Both handlers now load accessible inboxes via `fetch_inboxes_for_macro_id`, **retain only links owned by that `macro_id`** (excluding delegated/shared inboxes), and run the existing per-link work for **each** owned inbox.
> 
> On team add, contact fan-out (sent recipients, then received senders) runs once per owned link instead of once for the primary address. On team removal, `depopulate_link_in_team` is invoked for every owned link so teardown stays symmetric with populate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77c5b6051f01177d9a2e53d019711c34a38cbdf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->